### PR TITLE
fix: get trace from db instead of tracing storage

### DIFF
--- a/server/go/api_api_service.go
+++ b/server/go/api_api_service.go
@@ -162,11 +162,6 @@ func (s *ApiApiService) GetTestResult(ctx context.Context, testid string, id str
 	if err != nil {
 		return Response(http.StatusInternalServerError, err.Error()), err
 	}
-	tr, err := s.traceDB.GetTraceByID(ctx, res.TraceId)
-	if err == nil {
-		ttr := FixParent(tr, res.Response)
-		res.Trace = mapTrace(ttr)
-	}
 	return Response(http.StatusOK, *res), nil
 }
 


### PR DESCRIPTION
This PR makes the getTestResult endpoint get the traces from db instead of trying to get it from the tracing storage.

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
