### PR TITLE
use convention background color to span tags

### DIFF
--- a/web/src/components/AssertionCheckRow/AssertionCheckRow.styled.ts
+++ b/web/src/components/AssertionCheckRow/AssertionCheckRow.styled.ts
@@ -1,9 +1,11 @@
 import {Badge, Typography} from 'antd';
 import styled from 'styled-components';
+import {SemanticGroupNames} from '../../constants/SemanticGroupNames.constants';
+import {getNotchColor} from '../TraceNode/TraceNode.styled';
 
 export const AssertionCheckRow = styled.div`
   display: grid;
-  grid-template-columns: 1.5fr 1fr .8fr 1fr 1fr;
+  grid-template-columns: 1.5fr 1fr 0.8fr 1fr 1fr;
   gap: 14px;
   cursor: pointer;
 `;
@@ -26,9 +28,9 @@ export const Value = styled(Typography.Text)`
   font-size: 12px;
 `;
 
-export const LabelBadge = styled(Badge)`
+export const LabelBadge = styled(Badge)<{spanType?: SemanticGroupNames}>`
   > sup {
-    background-color: #f0f0f0;
+    background: ${({spanType}) => (spanType ? getNotchColor(spanType) : '#f0f0f0')};
     color: black;
     margin-right: 6px;
     border-radius: 2px;

--- a/web/src/components/AssertionCheckRow/AssertionCheckRow.tsx
+++ b/web/src/components/AssertionCheckRow/AssertionCheckRow.tsx
@@ -31,7 +31,7 @@ const AssertionCheckRow: React.FC<IAssertionCheckRowProps> = ({
     return (isSelected ? [<S.SelectedLabelBadge spanType={type} count="selected" key="selected" />] : []).concat(
       spanLabelList.map((label, index) => (
         // eslint-disable-next-line react/no-array-index-key
-        <S.LabelBadge spanType={index === 0 ? type : undefined} count={label} key={`${label}-${index}`} />
+        <S.LabelBadge spanType={!index ? type : undefined} count={label} key={`${label}-${index}`} />
       ))
     );
   }, [getIsSelectedSpan, spanId, spanLabelList, type]);

--- a/web/src/components/AssertionCheckRow/AssertionCheckRow.tsx
+++ b/web/src/components/AssertionCheckRow/AssertionCheckRow.tsx
@@ -1,22 +1,24 @@
-import {useMemo} from 'react';
 import {difference} from 'lodash';
+import {useMemo} from 'react';
 import OperatorService from '../../services/Operator.service';
 import {ISpanAssertionResult} from '../../types/Assertion.types';
 import {ISpan} from '../../types/Span.types';
-import * as S from './AssertionCheckRow.styled';
 import AttributeValue from '../AttributeValue';
+import * as S from './AssertionCheckRow.styled';
 
 interface IAssertionCheckRowProps {
   result: ISpanAssertionResult;
   span: ISpan;
   assertionSelectorList: string[];
+
   getIsSelectedSpan(spanId: string): boolean;
+
   onSelectSpan(spanId: string): void;
 }
 
 const AssertionCheckRow: React.FC<IAssertionCheckRowProps> = ({
   result: {propertyName, comparisonValue, operator, actualValue, hasPassed, spanId},
-  span: {signature},
+  span: {signature, type},
   assertionSelectorList,
   getIsSelectedSpan,
   onSelectSpan,
@@ -26,12 +28,13 @@ const AssertionCheckRow: React.FC<IAssertionCheckRowProps> = ({
   const badgeList = useMemo(() => {
     const isSelected = getIsSelectedSpan(spanId);
 
-    return (isSelected ? [<S.SelectedLabelBadge count="selected" key="selected" />] : []).concat(
-      spanLabelList
+    return (isSelected ? [<S.SelectedLabelBadge spanType={type} count="selected" key="selected" />] : []).concat(
+      spanLabelList.map((label, index) => (
         // eslint-disable-next-line react/no-array-index-key
-        .map((label, index) => <S.LabelBadge count={label} key={`${label}-${index}`} />)
+        <S.LabelBadge spanType={index === 0 ? type : undefined} count={label} key={`${label}-${index}`} />
+      ))
     );
-  }, [getIsSelectedSpan, spanId, spanLabelList]);
+  }, [getIsSelectedSpan, spanId, spanLabelList, type]);
 
   return (
     <S.AssertionCheckRow onClick={() => onSelectSpan(spanId)}>

--- a/web/src/components/TraceNode/TraceNode.styled.ts
+++ b/web/src/components/TraceNode/TraceNode.styled.ts
@@ -10,7 +10,7 @@ enum NotchColor {
   DEFAULT = '#FFBB96',
 }
 
-export const getNotchColor = (spanType: SemanticGroupNames) => {
+export const getNotchColor = (spanType: SemanticGroupNames): string => {
   switch (spanType) {
     case SemanticGroupNames.Http: {
       return NotchColor.HTTP;
@@ -57,12 +57,10 @@ export const TraceNode = styled.div<{selected: boolean}>`
 export const TraceNotch = styled.div<{spanType: SemanticGroupNames}>`
   background-color: ${({spanType}) => getNotchColor(spanType)};
   position: absolute;
-  top: 0px;
+  top: 0;
   margin-top: 1px;
   padding: 3px 6px;
-  border-radius: 2px;
-  border-bottom-left-radius: 0px;
-  border-bottom-right-radius: 0px;
+  border-radius: 2px 2px 0 0;
   width: 99%;
   font-weight: 700;
   align-items: center;


### PR DESCRIPTION
This PR set background color to assertion span tags.
We don't have a design for this, but it was Ken's request.
Let me know if proposed styling looks good. 

<img width="1440" alt="Screen Shot 2022-05-19 at 13 56 23" src="https://user-images.githubusercontent.com/6259987/169356730-fba7afb5-df67-4123-a2e4-3bf6b62715e8.png">

-

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
