### PR TITLE
🏷  402 updating the attributes selection to match affected spans

### DIFF
--- a/web/src/components/CreateAssertionModal/CreateAssertionModal.tsx
+++ b/web/src/components/CreateAssertionModal/CreateAssertionModal.tsx
@@ -16,7 +16,7 @@ interface IProps {
   assertion?: IAssertion;
 }
 
-const effectedSpanMessage = (spanCount: number) => {
+const affectedSpanMessage = (spanCount: number) => {
   if (spanCount <= 1) {
     return `Affects ${spanCount} span`;
   }
@@ -40,7 +40,7 @@ const CreateAssertionModal = ({testId, span, resultId, open, onClose, assertion}
     onClose();
   }, [onClose]);
 
-  const affectedSpanCount = useAppSelector(AssertionSelectors.selectAffectedSpanCount(testId, resultId, selectorList));
+  const affectedSpanList = useAppSelector(AssertionSelectors.selectAffectedSpanList(testId, resultId, selectorList));
 
   return (
     <Modal
@@ -51,7 +51,7 @@ const CreateAssertionModal = ({testId, span, resultId, open, onClose, assertion}
       title={
         <div style={{display: 'flex', justifyContent: 'space-between', marginRight: 36}}>
           <Typography.Title level={5}>{assertion ? 'Edit Assertion' : 'Create New Assertion'}</Typography.Title>
-          <Typography.Text>{effectedSpanMessage(affectedSpanCount)}</Typography.Text>
+          <Typography.Text>{affectedSpanMessage(affectedSpanList.length)}</Typography.Text>
         </div>
       }
       onOk={form?.submit}
@@ -61,6 +61,7 @@ const CreateAssertionModal = ({testId, span, resultId, open, onClose, assertion}
       okText="Save"
     >
       <CreateAssertionForm
+        affectedSpanList={affectedSpanList}
         assertion={assertion}
         onCreate={handleClose}
         onForm={onForm}

--- a/web/src/components/CreateAssertionModal/useAttributeList.tsx
+++ b/web/src/components/CreateAssertionModal/useAttributeList.tsx
@@ -1,0 +1,38 @@
+import {useMemo} from 'react';
+import SpanService from '../../services/Span.service';
+import {ISpan, ISpanFlatAttribute} from '../../types/Span.types';
+
+const renderTitle = (title: string, index: number) => <span key={`KEY_${title}_${index}`}>{title}</span>;
+
+const renderItem = ({key}: ISpanFlatAttribute) => ({
+  value: key,
+  label: (
+    <div
+      key={key}
+      style={{
+        display: 'flex',
+        justifyContent: 'space-between',
+      }}
+    >
+      {key}
+    </div>
+  ),
+});
+
+const useAttributeList = (selectedSpan: ISpan, affectedSpanList: ISpan[]) => {
+  return useMemo(() => {
+    const {intersectedList, differenceList} = SpanService.getSelectedSpanListAttributes(selectedSpan, affectedSpanList);
+    return [
+      {
+        label: renderTitle('Across all Spans', 0),
+        options: intersectedList.map(el => renderItem(el)),
+      },
+      {
+        label: renderTitle('For selected span', 1),
+        options: differenceList.map(el => renderItem(el)),
+      },
+    ];
+  }, [affectedSpanList, selectedSpan]);
+};
+
+export default useAttributeList;

--- a/web/src/selectors/Assertion.selectors.ts
+++ b/web/src/selectors/Assertion.selectors.ts
@@ -30,11 +30,11 @@ const AssertionSelectors = () => ({
       );
     });
   },
-  selectAffectedSpanCount(testId: string, resultId: string, selectorList: IItemSelector[]) {
+  selectAffectedSpanList(testId: string, resultId: string, selectorList: IItemSelector[]) {
     return createSelector(stateSelector, state => {
       const {data: result} = endpoints.getResultById.select({testId, resultId})(state);
 
-      if (!result) return 0;
+      if (!result) return [];
       const {trace} = result;
 
       return AssertionService.getEffectedSpansCount(trace!, selectorList);

--- a/web/src/services/Assertion.service.ts
+++ b/web/src/services/Assertion.service.ts
@@ -75,14 +75,14 @@ const AssertionService = () => ({
   },
 
   getEffectedSpansCount(trace: ITrace, selectors: IItemSelector[]) {
-    if (selectors.length === 0) return 0;
+    if (selectors.length === 0) return [];
 
     const itemSelector = `${getSelectorList(selectors)
       .map(condition => `attributeList[? ${condition}]`)
       .join(' && ')}`;
     const spanList: ISpan[] = search(trace.spans, escapeString(`[? ${itemSelector}]`)) || [];
 
-    return spanList.length;
+    return spanList;
   },
 });
 

--- a/web/src/services/Span.service.ts
+++ b/web/src/services/Span.service.ts
@@ -1,5 +1,8 @@
-import {SemanticGroupNameNodeMap} from '../constants/SemanticGroupNames.constants';
-import {ISpan} from '../types/Span.types';
+import {differenceBy, intersectionBy} from 'lodash';
+import {SELECTOR_DEFAULT_ATTRIBUTES, SemanticGroupNameNodeMap} from '../constants/SemanticGroupNames.constants';
+import {ISpan, ISpanFlatAttribute} from '../types/Span.types';
+
+const itemSelectorKeys = SELECTOR_DEFAULT_ATTRIBUTES.flatMap(el => el.attributes);
 
 const SpanService = () => ({
   getSpanNodeInfo(span: ISpan) {
@@ -18,6 +21,20 @@ const SpanService = () => ({
     return {
       primary: signatureObject[attributeKey] || '',
       heading: signatureObject[type],
+    };
+  },
+  getSelectedSpanListAttributes({attributeList}: ISpan, selectedSpanList: ISpan[]) {
+    const intersectedAttributeList = intersectionBy(...selectedSpanList.map(el => el.attributeList), 'key');
+
+    const selectedSpanAttributeList = attributeList?.reduce<ISpanFlatAttribute[]>((acc, item) => {
+      if (itemSelectorKeys.indexOf(item.key) !== -1) return acc;
+
+      return acc.concat([item]);
+    }, []);
+
+    return {
+      intersectedList: intersectedAttributeList,
+      differenceList: differenceBy(selectedSpanAttributeList, intersectedAttributeList, 'key'),
     };
   },
 });


### PR DESCRIPTION
This PR changes the way we present the attribute list to the selector when trying to create/edit an assertion, it now shows all of the attributes across the affected spans and the specific ones to the selected span.

## Changes

- Updates the CreateAssertionModal.

## Fixes

- https://github.com/kubeshop/tracetest/issues/402
- https://github.com/kubeshop/tracetest/issues/236

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test


https://www.loom.com/share/981900079a79407299550ef660662335