### PR TITLE
add trigger response attrs to parent span

### DIFF
--- a/server/go/api_api_service.go
+++ b/server/go/api_api_service.go
@@ -107,7 +107,7 @@ func (s *ApiApiService) GetTest(ctx context.Context, testid string) (ImplRespons
 		if err != nil {
 			return Response(http.StatusInternalServerError, err.Error()), err
 		}
-		ttr := FixParent(tr, string(tid[:]), string(sid[:]))
+		ttr := FixParent(tr, string(tid[:]), string(sid[:]), res.Response)
 		test.ReferenceTestRunResult.Trace = mapTrace(ttr)
 	}
 	return Response(200, test), nil
@@ -260,7 +260,7 @@ func (s *ApiApiService) TestsTestIdResultsResultIdGet(ctx context.Context, testi
 		if err != nil {
 			return Response(http.StatusInternalServerError, err.Error()), err
 		}
-		ttr := FixParent(tr, string(tid[:]), string(sid[:]))
+		ttr := FixParent(tr, string(tid[:]), string(sid[:]), res.Response)
 		res.Trace = mapTrace(ttr)
 	}
 	return Response(http.StatusOK, *res), nil


### PR DESCRIPTION
This PR adds information about the triggering transaction response to the parent span attributes.

## Changes

- add response attrs to parent span

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
