### PR TITLE
Add contains operator

### DIFF
--- a/web/src/components/CreateAssertionModal/CreateAssertionForm.tsx
+++ b/web/src/components/CreateAssertionModal/CreateAssertionForm.tsx
@@ -245,6 +245,7 @@ const CreateAssertionForm: React.FC<TCreateAssertionFormProps> = ({
                         <S.Select.Option value={COMPARE_OPERATOR.LESSTHAN}>lt</S.Select.Option>
                         <S.Select.Option value={COMPARE_OPERATOR.GREATOREQUALS}>ge</S.Select.Option>
                         <S.Select.Option value={COMPARE_OPERATOR.LESSOREQUAL}>le</S.Select.Option>
+                        <S.Select.Option value={COMPARE_OPERATOR.CONTAINS}>contains</S.Select.Option>
                       </S.Select>
                     </S.FullHeightFormItem>
                     <S.FullHeightFormItem

--- a/web/src/services/AssertionService.ts
+++ b/web/src/services/AssertionService.ts
@@ -23,6 +23,8 @@ const getOperator = (op: COMPARE_OPERATOR) => {
       return '>';
     case COMPARE_OPERATOR.LESSTHAN:
       return '<';
+    case COMPARE_OPERATOR.CONTAINS:
+      return 'contains';
     default:
       return '==';
   }
@@ -32,6 +34,11 @@ const buildValueSelector = (comparisonValue: string, compareOperator: string, va
   if (valueType === 'intValue') {
     return `to_number(value.${valueType}) ${compareOperator} \`${comparisonValue}\``;
   }
+
+  if (compareOperator === 'contains') {
+    return `contains(value.${valueType}, \`${comparisonValue}\`)`;
+  }
+
   return `value.${valueType} ${compareOperator} \`${comparisonValue}\``;
 };
 

--- a/web/src/types/index.ts
+++ b/web/src/types/index.ts
@@ -51,6 +51,7 @@ export const enum COMPARE_OPERATOR {
   NOTEQUALS = 'NOTEQUALS',
   GREATOREQUALS = 'GREATOREQUALS',
   LESSOREQUAL = 'LESSOREQUAL',
+  CONTAINS = 'CONTAINS',
 }
 
 export type ISpanAttributeValue = {

--- a/web/src/utils/index.ts
+++ b/web/src/utils/index.ts
@@ -20,6 +20,8 @@ export const getOperator = (op: COMPARE_OPERATOR) => {
       return 'gte';
     case COMPARE_OPERATOR.LESSOREQUAL:
       return 'lte';
+    case COMPARE_OPERATOR.CONTAINS:
+      return 'contains';
     default:
       return 'eq';
   }


### PR DESCRIPTION
This PR adds `contains` operator. This allows to compare to substrings.

## Changes

- add new operator

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
