### PR TITLE
feat: support :first and :last pseudo classes

### DIFF
--- a/server/assertions/selectors/builder.go
+++ b/server/assertions/selectors/builder.go
@@ -128,6 +128,10 @@ func createPseudoClass(parserPseudoClass parserPseudoClass) (PseudoClass, error)
 		return &NthChildPseudoClass{
 			N: *parserPseudoClass.Value.Int,
 		}, nil
+	case "first":
+		return &FirstPseudoClass{}, nil
+	case "last":
+		return &LastPseudoClass{}, nil
 	case "":
 		// No pseudoClass
 		return nil, nil

--- a/server/assertions/selectors/parser.go
+++ b/server/assertions/selectors/parser.go
@@ -30,8 +30,8 @@ type parserValue struct {
 }
 
 type parserPseudoClass struct {
-	Type  string       `":" @("nth_child")`
-	Value *parserValue `"(" @@* ")"`
+	Type  string       `":" @("nth_child" | "first" | "last")`
+	Value *parserValue `("(" @@* ")")*`
 }
 
 func CreateParser() (*participle.Parser, error) {

--- a/server/assertions/selectors/pseudo_classes.go
+++ b/server/assertions/selectors/pseudo_classes.go
@@ -13,9 +13,30 @@ type NthChildPseudoClass struct {
 }
 
 func (nc NthChildPseudoClass) Filter(spans []traces.Span) []traces.Span {
-	if len(spans) < int(nc.N) {
+	if int(nc.N) < 1 || int(nc.N) > len(spans) {
 		return []traces.Span{}
 	}
 
 	return []traces.Span{spans[int(nc.N-1)]}
+}
+
+type FirstPseudoClass struct{}
+
+func (fpc FirstPseudoClass) Filter(spans []traces.Span) []traces.Span {
+	if len(spans) == 0 {
+		return []traces.Span{}
+	}
+
+	return []traces.Span{spans[0]}
+}
+
+type LastPseudoClass struct{}
+
+func (lpc LastPseudoClass) Filter(spans []traces.Span) []traces.Span {
+	length := len(spans)
+	if length == 0 {
+		return []traces.Span{}
+	}
+
+	return []traces.Span{spans[length-1]}
 }

--- a/server/assertions/selectors/selector_test.go
+++ b/server/assertions/selectors/selector_test.go
@@ -92,7 +92,17 @@ func TestSelector(t *testing.T) {
 			ExpectedSpanIds: []trace.SpanID{updatePokemonDatabaseSpanID},
 		},
 		{
-			Name:            "Selector with pseudo class",
+			Name:            "Selector with first pseudo class",
+			Expression:      "span[tracetest.span.type=\"db\"]:first",
+			ExpectedSpanIds: []trace.SpanID{insertPokemonDatabaseSpanID},
+		},
+		{
+			Name:            "Selector with first pseudo class",
+			Expression:      "span[tracetest.span.type=\"db\"]:last",
+			ExpectedSpanIds: []trace.SpanID{updatePokemonDatabaseSpanID},
+		},
+		{
+			Name:            "Selector with nth_child pseudo class",
 			Expression:      "span[tracetest.span.type=\"db\"]:nth_child(2)",
 			ExpectedSpanIds: []trace.SpanID{updatePokemonDatabaseSpanID},
 		},


### PR DESCRIPTION
This PR enables users to use `:first` and `:last` on their selectors.

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [x] added a test
