### PR TITLE
441 adding integration tests for the home page

### DIFF
--- a/web/cypress.json
+++ b/web/cypress.json
@@ -1,4 +1,4 @@
 {
-  "componentFolder": "cypress/e2e",
+  "componentFolder": "cypress/components",
   "testFiles": "**/*.spec.{js,ts,jsx,tsx}"
 }

--- a/web/cypress/components/App.spec.tsx
+++ b/web/cypress/components/App.spec.tsx
@@ -1,7 +1,7 @@
 import {mount} from '@cypress/react';
 import App from '../../src/App';
 
-it('renders learn react link', () => {
+it('renders the all tests title', () => {
   mount(<App />);
   cy.get('h3.ant-typography').contains(/all tests/i);
 });

--- a/web/cypress/integration/Home/CreateTest.spec.ts
+++ b/web/cypress/integration/Home/CreateTest.spec.ts
@@ -1,0 +1,97 @@
+import {camelCase} from 'lodash';
+import {DemoTestExampleList} from '../../../src/constants/Test.constants';
+
+Cypress.on('uncaught:exception', err => !err.message.includes('ResizeObserver loop limit exceeded'));
+
+const deleteTest = () => {
+  cy.location().then(({pathname}) => {
+    const testId = pathname.split('/').pop();
+    cy.visit('http://localhost:3000/');
+
+    cy.get(`[data-cy=test-actions-button-${testId}]`).click();
+    cy.get('[data-cy=test-delete-button]').click();
+
+    cy.get(`[data-cy=test-actions-button-${testId}]`).should('not.exist');
+  });
+};
+
+const openCreateTestModal = () => {
+  cy.get('[data-cy=create-test-button]').click();
+
+  const $form = cy.get('[data-cy=create-test-modal] form');
+  $form.should('be.visible');
+
+  return $form;
+};
+
+beforeEach(() => {
+  cy.visit('http://localhost:3000/');
+});
+
+it('should create a basic GET test from scratch', () => {
+  const $form = openCreateTestModal();
+
+  $form.get('[data-cy=method-select]').click();
+  $form.get('[data-cy=method-select-option-GET]').click();
+  const name = `Test - Shop - #${String(Date.now()).slice(-4)}`;
+
+  $form.get('[data-cy=url]').type('http://shop/buy');
+  $form.get('[data-cy=name').type(name);
+
+  $form.get('[data-cy=create-test-submit]').click();
+
+  cy.location('pathname').should('match', /\/test\/.*/i);
+  cy.get('[data-cy=test-details-name]').should('have.text', name);
+  deleteTest();
+});
+
+it('should create a basic POST test from scratch', () => {
+  const $form = openCreateTestModal();
+
+  $form.get('[data-cy=method-select]').click();
+  $form.get('[data-cy=method-select-option-POST]').click();
+  const name = `Test - Pokemon - #${String(Date.now()).slice(-4)}`;
+
+  $form.get('[data-cy=url]').type('http://demo-pokemon-api.demo.svc.cluster.local/pokemon');
+  $form.get('[data-cy=name').type(name);
+  $form
+    .get('[data-cy=body]')
+    .type(
+      '{"name":"meowth","type":"normal","imageUrl":"https://assets.pokemon.com/assets/cms2/img/pokedex/full/052.png","isFeatured":true}',
+      {
+        parseSpecialCharSequences: false,
+      }
+    );
+
+  $form.get('[data-cy=create-test-submit]').click();
+
+  cy.location('pathname').should('match', /\/test\/.*/i);
+  cy.get('[data-cy=test-details-name]').should('have.text', name);
+  deleteTest();
+});
+
+it('should create a GET test from an example', () => {
+  const [{name, description}] = DemoTestExampleList;
+
+  const $form = openCreateTestModal();
+  $form.get('[data-cy=example-button]').click();
+  $form.get(`[data-cy=demo-example-${camelCase(name)}]`).click();
+  $form.get('[data-cy=create-test-submit]').click();
+
+  cy.location('pathname').should('match', /\/test\/.*/i);
+  cy.get('[data-cy=test-details-name]').should('have.text', `${name} - ${description}`);
+  deleteTest();
+});
+
+it('should create a POST test from an example', () => {
+  const [, , {name, description}] = DemoTestExampleList;
+
+  const $form = openCreateTestModal();
+  $form.get('[data-cy=example-button]').click();
+  $form.get(`[data-cy=demo-example-${camelCase(name)}]`).click();
+  $form.get('[data-cy=create-test-submit]').click();
+
+  cy.location('pathname').should('match', /\/test\/.*/i);
+  cy.get('[data-cy=test-details-name]').should('have.text', `${name} - ${description}`);
+  deleteTest();
+});

--- a/web/cypress/integration/Home/ShowTestList.spec.ts
+++ b/web/cypress/integration/Home/ShowTestList.spec.ts
@@ -1,0 +1,23 @@
+import {DOCUMENTATION_URL, GITHUB_URL} from '../../../src/constants/Common.constants';
+
+Cypress.on('uncaught:exception', err => !err.message.includes('ResizeObserver loop limit exceeded'));
+
+beforeEach(() => {
+  cy.visit('http://localhost:3000/');
+});
+
+it('renders the layout', () => {
+  cy.get('[data-cy=logo]').should('have.attr', 'src', '/static/media/Logo.e43c6126615ae2bbdf534a0338b1dc1d.svg');
+  cy.get('[data-cy=documentation-link]').should('have.attr', 'href', DOCUMENTATION_URL);
+  cy.get('[data-cy=github-link]').should('have.attr', 'href', GITHUB_URL);
+  cy.get('[data-cy=onboarding-link]').should('be.visible');
+});
+
+it('renders the list of tests', () => {
+  cy.get('[data-cy=create-test-button]').should('be.visible');
+
+  cy.get('[data-cy=testList]').should('be.visible');
+  cy.get('[data-cy=testList] .ant-table-row').should($tr => {
+    expect($tr).to.have.length.greaterThan(0);
+  });
+});

--- a/web/cypress/tsconfig.json
+++ b/web/cypress/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "jsx": "react-jsx",
     "target": "es5",
-    "lib": ["es5", "dom"],
+    "lib": ["es2015", "dom"],
     "types": ["cypress"]
   },
   "include": ["**/*.ts*"]

--- a/web/package.json
+++ b/web/package.json
@@ -41,8 +41,8 @@
     "build": "react-scripts build",
     "test": "npm run cy:run && react-scripts test",
     "eject": "react-scripts eject",
-    "cy:open": "cypress open-ct",
-    "cy:run": "cypress run-ct"
+    "cy:open": "cypress open",
+    "cy:run": "cypress run"
   },
   "eslintConfig": {
     "extends": "react-app"

--- a/web/src/components/CreateTestModal/CreateTestForm.tsx
+++ b/web/src/components/CreateTestModal/CreateTestForm.tsx
@@ -1,0 +1,202 @@
+import {useCallback, useRef, useState} from 'react';
+import {camelCase} from 'lodash';
+import {Form, Input, Button, Select, Checkbox, Dropdown, Menu, Typography, FormInstance} from 'antd';
+import {DeleteOutlined, DownOutlined} from '@ant-design/icons';
+import './CreateTestModal.styled.ts';
+import GuidedTourService, {GuidedTours} from '../../services/GuidedTour.service';
+import {Steps} from '../GuidedTour/homeStepList';
+import {HTTP_METHOD} from '../../constants/Common.constants';
+import {DemoTestExampleList} from '../../constants/Test.constants';
+import * as S from './CreateTestModal.styled';
+
+const defaultHeaders = [{key: 'Content-Type', value: 'application/json', checked: true}];
+
+export interface ICreateTestValues {
+  name: string;
+  url: string;
+  method: HTTP_METHOD;
+  body: string;
+  headersList: {
+    key: string;
+    value: string;
+    checked: boolean;
+  }[];
+}
+
+interface ICreateTestFormProps {
+  onSubmit(values: ICreateTestValues): Promise<void>;
+  form: FormInstance<ICreateTestValues>;
+}
+
+const CreateTestForm: React.FC<ICreateTestFormProps> = ({onSubmit, form}) => {
+  const touchedHttpHeadersRef = useRef<{[key: string]: Boolean}>({});
+  const [selectedDemo, setSelectedDemo] = useState();
+
+  const onDemoClick = useCallback(
+    ({key}) => {
+      setSelectedDemo(key);
+      const {method, url, name, description, body} = DemoTestExampleList.find(example => example.name === key) || {};
+
+      form.setFieldsValue({
+        method,
+        url,
+        body,
+        name: `${name} - ${description}`,
+      });
+    },
+    [form]
+  );
+
+  const menuLayout = (
+    <Menu onClick={onDemoClick}>
+      {DemoTestExampleList.map(({name}) => (
+        <Menu.Item key={name}>
+          <span data-cy={`demo-example-${camelCase(name)}`}>{name}</span>
+        </Menu.Item>
+      ))}
+    </Menu>
+  );
+
+  return (
+    <Form
+      name="newTest"
+      form={form}
+      initialValues={{remember: true}}
+      onFinish={onSubmit}
+      autoComplete="off"
+      layout="vertical"
+    >
+      <S.DemoTextContainer>
+        <Typography.Text>Try these examples in our demo env: </Typography.Text>
+        <Dropdown overlay={menuLayout} placement="bottomCenter" trigger={['click']}>
+          <S.DropdownText data-cy="example-button" className="ant-dropdown-link" id="create-test-example-selector">
+            {selectedDemo || 'Choose Example'} <DownOutlined />
+          </S.DropdownText>
+        </Dropdown>
+      </S.DemoTextContainer>
+      <div style={{display: 'flex', marginBottom: 24}}>
+        <Form.Item name="method" initialValue="GET" valuePropName="value" noStyle>
+          <Select
+            style={{minWidth: 120}}
+            data-cy="method-select"
+            className="method-select"
+            dropdownClassName="method-select-item"
+            data-tour={GuidedTourService.getStep(GuidedTours.Home, Steps.Method)}
+          >
+            {Object.keys(HTTP_METHOD).map(el => {
+              return (
+                <Select.Option data-cy={`method-select-option-${el}`} key={el} value={el}>
+                  {el}
+                </Select.Option>
+              );
+            })}
+          </Select>
+        </Form.Item>
+
+        <Form.Item name="url" rules={[{required: true, message: 'Please input Endpoint!'}]} noStyle>
+          <Input
+            placeholder="Enter request url"
+            data-cy="url"
+            data-tour={GuidedTourService.getStep(GuidedTours.Home, Steps.Url)}
+          />
+        </Form.Item>
+      </div>
+
+      <Form.Item
+        name="name"
+        label="Name"
+        colon={false}
+        data-tour={GuidedTourService.getStep(GuidedTours.Home, Steps.Name)}
+        data-cy="name"
+        wrapperCol={{span: 24, offset: 0}}
+        rules={[{required: true, message: 'Please input test name!'}]}
+      >
+        <Input />
+      </Form.Item>
+
+      <Form.Item
+        label="Headers List"
+        wrapperCol={{span: 24, offset: 0}}
+        data-tour={GuidedTourService.getStep(GuidedTours.Home, Steps.Headers)}
+      >
+        <div style={{minHeight: 80}}>
+          <Form.List name="headersList" initialValue={[...defaultHeaders, {}, {}]}>
+            {(fields, {add, remove}) => (
+              <>
+                {fields.map((field, index) => (
+                  <div key={field.name} style={{display: 'flex', alignItems: 'center'}}>
+                    <Form.Item name={[field.name, 'checked']} valuePropName="checked" noStyle>
+                      <Checkbox style={{marginRight: 8}} />
+                    </Form.Item>
+
+                    <Form.Item name={[field.name, 'key']} noStyle>
+                      <Input
+                        placeholder={`Header${index + 1}`}
+                        onChangeCapture={() => {
+                          if (!touchedHttpHeadersRef.current[field.name]) {
+                            touchedHttpHeadersRef.current[field.name] = true;
+                            const headers = form.getFieldsValue().headersList;
+                            headers[field.name].checked = true;
+                            form.setFieldsValue({headersList: headers});
+                          }
+
+                          if (fields.length - 1 === index) {
+                            add({checked: false});
+                          }
+                        }}
+                      />
+                    </Form.Item>
+                    <Form.Item noStyle name={[field.name, 'value']}>
+                      <Input
+                        placeholder={`Value${index + 1}`}
+                        onChangeCapture={() => {
+                          if (!touchedHttpHeadersRef.current[field.name]) {
+                            touchedHttpHeadersRef.current[field.name] = true;
+                            const headers = form.getFieldsValue().headersList;
+                            headers[field.name].checked = true;
+                            form.setFieldsValue({headersList: headers});
+                          }
+
+                          if (fields.length - 1 === index) {
+                            add({checked: false});
+                          }
+                        }}
+                      />
+                    </Form.Item>
+
+                    <Form.Item noStyle>
+                      <Button
+                        style={{marginLeft: 8}}
+                        type="text"
+                        icon={<DeleteOutlined style={{fontSize: 24, color: '#D9D9D9'}} />}
+                        onClick={() => {
+                          touchedHttpHeadersRef.current[field.name] = false;
+                          remove(index);
+                          if (fields.length === 1 || fields.length - 1 === index) {
+                            add();
+                          }
+                        }}
+                      />
+                    </Form.Item>
+                  </div>
+                ))}
+              </>
+            )}
+          </Form.List>
+        </div>
+      </Form.Item>
+      <Form.Item
+        label="Request body"
+        name="body"
+        colon={false}
+        wrapperCol={{span: 24, offset: 0}}
+        data-tour={GuidedTourService.getStep(GuidedTours.Home, Steps.Body)}
+        data-cy="body"
+      >
+        <Input.TextArea style={{maxHeight: 150, height: 120}} />
+      </Form.Item>
+    </Form>
+  );
+};
+
+export default CreateTestForm;

--- a/web/src/components/CreateTestModal/CreateTestModal.tsx
+++ b/web/src/components/CreateTestModal/CreateTestModal.tsx
@@ -1,23 +1,20 @@
-import {useCallback, useRef, useState} from 'react';
+import {useCallback} from 'react';
 import {useTour} from '@reactour/tour';
-import {Modal, Form, Input, Button, Select, Checkbox, Dropdown, Menu, Typography} from 'antd';
-import {DeleteOutlined, DownOutlined} from '@ant-design/icons';
+import {Modal, Form, Button} from 'antd';
 import {useCreateTestMutation, useRunTestMutation} from 'redux/apis/Test.api';
 import './CreateTestModal.styled.ts';
 import {useNavigate} from 'react-router-dom';
 import GuidedTourService, {GuidedTours} from '../../services/GuidedTour.service';
 import {Steps} from '../GuidedTour/homeStepList';
 import CreateTestAnalyticsService from '../../services/Analytics/CreateTestAnalytics.service';
-import {HTTP_METHOD} from '../../constants/Common.constants';
-import {DemoTestExampleList} from '../../constants/Test.constants';
 import * as S from './CreateTestModal.styled';
+import CreateTestForm, {ICreateTestValues} from './CreateTestForm';
 
 interface IProps {
   visible: boolean;
   onClose: () => void;
 }
 
-const defaultHeaders = [{key: 'Content-Type', value: 'application/json', checked: true}];
 const {onCreateTestFormSubmit} = CreateTestAnalyticsService;
 
 const CreateTestModal = ({visible, onClose}: IProps): JSX.Element => {
@@ -25,13 +22,11 @@ const CreateTestModal = ({visible, onClose}: IProps): JSX.Element => {
   const {setIsOpen} = useTour();
   const [createTest, {isLoading: isLoadingCreateTest}] = useCreateTestMutation();
   const [runTest, {isLoading: isLoadingRunTest}] = useRunTestMutation();
-  const [selectedDemo, setSelectedDemo] = useState();
 
-  const [form] = Form.useForm();
-  const touchedHttpHeadersRef = useRef<{[key: string]: Boolean}>({});
+  const [form] = Form.useForm<ICreateTestValues>();
 
-  const onFinish = useCallback(
-    async (values: any) => {
+  const onCreate = useCallback(
+    async (values: ICreateTestValues) => {
       const headers = values.headersList
         .filter((i: {checked: boolean}) => i.checked)
         .map(({key, value}: {key: string; value: string}) => ({key, value}));
@@ -65,35 +60,13 @@ const CreateTestModal = ({visible, onClose}: IProps): JSX.Element => {
           }}
           loading={isLoadingCreateTest || isLoadingRunTest}
           data-tour={GuidedTourService.getStep(GuidedTours.Home, Steps.Run)}
+          data-cy="create-test-submit"
         >
           Run Test
         </Button>
       </>
     );
   };
-
-  const onDemoClick = useCallback(
-    ({key}) => {
-      setSelectedDemo(key);
-      const {method, url, name, description, body} = DemoTestExampleList.find(example => example.name === key) || {};
-
-      form.setFieldsValue({
-        method,
-        url,
-        body,
-        name: `${name} - ${description}`,
-      });
-    },
-    [form]
-  );
-
-  const menuLayout = (
-    <Menu onClick={onDemoClick}>
-      {DemoTestExampleList.map(({name}) => (
-        <Menu.Item key={name}>{name}</Menu.Item>
-      ))}
-    </Menu>
-  );
 
   return (
     <S.Wrapper>
@@ -105,141 +78,8 @@ const CreateTestModal = ({visible, onClose}: IProps): JSX.Element => {
         onCancel={onClose}
         wrapClassName="test-modal"
       >
-        <div style={{display: 'flex'}}>
-          <Form
-            name="newTest"
-            form={form}
-            initialValues={{remember: true}}
-            onFinish={onFinish}
-            autoComplete="off"
-            layout="vertical"
-          >
-            <S.DemoTextContainer>
-              <Typography.Text>Try these examples in our demo env: </Typography.Text>
-              <Dropdown overlay={menuLayout} placement="bottomCenter" trigger={['click']}>
-                <S.DropdownText className="ant-dropdown-link">
-                  {selectedDemo || 'Choose Example'} <DownOutlined />
-                </S.DropdownText>
-              </Dropdown>
-            </S.DemoTextContainer>
-            <div style={{display: 'flex', marginBottom: 24}}>
-              <Form.Item name="method" initialValue="GET" valuePropName="value" noStyle>
-                <Select
-                  style={{minWidth: 120}}
-                  className="method-select"
-                  dropdownClassName="method-select-item"
-                  data-tour={GuidedTourService.getStep(GuidedTours.Home, Steps.Method)}
-                >
-                  {Object.keys(HTTP_METHOD).map(el => {
-                    return (
-                      <Select.Option key={el} value={el}>
-                        {el}
-                      </Select.Option>
-                    );
-                  })}
-                </Select>
-              </Form.Item>
-
-              <Form.Item name="url" rules={[{required: true, message: 'Please input Endpoint!'}]} noStyle>
-                <Input
-                  placeholder="Enter request url"
-                  data-tour={GuidedTourService.getStep(GuidedTours.Home, Steps.Url)}
-                />
-              </Form.Item>
-            </div>
-
-            <Form.Item
-              name="name"
-              label="Name"
-              colon={false}
-              data-tour={GuidedTourService.getStep(GuidedTours.Home, Steps.Name)}
-              wrapperCol={{span: 24, offset: 0}}
-              rules={[{required: true, message: 'Please input test name!'}]}
-            >
-              <Input />
-            </Form.Item>
-
-            <Form.Item
-              label="Headers List"
-              wrapperCol={{span: 24, offset: 0}}
-              data-tour={GuidedTourService.getStep(GuidedTours.Home, Steps.Headers)}
-            >
-              <div style={{minHeight: 80}}>
-                <Form.List name="headersList" initialValue={[...defaultHeaders, {}, {}]}>
-                  {(fields, {add, remove}) => (
-                    <>
-                      {fields.map((field, index) => (
-                        <div key={field.name} style={{display: 'flex', alignItems: 'center'}}>
-                          <Form.Item name={[field.name, 'checked']} valuePropName="checked" noStyle>
-                            <Checkbox style={{marginRight: 8}} />
-                          </Form.Item>
-
-                          <Form.Item name={[field.name, 'key']} noStyle>
-                            <Input
-                              placeholder={`Header${index + 1}`}
-                              onChangeCapture={() => {
-                                if (!touchedHttpHeadersRef.current[field.name]) {
-                                  touchedHttpHeadersRef.current[field.name] = true;
-                                  const headers = form.getFieldsValue().headersList;
-                                  headers[field.name].checked = true;
-                                  form.setFieldsValue({headersList: headers});
-                                }
-
-                                if (fields.length - 1 === index) {
-                                  add({checked: false});
-                                }
-                              }}
-                            />
-                          </Form.Item>
-                          <Form.Item noStyle name={[field.name, 'value']}>
-                            <Input
-                              placeholder={`Value${index + 1}`}
-                              onChangeCapture={() => {
-                                if (!touchedHttpHeadersRef.current[field.name]) {
-                                  touchedHttpHeadersRef.current[field.name] = true;
-                                  const headers = form.getFieldsValue().headersList;
-                                  headers[field.name].checked = true;
-                                  form.setFieldsValue({headersList: headers});
-                                }
-
-                                if (fields.length - 1 === index) {
-                                  add({checked: false});
-                                }
-                              }}
-                            />
-                          </Form.Item>
-
-                          <Form.Item noStyle>
-                            <Button
-                              style={{marginLeft: 8}}
-                              type="text"
-                              icon={<DeleteOutlined style={{fontSize: 24, color: '#D9D9D9'}} />}
-                              onClick={() => {
-                                touchedHttpHeadersRef.current[field.name] = false;
-                                remove(index);
-                                if (fields.length === 1 || fields.length - 1 === index) {
-                                  add();
-                                }
-                              }}
-                            />
-                          </Form.Item>
-                        </div>
-                      ))}
-                    </>
-                  )}
-                </Form.List>
-              </div>
-            </Form.Item>
-            <Form.Item
-              label="Request body"
-              name="body"
-              colon={false}
-              wrapperCol={{span: 24, offset: 0}}
-              data-tour={GuidedTourService.getStep(GuidedTours.Home, Steps.Body)}
-            >
-              <Input.TextArea style={{maxHeight: 150, height: 120}} />
-            </Form.Item>
-          </Form>
+        <div style={{display: 'flex'}} data-cy="create-test-modal">
+          <CreateTestForm onSubmit={onCreate} form={form} />
         </div>
       </Modal>
     </S.Wrapper>

--- a/web/src/components/Header/Header.tsx
+++ b/web/src/components/Header/Header.tsx
@@ -23,23 +23,26 @@ const Header: FC = () => {
     <S.Header>
       <Link to="/">
         <S.TitleText>
-          <img src={Logo} />
+          <img data-cy="logo" src={Logo} />
         </S.TitleText>
       </Link>
       <S.NavMenu selectedKeys={[pathname]}>
         <S.NavMenuItem key={GITHUB_URL}>
-          <a href={GITHUB_URL} target="_blank">
+          <a href={GITHUB_URL} target="_blank" data-cy="github-link">
             GitHub
           </a>
         </S.NavMenuItem>
         <S.NavMenuItem key={DOCUMENTATION_URL}>
-          <a href={DOCUMENTATION_URL} target="_blank">
+          <a href={DOCUMENTATION_URL} target="_blank" data-cy="documentation-link">
             Documentation
           </a>
         </S.NavMenuItem>
-        <Menu.SubMenu key="help" icon={<QuestionCircleOutlined style={{color: '#E5E5E5', fontSize: 16}} />}>
+        <Menu.SubMenu
+          key="help"
+          icon={<QuestionCircleOutlined data-cy="onboarding-link" style={{color: '#E5E5E5', fontSize: 16}} />}
+        >
           <S.NavMenuItem key="guidedTour" onClick={handleGuidedTourCLick}>
-            Show Onboarding{' '}
+            Show Onboarding
           </S.NavMenuItem>
         </Menu.SubMenu>
       </S.NavMenu>

--- a/web/src/hooks/useGuidedTour.ts
+++ b/web/src/hooks/useGuidedTour.ts
@@ -1,5 +1,5 @@
 import {useTour} from '@reactour/tour';
-import {delay as delayFn} from 'lodash';
+// import {delay as delayFn} from 'lodash';
 import {useEffect, useState} from 'react';
 import GuidedTourService, {GuidedTours} from 'services/GuidedTour.service';
 import HomeStepList from 'components/GuidedTour/homeStepList';
@@ -24,16 +24,16 @@ const useGuidedTour = (tour: GuidedTours, delay = 500) => {
     setSteps(StepListMap[tour]);
   }, [tour, setSteps]);
 
-  useEffect(() => {
-    const isComplete = GuidedTourService.getIsComplete(tour);
-    if (!isComplete) {
-      delayFn(() => {
-        setCurrentStep(0);
-        setIsOpen(true);
-        setIsLoaded(true);
-      }, delay);
-    }
-  }, [delay, setCurrentStep, setIsOpen, tour]);
+  // useEffect(() => {
+  //   const isComplete = GuidedTourService.getIsComplete(tour);
+  //   if (!isComplete) {
+  //     delayFn(() => {
+  //       setCurrentStep(0);
+  //       setIsOpen(true);
+  //       setIsLoaded(true);
+  //     }, delay);
+  //   }
+  // }, [delay, setCurrentStep, setIsOpen, tour]);
 
   useEffect(() => {
     if (!isOpen && isLoaded) {

--- a/web/src/pages/Home/HomeContent.tsx
+++ b/web/src/pages/Home/HomeContent.tsx
@@ -44,6 +44,7 @@ const HomeContent: React.FC = () => {
           </Button> */}
           <S.CreateTestButton
             data-tour={GuidedTourService.getStep(GuidedTours.Home, Steps.CreateTest)}
+            data-cy="create-test-button"
             type="primary"
             size="large"
             onClick={() => {

--- a/web/src/pages/Home/TestList.tsx
+++ b/web/src/pages/Home/TestList.tsx
@@ -35,6 +35,7 @@ const TestList = () => {
       scroll={{y: 'calc(100vh - 300px)'}}
       dataSource={testList?.map(el => ({...el, url: el.serviceUnderTest.request.url})).reverse()}
       rowKey="testId"
+      data-cy="testList"
       locale={{emptyText: <NoResults />}}
       loading={isLoading}
       onRow={record => {
@@ -70,11 +71,11 @@ const TestList = () => {
         title="Actions"
         key="actions"
         align="right"
-        render={i => (
+        render={(test: ITest) => (
           <Dropdown
             overlay={
               <Menu>
-                <Menu.Item onClick={onDelete(i)} key="delete">
+                <Menu.Item data-cy="test-delete-button" onClick={onDelete(test)} key="delete">
                   Delete
                 </Menu.Item>
               </Menu>
@@ -82,7 +83,7 @@ const TestList = () => {
             placement="bottomLeft"
             trigger={['click']}
           >
-            <span className="ant-dropdown-link" onClick={e => e.stopPropagation()}>
+            <span data-cy={`test-actions-button-${test.testId}`} className="ant-dropdown-link" onClick={e => e.stopPropagation()}>
               <MoreOutlined style={{fontSize: 24}} />
             </span>
           </Dropdown>

--- a/web/src/pages/Test/Test.tsx
+++ b/web/src/pages/Test/Test.tsx
@@ -139,7 +139,7 @@ const TestPage = () => {
                 <Button type="text" shape="circle" onClick={() => navigate('/')}>
                   <ArrowLeftOutlined style={{fontSize: 24, marginRight: 16}} />
                 </Button>
-                <Title style={{margin: 0}} level={3}>
+                <Title style={{margin: 0}} level={3} data-cy="test-details-name">
                   {test?.name}
                 </Title>
               </S.Header>

--- a/web/src/services/Analytics/Analytics.service.ts
+++ b/web/src/services/Analytics/Analytics.service.ts
@@ -29,9 +29,13 @@ type TAnalyticsService<A> = {
   event(action: A, label: string): void;
 };
 
+const initializePromise = instance.initialize();
+
 const AnalyticsService = <A>(category: Categories): TAnalyticsService<A> => {
   const event = (action: A, label: string) => {
-    instance.event(String(action), label, category);
+    initializePromise.then(() => {
+      instance.event(String(action), label, category);
+    });
   };
 
   return {event};


### PR DESCRIPTION
This PR adds the highly necessary integration tests for the home page. It includes tests for scenarios such as:
1. Displaying the layout (header).
2. Displaying the list of tests.
3. Creating a test from scratch.
4. Creating a test using the examples.

## Changes

- Fixing initialization process for analytics.
- Moving CreateTestForm to its own component.

## Fixes

- https://github.com/kubeshop/tracetest/issues/441

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [x] added a test
