### PR TITLE
feat: start pokemon api demo to run our integration tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ server-generate:
 	cd server; pwd; go fmt ./...; cd ..
 
 server-test:
-	cd server; go test ./...
+	cd server; go test ./... -timeout 1m
 
 server-vet:
 	cd server; go vet -structtag=false ./...

--- a/server/executor/integration_test.go
+++ b/server/executor/integration_test.go
@@ -1,0 +1,21 @@
+package executor_test
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/kubeshop/tracetest/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestExecutorIntegration(t *testing.T) {
+	demoAppConfig, err := test.GetDemoApplicationInstance()
+	require.NoError(t, err)
+
+	resp, err := http.Get(fmt.Sprintf("http://%s/pokemon/healthcheck", demoAppConfig.Endpoint))
+	assert.NoError(t, err)
+
+	assert.Equal(t, 200, resp.StatusCode)
+}

--- a/server/executor/integration_test.go
+++ b/server/executor/integration_test.go
@@ -11,10 +11,11 @@ import (
 )
 
 func TestExecutorIntegration(t *testing.T) {
-	demoAppConfig, err := test.GetDemoApplicationInstance()
+	demoApp, err := test.GetDemoApplicationInstance()
 	require.NoError(t, err)
+	defer demoApp.Stop()
 
-	resp, err := http.Get(fmt.Sprintf("http://%s/pokemon/healthcheck", demoAppConfig.Endpoint))
+	resp, err := http.Get(fmt.Sprintf("http://%s/pokemon/healthcheck", demoApp.Endpoint()))
 	assert.NoError(t, err)
 
 	assert.Equal(t, 200, resp.StatusCode)

--- a/server/go.mod
+++ b/server/go.mod
@@ -35,3 +35,12 @@ require (
 	google.golang.org/grpc v1.45.0
 	gopkg.in/yaml.v2 v2.4.0
 )
+
+// Temporary fix until we manage to merge the patch to the gnomock repo (https://github.com/orlangure/gnomock/pull/534)
+replace github.com/orlangure/gnomock v0.20.0 => github.com/mathnogueira/gnomock v0.21.0
+
+replace github.com/orlangure/gnomock/preset/postgres v0.20.0 => github.com/mathnogueira/gnomock/preset/postgres v0.21.0
+
+replace github.com/orlangure/gnomock/preset/redis v0.20.0 => github.com/mathnogueira/gnomock/preset/redis v0.21.0
+
+replace github.com/orlangure/gnomock/preset/rabbitmq v0.20.0 => github.com/mathnogueira/gnomock/preset/rabbitmq v0.21.0

--- a/server/go.sum
+++ b/server/go.sum
@@ -702,7 +702,9 @@ github.com/go-playground/universal-translator v0.17.0/go.mod h1:UkSxE5sNxxRwHyU+
 github.com/go-playground/universal-translator v0.18.0/go.mod h1:UvRDBj+xPUEGrFYl+lu/H90nyDXpg0fqeB/AQUGNTVA=
 github.com/go-playground/validator/v10 v10.4.1/go.mod h1:nlOn6nFhuKACm19sB/8EGNn9GlaMV7XkbRSipzJ0Ii4=
 github.com/go-playground/validator/v10 v10.10.1/go.mod h1:i+3WkQ1FvaUjjxh1kSvIA4dMGDBiPU55YFDl0WbKdWU=
+github.com/go-redis/redis v6.15.9+incompatible h1:K0pv1D7EQUjfyoMql+r/jZqCLizCGKFlFgcHWWmHQjg=
 github.com/go-redis/redis v6.15.9+incompatible/go.mod h1:NAIEuMOZ/fxfXJIrKDQDz8wamY7mA7PouImQ2Jvg6kA=
+github.com/go-redis/redis/v7 v7.4.1 h1:PASvf36gyUpr2zdOUS/9Zqc80GbM+9BDyiJSJDDOrTI=
 github.com/go-redis/redis/v7 v7.4.1/go.mod h1:JDNMw23GTyLNC4GZu9njt15ctBQVn7xjRfnwdHj/Dcg=
 github.com/go-resty/resty/v2 v2.1.1-0.20191201195748-d7b97669fe48/go.mod h1:dZGr0i9PLlaaTD4H/hoZIDjQ+r6xq8mgbRzHZf7f2J8=
 github.com/go-sql-driver/mysql v1.4.0/go.mod h1:zAC/RDZ24gD3HViQzih4MyKcchzm+sOG5ZlKdlhCg5w=
@@ -1185,6 +1187,8 @@ github.com/markbates/oncer v0.0.0-20181203154359-bf2de49a0be2/go.mod h1:Ld9puTsI
 github.com/markbates/pkger v0.15.1/go.mod h1:0JoVlrol20BSywW79rN3kdFFsE5xYM+rSCQDXbLhiuI=
 github.com/markbates/safe v1.0.1/go.mod h1:nAqgmRi7cY2nqMc92/bSEeQA+R4OheNU2T1kNSCBdG0=
 github.com/marstr/guid v1.1.0/go.mod h1:74gB1z2wpxxInTG6yaqA7KrtM0NZ+RbrcqDvYHefzho=
+github.com/mathnogueira/gnomock v0.21.0 h1:KTbzV8cpu+SWeq4ibeNETsnSEpKTGcH9xXAn4NxjoaI=
+github.com/mathnogueira/gnomock v0.21.0/go.mod h1:N535y2x1yCqcNNCycTCHqBrpy0Nn/fBdTtZkbzOAWes=
 github.com/matryer/moq v0.0.0-20190312154309-6cfb0558e1bd/go.mod h1:9ELz6aaclSIGnZBoaSLZ3NAl1VTufbOrXBPvtcy6WiQ=
 github.com/matryer/moq v0.2.7/go.mod h1:kITsx543GOENm48TUAQyJ9+SAvFSr7iGQXPoth/VUBk=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
@@ -1301,6 +1305,7 @@ github.com/neo4j/neo4j-go-driver v1.8.1-0.20200803113522-b626aa943eba/go.mod h1:
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/npillmayer/nestext v0.1.3/go.mod h1:h2lrijH8jpicr25dFY+oAJLyzlya6jhnuG+zWp9L0Uk=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=
+github.com/nxadm/tail v1.4.8 h1:nPr65rt6Y5JFSKQO7qToXr7pePgD6Gwiw05lkbyAQTE=
 github.com/nxadm/tail v1.4.8/go.mod h1:+ncqLTQzXmGhMZNUePPaPqPvBxHAIsmXswZKocGu+AU=
 github.com/oklog/oklog v0.3.2/go.mod h1:FCV+B7mhrz4o+ueLpx+KqkyXRGMWOYEvfiXtdGtbWGs=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
@@ -1319,6 +1324,7 @@ github.com/onsi/ginkgo v1.12.0/go.mod h1:oUhWkIvk5aDxtKvDDuw8gItl8pKl42LzjC9KZE0
 github.com/onsi/ginkgo v1.12.1/go.mod h1:zj2OWP4+oCPe1qIXoGWkgMRwljMUYCdkwsT2108oapk=
 github.com/onsi/ginkgo v1.13.0/go.mod h1:+REjRxOmWfHCjfv9TTWB1jD1Frx4XydAD3zm1lskyM0=
 github.com/onsi/ginkgo v1.14.0/go.mod h1:iSB4RoI2tjJc9BBv4NKIKWKya62Rps+oPG/Lv9klQyY=
+github.com/onsi/ginkgo v1.16.4 h1:29JGrr5oVBm5ulCWet69zQkzWipVXIol6ygQUe/EzNc=
 github.com/onsi/ginkgo v1.16.4/go.mod h1:dX+/inL/fNMqNlz0e9LfyB9TswhZpCVdJM/Z6Vvnwo0=
 github.com/onsi/gomega v0.0.0-20151007035656-2152b45fa28a/go.mod h1:C1qb7wdrVGGVU+Z6iS04AVkA3Q65CEZX59MT0QO5uiA=
 github.com/onsi/gomega v0.0.0-20170829124025-dcabb60a477c/go.mod h1:C1qb7wdrVGGVU+Z6iS04AVkA3Q65CEZX59MT0QO5uiA=
@@ -1329,6 +1335,7 @@ github.com/onsi/gomega v1.7.1/go.mod h1:XdKZgCCFLUoM/7CFJVPcG8C1xQ1AJ0vpAezJrB7J
 github.com/onsi/gomega v1.9.0/go.mod h1:Ho0h+IUsWyvy1OpqCwxlQ/21gkhVunqlU8fDGcoTdcA=
 github.com/onsi/gomega v1.10.1/go.mod h1:iN09h71vgCQne3DLsj+A5owkum+a2tYe+TOCB1ybHNo=
 github.com/onsi/gomega v1.10.3/go.mod h1:V9xEwhxec5O8UDM77eCW8vLymOMltsqPVYWrpDsH8xc=
+github.com/onsi/gomega v1.15.0 h1:WjP/FQ/sk43MRmnEcT+MlDw2TFvkrXlprrPST/IudjU=
 github.com/onsi/gomega v1.15.0/go.mod h1:cIuvLEne0aoVhAgh/O6ac0Op8WWw9H6eYCriF+tEHG0=
 github.com/op/go-logging v0.0.0-20160315200505-970db520ece7/go.mod h1:HzydrMdWErDVzsI23lYNej1Htcns9BCg93Dk0bBINWk=
 github.com/opencontainers/go-digest v0.0.0-20170106003457-a6d0ee40d420/go.mod h1:cMLVZDEM3+U2I4VmLI6N8jQYUd2OVphdqWwCJHrFt2s=
@@ -1372,8 +1379,6 @@ github.com/openzipkin-contrib/zipkin-go-opentracing v0.4.5/go.mod h1:/wsWhb9smxS
 github.com/openzipkin/zipkin-go v0.1.6/go.mod h1:QgAqvLzwWbR/WpD4A3cGpPtJrZXNIiJc5AZX7/PBEpw=
 github.com/openzipkin/zipkin-go v0.2.1/go.mod h1:NaW6tEwdmWMaCDZzg8sh+IBNOxHMPnhQw8ySjnjRyN4=
 github.com/openzipkin/zipkin-go v0.2.2/go.mod h1:NaW6tEwdmWMaCDZzg8sh+IBNOxHMPnhQw8ySjnjRyN4=
-github.com/orlangure/gnomock v0.20.0 h1:YrgEekKJrglY0EOFnmIl46KjULufxdTeVvs9Y5CsYYE=
-github.com/orlangure/gnomock v0.20.0/go.mod h1:N535y2x1yCqcNNCycTCHqBrpy0Nn/fBdTtZkbzOAWes=
 github.com/pact-foundation/pact-go v1.0.4/go.mod h1:uExwJY4kCzNPcHRj+hCR/HBbOOIwwtUjcrb0b5/5kLM=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pascaldekloe/goe v0.1.0/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
@@ -1571,6 +1576,7 @@ github.com/stefanberger/go-pkcs11uri v0.0.0-20201008174630-78d3cae3a980/go.mod h
 github.com/stoewer/go-strcase v1.2.0/go.mod h1:IBiWB2sKIp3wVVQ3Y035++gc+knqhUQag1KpM8ahLw8=
 github.com/streadway/amqp v0.0.0-20190404075320-75d898a42a94/go.mod h1:AZpEONHx3DKn8O/DFsRAY58/XVQiIPMTMB1SddzLXVw=
 github.com/streadway/amqp v0.0.0-20190827072141-edfb9018d271/go.mod h1:AZpEONHx3DKn8O/DFsRAY58/XVQiIPMTMB1SddzLXVw=
+github.com/streadway/amqp v1.0.0 h1:kuuDrUJFZL1QYL9hUNuCxNObNzB0bV/ZG5jV3RWAQgo=
 github.com/streadway/amqp v1.0.0/go.mod h1:AZpEONHx3DKn8O/DFsRAY58/XVQiIPMTMB1SddzLXVw=
 github.com/streadway/handy v0.0.0-20190108123426-d5acb3125c2a/go.mod h1:qNTQ5P5JnDBl6z3cMAg/SywNDC5ABu5ApDIw6lUbRmI=
 github.com/stretchr/objx v0.0.0-20180129172003-8a3f7159479f/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
@@ -2522,6 +2528,7 @@ gopkg.in/resty.v1 v1.12.0/go.mod h1:mDo4pnntr5jdWRML875a/NmxYqAlA73dVijT2AXvQQo=
 gopkg.in/square/go-jose.v2 v2.2.2/go.mod h1:M9dMgbHiYLoDGQrXy7OpJDJWiKiU//h+vD76mk0e1AI=
 gopkg.in/square/go-jose.v2 v2.3.1/go.mod h1:M9dMgbHiYLoDGQrXy7OpJDJWiKiU//h+vD76mk0e1AI=
 gopkg.in/square/go-jose.v2 v2.5.1/go.mod h1:M9dMgbHiYLoDGQrXy7OpJDJWiKiU//h+vD76mk0e1AI=
+gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 h1:uRGJdciOHaEIrze2W8Q3AKkepLTh2hOroT7a+7czfdQ=
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7/go.mod h1:dt/ZhP58zS4L8KSrWDmTeBkI65Dw0HsyUHuEVlX15mw=
 gopkg.in/warnings.v0 v0.1.2/go.mod h1:jksf8JmL6Qr/oQM2OXTHunEvvTAsrWBLb6OOjuVWRNI=
 gopkg.in/yaml.v2 v2.0.0-20170812160011-eb3733d160e7/go.mod h1:JAlM8MvJe8wmxCU4Bli9HhUf9+ttbYbLASfIpnQbh74=

--- a/server/test/database.go
+++ b/server/test/database.go
@@ -9,11 +9,17 @@ import (
 	"github.com/orlangure/gnomock/preset/postgres"
 )
 
-var container *gnomock.Container
+var pgContainer *gnomock.Container
 
 func GetTestingDatabase() (*sql.DB, error) {
-	container, err := getPostgresContainer()
-	db, err := getMainDatabaseConnection(container)
+	pgContainer, err := getPostgresContainer()
+	if err != nil {
+		return nil, err
+	}
+	db, err := getMainDatabaseConnection(pgContainer)
+	if err != nil {
+		return nil, err
+	}
 	newDbConnection, err := createRandomDatabaseForTest(db, "tracetest")
 
 	if err != nil {
@@ -42,15 +48,15 @@ func createRandomDatabaseForTest(db *sql.DB, baseDatabase string) (*sql.DB, erro
 
 	connStr := fmt.Sprintf(
 		"host=%s port=%d user=%s password=%s  dbname=%s sslmode=disable",
-		container.Host, container.DefaultPort(), "tracetest", "tracetest", newDatabaseName,
+		pgContainer.Host, pgContainer.DefaultPort(), "tracetest", "tracetest", newDatabaseName,
 	)
 
 	return sql.Open("postgres", connStr)
 }
 
 func getPostgresContainer() (*gnomock.Container, error) {
-	if container != nil {
-		return container, nil
+	if pgContainer != nil {
+		return pgContainer, nil
 	}
 
 	preset := postgres.Preset(
@@ -63,7 +69,7 @@ func getPostgresContainer() (*gnomock.Container, error) {
 		return nil, fmt.Errorf("could not start postgres container")
 	}
 
-	container = dbContainer
+	pgContainer = dbContainer
 
 	return dbContainer, nil
 }

--- a/server/test/pokeshop.go
+++ b/server/test/pokeshop.go
@@ -172,7 +172,7 @@ func getRabbitMQInstance(wg *sync.WaitGroup, pokeshopConfig *pokeshopConfig) err
 func getJaegerInstance(wg *sync.WaitGroup, pokeshopConfig *pokeshopConfig) error {
 	defer wg.Done()
 
-	container, err := gnomock.StartCustom(
+	_, err := gnomock.StartCustom(
 		"jaegertracing/all-in-one:latest",
 		gnomock.NamedPorts{
 			"6832":  gnomock.Port{Protocol: "udp", Port: 6832},
@@ -190,7 +190,7 @@ func getJaegerInstance(wg *sync.WaitGroup, pokeshopConfig *pokeshopConfig) error
 
 	pokeshopConfig.jaeger = jaegerConfig{
 		host: "pokeshop_jaeger",
-		port: container.Port("6832"),
+		port: 6832,
 	}
 
 	return nil

--- a/server/test/pokeshop.go
+++ b/server/test/pokeshop.go
@@ -1,0 +1,248 @@
+package test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"sync"
+
+	"github.com/orlangure/gnomock"
+	"github.com/orlangure/gnomock/preset/postgres"
+	"github.com/orlangure/gnomock/preset/rabbitmq"
+	"github.com/orlangure/gnomock/preset/redis"
+)
+
+type pokeshopConfig struct {
+	postgres postgresConfig
+	redis    redisConfig
+	rabbitmq rabbitmqConfig
+	jaeger   jaegerConfig
+}
+
+type postgresConfig struct {
+	host     string
+	port     int
+	db       string
+	user     string
+	password string
+}
+
+type redisConfig struct {
+	endpoint string
+}
+
+type rabbitmqConfig struct {
+	endpoint string
+}
+
+type jaegerConfig struct {
+	host string
+	port int
+}
+
+type DemoAppConfig struct {
+	Endpoint string
+}
+
+func GetDemoApplicationInstance() (DemoAppConfig, error) {
+	demoConfig := pokeshopConfig{}
+	var wg sync.WaitGroup
+	wg.Add(4)
+	var err error
+
+	go func(wg *sync.WaitGroup, pokeshopConfig *pokeshopConfig) {
+		postgresConfig := postgresConfig{
+			db:       "pokeshop",
+			user:     "ashketchum",
+			password: "squirtle123",
+		}
+
+		pgErr := getDemoPostgresInstance(postgresConfig, wg, pokeshopConfig)
+		if err != nil {
+			err = pgErr
+		}
+	}(&wg, &demoConfig)
+
+	go func(wg *sync.WaitGroup, pokeshopConfig *pokeshopConfig) {
+		redisErr := getRedisInstance(wg, pokeshopConfig)
+		if err != nil {
+			err = redisErr
+		}
+	}(&wg, &demoConfig)
+
+	go func(wg *sync.WaitGroup, pokeshopConfig *pokeshopConfig) {
+		rabbitErr := getRabbitMQInstance(wg, pokeshopConfig)
+		if err != nil {
+			err = rabbitErr
+		}
+	}(&wg, &demoConfig)
+
+	go func(wg *sync.WaitGroup, pokeshopConfig *pokeshopConfig) {
+		jaegerErr := getJaegerInstance(wg, pokeshopConfig)
+		if err != nil {
+			err = jaegerErr
+		}
+	}(&wg, &demoConfig)
+
+	wg.Wait()
+
+	if err != nil {
+		return DemoAppConfig{}, err
+	}
+
+	container, err = getPokeshopInstance(demoConfig)
+	if err != nil {
+		return DemoAppConfig{}, err
+	}
+
+	return DemoAppConfig{
+		Endpoint: fmt.Sprintf("%s:%d", container.Host, container.DefaultPort()),
+	}, nil
+}
+
+func getDemoPostgresInstance(config postgresConfig, wg *sync.WaitGroup, pokeshopConfig *pokeshopConfig) error {
+	defer wg.Done()
+	preset := postgres.Preset(
+		postgres.WithDatabase(config.db),
+		postgres.WithUser(config.user, config.password),
+	)
+
+	_, err := gnomock.Start(
+		preset,
+		gnomock.WithContainerName("pokeshop_postgres"),
+		gnomock.WithNetwork("pokeshop"),
+	)
+	if err != nil {
+		return fmt.Errorf("could not start demo app's postgres: %w", err)
+	}
+
+	pokeshopConfig.postgres = postgresConfig{
+		host:     "pokeshop_postgres",
+		port:     5432,
+		db:       config.db,
+		user:     config.user,
+		password: config.password,
+	}
+
+	return nil
+}
+
+func getRedisInstance(wg *sync.WaitGroup, pokeshopConfig *pokeshopConfig) error {
+	defer wg.Done()
+	preset := redis.Preset()
+
+	_, err := gnomock.Start(
+		preset,
+		gnomock.WithContainerName("pokeshop_redis"),
+		gnomock.WithNetwork("pokeshop"),
+	)
+	if err != nil {
+		return fmt.Errorf("could not start redis container: %w", err)
+	}
+
+	pokeshopConfig.redis = redisConfig{
+		endpoint: fmt.Sprintf("%s", "pokeshop_redis"),
+	}
+
+	return nil
+}
+
+func getRabbitMQInstance(wg *sync.WaitGroup, pokeshopConfig *pokeshopConfig) error {
+	defer wg.Done()
+	preset := rabbitmq.Preset()
+
+	_, err := gnomock.Start(
+		preset,
+		gnomock.WithContainerName("pokeshop_rabbitmq"),
+		gnomock.WithNetwork("pokeshop"),
+	)
+	if err != nil {
+		return fmt.Errorf("could not start rabbitMQ container: %w", err)
+	}
+
+	pokeshopConfig.rabbitmq = rabbitmqConfig{
+		endpoint: fmt.Sprintf("%s:%d", "pokeshop_rabbitmq", 5672),
+	}
+
+	return nil
+}
+
+func getJaegerInstance(wg *sync.WaitGroup, pokeshopConfig *pokeshopConfig) error {
+	defer wg.Done()
+
+	container, err := gnomock.StartCustom(
+		"jaegertracing/all-in-one:latest",
+		gnomock.NamedPorts{
+			"6832":  gnomock.Port{Protocol: "udp", Port: 6832},
+			"9411":  gnomock.Port{Protocol: "TCP", Port: 9411},
+			"16686": gnomock.Port{Protocol: "TCP", Port: 16686},
+		},
+		gnomock.WithEnv("COLLECTOR_ZIPKIN_HOST_PORT=9411"),
+		gnomock.WithContainerName("pokeshop_jaeger"),
+		gnomock.WithNetwork("pokeshop"),
+	)
+
+	if err != nil {
+		return fmt.Errorf("could not start jaeger container: %w", err)
+	}
+
+	pokeshopConfig.jaeger = jaegerConfig{
+		host: "pokeshop_jaeger",
+		port: container.Port("6832"),
+	}
+
+	return nil
+}
+
+func getPokeshopInstance(config pokeshopConfig) (*gnomock.Container, error) {
+	databaseUrl := fmt.Sprintf(
+		"postgresql://%s:%s@%s:%d/%s?schema=public",
+		config.postgres.user,
+		config.postgres.password,
+		config.postgres.host,
+		config.postgres.port,
+		config.postgres.db,
+	)
+
+	healthCheckFunction := func(ctx context.Context, c *gnomock.Container) error {
+		url := fmt.Sprintf("http://%s:%d/pokemon/healthcheck", c.Host, c.DefaultPort())
+		resp, err := http.Get(url)
+		if err != nil {
+			return err
+		}
+
+		body, _ := ioutil.ReadAll(resp.Body)
+		var x = make(map[string]interface{}, 0)
+		json.Unmarshal(body, &x)
+
+		if resp.StatusCode != 200 {
+			return fmt.Errorf("expected status code 200, got %d", resp.StatusCode)
+		}
+
+		return nil
+	}
+
+	container, err := gnomock.StartCustom(
+		"kubeshop/demo-pokemon-api:0.0.11",
+		gnomock.DefaultTCP(80),
+		gnomock.WithEnv(fmt.Sprintf("DATABASE_URL=%s", databaseUrl)),
+		gnomock.WithEnv(fmt.Sprintf("REDIS_URL=%s", config.redis.endpoint)),
+		gnomock.WithEnv(fmt.Sprintf("RABBITMQ_HOST=%s", config.rabbitmq.endpoint)),
+		gnomock.WithEnv(fmt.Sprintf("JAEGER_HOST=%s", config.jaeger.host)),
+		gnomock.WithEnv(fmt.Sprintf("JAEGER_PORT=%d", config.jaeger.port)),
+		gnomock.WithEnv("POKE_API_BASE_URL=https://pokeapi.co/api/v2"),
+		gnomock.WithEnv("NPM_RUN_COMMAND=api"),
+		gnomock.WithContainerName("pokeshop-api"),
+		gnomock.WithDebugMode(),
+		gnomock.WithHealthCheck(healthCheckFunction),
+		gnomock.WithNetwork("pokeshop"),
+	)
+
+	if err != nil {
+		return nil, fmt.Errorf("could not create demo app container: %w", err)
+	}
+
+	return container, nil
+}


### PR DESCRIPTION
This PR adds a test function that starts the pokemon api demo so we can run integration tests against it.

## Checklist

- [x] tested locally
- [x] added new dependencies
- [ ] updated the docs
- [x] added a test
