### PR TITLE
docs: remove extra space that prevented copy-paste

### DIFF
--- a/docs/installing.md
+++ b/docs/installing.md
@@ -47,7 +47,7 @@ helm repo add kubeshop https://kubeshop.github.io/helm-charts
 helm repo update
 
 helm install tracetest kubeshop/tracetest \
-  --set tracingBackend=tempo \ 
+  --set tracingBackend=tempo \
   --set tempoConnectionConfig.endpoint="grafana-tempo:9095"
 ```
 


### PR DESCRIPTION
This PR enables a user to copy and paste from our installation docs to its terminal without having the command being split into two.

Solves #153

## Checklist

- [ ] tested locally
- [ ] added new dependencies
- [x] updated the docs
- [ ] added a test
