### PR TITLE
fix: analytics client

### DIFF
--- a/server/analytics/analytics.go
+++ b/server/analytics/analytics.go
@@ -2,7 +2,6 @@ package analytics
 
 import (
 	"bytes"
-	"crypto/tls"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -10,7 +9,6 @@ import (
 	"os"
 	"runtime"
 	"strconv"
-	"time"
 
 	"github.com/denisbrodbeck/machineid"
 )
@@ -192,7 +190,7 @@ func sendPayloadToURL(payload Payload, url string) (*http.Response, []byte, erro
 
 	request.Header.Set("Content-Type", "application/json")
 
-	client := getClient()
+	client := http.DefaultClient
 
 	resp, err := client.Do(request)
 	if err != nil {
@@ -205,16 +203,4 @@ func sendPayloadToURL(payload Payload, url string) (*http.Response, []byte, erro
 	}
 
 	return resp, body, err
-}
-
-func getClient() *http.Client {
-	return &http.Client{
-		Transport: &http.Transport{
-			TLSClientConfig: &tls.Config{
-				// TODO: point to valid certificate
-				InsecureSkipVerify: true,
-			},
-		},
-		Timeout: 10 * time.Second,
-	}
 }

--- a/server/http/controller.go
+++ b/server/http/controller.go
@@ -32,7 +32,7 @@ func (s *controller) CreateTest(ctx context.Context, test openapi.Test) (openapi
 		return openapi.Response(http.StatusInternalServerError, err.Error()), err
 	}
 
-	analytics.CreateAndSendEvent("test-created-backend", "test")
+	analytics.CreateAndSendEvent("test_created_backend", "test")
 
 	test.TestId = id
 	return openapi.Response(200, test), nil
@@ -56,7 +56,7 @@ func (s *controller) UpdateTest(ctx context.Context, testid string, updated open
 		return openapi.Response(http.StatusInternalServerError, err.Error()), err
 	}
 
-	analytics.CreateAndSendEvent("test-updated-backend", "test")
+	analytics.CreateAndSendEvent("test_updated_backend", "test")
 
 	return openapi.Response(204, nil), nil
 }
@@ -77,7 +77,7 @@ func (s *controller) DeleteTest(ctx context.Context, testid string) (openapi.Imp
 		return openapi.Response(http.StatusInternalServerError, err.Error()), err
 	}
 
-	analytics.CreateAndSendEvent("test-deleted-backend", "test")
+	analytics.CreateAndSendEvent("test_deleted_backend", "test")
 
 	return openapi.Response(204, nil), nil
 }
@@ -126,7 +126,7 @@ func (s *controller) RunTest(ctx context.Context, testid string) (openapi.ImplRe
 
 	result := s.runner.Run(*test)
 
-	analytics.CreateAndSendEvent("test-run-backend", "test")
+	analytics.CreateAndSendEvent("test_run_backend", "test")
 
 	return openapi.Response(200, result), nil
 }
@@ -219,7 +219,7 @@ func (s *controller) UpdateAssertion(ctx context.Context, testID string, asserti
 		return openapi.Response(http.StatusInternalServerError, err.Error()), err
 	}
 
-	analytics.CreateAndSendEvent("assertion-updated-backend", "test")
+	analytics.CreateAndSendEvent("assertion_updated_backend", "test")
 
 	return openapi.Response(http.StatusNoContent, nil), nil
 }
@@ -235,7 +235,7 @@ func (s *controller) DeleteAssertion(ctx context.Context, testID string, asserti
 		return openapi.Response(http.StatusInternalServerError, err.Error()), err
 	}
 
-	analytics.CreateAndSendEvent("assertion-deleted-backend", "test")
+	analytics.CreateAndSendEvent("assertion_deleted_backend", "test")
 
 	return openapi.Response(http.StatusNoContent, nil), nil
 }

--- a/server/main.go
+++ b/server/main.go
@@ -94,7 +94,7 @@ func main() {
 		}
 	})
 
-	err = analytics.CreateAndSendEvent("server-started-backend", "beacon")
+	err = analytics.CreateAndSendEvent("server_started_backend", "beacon")
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
This PR fixes insecure TLS connection

## Changes

-

## Fixes

- Analytics names (google doesn't accept dashes in the event name)

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
