### PR TITLE
feat: websocket endpoint

### DIFF
--- a/server/README.md
+++ b/server/README.md
@@ -13,7 +13,7 @@ To see how to make this your own, look here:
 [README](https://openapi-generator.tech)
 
 - API version: 0.0.1
-- Build date: 2022-04-21T16:07:39.699-03:00[America/Argentina/Buenos_Aires]
+- Build date: 2022-04-27T09:38:35.328275257-03:00[America/Sao_Paulo]
 
 
 ### Running the server

--- a/server/go.mod
+++ b/server/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/golang/mock v1.6.0
 	github.com/google/uuid v1.3.0
 	github.com/gorilla/mux v1.8.0
+	github.com/gorilla/websocket v1.5.0 // indirect
 	github.com/j2gg0s/otsql v0.14.0
 	github.com/lib/pq v1.10.4
 	github.com/mitchellh/mapstructure v1.4.3

--- a/server/go.sum
+++ b/server/go.sum
@@ -735,6 +735,8 @@ github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB7
 github.com/gorilla/websocket v0.0.0-20170926233335-4201258b820c/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
 github.com/gorilla/websocket v1.4.0/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
 github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
+github.com/gorilla/websocket v1.5.0 h1:PPwGk2jz7EePpoHN/+ClbZu8SPxiqlu12wZP/3sWmnc=
+github.com/gorilla/websocket v1.5.0/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7/go.mod h1:FecbI9+v66THATjSRHfNgh1IVFe/9kFxbXtjV0ctIMA=
 github.com/grpc-ecosystem/go-grpc-middleware v1.0.0/go.mod h1:FiyG127CGDf3tlThmgyCl78X/SZQqEOJBCDaAfeWzPs=
 github.com/grpc-ecosystem/go-grpc-middleware v1.0.1-0.20190118093823-f849b5445de4/go.mod h1:FiyG127CGDf3tlThmgyCl78X/SZQqEOJBCDaAfeWzPs=

--- a/server/go/websocket/messages.go
+++ b/server/go/websocket/messages.go
@@ -1,0 +1,13 @@
+package websocket
+
+type Message struct {
+	Type    string
+	Message interface{}
+}
+
+func Error(err error) Message {
+	return Message{
+		Type:    "error",
+		Message: err.Error(),
+	}
+}

--- a/server/go/websocket/router.go
+++ b/server/go/websocket/router.go
@@ -1,0 +1,47 @@
+package websocket
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+
+	"github.com/gorilla/websocket"
+)
+
+type MessageExecutor func(*websocket.Conn, Message)
+
+type Router struct {
+	routes map[string]MessageExecutor
+}
+
+func NewRouter() *Router {
+	return &Router{
+		routes: make(map[string]MessageExecutor),
+	}
+}
+
+func (r *Router) Add(messageType string, executor MessageExecutor) {
+	r.routes[messageType] = executor
+}
+
+func (r *Router) ListenAndServe(addr string) {
+	routingFunction := func(conn *websocket.Conn, message []byte) {
+		messageObject := Message{}
+		err := json.Unmarshal(message, &messageObject)
+		if err != nil {
+			errMessage := Error(fmt.Errorf("could not unmarshal message: %w", err))
+			conn.WriteJSON(errMessage)
+			return
+		}
+
+		if handler, exists := r.routes[messageObject.Type]; exists {
+			handler(conn, messageObject)
+		} else {
+			conn.WriteJSON(Error(fmt.Errorf("No routes for message type %s", messageObject.Type)))
+		}
+	}
+
+	http.HandleFunc("/ws", createHandler(routingFunction))
+	log.Fatal(http.ListenAndServe(addr, nil))
+}

--- a/server/go/websocket/websocket.go
+++ b/server/go/websocket/websocket.go
@@ -1,0 +1,41 @@
+package websocket
+
+import (
+	"log"
+	"net/http"
+
+	"github.com/gorilla/websocket"
+)
+
+var upgrader = websocket.Upgrader{
+	CheckOrigin: func(r *http.Request) bool { return true },
+}
+
+func createHandler(messageExecutor func(*websocket.Conn, []byte)) http.HandlerFunc {
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			log.Printf("could not upgrade connection: %s\n", err.Error())
+			return
+		}
+
+		defer conn.Close()
+
+		for {
+			messageType, message, err := conn.ReadMessage()
+			if err != nil {
+				log.Printf("could not read message: %s\n", err.Error())
+				continue
+			}
+
+			if messageType != websocket.TextMessage {
+				log.Printf("only text messages are supported: %s\n", err.Error())
+				continue
+			}
+
+			messageExecutor(conn, message)
+		}
+	}
+
+	return handler
+}

--- a/server/go/websocket/websocket.go
+++ b/server/go/websocket/websocket.go
@@ -25,7 +25,7 @@ func createHandler(messageExecutor func(*websocket.Conn, []byte)) http.HandlerFu
 			messageType, message, err := conn.ReadMessage()
 			if err != nil {
 				log.Printf("could not read message: %s\n", err.Error())
-				continue
+				break
 			}
 
 			if messageType != websocket.TextMessage {

--- a/server/main.go
+++ b/server/main.go
@@ -27,6 +27,7 @@ import (
 	"github.com/kubeshop/tracetest/server/go/tracedb"
 	"github.com/kubeshop/tracetest/server/go/tracedb/jaegerdb"
 	"github.com/kubeshop/tracetest/server/go/tracedb/tempodb"
+	"github.com/kubeshop/tracetest/server/go/websocket"
 	"go.opentelemetry.io/contrib/instrumentation/github.com/gorilla/mux/otelmux"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace"
@@ -112,8 +113,16 @@ func main() {
 		log.Fatal(err)
 	}
 
-	log.Printf("Server started")
+	go startWebsocketServer()
+	log.Printf("HTTP Server started")
 	log.Fatal(http.ListenAndServe(":8080", router))
+}
+
+func startWebsocketServer() {
+	wsRouter := websocket.NewRouter()
+	log.Printf("WS Server started")
+
+	wsRouter.ListenAndServe(":8081")
 }
 
 type gaParams struct {


### PR DESCRIPTION
This PR adds an endpoint to handle Websocket connections

## Changes

- This only adds a `/ws` endpoint that does nothing yet;
- It creates the structure to handle message routing based on the message `type` attribute.

## Checklist

- [x] tested locally
- [x] added new dependencies
- [ ] updated the docs
- [ ] added a test
