### PR TITLE
feat: websocket result updates

### DIFF
--- a/docs/websocket.md
+++ b/docs/websocket.md
@@ -1,0 +1,67 @@
+# Websocket endpoint
+
+Tracetest allow you to subscribe to updates of resources using websockets. There are two endpoints that you can use to manage subscriptions:
+
+## Endpoint
+ 
+You can open a websocket connection by sending a request to port `8081` using the path `/ws`. Example: `ws://localhost:8081/ws`.
+
+## Messages
+
+### Subscribing to updates
+
+Once the connection is open, you can send a message with the format:
+
+```json
+{
+    "type": "subscribe",
+    "resource": "test/{testID}/result/{resultID}"
+}
+```
+
+If a problem happens, you will see an error like:
+
+```json
+{
+    "type": "error",
+    "message": "details of the error"
+}
+```
+
+If the operation executes successfully, you will see a response like:
+
+```json
+{
+    "type": "success",
+    "message": {
+        "subscriptionId": "bdbc6cc8-bba6-4208-a8d3-d3c2c5b3e38b"
+    }
+}
+```
+
+The `subscriptionId` is an important field because it is required to cancel the subscription. You should store it, otherwise you will keep receiving updates of a resource that you might not want.
+
+### Cancel a susbcription
+
+Once you have a subscription to a resource, you might want to stop receiving events from that resource. So, there is a `unsubscribe` message that you can send to achieve that.
+
+But send this message to the websocket connection:
+
+```json
+{
+    "type": "unsubscribe",
+    "resource": "test/{testID}/result/{resultID}",
+    "subscriptionId": "id returned in the subscription command"
+}
+```
+
+You will receive an error message if any required field is not field. But in case of a successful operation, you will receive a message like:
+
+```json
+{
+    "type":"success",
+    "message":"ok"
+}
+```
+
+This message will be sent regardless if the subscription exists or not.

