### PR TITLE
🐛  Fixing minor bugs for both the assertion form and the custom table

### DIFF
--- a/web/src/components/CreateAssertionModal/CreateAssertionForm.tsx
+++ b/web/src/components/CreateAssertionModal/CreateAssertionForm.tsx
@@ -74,7 +74,7 @@ const CreateAssertionForm: React.FC<TCreateAssertionFormProps> = ({
   }, [onForm, form]);
 
   useEffect(() => {
-    onSelectorList(defaultSelectorList);
+    onSelectorList(assertion ? assertion.selectors : defaultSelectorList);
   }, [onSelectorList, defaultSelectorList]);
 
   const spanTagsMap = attrs?.reduce((acc: {[x: string]: any}, item: {key: string}) => {

--- a/web/src/components/CustomTable/CustomTable.tsx
+++ b/web/src/components/CustomTable/CustomTable.tsx
@@ -9,12 +9,12 @@ const CustomTable = styled(Table).attrs({
     font-weight: 600;
   }
 
-  .ant-table.ant-table-bordered > .ant-table-container > .ant-table-content > table > tbody > tr > td,
-  .ant-table.ant-table-bordered > .ant-table-container > .ant-table-content > table > thead > tr > th {
+  .ant-table.ant-table-bordered > .ant-table-container > .ant-table-body > table > tbody > tr > td,
+  .ant-table.ant-table-bordered > .ant-table-container > .ant-table-header > table > thead > tr > th {
     border-right: none;
   }
 
-  .ant-table.ant-table-bordered > .ant-table-container {
+  .ant-table.ant-table-bordered > .ant-table-body {
     border-right: 1px solid #f0f0f0;
   }
 


### PR DESCRIPTION
## Fixes

- Style broke for the tables, I think it was caused by an ant update. Still investigating...
- When editing an assertion the initial selector list was displaying the wrong number of selected spans.

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
