### PR TITLE
fix: condition on when to stop trace pooling

### DIFF
--- a/server/go/trace_poller.go
+++ b/server/go/trace_poller.go
@@ -151,7 +151,9 @@ func (tp tracePoller) processJob(job tracePollReq) {
 
 func (tp tracePoller) donePollingTraces(job tracePollReq, currentResults TestRunResult) bool {
 	// we're done if we have the same amount of spans after polling `maxTracePollRetry` times
-	return len(currentResults.Trace.ResourceSpans) == len(job.result.Trace.ResourceSpans) && job.count == tp.maxTracePollRetry
+	return len(currentResults.Trace.ResourceSpans) > 0 &&
+		len(currentResults.Trace.ResourceSpans) == len(job.result.Trace.ResourceSpans) &&
+		job.count == tp.maxTracePollRetry
 }
 
 func (tp tracePoller) handleTraceDBError(job tracePollReq, err error) {


### PR DESCRIPTION
This PR makes sure tracing pooling doesn't stop after not finding any trace more than `maxTracePollRetry` times.

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
