### PR TITLE
320 allowing removal of every assertion check from the modal

### DIFF
--- a/web/src/components/CreateAssertionModal/CreateAssertionForm.tsx
+++ b/web/src/components/CreateAssertionModal/CreateAssertionForm.tsx
@@ -58,7 +58,7 @@ const CreateAssertionForm: React.FC<TCreateAssertionFormProps> = ({
 
   const defaultAssertionList = useMemo<AssertionSpan[]>(() => {
     if (assertion) {
-      return assertion.spanAssertions.map(({propertyName, operator, comparisonValue}) => ({
+      return assertion.spanAssertions?.map(({propertyName, operator, comparisonValue}) => ({
         key: propertyName,
         compareOp: operator,
         value: comparisonValue,
@@ -259,7 +259,7 @@ const CreateAssertionForm: React.FC<TCreateAssertionFormProps> = ({
                     <MinusCircleOutlined
                       color="error"
                       style={{cursor: 'pointer', color: 'rgb(140, 140, 140)'}}
-                      onClick={() => index > 0 && remove(name)}
+                      onClick={() => remove(name)}
                     />
                   </Space>
                 ))}

--- a/web/src/services/AssertionService.ts
+++ b/web/src/services/AssertionService.ts
@@ -82,9 +82,9 @@ const buildConditionArray = (itemSelectors: ItemSelector[]) => {
 export const runSpanAssertionByResourceSpan = (
   span: ResourceSpan,
   spanId: string,
-  assertion: Assertion
+  { spanAssertions = [] }: Assertion
 ): Array<SpanAssertionResult> => {
-  const assertionTestResultArray = assertion.spanAssertions.map(spanAssertion => {
+  const assertionTestResultArray = spanAssertions.map(spanAssertion => {
     const {comparisonValue, operator, valueType, locationName, propertyName} = spanAssertion;
     const valueSelector = buildValueSelector(comparisonValue, getOperator(operator), valueType);
 

--- a/web/src/services/TraceService.ts
+++ b/web/src/services/TraceService.ts
@@ -24,7 +24,7 @@ export const parseTestResultToAssertionResultList = (
           return span;
         });
 
-        const spanAssertion = assertion?.spanAssertions.find(({spanAssertionId: id}) => id === spanAssertionId);
+        const spanAssertion = assertion?.spanAssertions?.find(({spanAssertionId: id}) => id === spanAssertionId);
 
         return {
           span: resourceSpan!,


### PR DESCRIPTION
This PR allows users to delete all of the assertions checks when creating and editing an assertion.

## Changes

- CreateAssertionForm

## Fixes

- Allows removal of all of the assertion checks

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
