### PR TITLE
🐛 fixing guided tour not saving to the storage

### DIFF
--- a/web/src/components/GuidedTour/useGuidedTour.ts
+++ b/web/src/components/GuidedTour/useGuidedTour.ts
@@ -1,6 +1,6 @@
 import {useTour} from '@reactour/tour';
 import {delay as delayFn} from 'lodash';
-import {useEffect} from 'react';
+import {useEffect, useState} from 'react';
 import GuidedTourService, {GuidedTours} from '../../services/GuidedTourService';
 import HomeStepList from './homeStepList';
 import AssertionStepList from './assertionStepList';
@@ -15,10 +15,12 @@ const StepListMap = {
 };
 
 const useGuidedTour = (tour: GuidedTours, delay = 500) => {
+  const [isLoaded, setIsLoaded] = useState(false);
   const tourFn = useTour();
-  const {setCurrentStep, setIsOpen, setSteps} = tourFn;
+  const {setCurrentStep, setIsOpen, setSteps, isOpen} = tourFn;
 
   useEffect(() => {
+    setIsLoaded(false);
     setSteps(StepListMap[tour]);
   }, [tour, setSteps]);
 
@@ -28,9 +30,14 @@ const useGuidedTour = (tour: GuidedTours, delay = 500) => {
       delayFn(() => {
         setCurrentStep(0);
         setIsOpen(true);
+        setIsLoaded(true);
       }, delay);
     }
   }, [delay, setCurrentStep, setIsOpen, tour]);
+
+  useEffect(() => {
+    if (!isOpen && isLoaded) GuidedTourService.save(tour);
+  }, [isLoaded, isOpen, tour]);
 
   return tourFn;
 };


### PR DESCRIPTION
This PR fixes an issue with the guided tour complete flag not being saved to the storage.

## Changes

- useGuidedTour

## Fixes

- Guided tour displayed on every refresh even after close.

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