--- a/server/go/trace_poller.go
+++ b/server/go/trace_poller.go
@@ -142,11 +142,7 @@ func (tp tracePoller) processJob(job tracePollReq) {
 
 	fmt.Printf("completed polling result %s after %d times\n", job.result.ResultId, job.count)
 
-	err = tp.resultDB.UpdateResult(job.ctx, &res)
-	if err != nil {
-		tp.handleDBError(err)
-		return
-	}
+	tp.handleDBError(tp.resultDB.UpdateResult(job.ctx, &res))
 
 	resource := fmt.Sprintf("test/%s/result/%s", res.TestId, res.ResultId)
 	tp.subscriptionManager.PublishUpdate(resource, subscription.Message{

--- a/server/go/trace_poller.go
+++ b/server/go/trace_poller.go
@@ -29,7 +29,12 @@ type TraceFetcher interface {
 	GetTraceByID(ctx context.Context, traceID string) (*v1.TracesData, error)
 }
 
-func NewTracePoller(tf TraceFetcher, ru ResultUpdater, maxWaitTimeForTrace time.Duration) PersistentTracePoller {
+func NewTracePoller(
+	tf TraceFetcher,
+	ru ResultUpdater,
+	maxWaitTimeForTrace time.Duration,
+	subscriptionManager *subscription.Manager,
+) PersistentTracePoller {
 	retryDelay := 500 * time.Millisecond
 	maxTracePollRetry := int(math.Ceil(float64(maxWaitTimeForTrace) / float64(retryDelay)))
 	return tracePoller{
@@ -40,7 +45,7 @@ func NewTracePoller(tf TraceFetcher, ru ResultUpdater, maxWaitTimeForTrace time.
 		retryDelay:          retryDelay,
 		executeQueue:        make(chan tracePollReq, 5),
 		exit:                make(chan bool, 1),
-		subscriptionManager: subscription.GetManager(),
+		subscriptionManager: subscriptionManager,
 	}
 }
 

--- a/server/go/websocket/messages.go
+++ b/server/go/websocket/messages.go
@@ -1,13 +1,30 @@
 package websocket
 
+import "encoding/json"
+
 type Message struct {
-	Type    string
-	Message interface{}
+	Type    string      `json:"type"`
+	Message interface{} `json:"message"`
+}
+
+func SuccessMessage(messageType string) Message {
+	return Message{
+		Type:    messageType,
+		Message: "success",
+	}
 }
 
 func Error(err error) Message {
 	return Message{
 		Type:    "error",
 		Message: err.Error(),
+	}
+}
+
+func UpdateMessage(object interface{}) Message {
+	jsonContent, _ := json.Marshal(object)
+	return Message{
+		Type:    "update",
+		Message: jsonContent,
 	}
 }

--- a/server/go/websocket/messages.go
+++ b/server/go/websocket/messages.go
@@ -10,10 +10,19 @@ type Event struct {
 	Event interface{} `json:"event"`
 }
 
-func SuccessMessage(messageType string) Message {
+func SubscriptionSuccess(subscriptionId string) Message {
 	return Message{
-		Type:    messageType,
-		Message: "success",
+		Type: "success",
+		Message: struct {
+			SubscriptionId string `json:"subscriptionId"`
+		}{SubscriptionId: subscriptionId},
+	}
+}
+
+func UnsubscribeSuccess() Message {
+	return Message{
+		Type:    "success",
+		Message: "ok",
 	}
 }
 

--- a/server/go/websocket/messages.go
+++ b/server/go/websocket/messages.go
@@ -7,6 +7,11 @@ type Message struct {
 	Message interface{} `json:"message"`
 }
 
+type Event struct {
+	Type  string      `json:"type"`
+	Event interface{} `json:"event"`
+}
+
 func SuccessMessage(messageType string) Message {
 	return Message{
 		Type:    messageType,
@@ -14,17 +19,17 @@ func SuccessMessage(messageType string) Message {
 	}
 }
 
-func Error(err error) Message {
+func ErrorMessage(err error) Message {
 	return Message{
 		Type:    "error",
 		Message: err.Error(),
 	}
 }
 
-func UpdateMessage(object interface{}) Message {
-	jsonContent, _ := json.Marshal(object)
-	return Message{
-		Type:    "update",
-		Message: jsonContent,
+func ResourceUpdatedEvent(resource interface{}) Event {
+	jsonContent, _ := json.Marshal(resource)
+	return Event{
+		Type:  "update",
+		Event: jsonContent,
 	}
 }

--- a/server/go/websocket/messages.go
+++ b/server/go/websocket/messages.go
@@ -1,7 +1,5 @@
 package websocket
 
-import "encoding/json"
-
 type Message struct {
 	Type    string      `json:"type"`
 	Message interface{} `json:"message"`
@@ -27,9 +25,8 @@ func ErrorMessage(err error) Message {
 }
 
 func ResourceUpdatedEvent(resource interface{}) Event {
-	jsonContent, _ := json.Marshal(resource)
 	return Event{
 		Type:  "update",
-		Event: jsonContent,
+		Event: resource,
 	}
 }

--- a/server/go/websocket/router.go
+++ b/server/go/websocket/router.go
@@ -34,7 +34,7 @@ func (r *Router) ListenAndServe(addr string) {
 		messageObject := routingMessage{}
 		err := json.Unmarshal(message, &messageObject)
 		if err != nil {
-			errMessage := Error(fmt.Errorf("could not unmarshal message: %w", err))
+			errMessage := ErrorMessage(fmt.Errorf("could not unmarshal message: %w", err))
 			conn.WriteJSON(errMessage)
 			return
 		}
@@ -42,7 +42,7 @@ func (r *Router) ListenAndServe(addr string) {
 		if handler, exists := r.routes[messageObject.Type]; exists {
 			handler(conn, message)
 		} else {
-			conn.WriteJSON(Error(fmt.Errorf("No routes for message type %s", messageObject.Type)))
+			conn.WriteJSON(ErrorMessage(fmt.Errorf("No routes for message type %s", messageObject.Type)))
 		}
 	}
 

--- a/server/go/websocket/router.go
+++ b/server/go/websocket/router.go
@@ -9,7 +9,11 @@ import (
 	"github.com/gorilla/websocket"
 )
 
-type MessageExecutor func(*websocket.Conn, Message)
+type MessageExecutor func(*websocket.Conn, []byte)
+
+type routingMessage struct {
+	Type string `json:"type"`
+}
 
 type Router struct {
 	routes map[string]MessageExecutor
@@ -27,7 +31,7 @@ func (r *Router) Add(messageType string, executor MessageExecutor) {
 
 func (r *Router) ListenAndServe(addr string) {
 	routingFunction := func(conn *websocket.Conn, message []byte) {
-		messageObject := Message{}
+		messageObject := routingMessage{}
 		err := json.Unmarshal(message, &messageObject)
 		if err != nil {
 			errMessage := Error(fmt.Errorf("could not unmarshal message: %w", err))
@@ -36,7 +40,7 @@ func (r *Router) ListenAndServe(addr string) {
 		}
 
 		if handler, exists := r.routes[messageObject.Type]; exists {
-			handler(conn, messageObject)
+			handler(conn, message)
 		} else {
 			conn.WriteJSON(Error(fmt.Errorf("No routes for message type %s", messageObject.Type)))
 		}

--- a/server/go/websocket/subscribe.go
+++ b/server/go/websocket/subscribe.go
@@ -17,17 +17,17 @@ func HandleSubscribeCommand(conn *websocket.Conn, message []byte) {
 	msg := subscriptionMessage{}
 	err := json.Unmarshal(message, &msg)
 	if err != nil {
-		conn.WriteJSON(Error(fmt.Errorf("invalid subscription message: %w", err)))
+		conn.WriteJSON(ErrorMessage(fmt.Errorf("invalid subscription message: %w", err)))
 		return
 	}
 
 	if msg.ResourceID == "" || msg.ResourceType == "" {
-		conn.WriteJSON(Error(fmt.Errorf("either ResourceType or ResourceID is empty")))
+		conn.WriteJSON(ErrorMessage(fmt.Errorf("either ResourceType or ResourceID is empty")))
 		return
 	}
 
 	messageConverter := subscription.NewSubscriberFunction(func(m *subscription.Message) error {
-		err := conn.WriteJSON(UpdateMessage(m.Content))
+		err := conn.WriteJSON(ResourceUpdatedEvent(m.Content))
 		if err != nil {
 			return fmt.Errorf("could not send update message: %w", err)
 		}

--- a/server/go/websocket/subscribe.go
+++ b/server/go/websocket/subscribe.go
@@ -1,0 +1,43 @@
+package websocket
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/gorilla/websocket"
+	"github.com/kubeshop/tracetest/server/go/subscription"
+)
+
+type subscriptionMessage struct {
+	ResourceType string `json:"resourceType"`
+	ResourceID   string `json:"resourceId"`
+}
+
+func HandleSubscribeCommand(conn *websocket.Conn, message []byte) {
+	msg := subscriptionMessage{}
+	err := json.Unmarshal(message, &msg)
+	if err != nil {
+		conn.WriteJSON(Error(fmt.Errorf("invalid subscription message: %w", err)))
+		return
+	}
+
+	if msg.ResourceID == "" || msg.ResourceType == "" {
+		conn.WriteJSON(Error(fmt.Errorf("either ResourceType or ResourceID is empty")))
+		return
+	}
+
+	messageConverter := subscription.NewSubscriberFunction(func(m *subscription.Message) error {
+		err := conn.WriteJSON(UpdateMessage(m.Content))
+		if err != nil {
+			return fmt.Errorf("could not send update message: %w", err)
+		}
+
+		return nil
+	})
+
+	manager := subscription.GetManager()
+	resourceName := fmt.Sprintf("%s:%s", msg.ResourceType, msg.ResourceID)
+	manager.Subscribe(resourceName, messageConverter)
+
+	conn.WriteJSON(SuccessMessage("susbcribe"))
+}

--- a/server/go/websocket/subscribe.go
+++ b/server/go/websocket/subscribe.go
@@ -37,5 +37,5 @@ func HandleSubscribeCommand(conn *websocket.Conn, message []byte) {
 	manager := subscription.GetManager()
 	manager.Subscribe(msg.Resource, messageConverter)
 
-	conn.WriteJSON(SuccessMessage("susbcribe"))
+	conn.WriteJSON(SubscriptionSuccess(messageConverter.ID()))
 }

--- a/server/go/websocket/subscribe.go
+++ b/server/go/websocket/subscribe.go
@@ -9,8 +9,7 @@ import (
 )
 
 type subscriptionMessage struct {
-	ResourceType string `json:"resourceType"`
-	ResourceID   string `json:"resourceId"`
+	Resource string `json:"resource"`
 }
 
 func HandleSubscribeCommand(conn *websocket.Conn, message []byte) {
@@ -21,8 +20,8 @@ func HandleSubscribeCommand(conn *websocket.Conn, message []byte) {
 		return
 	}
 
-	if msg.ResourceID == "" || msg.ResourceType == "" {
-		conn.WriteJSON(ErrorMessage(fmt.Errorf("either ResourceType or ResourceID is empty")))
+	if msg.Resource == "" {
+		conn.WriteJSON(ErrorMessage(fmt.Errorf("Resource cannot be empty")))
 		return
 	}
 
@@ -36,8 +35,7 @@ func HandleSubscribeCommand(conn *websocket.Conn, message []byte) {
 	})
 
 	manager := subscription.GetManager()
-	resourceName := fmt.Sprintf("%s:%s", msg.ResourceType, msg.ResourceID)
-	manager.Subscribe(resourceName, messageConverter)
+	manager.Subscribe(msg.Resource, messageConverter)
 
 	conn.WriteJSON(SuccessMessage("susbcribe"))
 }

--- a/server/go/websocket/unsubscribe.go
+++ b/server/go/websocket/unsubscribe.go
@@ -1,0 +1,33 @@
+package websocket
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/gorilla/websocket"
+	"github.com/kubeshop/tracetest/server/go/subscription"
+)
+
+type unsubscribeMessage struct {
+	Resource       string `json:"resource"`
+	SubscriptionId string `json:"subscriptionId"`
+}
+
+func HandleUnsubscribeCommand(conn *websocket.Conn, message []byte) {
+	msg := unsubscribeMessage{}
+	err := json.Unmarshal(message, &msg)
+	if err != nil {
+		conn.WriteJSON(ErrorMessage(fmt.Errorf("invalid unsubscription message: %w", err)))
+		return
+	}
+
+	if msg.Resource == "" {
+		conn.WriteJSON(ErrorMessage(fmt.Errorf("Resource cannot be empty")))
+		return
+	}
+
+	manager := subscription.GetManager()
+	manager.Unsubscribe(msg.Resource, msg.SubscriptionId)
+
+	conn.WriteJSON(UnsubscribeSuccess())
+}

--- a/server/go/websocket/unsubscribe.go
+++ b/server/go/websocket/unsubscribe.go
@@ -13,7 +13,19 @@ type unsubscribeMessage struct {
 	SubscriptionId string `json:"subscriptionId"`
 }
 
-func HandleUnsubscribeCommand(conn *websocket.Conn, message []byte) {
+type UnsubscribeCommandExecutor struct {
+	subscriptionManager *subscription.Manager
+}
+
+func NewUnsubscribeCommandExecutor(manager *subscription.Manager) UnsubscribeCommandExecutor {
+	return UnsubscribeCommandExecutor{
+		subscriptionManager: manager,
+	}
+}
+
+var _ MessageExecutor = &UnsubscribeCommandExecutor{}
+
+func (e UnsubscribeCommandExecutor) Execute(conn *websocket.Conn, message []byte) {
 	msg := unsubscribeMessage{}
 	err := json.Unmarshal(message, &msg)
 	if err != nil {
@@ -26,8 +38,7 @@ func HandleUnsubscribeCommand(conn *websocket.Conn, message []byte) {
 		return
 	}
 
-	manager := subscription.GetManager()
-	manager.Unsubscribe(msg.Resource, msg.SubscriptionId)
+	e.subscriptionManager.Unsubscribe(msg.Resource, msg.SubscriptionId)
 
 	conn.WriteJSON(UnsubscribeSuccess())
 }

--- a/server/go/websocket/websocket.go
+++ b/server/go/websocket/websocket.go
@@ -50,16 +50,20 @@ func keepAlive(conn *websocket.Conn, timeout time.Duration) {
 		return nil
 	})
 
+	ticker := time.NewTicker(timeout / 2)
+
 	go func() {
 		for {
-			err := conn.WriteMessage(websocket.PingMessage, []byte("keepalive"))
-			if err != nil {
-				return
-			}
-			time.Sleep(timeout / 2)
-			if time.Since(lastResponse) > timeout {
-				conn.Close()
-				return
+			select {
+			case <-ticker.C:
+				err := conn.WriteMessage(websocket.PingMessage, []byte("keepalive"))
+				if err != nil {
+					return
+				}
+				if time.Since(lastResponse) > timeout {
+					conn.Close()
+					return
+				}
 			}
 		}
 	}()

--- a/server/main.go
+++ b/server/main.go
@@ -121,6 +121,7 @@ func main() {
 func startWebsocketServer() {
 	wsRouter := websocket.NewRouter()
 	wsRouter.Add("subscribe", websocket.HandleSubscribeCommand)
+	wsRouter.Add("unsubscribe", websocket.HandleUnsubscribeCommand)
 	log.Printf("WS Server started")
 
 	wsRouter.ListenAndServe(":8081")

--- a/server/main.go
+++ b/server/main.go
@@ -120,6 +120,7 @@ func main() {
 
 func startWebsocketServer() {
 	wsRouter := websocket.NewRouter()
+	wsRouter.Add("subscribe", websocket.HandleSubscribeCommand)
 	log.Printf("WS Server started")
 
 	wsRouter.ListenAndServe(":8081")


### PR DESCRIPTION
This PR adds a websocket endpoint to receive updates when a test has run and the result (traces) are received.

Depends on #371 and #370 

## Changes

- Add behavior to the `/ws` endpoint
- Enable users to subscribe to updates to a resource (right now only test results are supported)
- Enable users to cancel a subscription
- Adds the endpoint documentation on the `docs` folder.

## Images
Subscribing to updates of a test result (response was received ~60 seconds after the subscription was created)
![image](https://user-images.githubusercontent.com/2704737/165571547-37cf98ac-2bcf-47d8-b5a7-f3d13f206e5c.png)

Unsubscribing
![image](https://user-images.githubusercontent.com/2704737/165572143-0a70eb04-6aa2-49c0-a608-5423b4eec34f.png)



## Checklist

- [x] tested locally
- [x] added new dependencies
- [x] updated the docs
- [ ] added a test
