### PR TITLE
🏷  Moving the selected badge to the beginning

### DIFF
--- a/web/src/components/TraceAssertionsTable/TraceAssertionsTable.tsx
+++ b/web/src/components/TraceAssertionsTable/TraceAssertionsTable.tsx
@@ -99,10 +99,11 @@ const TraceAssertionsResultTable: FC<IProps> = ({
           ellipsis
           width="40%"
           render={(value: string[], record: TParsedAssertion) =>
-            value
-              // eslint-disable-next-line react/no-array-index-key
-              .map((label, index) => <S.LabelBadge count={label} key={`${label}-${index}`} />)
-              .concat(getIsSelected(record.spanId) ? [<S.SelectedLabelBadge count="selected" key="selected" />] : [])
+            (getIsSelected(record.spanId) ? [<S.SelectedLabelBadge count="selected" key="selected" />] : []).concat(
+              value
+                // eslint-disable-next-line react/no-array-index-key
+                .map((label, index) => <S.LabelBadge count={label} key={`${label}-${index}`} />)
+            )
           }
         />
         <Table.Column title="Property" dataIndex="property" key="property" ellipsis width="25%" />


### PR DESCRIPTION
This PR moves the selected badge from the last item to the start

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

![Screen Shot 2022-04-21 at 1 53 07 p m](https://user-images.githubusercontent.com/11051031/164532976-ef5ce4df-be13-4458-a72e-4b30d4a78c8d.png)
![Screen Shot 2022-04-21 at 1 53 45 p m](https://user-images.githubusercontent.com/11051031/164532981-5f80ac10-c3f8-40aa-aa05-a706c876c69a.png)

