### PR TITLE
234 adding default props for the custom table to have fixed layout

### DIFF
--- a/web/src/components/AssertionsTable/AssertionsTable.tsx
+++ b/web/src/components/AssertionsTable/AssertionsTable.tsx
@@ -49,10 +49,8 @@ const AssertionsResultTable = ({assertionResults, assertion: {selectors = []}, s
         size="small"
         pagination={{hideOnSinglePage: true}}
         dataSource={parsedAssertionList}
-        bordered
-        tableLayout="fixed"
       >
-        <Table.Column title="Property" dataIndex="property" key="property" ellipsis width="60%" />
+        <Table.Column title="Property" dataIndex="property" key="property" ellipsis width="50%" />
         <Table.Column title="Comparison" dataIndex="comparison" key="comparison" render={value => getOperator(value)} />
         <Table.Column title="Value" dataIndex="value" key="value" />
         <Table.Column

--- a/web/src/components/CustomTable/CustomTable.tsx
+++ b/web/src/components/CustomTable/CustomTable.tsx
@@ -3,6 +3,7 @@ import styled from 'styled-components';
 
 const CustomTable = styled(Table).attrs({
   bordered: true,
+  tableLayout: 'fixed',
 })`
   .ant-table-thead > tr > th {
     font-weight: 600;

--- a/web/src/components/SpanAttributesTable/SpanAttributesTable.tsx
+++ b/web/src/components/SpanAttributesTable/SpanAttributesTable.tsx
@@ -13,8 +13,6 @@ const SpanAttributesTable: FC<TSpanAttributesTableProps> = ({spanAttributesList}
       size="small"
       pagination={false}
       dataSource={spanAttributesList}
-      bordered
-      tableLayout="fixed"
       showHeader={false}
     >
       <Table.Column

--- a/web/src/components/TraceAssertionsTable/TraceAssertionsTable.tsx
+++ b/web/src/components/TraceAssertionsTable/TraceAssertionsTable.tsx
@@ -88,8 +88,6 @@ const TraceAssertionsResultTable: FC<IProps> = ({
         size="small"
         pagination={false}
         dataSource={parsedAssertionList}
-        bordered
-        tableLayout="fixed"
         onRow={record => ({
           onClick: () => onSpanSelected((record as TParsedAssertion).spanId),
         })}

--- a/web/src/pages/Home/TestList.tsx
+++ b/web/src/pages/Home/TestList.tsx
@@ -21,7 +21,7 @@ const TestList = () => {
         };
       }}
     >
-      <Table.Column title="Name" dataIndex="name" key="name" />
+      <Table.Column title="Name" dataIndex="name" key="name" width="25%" />
       <Table.Column title="Endpoint" dataIndex="url" key="url" />
     </CustomTable>
   );

--- a/web/src/pages/Test/Assertions.tsx
+++ b/web/src/pages/Test/Assertions.tsx
@@ -1,6 +1,7 @@
-import {Button, Table} from 'antd';
+import {Button} from 'antd';
 import {ColumnsType} from 'antd/lib/table';
 import Title from 'antd/lib/typography/Title';
+import CustomTable from '../../components/CustomTable';
 
 const Assertions = () => {
   const dataSource = [
@@ -103,7 +104,7 @@ const Assertions = () => {
         <Title level={4}>Assertions</Title>
         <Button>New Assertion</Button>
       </div>
-      <Table dataSource={dataSource} columns={columns} />
+      <CustomTable dataSource={dataSource} columns={columns} />
     </>
   );
 };


### PR DESCRIPTION
This PR updates the base CustomTable styled component to include the fixed layout prop as the default

## Changes

- Updating all tables to use the CustomTable component
- Adding a fixed layout for the CustomTable component

## Fixes

- https://github.com/kubeshop/tracetest/issues/234

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test


## Screenshots
![Screen Shot 2022-04-19 at 10 40 23 a m](https://user-images.githubusercontent.com/11051031/164043095-cf2da8f7-a223-43c1-8e56-06dffd765d7c.png)
![Screen Shot 2022-04-19 at 10 40 20 a m](https://user-images.githubusercontent.com/11051031/164043096-fe304d84-2208-4232-b12a-d6fe3847fa43.png)