### PR TITLE
🐛  426 bug enable json comparison

### DIFF
--- a/web/src/components/ErrorBoundary/ErrorBoundary.tsx
+++ b/web/src/components/ErrorBoundary/ErrorBoundary.tsx
@@ -11,7 +11,7 @@ const ErrorBoundary: React.FC<IErrorBoundaryProps> = ({error}) => {
     <S.Container>
       <CloseCircleFilled style={{color: 'red', fontSize: 32}} />
       <Typography.Title level={2}>Something went wrong!</Typography.Title>
-      <div style={{display: 'grid', gap: 8, gridTemplateColumns: '1fr 1fr'}}>{error.toString()}</div>
+      <div style={{display: 'flex', maxWidth: '800px', padding: '24px'}}>{error.toString()}</div>
     </S.Container>
   );
 };

--- a/web/src/utils/Common.ts
+++ b/web/src/utils/Common.ts
@@ -5,3 +5,12 @@ export const escapeString = (str: string): string => {
   // eslint-disable-next-line no-control-regex
   return str.replace(/[\\"']/g, '\\$&').replace(/\u0000/g, '\\0');
 };
+
+export const isJson = (str: string) => {
+  try {
+    JSON.parse(str);
+  } catch (e) {
+    return false;
+  }
+  return true;
+};


### PR DESCRIPTION
This PR fixes a bug we had when trying to compare json strings.

## Changes

- Add an isJson check to validate if the incoming value can be parsed.

## Fixes

- https://github.com/kubeshop/tracetest/issues/426

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test


## Screenshots
![Screen Shot 2022-05-05 at 9 54 49 a m](https://user-images.githubusercontent.com/11051031/166951581-a32546df-374c-459e-ac53-07fa77562b29.png)
