### PR TITLE
feat: add subscription module

### DIFF
--- a/server/go/subscription/manager.go
+++ b/server/go/subscription/manager.go
@@ -9,15 +9,7 @@ type Manager struct {
 
 var managerInstance *Manager = nil
 
-func GetManager() *Manager {
-	if managerInstance == nil {
-		managerInstance = newManager()
-	}
-
-	return managerInstance
-}
-
-func newManager() *Manager {
+func NewManager() *Manager {
 	return &Manager{
 		subscriptions: make(map[string][]Subscriber),
 		mutex:         sync.Mutex{},

--- a/server/go/subscription/manager.go
+++ b/server/go/subscription/manager.go
@@ -7,8 +7,6 @@ type Manager struct {
 	mutex         sync.Mutex
 }
 
-var managerInstance *Manager = nil
-
 func NewManager() *Manager {
 	return &Manager{
 		subscriptions: make(map[string][]Subscriber),

--- a/server/go/subscription/manager.go
+++ b/server/go/subscription/manager.go
@@ -38,14 +38,14 @@ func (m *Manager) Subscribe(resourceID string, subscriber Subscriber) {
 	m.subscriptions[resourceID] = array
 }
 
-func (m *Manager) Unsubscribe(resourceID string, subscriber Subscriber) {
+func (m *Manager) Unsubscribe(resourceID string, subscriptionID string) {
 	m.mutex.Lock()
 	defer m.mutex.Unlock()
 
 	if array, ok := m.subscriptions[resourceID]; ok {
 		newArray := make([]Subscriber, 0, len(array)-1)
 		for _, item := range array {
-			if item.ID() != subscriber.ID() {
+			if item.ID() != subscriptionID {
 				newArray = append(newArray, item)
 			}
 		}

--- a/server/go/subscription/manager.go
+++ b/server/go/subscription/manager.go
@@ -53,7 +53,7 @@ func (m *Manager) PublishUpdate(resourceID string, message Message) {
 
 	if subscribers, ok := m.subscriptions[resourceID]; ok {
 		for _, subscriber := range subscribers {
-			(subscriber).Notify(&message)
+			subscriber.Notify(message)
 		}
 	}
 }

--- a/server/go/subscription/manager.go
+++ b/server/go/subscription/manager.go
@@ -34,17 +34,19 @@ func (m *Manager) Unsubscribe(resourceID string, subscriptionID string) {
 	m.mutex.Lock()
 	defer m.mutex.Unlock()
 
-	if array, ok := m.subscriptions[resourceID]; ok {
-		newArray := make([]Subscriber, 0, len(array)-1)
-		for _, item := range array {
-			if item.ID() != subscriptionID {
-				newArray = append(newArray, item)
-			}
-		}
-
-		m.subscriptions[resourceID] = newArray
+	array, exists := m.subscriptions[resourceID]
+	if !exists {
+		return
 	}
 
+	newArray := make([]Subscriber, 0, len(array)-1)
+	for _, item := range array {
+		if item.ID() != subscriptionID {
+			newArray = append(newArray, item)
+		}
+	}
+
+	m.subscriptions[resourceID] = newArray
 }
 
 func (m *Manager) PublishUpdate(resourceID string, message Message) {

--- a/server/go/subscription/manager_test.go
+++ b/server/go/subscription/manager_test.go
@@ -100,7 +100,7 @@ func TestManagerUnsubscribe(t *testing.T) {
 
 	assert.Equal(t, &message1, receivedMessage)
 
-	manager.Unsubscribe("test:1", subscriber)
+	manager.Unsubscribe("test:1", subscriber.ID())
 	manager.PublishUpdate("test:1", message2)
 
 	assert.Equal(t, &message1, receivedMessage, "subscriber should not be notified after unsubscribed")

--- a/server/go/subscription/manager_test.go
+++ b/server/go/subscription/manager_test.go
@@ -1,0 +1,108 @@
+package subscription_test
+
+import (
+	"testing"
+
+	"github.com/kubeshop/tracetest/server/go/subscription"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestManagerIsSingleton(t *testing.T) {
+	manager1 := subscription.GetManager()
+	manager2 := subscription.GetManager()
+
+	assert.Equal(t, manager1, manager2, "managers should be the same instance")
+}
+
+func TestManagerSubscriptionDifferentResources(t *testing.T) {
+	manager := subscription.GetManager()
+	var messageReceivedBySubscriber1, messageReceivedBySubscriber2 *subscription.Message
+
+	subscriber1 := subscription.NewSubscriberFunction(func(message *subscription.Message) error {
+		messageReceivedBySubscriber1 = message
+		return nil
+	})
+
+	subscriber2 := subscription.NewSubscriberFunction(func(message *subscription.Message) error {
+		messageReceivedBySubscriber2 = message
+		return nil
+	})
+
+	manager.Subscribe("test:1", subscriber1)
+	manager.Subscribe("test:2", subscriber2)
+
+	test1Message := subscription.Message{
+		Type:    "test_update",
+		Content: "test1 update",
+	}
+
+	test2Message := subscription.Message{
+		Type:    "test_update",
+		Content: "test2 update",
+	}
+
+	manager.PublishUpdate("test:1", test1Message)
+	manager.PublishUpdate("test:2", test2Message)
+
+	assert.Equal(t, &test1Message, messageReceivedBySubscriber1, "received message should be equal to the one sent")
+	assert.Equal(t, &test2Message, messageReceivedBySubscriber2, "received message should be equal to the one sent")
+}
+
+func TestManagerSubscriptionSameResourceDifferentSubscribers(t *testing.T) {
+	manager := subscription.GetManager()
+	var messageReceivedBySubscriber1, messageReceivedBySubscriber2 *subscription.Message
+
+	subscriber1 := subscription.NewSubscriberFunction(func(message *subscription.Message) error {
+		messageReceivedBySubscriber1 = message
+		return nil
+	})
+
+	subscriber2 := subscription.NewSubscriberFunction(func(message *subscription.Message) error {
+		messageReceivedBySubscriber2 = message
+		return nil
+	})
+
+	manager.Subscribe("test:1", subscriber1)
+	manager.Subscribe("test:1", subscriber2)
+
+	test1Message := subscription.Message{
+		Type:    "test_update",
+		Content: "test1 update",
+	}
+
+	manager.PublishUpdate("test:1", test1Message)
+
+	assert.NotNil(t, messageReceivedBySubscriber1, "message received by subscriber should not be nil")
+	assert.Equal(t, messageReceivedBySubscriber1, messageReceivedBySubscriber2, "subscribers of the same resource should receive the same message")
+}
+
+func TestManagerUnsubscribe(t *testing.T) {
+	manager := subscription.GetManager()
+	var receivedMessage *subscription.Message
+
+	subscriber := subscription.NewSubscriberFunction(func(message *subscription.Message) error {
+		receivedMessage = message
+		return nil
+	})
+
+	message1 := subscription.Message{
+		Type:    "test_update",
+		Content: "Test was updated",
+	}
+
+	message2 := subscription.Message{
+		Type:    "test_deleted",
+		Content: "Test was deleted",
+	}
+
+	manager.Subscribe("test:1", subscriber)
+	manager.PublishUpdate("test:1", message1)
+
+	assert.Equal(t, &message1, receivedMessage)
+
+	manager.Unsubscribe("test:1", subscriber)
+	manager.PublishUpdate("test:1", message2)
+
+	assert.Equal(t, &message1, receivedMessage, "subscriber should not be notified after unsubscribed")
+
+}

--- a/server/go/subscription/manager_test.go
+++ b/server/go/subscription/manager_test.go
@@ -9,14 +9,14 @@ import (
 
 func TestManagerSubscriptionDifferentResources(t *testing.T) {
 	manager := subscription.NewManager()
-	var messageReceivedBySubscriber1, messageReceivedBySubscriber2 *subscription.Message
+	var messageReceivedBySubscriber1, messageReceivedBySubscriber2 subscription.Message
 
-	subscriber1 := subscription.NewSubscriberFunction(func(message *subscription.Message) error {
+	subscriber1 := subscription.NewSubscriberFunction(func(message subscription.Message) error {
 		messageReceivedBySubscriber1 = message
 		return nil
 	})
 
-	subscriber2 := subscription.NewSubscriberFunction(func(message *subscription.Message) error {
+	subscriber2 := subscription.NewSubscriberFunction(func(message subscription.Message) error {
 		messageReceivedBySubscriber2 = message
 		return nil
 	})
@@ -37,20 +37,20 @@ func TestManagerSubscriptionDifferentResources(t *testing.T) {
 	manager.PublishUpdate("test:1", test1Message)
 	manager.PublishUpdate("test:2", test2Message)
 
-	assert.Equal(t, &test1Message, messageReceivedBySubscriber1, "received message should be equal to the one sent")
-	assert.Equal(t, &test2Message, messageReceivedBySubscriber2, "received message should be equal to the one sent")
+	assert.Equal(t, test1Message, messageReceivedBySubscriber1, "received message should be equal to the one sent")
+	assert.Equal(t, test2Message, messageReceivedBySubscriber2, "received message should be equal to the one sent")
 }
 
 func TestManagerSubscriptionSameResourceDifferentSubscribers(t *testing.T) {
 	manager := subscription.NewManager()
-	var messageReceivedBySubscriber1, messageReceivedBySubscriber2 *subscription.Message
+	var messageReceivedBySubscriber1, messageReceivedBySubscriber2 subscription.Message
 
-	subscriber1 := subscription.NewSubscriberFunction(func(message *subscription.Message) error {
+	subscriber1 := subscription.NewSubscriberFunction(func(message subscription.Message) error {
 		messageReceivedBySubscriber1 = message
 		return nil
 	})
 
-	subscriber2 := subscription.NewSubscriberFunction(func(message *subscription.Message) error {
+	subscriber2 := subscription.NewSubscriberFunction(func(message subscription.Message) error {
 		messageReceivedBySubscriber2 = message
 		return nil
 	})
@@ -66,14 +66,15 @@ func TestManagerSubscriptionSameResourceDifferentSubscribers(t *testing.T) {
 	manager.PublishUpdate("test:1", test1Message)
 
 	assert.NotNil(t, messageReceivedBySubscriber1, "message received by subscriber should not be nil")
-	assert.Equal(t, messageReceivedBySubscriber1, messageReceivedBySubscriber2, "subscribers of the same resource should receive the same message")
+	assert.Equal(t, messageReceivedBySubscriber1.Type, messageReceivedBySubscriber2.Type, "subscribers of the same resource should receive the same message")
+	assert.Equal(t, messageReceivedBySubscriber1.Content, messageReceivedBySubscriber2.Content, "subscribers of the same resource should receive the same message")
 }
 
 func TestManagerUnsubscribe(t *testing.T) {
 	manager := subscription.NewManager()
-	var receivedMessage *subscription.Message
+	var receivedMessage subscription.Message
 
-	subscriber := subscription.NewSubscriberFunction(func(message *subscription.Message) error {
+	subscriber := subscription.NewSubscriberFunction(func(message subscription.Message) error {
 		receivedMessage = message
 		return nil
 	})
@@ -91,11 +92,13 @@ func TestManagerUnsubscribe(t *testing.T) {
 	manager.Subscribe("test:1", subscriber)
 	manager.PublishUpdate("test:1", message1)
 
-	assert.Equal(t, &message1, receivedMessage)
+	assert.Equal(t, message1.Type, receivedMessage.Type)
+	assert.Equal(t, message1.Content, receivedMessage.Content)
 
 	manager.Unsubscribe("test:1", subscriber.ID())
 	manager.PublishUpdate("test:1", message2)
 
-	assert.Equal(t, &message1, receivedMessage, "subscriber should not be notified after unsubscribed")
+	assert.Equal(t, message1.Type, receivedMessage.Type, "subscriber should not be notified after unsubscribed")
+	assert.Equal(t, message1.Content, receivedMessage.Content, "subscriber should not be notified after unsubscribed")
 
 }

--- a/server/go/subscription/manager_test.go
+++ b/server/go/subscription/manager_test.go
@@ -7,15 +7,8 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestManagerIsSingleton(t *testing.T) {
-	manager1 := subscription.GetManager()
-	manager2 := subscription.GetManager()
-
-	assert.Equal(t, manager1, manager2, "managers should be the same instance")
-}
-
 func TestManagerSubscriptionDifferentResources(t *testing.T) {
-	manager := subscription.GetManager()
+	manager := subscription.NewManager()
 	var messageReceivedBySubscriber1, messageReceivedBySubscriber2 *subscription.Message
 
 	subscriber1 := subscription.NewSubscriberFunction(func(message *subscription.Message) error {
@@ -49,7 +42,7 @@ func TestManagerSubscriptionDifferentResources(t *testing.T) {
 }
 
 func TestManagerSubscriptionSameResourceDifferentSubscribers(t *testing.T) {
-	manager := subscription.GetManager()
+	manager := subscription.NewManager()
 	var messageReceivedBySubscriber1, messageReceivedBySubscriber2 *subscription.Message
 
 	subscriber1 := subscription.NewSubscriberFunction(func(message *subscription.Message) error {
@@ -77,7 +70,7 @@ func TestManagerSubscriptionSameResourceDifferentSubscribers(t *testing.T) {
 }
 
 func TestManagerUnsubscribe(t *testing.T) {
-	manager := subscription.GetManager()
+	manager := subscription.NewManager()
 	var receivedMessage *subscription.Message
 
 	subscriber := subscription.NewSubscriberFunction(func(message *subscription.Message) error {

--- a/server/go/subscription/message.go
+++ b/server/go/subscription/message.go
@@ -1,0 +1,6 @@
+package subscription
+
+type Message struct {
+	Type    string
+	Content interface{}
+}

--- a/server/go/subscription/subscription.go
+++ b/server/go/subscription/subscription.go
@@ -1,0 +1,7 @@
+package subscription
+
+// Subscription represents a group of subscribers that are waiting for updates of a specific resource
+type Subscription struct {
+	resourceID  string
+	subscribers []Subscriber
+}

--- a/server/go/subscription/watcher.go
+++ b/server/go/subscription/watcher.go
@@ -1,0 +1,28 @@
+package subscription
+
+import "github.com/google/uuid"
+
+type Subscriber interface {
+	ID() string
+	Notify(message *Message) error
+}
+
+type SubscriberFunction struct {
+	id       string
+	function func(*Message) error
+}
+
+func (sf *SubscriberFunction) ID() string {
+	return sf.id
+}
+
+func (sf *SubscriberFunction) Notify(message *Message) error {
+	return sf.function(message)
+}
+
+func NewSubscriberFunction(function func(*Message) error) Subscriber {
+	return &SubscriberFunction{
+		id:       uuid.New().String(),
+		function: function,
+	}
+}

--- a/server/go/subscription/watcher.go
+++ b/server/go/subscription/watcher.go
@@ -4,23 +4,23 @@ import "github.com/google/uuid"
 
 type Subscriber interface {
 	ID() string
-	Notify(message *Message) error
+	Notify(message Message) error
 }
 
 type SubscriberFunction struct {
 	id       string
-	function func(*Message) error
+	function func(Message) error
 }
 
 func (sf *SubscriberFunction) ID() string {
 	return sf.id
 }
 
-func (sf *SubscriberFunction) Notify(message *Message) error {
+func (sf *SubscriberFunction) Notify(message Message) error {
 	return sf.function(message)
 }
 
-func NewSubscriberFunction(function func(*Message) error) Subscriber {
+func NewSubscriberFunction(function func(Message) error) Subscriber {
 	return &SubscriberFunction{
 		id:       uuid.New().String(),
 		function: function,


### PR DESCRIPTION
This PR adds a module responsible for handling subscriptions and notifications in tracetest. This will be used to send updates from tracetest to the websocket endpoint.

## Changes

- Add a new isolated module
- Enable messages to be sent from a place to another without coupling them. It is based on event-driven programming.

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [x] added a test
