### PR TITLE
fix validation of result update

### DIFF
--- a/server/http/controller.go
+++ b/server/http/controller.go
@@ -167,7 +167,9 @@ func (s *controller) UpdateTestResult(ctx context.Context, testid string, id str
 
 	testResult.AssertionResultState = testRunResult.AssertionResultState
 	testResult.AssertionResult = testRunResult.AssertionResult
-	testResult.State = executor.TestRunStateFinished
+	if isExpectingResultStateUpdate(testResult) {
+		testResult.State = executor.TestRunStateFinished
+	}
 
 	err = s.testDB.UpdateResult(ctx, testResult)
 	if err != nil {
@@ -175,6 +177,11 @@ func (s *controller) UpdateTestResult(ctx context.Context, testid string, id str
 	}
 
 	return openapi.Response(http.StatusOK, *testResult), nil
+}
+
+func isExpectingResultStateUpdate(r *openapi.TestRunResult) bool {
+	return r.State == executor.TestRunStateAwaitingTestResults
+
 }
 
 func (s *controller) CreateAssertion(ctx context.Context, testID string, assertion openapi.Assertion) (openapi.ImplResponse, error) {


### PR DESCRIPTION
This PR adds a validation in the backend so that the test result state can only be updated by the frontend if the state is `awaiting test results`. That is the only case where the FE should update the test state.

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
