### PR TITLE
🧪  442 adding integration tests for the test details page

### DIFF
--- a/web/.gitignore
+++ b/web/.gitignore
@@ -23,3 +23,4 @@ yarn-debug.log*
 yarn-error.log*
 
 cypress/videos
+cypress/screenshots

--- a/web/cypress/integration/Home/CreateTest.spec.ts
+++ b/web/cypress/integration/Home/CreateTest.spec.ts
@@ -3,7 +3,7 @@ import {DemoTestExampleList} from '../../../src/constants/Test.constants';
 
 Cypress.on('uncaught:exception', err => !err.message.includes('ResizeObserver loop limit exceeded'));
 
-const deleteTest = () => {
+export const deleteTest = () => {
   cy.location().then(({pathname}) => {
     const testId = pathname.split('/').pop();
     cy.visit('http://localhost:3000/');
@@ -15,7 +15,7 @@ const deleteTest = () => {
   });
 };
 
-const openCreateTestModal = () => {
+export const openCreateTestModal = () => {
   cy.get('[data-cy=create-test-button]').click();
 
   const $form = cy.get('[data-cy=create-test-modal] form');
@@ -24,74 +24,76 @@ const openCreateTestModal = () => {
   return $form;
 };
 
-beforeEach(() => {
-  cy.visit('http://localhost:3000/');
-});
+describe('Create test', () => {
+  beforeEach(() => {
+    cy.visit('http://localhost:3000/');
+  });
 
-it('should create a basic GET test from scratch', () => {
-  const $form = openCreateTestModal();
+  it('should create a basic GET test from scratch', () => {
+    const $form = openCreateTestModal();
 
-  $form.get('[data-cy=method-select]').click();
-  $form.get('[data-cy=method-select-option-GET]').click();
-  const name = `Test - Shop - #${String(Date.now()).slice(-4)}`;
+    $form.get('[data-cy=method-select]').click();
+    $form.get('[data-cy=method-select-option-GET]').click();
+    const name = `Test - Shop - #${String(Date.now()).slice(-4)}`;
 
-  $form.get('[data-cy=url]').type('http://shop/buy');
-  $form.get('[data-cy=name').type(name);
+    $form.get('[data-cy=url]').type('http://shop/buy');
+    $form.get('[data-cy=name').type(name);
 
-  $form.get('[data-cy=create-test-submit]').click();
+    $form.get('[data-cy=create-test-submit]').click();
 
-  cy.location('pathname').should('match', /\/test\/.*/i);
-  cy.get('[data-cy=test-details-name]').should('have.text', name);
-  deleteTest();
-});
+    cy.location('pathname').should('match', /\/test\/.*/i);
+    cy.get('[data-cy=test-details-name]').should('have.text', name);
+    deleteTest();
+  });
 
-it('should create a basic POST test from scratch', () => {
-  const $form = openCreateTestModal();
+  it('should create a basic POST test from scratch', () => {
+    const $form = openCreateTestModal();
 
-  $form.get('[data-cy=method-select]').click();
-  $form.get('[data-cy=method-select-option-POST]').click();
-  const name = `Test - Pokemon - #${String(Date.now()).slice(-4)}`;
+    $form.get('[data-cy=method-select]').click();
+    $form.get('[data-cy=method-select-option-POST]').click();
+    const name = `Test - Pokemon - #${String(Date.now()).slice(-4)}`;
 
-  $form.get('[data-cy=url]').type('http://demo-pokemon-api.demo.svc.cluster.local/pokemon');
-  $form.get('[data-cy=name').type(name);
-  $form
-    .get('[data-cy=body]')
-    .type(
-      '{"name":"meowth","type":"normal","imageUrl":"https://assets.pokemon.com/assets/cms2/img/pokedex/full/052.png","isFeatured":true}',
-      {
-        parseSpecialCharSequences: false,
-      }
-    );
+    $form.get('[data-cy=url]').type('http://demo-pokemon-api.demo.svc.cluster.local/pokemon');
+    $form.get('[data-cy=name').type(name);
+    $form
+      .get('[data-cy=body]')
+      .type(
+        '{"name":"meowth","type":"normal","imageUrl":"https://assets.pokemon.com/assets/cms2/img/pokedex/full/052.png","isFeatured":true}',
+        {
+          parseSpecialCharSequences: false,
+        }
+      );
 
-  $form.get('[data-cy=create-test-submit]').click();
+    $form.get('[data-cy=create-test-submit]').click();
 
-  cy.location('pathname').should('match', /\/test\/.*/i);
-  cy.get('[data-cy=test-details-name]').should('have.text', name);
-  deleteTest();
-});
+    cy.location('pathname').should('match', /\/test\/.*/i);
+    cy.get('[data-cy=test-details-name]').should('have.text', name);
+    deleteTest();
+  });
 
-it('should create a GET test from an example', () => {
-  const [{name, description}] = DemoTestExampleList;
+  it('should create a GET test from an example', () => {
+    const [{name, description}] = DemoTestExampleList;
 
-  const $form = openCreateTestModal();
-  $form.get('[data-cy=example-button]').click();
-  $form.get(`[data-cy=demo-example-${camelCase(name)}]`).click();
-  $form.get('[data-cy=create-test-submit]').click();
+    const $form = openCreateTestModal();
+    $form.get('[data-cy=example-button]').click();
+    $form.get(`[data-cy=demo-example-${camelCase(name)}]`).click();
+    $form.get('[data-cy=create-test-submit]').click();
 
-  cy.location('pathname').should('match', /\/test\/.*/i);
-  cy.get('[data-cy=test-details-name]').should('have.text', `${name} - ${description}`);
-  deleteTest();
-});
+    cy.location('pathname').should('match', /\/test\/.*/i);
+    cy.get('[data-cy=test-details-name]').should('have.text', `${name} - ${description}`);
+    deleteTest();
+  });
 
-it('should create a POST test from an example', () => {
-  const [, , {name, description}] = DemoTestExampleList;
+  it('should create a POST test from an example', () => {
+    const [, , {name, description}] = DemoTestExampleList;
 
-  const $form = openCreateTestModal();
-  $form.get('[data-cy=example-button]').click();
-  $form.get(`[data-cy=demo-example-${camelCase(name)}]`).click();
-  $form.get('[data-cy=create-test-submit]').click();
+    const $form = openCreateTestModal();
+    $form.get('[data-cy=example-button]').click();
+    $form.get(`[data-cy=demo-example-${camelCase(name)}]`).click();
+    $form.get('[data-cy=create-test-submit]').click();
 
-  cy.location('pathname').should('match', /\/test\/.*/i);
-  cy.get('[data-cy=test-details-name]').should('have.text', `${name} - ${description}`);
-  deleteTest();
+    cy.location('pathname').should('match', /\/test\/.*/i);
+    cy.get('[data-cy=test-details-name]').should('have.text', `${name} - ${description}`);
+    deleteTest();
+  });
 });

--- a/web/cypress/integration/Home/ShowTestList.spec.ts
+++ b/web/cypress/integration/Home/ShowTestList.spec.ts
@@ -2,22 +2,24 @@ import {DOCUMENTATION_URL, GITHUB_URL} from '../../../src/constants/Common.const
 
 Cypress.on('uncaught:exception', err => !err.message.includes('ResizeObserver loop limit exceeded'));
 
-beforeEach(() => {
-  cy.visit('http://localhost:3000/');
-});
+describe('Home', () => {
+  beforeEach(() => {
+    cy.visit('http://localhost:3000/');
+  });
 
-it('renders the layout', () => {
-  cy.get('[data-cy=logo]').should('have.attr', 'src', '/static/media/Logo.e43c6126615ae2bbdf534a0338b1dc1d.svg');
-  cy.get('[data-cy=documentation-link]').should('have.attr', 'href', DOCUMENTATION_URL);
-  cy.get('[data-cy=github-link]').should('have.attr', 'href', GITHUB_URL);
-  cy.get('[data-cy=onboarding-link]').should('be.visible');
-});
+  it('renders the layout', () => {
+    cy.get('[data-cy=logo]').should('have.attr', 'src', '/static/media/Logo.e43c6126615ae2bbdf534a0338b1dc1d.svg');
+    cy.get('[data-cy=documentation-link]').should('have.attr', 'href', DOCUMENTATION_URL);
+    cy.get('[data-cy=github-link]').should('have.attr', 'href', GITHUB_URL);
+    cy.get('[data-cy=onboarding-link]').should('be.visible');
+  });
 
-it('renders the list of tests', () => {
-  cy.get('[data-cy=create-test-button]').should('be.visible');
+  it('renders the list of tests', () => {
+    cy.get('[data-cy=create-test-button]').should('be.visible');
 
-  cy.get('[data-cy=testList]').should('be.visible');
-  cy.get('[data-cy=testList] .ant-table-row').should($tr => {
-    expect($tr).to.have.length.greaterThan(0);
+    cy.get('[data-cy=testList]').should('be.visible');
+    cy.get('[data-cy=testList] .ant-table-row').should($tr => {
+      expect($tr).to.have.length.greaterThan(0);
+    });
   });
 });

--- a/web/cypress/integration/TestDetails/ShowTestDetails.spec.ts
+++ b/web/cypress/integration/TestDetails/ShowTestDetails.spec.ts
@@ -1,0 +1,73 @@
+import {camelCase} from 'lodash';
+import {openCreateTestModal, deleteTest} from '../Home/CreateTest.spec';
+import {DemoTestExampleList} from '../../../src/constants/Test.constants';
+
+const [, {name, description}] = DemoTestExampleList;
+let testId = '';
+
+export const createTest = () => {
+  cy.visit('http://localhost:3000/');
+  const $form = openCreateTestModal();
+
+  $form.get('[data-cy=example-button]').click();
+  $form.get(`[data-cy=demo-example-${camelCase(name)}]`).click();
+  $form.get('[data-cy=create-test-submit]').click();
+
+  cy.location('pathname').should('match', /\/test\/.*/i);
+  cy.location().then(({pathname}) => {
+    testId = pathname.split('/').pop();
+  });
+  cy.visit('http://localhost:3000/');
+};
+
+describe('Show test details', () => {
+  before(() => {
+    createTest();
+  });
+
+  after(() => {
+    deleteTest();
+  });
+
+  it('should show the test details for any trace', () => {
+    cy.get(`[data-cy=test-url-${testId}]`).click();
+
+    cy.location('pathname').should('match', /\/test\/.*/i);
+    cy.get('[data-cy=test-details-name]').should('have.text', `${name} - ${description}`);
+    cy.get('[data-cy=test-result-table]').should('be.visible');
+    cy.get('[data-cy=test-result-table] .ant-table-row').should('have.length.above', 0);
+  });
+
+  it('should run a new test', () => {
+    cy.visit(`http://localhost:3000/test/${testId}`);
+    let testRunResultId = '';
+    cy.get(`[data-cy=test-details-run-test-button]`).click();
+    cy.location('href').should('match', /resultId=.*/i);
+
+    cy.location().then(({href}) => {
+      testRunResultId = href.split('?').pop().split('=').pop();
+
+      cy.wait(2000);
+      cy.get('#rc-tabs-0-tab-1').click();
+      cy.get(`[data-cy=test-run-result-${testRunResultId}]`).should('be.visible');
+    });
+  });
+
+  it('should update the test run result status', () => {
+    cy.visit(`http://localhost:3000/test/${testId}`);
+    let testRunResultId = '';
+    cy.get(`[data-cy=test-details-run-test-button]`).click();
+    cy.location('href').should('match', /resultId=.*/i);
+
+    cy.location().then(({href}) => {
+      testRunResultId = href.split('?').pop().split('=').pop();
+
+      cy.wait(2000);
+      cy.get('[data-cy=test-run-result-status]').should('have.text', 'Test status:Awaiting trace');
+      cy.wait(2000);
+      cy.get('[data-cy=test-run-result-status]').should('have.text', 'Test status:Finished');
+      cy.get('#rc-tabs-0-tab-1').click();
+      cy.get(`[data-cy=test-run-result-status-${testRunResultId}]`).should('have.text', 'Finished');
+    });
+  });
+});

--- a/web/package.json
+++ b/web/package.json
@@ -39,9 +39,9 @@
   "scripts": {
     "start": "react-scripts start",
     "build": "react-scripts build",
-    "test:unit": "react-scripts test",
+    "test:unit": "react-scripts test --watchAll=false",
     "test:integration": "npm run cy:run",
-    "test:lint": "eslint",
+    "test:lint": "eslint ./src/**/*.{ts,tsx}",
     "test:types": "tsc",
     "test": "npm run test:lint && npm run test:types && npm run test:unit && npm run test:integration",
     "eject": "react-scripts eject",

--- a/web/src/hooks/useDoubleClick.tsx
+++ b/web/src/hooks/useDoubleClick.tsx
@@ -24,6 +24,6 @@ export const useDoubleClick = (doubleClick: any, click?: any, timeout = 200) => 
         doubleClick(event);
       }
     },
-    [click, doubleClick]
+    [click, doubleClick, timeout]
   );
 };

--- a/web/src/pages/Home/TestList.tsx
+++ b/web/src/pages/Home/TestList.tsx
@@ -54,10 +54,11 @@ const TestList = () => {
         title="Endpoint"
         dataIndex="url"
         key="url"
-        render={value => {
+        render={(value, {testId}: ITest) => {
           return (
             <span
               style={{paddingLeft: 16, paddingRight: 16}}
+              data-cy={`test-url-${testId}`}
               onMouseDown={handleMouseUp}
               onMouseUp={handleMouseUp}
               onClick={handleMouseUp}
@@ -83,7 +84,11 @@ const TestList = () => {
             placement="bottomLeft"
             trigger={['click']}
           >
-            <span data-cy={`test-actions-button-${test.testId}`} className="ant-dropdown-link" onClick={e => e.stopPropagation()}>
+            <span
+              data-cy={`test-actions-button-${test.testId}`}
+              className="ant-dropdown-link"
+              onClick={e => e.stopPropagation()}
+            >
               <MoreOutlined style={{fontSize: 24}} />
             </span>
           </Dropdown>

--- a/web/src/pages/Test/Test.tsx
+++ b/web/src/pages/Test/Test.tsx
@@ -129,7 +129,7 @@ const TestPage = () => {
               </S.Header>
             ),
             right: activeTestResult?.resultId && activeTestResultDetails?.state && (
-              <div style={{marginRight: 24}}>
+              <div style={{marginRight: 24}} data-cy="test-run-result-status">
                 <Typography.Text style={{marginRight: 8, color: '#8C8C8C', fontSize: 14}}>Test status:</Typography.Text>
                 <TestStateBadge style={{fontSize: 16}} testState={activeTestResultDetails?.state} />
               </div>
@@ -143,7 +143,7 @@ const TestPage = () => {
           onEdit={onEditTab}
           style={{flexGrow: 1, display: 'flex', margin: 0}}
         >
-          <Tabs.TabPane tab="Test Details" key="1" closeIcon={<CloseOutlined hidden />}>
+          <Tabs.TabPane data-cy="test-details" tab="Test Details" key="1" closeIcon={<CloseOutlined hidden />}>
             <S.Wrapper detail>
               <TestDetails
                 testResultList={testResultList}

--- a/web/src/pages/Test/TestDetails.tsx
+++ b/web/src/pages/Test/TestDetails.tsx
@@ -39,6 +39,7 @@ const TestDetails: FC<TTestDetailsProps> = ({testId, testResultList, isLoading, 
           onClick={handleRunTest}
           loading={result.isLoading}
           type="primary"
+          data-cy="test-details-run-test-button"
           ghost
           data-tour={GuidedTourService.getStep(GuidedTours.TestDetails, Steps.RunTest)}
         >

--- a/web/src/pages/Test/TestDetailsTable.tsx
+++ b/web/src/pages/Test/TestDetailsTable.tsx
@@ -47,6 +47,7 @@ const TextDetailsTable: FC<TextRowProps> = ({isLoading, onSelectResult, testResu
     <CustomTable
       pagination={{pageSize: 10}}
       rowKey="resultId"
+      data-cy="test-result-table"
       loading={isLoading}
       dataSource={testResultList?.slice()?.reverse()}
       onRow={record => {
@@ -64,9 +65,11 @@ const TextDetailsTable: FC<TextRowProps> = ({isLoading, onSelectResult, testResu
         dataIndex="createdAt"
         key="createdAt"
         width="30%"
-        render={value =>
-          Intl.DateTimeFormat('default', {dateStyle: 'full', timeStyle: 'medium'} as any).format(new Date(value))
-        }
+        render={(value, {resultId}: ITestRunResult) => (
+          <span data-cy={`test-run-result-${resultId}`}>
+            {Intl.DateTimeFormat('default', {dateStyle: 'full', timeStyle: 'medium'} as any).format(new Date(value))}
+          </span>
+        )}
       />
       <Table.Column
         title={
@@ -87,8 +90,8 @@ const TextDetailsTable: FC<TextRowProps> = ({isLoading, onSelectResult, testResu
         title={<span data-tour={GuidedTourService.getStep(GuidedTours.TestDetails, Steps.Status)}>Status</span>}
         key="state"
         width="20%"
-        render={(value, {state}: ITestRunResult) => {
-          return <TestStateBadge testState={state} />;
+        render={(value, {state, resultId}: ITestRunResult) => {
+          return <TestStateBadge data-cy={`test-run-result-status-${resultId}`} testState={state} />;
         }}
       />
       <Table.Column


### PR DESCRIPTION
This PR adds integration tests for the test details page

## Changes

- Adds scripts to run all tests at once.
- Adds test specs for the details page.
- Includes `data-cy` for some dom elements.

## Fixes

- https://github.com/kubeshop/tracetest/issues/442

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [x] added a test

https://www.loom.com/share/45cfaf062179489fb0c93b2e5080a4fb