### PR TITLE
feat: add github bot to change issue states based on project

### DIFF
--- a/.github/workflows/issues-bot.yml
+++ b/.github/workflows/issues-bot.yml
@@ -1,0 +1,21 @@
+name: 'Issues Bot'
+
+on:
+  project_card:
+    types: [created, edited, moved]
+
+permissions:
+  repository-projects: read
+  issues: write
+  pull-requests: write
+
+jobs:
+  action:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: dessant/issue-states@v2
+        with:
+          github-token: ${{ github.token }}
+          open-issue-columns: 'Backlog, In progress, Waiting for approval'
+          closed-issue-columns: 'Done'
+          log-output: false


### PR DESCRIPTION
This PR adds an automation that already closes our issues when they are moved to the "Done" column.

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
