### PR TITLE
feat: paginate /tests and /tests/:testID/results endpoints

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -13,6 +13,19 @@ paths:
       summary: "Get tests"
       description: "get tests"
       operationId: getTests
+      parameters:
+        - in: query
+          name: take
+          description: "indicates how many tests can be returned by each page"
+          schema:
+            type: integer
+            default: 20
+        - in: query
+          name: skip
+          description: "indicates how many tests will be skipped when paginating"
+          schema:
+            type: integer
+            default: 0
       responses:
         200:
           description: successful operation

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -209,6 +209,18 @@ paths:
             type: string
             format: uuid
           required: true
+        - in: query
+          name: take
+          description: "indicates how many results can be returned by each page"
+          schema:
+            type: integer
+            default: 20
+        - in: query
+          name: skip
+          description: "indicates how many results will be skipped when paginating"
+          schema:
+            type: integer
+            default: 0
       summary: "get the results for a test"
       description: "get the results from a particular test"
       operationId: getTestResults

--- a/server/executor/runner_test.go
+++ b/server/executor/runner_test.go
@@ -181,8 +181,8 @@ func (m *mockTestDB) DeleteTest(ctx context.Context, test *openapi.Test) error {
 	return args.Error(0)
 }
 
-func (m *mockTestDB) GetTests(ctx context.Context) ([]openapi.Test, error) {
-	args := m.Called(ctx)
+func (m *mockTestDB) GetTests(ctx context.Context, take, skip int32) ([]openapi.Test, error) {
+	args := m.Called(ctx, take, skip)
 	return args.Get(0).([]openapi.Test), args.Error(1)
 }
 
@@ -216,8 +216,8 @@ func (m *mockResultsDB) GetResult(ctx context.Context, id string) (*openapi.Test
 	return args.Get(0).(*openapi.TestRunResult), args.Error(1)
 }
 
-func (m *mockResultsDB) GetResultsByTestID(ctx context.Context, testid string) ([]openapi.TestRunResult, error) {
-	args := m.Called(ctx, testid)
+func (m *mockResultsDB) GetResultsByTestID(ctx context.Context, testid string, take, skip int32) ([]openapi.TestRunResult, error) {
+	args := m.Called(ctx, testid, take, skip)
 	return args.Get(0).([]openapi.TestRunResult), args.Error(1)
 }
 

--- a/server/http/controller.go
+++ b/server/http/controller.go
@@ -104,8 +104,12 @@ func (s *controller) GetTest(ctx context.Context, testid string) (openapi.ImplRe
 	return openapi.Response(200, test), nil
 }
 
-func (s *controller) GetTests(ctx context.Context) (openapi.ImplResponse, error) {
-	tests, err := s.testDB.GetTests(ctx)
+func (s *controller) GetTests(ctx context.Context, take, skip int32) (openapi.ImplResponse, error) {
+	if take == 0 {
+		take = 20
+	}
+
+	tests, err := s.testDB.GetTests(ctx, take, skip)
 	if err != nil {
 		return openapi.Response(http.StatusInternalServerError, err.Error()), err
 	}

--- a/server/http/controller.go
+++ b/server/http/controller.go
@@ -131,8 +131,12 @@ func (s *controller) RunTest(ctx context.Context, testid string) (openapi.ImplRe
 	return openapi.Response(200, result), nil
 }
 
-func (s *controller) GetTestResults(ctx context.Context, id string) (openapi.ImplResponse, error) {
-	res, err := s.testDB.GetResultsByTestID(ctx, id)
+func (s *controller) GetTestResults(ctx context.Context, id string, take, skip int32) (openapi.ImplResponse, error) {
+	if take == 0 {
+		take = 20
+	}
+
+	res, err := s.testDB.GetResultsByTestID(ctx, id, take, skip)
 	if err != nil {
 		return openapi.Response(http.StatusInternalServerError, err.Error()), err
 	}

--- a/server/openapi/api.go
+++ b/server/openapi/api.go
@@ -45,7 +45,7 @@ type ApiApiServicer interface {
 	GetAssertions(context.Context, string) (ImplResponse, error)
 	GetTest(context.Context, string) (ImplResponse, error)
 	GetTestResult(context.Context, string, string) (ImplResponse, error)
-	GetTestResults(context.Context, string) (ImplResponse, error)
+	GetTestResults(context.Context, string, int32, int32) (ImplResponse, error)
 	GetTests(context.Context) (ImplResponse, error)
 	RunTest(context.Context, string) (ImplResponse, error)
 	UpdateAssertion(context.Context, string, string, Assertion) (ImplResponse, error)

--- a/server/openapi/api.go
+++ b/server/openapi/api.go
@@ -46,7 +46,7 @@ type ApiApiServicer interface {
 	GetTest(context.Context, string) (ImplResponse, error)
 	GetTestResult(context.Context, string, string) (ImplResponse, error)
 	GetTestResults(context.Context, string, int32, int32) (ImplResponse, error)
-	GetTests(context.Context) (ImplResponse, error)
+	GetTests(context.Context, int32, int32) (ImplResponse, error)
 	RunTest(context.Context, string) (ImplResponse, error)
 	UpdateAssertion(context.Context, string, string, Assertion) (ImplResponse, error)
 	UpdateTest(context.Context, string, Test) (ImplResponse, error)

--- a/server/openapi/api_api.go
+++ b/server/openapi/api_api.go
@@ -295,7 +295,18 @@ func (c *ApiApiController) GetTestResults(w http.ResponseWriter, r *http.Request
 
 // GetTests - Get tests
 func (c *ApiApiController) GetTests(w http.ResponseWriter, r *http.Request) {
-	result, err := c.service.GetTests(r.Context())
+	query := r.URL.Query()
+	takeParam, err := parseInt32Parameter(query.Get("take"), false)
+	if err != nil {
+		c.errorHandler(w, r, &ParsingError{Err: err}, nil)
+		return
+	}
+	skipParam, err := parseInt32Parameter(query.Get("skip"), false)
+	if err != nil {
+		c.errorHandler(w, r, &ParsingError{Err: err}, nil)
+		return
+	}
+	result, err := c.service.GetTests(r.Context(), takeParam, skipParam)
 	// If an error occurred, encode the error with the status code
 	if err != nil {
 		c.errorHandler(w, r, err, &result)

--- a/server/openapi/api_api.go
+++ b/server/openapi/api_api.go
@@ -269,9 +269,20 @@ func (c *ApiApiController) GetTestResult(w http.ResponseWriter, r *http.Request)
 // GetTestResults - get the results for a test
 func (c *ApiApiController) GetTestResults(w http.ResponseWriter, r *http.Request) {
 	params := mux.Vars(r)
+	query := r.URL.Query()
 	testIdParam := params["testId"]
 
-	result, err := c.service.GetTestResults(r.Context(), testIdParam)
+	takeParam, err := parseInt32Parameter(query.Get("take"), false)
+	if err != nil {
+		c.errorHandler(w, r, &ParsingError{Err: err}, nil)
+		return
+	}
+	skipParam, err := parseInt32Parameter(query.Get("skip"), false)
+	if err != nil {
+		c.errorHandler(w, r, &ParsingError{Err: err}, nil)
+		return
+	}
+	result, err := c.service.GetTestResults(r.Context(), testIdParam, takeParam, skipParam)
 	// If an error occurred, encode the error with the status code
 	if err != nil {
 		c.errorHandler(w, r, err, &result)

--- a/server/testdb/postgres.go
+++ b/server/testdb/postgres.go
@@ -371,14 +371,14 @@ func (td *postgresDB) GetResultByTraceID(ctx context.Context, testID, traceID st
 	return run, nil
 }
 
-func (td *postgresDB) GetResultsByTestID(ctx context.Context, testID string) ([]openapi.TestRunResult, error) {
-	stmt, err := td.db.Prepare("SELECT result FROM results WHERE test_id = $1 ORDER BY result ->> 'createdAt' DESC")
+func (td *postgresDB) GetResultsByTestID(ctx context.Context, testID string, take, skip int32) ([]openapi.TestRunResult, error) {
+	stmt, err := td.db.Prepare("SELECT result FROM results WHERE test_id = $1 ORDER BY result ->> 'createdAt' DESC LIMIT $2 OFFSET $3")
 	if err != nil {
 		return nil, err
 	}
 	defer stmt.Close()
 
-	rows, err := stmt.QueryContext(ctx, testID) //.Scan(&b)
+	rows, err := stmt.QueryContext(ctx, testID, take, skip) //.Scan(&b)
 	if err != nil {
 		return nil, err
 	}

--- a/server/testdb/postgres.go
+++ b/server/testdb/postgres.go
@@ -141,14 +141,14 @@ func (td *postgresDB) GetTest(ctx context.Context, id string) (*openapi.Test, er
 	return &test, nil
 }
 
-func (td *postgresDB) GetTests(ctx context.Context) ([]openapi.Test, error) {
-	stmt, err := td.db.Prepare("SELECT test FROM tests")
+func (td *postgresDB) GetTests(ctx context.Context, take, skip int32) ([]openapi.Test, error) {
+	stmt, err := td.db.Prepare("SELECT test FROM tests LIMIT $1 OFFSET $2")
 	if err != nil {
 		return nil, err
 	}
 	defer stmt.Close()
 
-	rows, err := stmt.QueryContext(ctx)
+	rows, err := stmt.QueryContext(ctx, take, skip)
 	if err != nil {
 		return nil, err
 	}

--- a/server/testdb/testdb.go
+++ b/server/testdb/testdb.go
@@ -21,7 +21,7 @@ type ResultRepository interface {
 	CreateResult(ctx context.Context, testID string, res *openapi.TestRunResult) error
 	UpdateResult(ctx context.Context, res *openapi.TestRunResult) error
 	GetResult(ctx context.Context, id string) (*openapi.TestRunResult, error)
-	GetResultsByTestID(ctx context.Context, testid string) ([]openapi.TestRunResult, error)
+	GetResultsByTestID(ctx context.Context, testid string, take, skip int32) ([]openapi.TestRunResult, error)
 	GetResultByTraceID(ctx context.Context, testid, traceid string) (openapi.TestRunResult, error)
 }
 

--- a/server/testdb/testdb.go
+++ b/server/testdb/testdb.go
@@ -13,7 +13,7 @@ type TestRepository interface {
 	CreateTest(ctx context.Context, test *openapi.Test) (string, error)
 	UpdateTest(ctx context.Context, test *openapi.Test) error
 	DeleteTest(ctx context.Context, test *openapi.Test) error
-	GetTests(ctx context.Context) ([]openapi.Test, error)
+	GetTests(ctx context.Context, take, skip int32) ([]openapi.Test, error)
 	GetTest(ctx context.Context, id string) (*openapi.Test, error)
 }
 

--- a/server/testdb/testdb_test.go
+++ b/server/testdb/testdb_test.go
@@ -136,7 +136,7 @@ func TestGetTests(t *testing.T) {
 			t.Fatal(err)
 		}
 	}
-	gotTests, err := db.GetTests(ctx)
+	gotTests, err := db.GetTests(ctx, 20, 0)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -186,7 +186,7 @@ func TestCreateResults(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, &res2, gotRes)
 
-	gotResults, err := db.GetResultsByTestID(ctx, testID)
+	gotResults, err := db.GetResultsByTestID(ctx, testID, 20, 0)
 	assert.NoError(t, err)
 	assert.Equal(t, res2, gotResults[0])
 }


### PR DESCRIPTION
This PR allows pagination in the getTests and getTestResults endpoints. It introduces query parameters `take` and `skip` to control how many tests to get and how many should be ignored.

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
