### PR TITLE
convert span duration to milliseconds

### DIFF
--- a/server/go/utils.go
+++ b/server/go/utils.go
@@ -137,7 +137,7 @@ func mapTrace(tr *v1.TracesData) ApiV3SpansResponseChunk {
 				attributes := mapAttributes(sp.GetAttributes())
 
 				if sp.GetStartTimeUnixNano() != 0 && sp.GetEndTimeUnixNano() != 0 {
-					spanDuration := (sp.GetEndTimeUnixNano() - sp.GetStartTimeUnixNano()) // in nanoseconds
+					spanDuration := (sp.GetEndTimeUnixNano() - sp.GetStartTimeUnixNano()) / 1000 / 1000 // in milliseconds
 
 					attributes = append(attributes, V1KeyValue{
 						Key: "tracetest.span.duration",


### PR DESCRIPTION
This PR converts span duration attributes to milliseconds. This only works for fresh test runs.

## Changes

- divide nanoseconds by 1e6 to convert to milli

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
