### PR TITLE
feat: support empty selector

### DIFF
--- a/docs/advanced-selectors.md
+++ b/docs/advanced-selectors.md
@@ -147,6 +147,9 @@ flowchart TD
 
 # Features
 
+## Empty selector
+By providing an empty selector, all spans from the trace are selected. Note that an empty selector is an empty string. Providing `span` or `span[]` as a selector will result as a syntax error.
+
 ## Filter by attributes
 The most basic way of filtering the spans you want to apply an assertion on is by using its attributes. A good starting example would be filtering all spans of type `http`:
 

--- a/server/assertions/selectors/parser.go
+++ b/server/assertions/selectors/parser.go
@@ -7,7 +7,7 @@ import (
 )
 
 type ParserSelector struct {
-	SpanSelectors []parserSpanSelector `( @@* ( "," @@ )*)`
+	SpanSelectors []parserSpanSelector `( @@* ( "," @@ )*)*`
 }
 
 type parserSpanSelector struct {

--- a/server/assertions/selectors/selector.go
+++ b/server/assertions/selectors/selector.go
@@ -12,6 +12,11 @@ type Selector struct {
 }
 
 func (s Selector) Filter(trace traces.Trace) []traces.Span {
+	if len(s.spanSelectors) == 0 {
+		// empty selector should select everything
+		return getAllSpans(trace)
+	}
+
 	allFilteredSpans := make([]traces.Span, 0)
 	for _, spanSelector := range s.spanSelectors {
 		spans := filterSpans(trace.RootSpan, spanSelector)
@@ -19,6 +24,15 @@ func (s Selector) Filter(trace traces.Trace) []traces.Span {
 	}
 
 	return allFilteredSpans
+}
+
+func getAllSpans(trace traces.Trace) []traces.Span {
+	var allSpans = make([]traces.Span, 0)
+	traverseTree(trace.RootSpan, func(span traces.Span) {
+		allSpans = append(allSpans, span)
+	})
+
+	return allSpans
 }
 
 type spanSelector struct {

--- a/server/assertions/selectors/selector_test.go
+++ b/server/assertions/selectors/selector_test.go
@@ -67,6 +67,11 @@ func TestSelector(t *testing.T) {
 		ExpectedSpanIds []trace.SpanID
 	}{
 		{
+			Name:            "Empty selector should select all spans",
+			Expression:      ``,
+			ExpectedSpanIds: []trace.SpanID{postImportSpanID, insertPokemonDatabaseSpanID, getPokemonFromExternalAPISpanID, updatePokemonDatabaseSpanID},
+		},
+		{
 			Name:            "Selector with span name",
 			Expression:      `span[name="Get pokemon from external API"]`,
 			ExpectedSpanIds: []trace.SpanID{getPokemonFromExternalAPISpanID},


### PR DESCRIPTION
This PR enables an empty selector. The behavior for such selector is to select all spans in the tree.

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [x] updated the docs
- [x] added a test
