### PR TITLE
fix: json request body

### DIFF
--- a/server/go/executor/executor.go
+++ b/server/go/executor/executor.go
@@ -65,6 +65,8 @@ func (te *TestExecutor) Execute(test *openapi.Test, tid trace.TraceID, sid trace
 	var body io.Reader
 	if tReq.Body != "" {
 		body = bytes.NewBufferString(tReq.Body)
+		// Without this header, some servers will ignore the request body.
+		req.Header.Set("Content-Type", "application/json")
 	}
 	req, err := http.NewRequest(strings.ToUpper(tReq.Method), tReq.Url, body)
 	if err != nil {


### PR DESCRIPTION
This PR makes Tracetest send the `Content-type`: `application/json` header when the request body is present. Without this header, some servers just ignore the request body.

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
