### PR TITLE
docs: link selectors documentation on doc page

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -24,6 +24,7 @@ nav:
   - Architecture: architecture.md
   - Creating Tests: create-test.md
   - Adding Assertions: adding-assertions.md
+  - Selectors: advanced-selectors.md
   - OpenAPI Definition: openapi.md
   - Development: development.md
 


### PR DESCRIPTION
This PR adds the selector documentation to our documentation nav bar.
## Checklist

- [ ] tested locally
- [ ] added new dependencies
- [x] updated the docs
- [ ] added a test
