### PR TITLE
feat: default Content-Type header in test creation modal

### DIFF
--- a/web/src/components/CreateTest/CreateTestModal.tsx
+++ b/web/src/components/CreateTest/CreateTestModal.tsx
@@ -11,6 +11,8 @@ interface IProps {
   onClose: () => void;
 }
 
+const defaultHeaders = [{key: 'Content-Type', value: 'application/json', checked: true}];
+
 const CreateTestModal = ({visible, onClose}: IProps): JSX.Element => {
   const navigate = useNavigate();
   const [createTest, {isLoading: isLoadingCreateTest}] = useCreateTestMutation();
@@ -99,7 +101,7 @@ const CreateTestModal = ({visible, onClose}: IProps): JSX.Element => {
 
           <Form.Item label="Headers List" wrapperCol={{span: 24, offset: 0}}>
             <div style={{minHeight: 80}}>
-              <Form.List name="headersList" initialValue={[{}, {}, {}]}>
+              <Form.List name="headersList" initialValue={[...defaultHeaders, {}, {}]}>
                 {(fields, {add, remove}) => (
                   <>
                     {fields.map((field, index) => (


### PR DESCRIPTION
This PR adds `Content-Type`: `application/json` as a default header in the test creation modal. This prevents #207 from happening.

How it looks like when you open the modal:
![image](https://user-images.githubusercontent.com/2704737/163825453-4c53fe1d-d890-43af-8c98-db03e1c2f108.png)


## Fixes

- #207

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
