### PR TITLE
Fix ga settings

### DIFF
--- a/docs/run-locally.md
+++ b/docs/run-locally.md
@@ -61,46 +61,11 @@ Now Tracetest is available at [http://localhost:8080]
 ## **Run a Development Build**
 
 Now that Tracetest is running, we can expose the dependencies in our cluster to the host machine so they are accessible to the development build.
-
-### Expose jaeger-query
-
-Any method for exposing a service will work. Here is an example using `LoadBalancer`
+Tracetests needs postgres to store the tests, results, etc, and access to the trace backend (jaeger, tempo, etc) to fetch traces.
+We can use kubectl's port forwarding capabilites for this
 
 ```
-cat <<EOF | kubectl create -f -
-apiVersion: v1
-kind: Service
-metadata:
-  name: jaeger-query-exposed
-spec:
-  type: LoadBalancer
-  ports:
-    - port: 16685
-      targetPort: 16685
-  selector:
-    app: jaeger
-EOF
-```
-
-### Expose postgres
-
-Any method for exposing a service will work. Here is an example using `LoadBalancer`
-
-```
-cat <<EOF | kubectl create -f -
-apiVersion: v1
-kind: Service
-metadata:
-  name: psql
-spec:
-  type: LoadBalancer
-  ports:
-    - port: 5432
-      targetPort: 5432
-  selector:
-    app.kubernetes.io/instance: tracetest
-    app.kubernetes.io/name: postgresql
-EOF
+(trap "kill 0" SIGINT; kubectl port-forward svc/tracetest-postgresql 5432:5432 & kubectl port-forward svc/jaeger-query 16685:16685)
 ```
 
 ### Start Development Server
@@ -110,8 +75,7 @@ When running the development version, the frontend and backend are built and run
 To start the backend server:
 
 ```
-cd server
-make run-server # builds the server and starts it
+make server-run
 ```
 
 To start the frontend server:

--- a/server/config.yaml.sample
+++ b/server/config.yaml.sample
@@ -1,6 +1,12 @@
-maxWaitTimeForTrace: 30s
 postgresConnString: "host=postgres user=postgres password=postgres port=5432 sslmode=disable"
 jaegerConnectionConfig:
   endpoint: jaeger-query:16685
   tls:
     insecure: true
+
+maxWaitTimeForTrace: 30s
+
+googleAnalytics:
+  enabled: false
+  measurementId: ""
+  secretKey: ""

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -10,12 +10,21 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
-type Config struct {
-	PostgresConnString     string                         `mapstructure:"postgresConnString"`
-	JaegerConnectionConfig *configgrpc.GRPCClientSettings `mapstructure:"jaegerConnectionConfig"`
-	TempoConnectionConfig  *configgrpc.GRPCClientSettings `mapstructure:"tempoConnectionConfig"`
-	MaxWaitTimeForTrace    string                         `mapstructure:"maxWaitTimeForTrace"`
-}
+type (
+	Config struct {
+		PostgresConnString     string                         `mapstructure:"postgresConnString"`
+		JaegerConnectionConfig *configgrpc.GRPCClientSettings `mapstructure:"jaegerConnectionConfig"`
+		TempoConnectionConfig  *configgrpc.GRPCClientSettings `mapstructure:"tempoConnectionConfig"`
+		MaxWaitTimeForTrace    string                         `mapstructure:"maxWaitTimeForTrace"`
+		GA                     GoogleAnalytics                `mapstructure:"googleAnalytics"`
+	}
+
+	GoogleAnalytics struct {
+		MeasurementID string `mapstructure:"measurementId"`
+		SecretKey     string `mapstructure:"secretKey"`
+		Enabled       bool   `mapstructure:"enabled"`
+	}
+)
 
 func (c Config) MaxWaitTimeForTraceDuration() time.Duration {
 	maxWaitTimeForTrace, err := time.ParseDuration(c.MaxWaitTimeForTrace)

--- a/server/config/config_test.go
+++ b/server/config/config_test.go
@@ -75,7 +75,7 @@ func TestFromFileError(t *testing.T) {
 			cl := c
 			t.Parallel()
 
-			_, err := config.FromFile("./testdata/config.yaml")
+			_, err := config.FromFile(cl.file)
 
 			assert.True(t, strings.HasPrefix(err.Error(), cl.expected))
 

--- a/server/main.go
+++ b/server/main.go
@@ -48,6 +48,11 @@ func main() {
 		log.Fatal(err)
 	}
 
+	err = analytics.Init(cfg.GA, "tracetest", os.Getenv("VERSION"))
+	if err != nil {
+		log.Fatal(err)
+	}
+
 	ctx := context.Background()
 	tp := initOtelTracing(ctx)
 	defer func() { _ = tp.Shutdown(ctx) }()
@@ -90,7 +95,7 @@ func main() {
 	fileMatcher := regexp.MustCompile(`\.[a-zA-Z]*$`)
 	router.PathPrefix("/").HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if !fileMatcher.MatchString(r.URL.Path) {
-			serveIndex(w, dir+"/index.html")
+			serveIndex(cfg, w, dir+"/index.html")
 		} else {
 			fileServer.ServeHTTP(w, r)
 		}
@@ -118,10 +123,10 @@ type gaParams struct {
 	AnalyticsEnabled bool
 }
 
-func serveIndex(w http.ResponseWriter, path string) {
+func serveIndex(cfg config.Config, w http.ResponseWriter, path string) {
 	templateData := gaParams{
-		MeasurementId:    os.Getenv("GOOGLE_ANALYTICS_MEASUREMENT_ID"),
-		AnalyticsEnabled: os.Getenv("ANALYTICS_ENABLED") == "true",
+		MeasurementId:    cfg.GA.MeasurementID,
+		AnalyticsEnabled: cfg.GA.Enabled,
 	}
 
 	tpl, err := template.ParseFiles(path)


### PR DESCRIPTION
This PR moves the GA settings parsing to the config package, and removes all `os.getenv` calls from the `analytics` package. It also fixes the gh action so it keeps analytics enabled every deploy.

Depends on https://github.com/kubeshop/helm-charts/pull/157

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [x] updated the docs
- [ ] added a test
