### PR TITLE
add calculated span duration

### DIFF
--- a/server/go/utils.go
+++ b/server/go/utils.go
@@ -137,7 +137,7 @@ func mapTrace(tr *v1.TracesData) ApiV3SpansResponseChunk {
 				attributes := mapAttributes(sp.GetAttributes())
 
 				if sp.GetStartTimeUnixNano() != 0 && sp.GetEndTimeUnixNano() != 0 {
-					spanDuration := (sp.GetEndTimeUnixNano() - sp.GetStartTimeUnixNano()) / 1000 / 1000 // in milliseconds
+					spanDuration := (sp.GetEndTimeUnixNano() - sp.GetStartTimeUnixNano()) // in nanoseconds
 
 					attributes = append(attributes, V1KeyValue{
 						Key: "tracetest.span.duration",


### PR DESCRIPTION
This PR calculates the duration of each span and adds it to its attributes, so it can be asserted against.

## Changes

- add a `tracetest.span.duration` attribute when possible

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
