### PR TITLE
feat: add version to Test and TestRun API definitions

### DIFF
--- a/api/tests.yaml
+++ b/api/tests.yaml
@@ -12,6 +12,9 @@ components:
           type: string
         description:
           type: string
+        version:
+          type: string
+          description: version number of the test
         serviceUnderTest:
           type: object
           properties:
@@ -71,6 +74,9 @@ components:
         spanId:
           type: string
           readOnly: true
+        testVersion:
+          type: string
+          description: Test version used when running this test run
         state:
           type: string
           enum: [CREATED, EXECUTING, AWAITING_TRACE, AWAITING_TEST_RESULTS, FINISHED, FAILED]

--- a/api/tests.yaml
+++ b/api/tests.yaml
@@ -13,7 +13,7 @@ components:
         description:
           type: string
         version:
-          type: string
+          type: integer
           description: version number of the test
         serviceUnderTest:
           type: object
@@ -75,7 +75,7 @@ components:
           type: string
           readOnly: true
         testVersion:
-          type: string
+          type: integer
           description: Test version used when running this test run
         state:
           type: string

--- a/cli/openapi/model_span.go
+++ b/cli/openapi/model_span.go
@@ -12,12 +12,16 @@ package openapi
 
 import (
 	"encoding/json"
+	"time"
 )
 
 // Span struct for Span
 type Span struct {
-	Id   *string `json:"id,omitempty"`
-	Name *string `json:"name,omitempty"`
+	Id        *string    `json:"id,omitempty"`
+	ParentId  *string    `json:"parentId,omitempty"`
+	Name      *string    `json:"name,omitempty"`
+	StartTime *time.Time `json:"startTime,omitempty"`
+	EndTime   *time.Time `json:"endTime,omitempty"`
 	// Key-Value of span attributes
 	Attributes *map[string]string `json:"attributes,omitempty"`
 	Children   []Span             `json:"children,omitempty"`
@@ -72,6 +76,38 @@ func (o *Span) SetId(v string) {
 	o.Id = &v
 }
 
+// GetParentId returns the ParentId field value if set, zero value otherwise.
+func (o *Span) GetParentId() string {
+	if o == nil || o.ParentId == nil {
+		var ret string
+		return ret
+	}
+	return *o.ParentId
+}
+
+// GetParentIdOk returns a tuple with the ParentId field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *Span) GetParentIdOk() (*string, bool) {
+	if o == nil || o.ParentId == nil {
+		return nil, false
+	}
+	return o.ParentId, true
+}
+
+// HasParentId returns a boolean if a field has been set.
+func (o *Span) HasParentId() bool {
+	if o != nil && o.ParentId != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetParentId gets a reference to the given string and assigns it to the ParentId field.
+func (o *Span) SetParentId(v string) {
+	o.ParentId = &v
+}
+
 // GetName returns the Name field value if set, zero value otherwise.
 func (o *Span) GetName() string {
 	if o == nil || o.Name == nil {
@@ -102,6 +138,70 @@ func (o *Span) HasName() bool {
 // SetName gets a reference to the given string and assigns it to the Name field.
 func (o *Span) SetName(v string) {
 	o.Name = &v
+}
+
+// GetStartTime returns the StartTime field value if set, zero value otherwise.
+func (o *Span) GetStartTime() time.Time {
+	if o == nil || o.StartTime == nil {
+		var ret time.Time
+		return ret
+	}
+	return *o.StartTime
+}
+
+// GetStartTimeOk returns a tuple with the StartTime field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *Span) GetStartTimeOk() (*time.Time, bool) {
+	if o == nil || o.StartTime == nil {
+		return nil, false
+	}
+	return o.StartTime, true
+}
+
+// HasStartTime returns a boolean if a field has been set.
+func (o *Span) HasStartTime() bool {
+	if o != nil && o.StartTime != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetStartTime gets a reference to the given time.Time and assigns it to the StartTime field.
+func (o *Span) SetStartTime(v time.Time) {
+	o.StartTime = &v
+}
+
+// GetEndTime returns the EndTime field value if set, zero value otherwise.
+func (o *Span) GetEndTime() time.Time {
+	if o == nil || o.EndTime == nil {
+		var ret time.Time
+		return ret
+	}
+	return *o.EndTime
+}
+
+// GetEndTimeOk returns a tuple with the EndTime field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *Span) GetEndTimeOk() (*time.Time, bool) {
+	if o == nil || o.EndTime == nil {
+		return nil, false
+	}
+	return o.EndTime, true
+}
+
+// HasEndTime returns a boolean if a field has been set.
+func (o *Span) HasEndTime() bool {
+	if o != nil && o.EndTime != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetEndTime gets a reference to the given time.Time and assigns it to the EndTime field.
+func (o *Span) SetEndTime(v time.Time) {
+	o.EndTime = &v
 }
 
 // GetAttributes returns the Attributes field value if set, zero value otherwise.
@@ -173,8 +273,17 @@ func (o Span) MarshalJSON() ([]byte, error) {
 	if o.Id != nil {
 		toSerialize["id"] = o.Id
 	}
+	if o.ParentId != nil {
+		toSerialize["parentId"] = o.ParentId
+	}
 	if o.Name != nil {
 		toSerialize["name"] = o.Name
+	}
+	if o.StartTime != nil {
+		toSerialize["startTime"] = o.StartTime
+	}
+	if o.EndTime != nil {
+		toSerialize["endTime"] = o.EndTime
 	}
 	if o.Attributes != nil {
 		toSerialize["attributes"] = o.Attributes

--- a/cli/openapi/model_test_.go
+++ b/cli/openapi/model_test_.go
@@ -16,9 +16,11 @@ import (
 
 // Test struct for Test
 type Test struct {
-	Id               *string               `json:"id,omitempty"`
-	Name             *string               `json:"name,omitempty"`
-	Description      *string               `json:"description,omitempty"`
+	Id          *string `json:"id,omitempty"`
+	Name        *string `json:"name,omitempty"`
+	Description *string `json:"description,omitempty"`
+	// version number of the test
+	Version          *string               `json:"version,omitempty"`
 	ServiceUnderTest *TestServiceUnderTest `json:"serviceUnderTest,omitempty"`
 	Definition       *TestDefinition       `json:"definition,omitempty"`
 	ReferenceTestRun *TestRun              `json:"referenceTestRun,omitempty"`
@@ -137,6 +139,38 @@ func (o *Test) SetDescription(v string) {
 	o.Description = &v
 }
 
+// GetVersion returns the Version field value if set, zero value otherwise.
+func (o *Test) GetVersion() string {
+	if o == nil || o.Version == nil {
+		var ret string
+		return ret
+	}
+	return *o.Version
+}
+
+// GetVersionOk returns a tuple with the Version field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *Test) GetVersionOk() (*string, bool) {
+	if o == nil || o.Version == nil {
+		return nil, false
+	}
+	return o.Version, true
+}
+
+// HasVersion returns a boolean if a field has been set.
+func (o *Test) HasVersion() bool {
+	if o != nil && o.Version != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetVersion gets a reference to the given string and assigns it to the Version field.
+func (o *Test) SetVersion(v string) {
+	o.Version = &v
+}
+
 // GetServiceUnderTest returns the ServiceUnderTest field value if set, zero value otherwise.
 func (o *Test) GetServiceUnderTest() TestServiceUnderTest {
 	if o == nil || o.ServiceUnderTest == nil {
@@ -243,6 +277,9 @@ func (o Test) MarshalJSON() ([]byte, error) {
 	}
 	if o.Description != nil {
 		toSerialize["description"] = o.Description
+	}
+	if o.Version != nil {
+		toSerialize["version"] = o.Version
 	}
 	if o.ServiceUnderTest != nil {
 		toSerialize["serviceUnderTest"] = o.ServiceUnderTest

--- a/cli/openapi/model_test_.go
+++ b/cli/openapi/model_test_.go
@@ -20,7 +20,7 @@ type Test struct {
 	Name        *string `json:"name,omitempty"`
 	Description *string `json:"description,omitempty"`
 	// version number of the test
-	Version          *string               `json:"version,omitempty"`
+	Version          *int32                `json:"version,omitempty"`
 	ServiceUnderTest *TestServiceUnderTest `json:"serviceUnderTest,omitempty"`
 	Definition       *TestDefinition       `json:"definition,omitempty"`
 	ReferenceTestRun *TestRun              `json:"referenceTestRun,omitempty"`
@@ -140,9 +140,9 @@ func (o *Test) SetDescription(v string) {
 }
 
 // GetVersion returns the Version field value if set, zero value otherwise.
-func (o *Test) GetVersion() string {
+func (o *Test) GetVersion() int32 {
 	if o == nil || o.Version == nil {
-		var ret string
+		var ret int32
 		return ret
 	}
 	return *o.Version
@@ -150,7 +150,7 @@ func (o *Test) GetVersion() string {
 
 // GetVersionOk returns a tuple with the Version field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *Test) GetVersionOk() (*string, bool) {
+func (o *Test) GetVersionOk() (*int32, bool) {
 	if o == nil || o.Version == nil {
 		return nil, false
 	}
@@ -166,8 +166,8 @@ func (o *Test) HasVersion() bool {
 	return false
 }
 
-// SetVersion gets a reference to the given string and assigns it to the Version field.
-func (o *Test) SetVersion(v string) {
+// SetVersion gets a reference to the given int32 and assigns it to the Version field.
+func (o *Test) SetVersion(v int32) {
 	o.Version = &v
 }
 

--- a/cli/openapi/model_test_run.go
+++ b/cli/openapi/model_test_run.go
@@ -21,7 +21,7 @@ type TestRun struct {
 	TraceId *string `json:"traceId,omitempty"`
 	SpanId  *string `json:"spanId,omitempty"`
 	// Test version used when running this test run
-	TestVersion *string `json:"testVersion,omitempty"`
+	TestVersion *int32 `json:"testVersion,omitempty"`
 	// Current execution state
 	State *string `json:"state,omitempty"`
 	// Details of the cause for the last `FAILED` state
@@ -148,9 +148,9 @@ func (o *TestRun) SetSpanId(v string) {
 }
 
 // GetTestVersion returns the TestVersion field value if set, zero value otherwise.
-func (o *TestRun) GetTestVersion() string {
+func (o *TestRun) GetTestVersion() int32 {
 	if o == nil || o.TestVersion == nil {
-		var ret string
+		var ret int32
 		return ret
 	}
 	return *o.TestVersion
@@ -158,7 +158,7 @@ func (o *TestRun) GetTestVersion() string {
 
 // GetTestVersionOk returns a tuple with the TestVersion field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *TestRun) GetTestVersionOk() (*string, bool) {
+func (o *TestRun) GetTestVersionOk() (*int32, bool) {
 	if o == nil || o.TestVersion == nil {
 		return nil, false
 	}
@@ -174,8 +174,8 @@ func (o *TestRun) HasTestVersion() bool {
 	return false
 }
 
-// SetTestVersion gets a reference to the given string and assigns it to the TestVersion field.
-func (o *TestRun) SetTestVersion(v string) {
+// SetTestVersion gets a reference to the given int32 and assigns it to the TestVersion field.
+func (o *TestRun) SetTestVersion(v int32) {
 	o.TestVersion = &v
 }
 

--- a/cli/openapi/model_test_run.go
+++ b/cli/openapi/model_test_run.go
@@ -20,6 +20,8 @@ type TestRun struct {
 	Id      *string `json:"id,omitempty"`
 	TraceId *string `json:"traceId,omitempty"`
 	SpanId  *string `json:"spanId,omitempty"`
+	// Test version used when running this test run
+	TestVersion *string `json:"testVersion,omitempty"`
 	// Current execution state
 	State *string `json:"state,omitempty"`
 	// Details of the cause for the last `FAILED` state
@@ -143,6 +145,38 @@ func (o *TestRun) HasSpanId() bool {
 // SetSpanId gets a reference to the given string and assigns it to the SpanId field.
 func (o *TestRun) SetSpanId(v string) {
 	o.SpanId = &v
+}
+
+// GetTestVersion returns the TestVersion field value if set, zero value otherwise.
+func (o *TestRun) GetTestVersion() string {
+	if o == nil || o.TestVersion == nil {
+		var ret string
+		return ret
+	}
+	return *o.TestVersion
+}
+
+// GetTestVersionOk returns a tuple with the TestVersion field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *TestRun) GetTestVersionOk() (*string, bool) {
+	if o == nil || o.TestVersion == nil {
+		return nil, false
+	}
+	return o.TestVersion, true
+}
+
+// HasTestVersion returns a boolean if a field has been set.
+func (o *TestRun) HasTestVersion() bool {
+	if o != nil && o.TestVersion != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetTestVersion gets a reference to the given string and assigns it to the TestVersion field.
+func (o *TestRun) SetTestVersion(v string) {
+	o.TestVersion = &v
 }
 
 // GetState returns the State field value if set, zero value otherwise.
@@ -411,6 +445,9 @@ func (o TestRun) MarshalJSON() ([]byte, error) {
 	}
 	if o.SpanId != nil {
 		toSerialize["spanId"] = o.SpanId
+	}
+	if o.TestVersion != nil {
+		toSerialize["testVersion"] = o.TestVersion
 	}
 	if o.State != nil {
 		toSerialize["state"] = o.State

--- a/server/executor/runner.go
+++ b/server/executor/runner.go
@@ -115,7 +115,7 @@ func (r persistentRunner) processExecQueue(job execReq) {
 
 	if job.test.ReferenceRun == nil {
 		job.test.ReferenceRun = &run
-		r.handleDBError(r.tests.UpdateTest(job.ctx, job.test))
+		r.handleDBError(r.tests.UpdateTestVersion(job.ctx, job.test))
 	}
 
 	r.handleDBError(r.tests.UpdateRun(job.ctx, run))

--- a/server/executor/runner_test.go
+++ b/server/executor/runner_test.go
@@ -101,7 +101,7 @@ func (f runnerFixture) expectSuccessExec(test model.Test) {
 func (f runnerFixture) expectSuccessResultPersist(test model.Test) {
 	expectCreateRun(f.mockDB, test)
 	f.mockDB.On("UpdateRun", mock.Anything).Return(noError)
-	f.mockDB.On("UpdateTest", mock.Anything).Return(noError)
+	f.mockDB.On("UpdateTestVersion", mock.Anything).Return(noError)
 	f.mockDB.On("UpdateRun", mock.Anything).Return(noError)
 	f.mockTracePoller.expectPoll(test)
 }

--- a/server/http/controller.go
+++ b/server/http/controller.go
@@ -290,11 +290,11 @@ func (c *controller) UpdateTest(ctx context.Context, testID string, in openapi.T
 
 	if testHasChanged {
 		updated.Version = test.Version + 1
-	}
 
-	err = c.testDB.UpdateTest(ctx, updated)
-	if err != nil {
-		return handleDBError(err), err
+		_, err = c.testDB.CreateTestVersion(ctx, updated)
+		if err != nil {
+			return handleDBError(err), err
+		}
 	}
 
 	return openapi.Response(204, nil), nil

--- a/server/http/controller.go
+++ b/server/http/controller.go
@@ -283,16 +283,9 @@ func (c *controller) UpdateTest(ctx context.Context, testID string, in openapi.T
 	updated.ID = test.ID
 	updated.ReferenceRun = nil
 
-	updated, err = model.BumpTestVersionIfNeeded(test, updated)
+	_, err = c.testDB.UpdateTest(ctx, updated)
 	if err != nil {
-		return openapi.Response(http.StatusUnprocessableEntity, err.Error()), err
-	}
-
-	if updated.Version != test.Version {
-		_, err = c.testDB.CreateTestVersion(ctx, updated)
-		if err != nil {
-			return handleDBError(err), err
-		}
+		return handleDBError(err), err
 	}
 
 	return openapi.Response(204, nil), nil

--- a/server/http/controller.go
+++ b/server/http/controller.go
@@ -69,7 +69,7 @@ func (c *controller) DeleteTest(ctx context.Context, testID string) (openapi.Imp
 		return openapi.Response(http.StatusUnprocessableEntity, err.Error()), err
 	}
 
-	test, err := c.testDB.GetTest(ctx, id)
+	test, err := c.testDB.GetLatestTestVersion(ctx, id)
 	if err != nil {
 		return handleDBError(err), err
 	}
@@ -91,7 +91,7 @@ func (c *controller) GetTest(ctx context.Context, testID string) (openapi.ImplRe
 		return openapi.Response(http.StatusUnprocessableEntity, err.Error()), err
 	}
 
-	test, err := c.testDB.GetTest(ctx, id)
+	test, err := c.testDB.GetLatestTestVersion(ctx, id)
 	if err != nil {
 		return handleDBError(err), err
 	}
@@ -105,7 +105,7 @@ func (c *controller) GetTestDefinition(ctx context.Context, testID string) (open
 		return openapi.Response(http.StatusUnprocessableEntity, err.Error()), err
 	}
 
-	test, err := c.testDB.GetTest(ctx, id)
+	test, err := c.testDB.GetLatestTestVersion(ctx, id)
 	if err != nil {
 		return handleDBError(err), err
 	}
@@ -167,7 +167,7 @@ func (c *controller) GetTestRuns(ctx context.Context, testID string, take, skip 
 		return openapi.Response(http.StatusUnprocessableEntity, err.Error()), err
 	}
 
-	test, err := c.testDB.GetTest(ctx, id)
+	test, err := c.testDB.GetLatestTestVersion(ctx, id)
 	if err != nil {
 		return handleDBError(err), err
 	}
@@ -199,7 +199,7 @@ func (c *controller) RerunTestRun(ctx context.Context, testID string, runID stri
 		return openapi.Response(http.StatusUnprocessableEntity, err.Error()), err
 	}
 
-	test, err := c.testDB.GetTest(ctx, id)
+	test, err := c.testDB.GetLatestTestVersion(ctx, id)
 	if err != nil {
 		return handleDBError(err), err
 	}
@@ -236,7 +236,7 @@ func (c *controller) RunTest(ctx context.Context, testID string) (openapi.ImplRe
 		return openapi.Response(http.StatusUnprocessableEntity, err.Error()), err
 	}
 
-	test, err := c.testDB.GetTest(ctx, id)
+	test, err := c.testDB.GetLatestTestVersion(ctx, id)
 	if err != nil {
 		return handleDBError(err), err
 	}
@@ -254,7 +254,7 @@ func (c *controller) SetTestDefinition(ctx context.Context, testID string, def o
 		return openapi.Response(http.StatusUnprocessableEntity, err.Error()), err
 	}
 
-	test, err := c.testDB.GetTest(ctx, id)
+	test, err := c.testDB.GetLatestTestVersion(ctx, id)
 	if err != nil {
 		return handleDBError(err), err
 	}
@@ -273,7 +273,7 @@ func (c *controller) UpdateTest(ctx context.Context, testID string, in openapi.T
 		return openapi.Response(http.StatusUnprocessableEntity, err.Error()), err
 	}
 
-	test, err := c.testDB.GetTest(ctx, id)
+	test, err := c.testDB.GetLatestTestVersion(ctx, id)
 	if err != nil {
 		return handleDBError(err), err
 	}

--- a/server/http/controller.go
+++ b/server/http/controller.go
@@ -3,6 +3,7 @@ package http
 import (
 	"context"
 	"encoding/hex"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
@@ -282,6 +283,15 @@ func (c *controller) UpdateTest(ctx context.Context, testID string, in openapi.T
 	updated.ID = test.ID
 	updated.ReferenceRun = nil
 
+	testHasChanged, err := c.testHasChanged(test, updated)
+	if err != nil {
+		return openapi.Response(http.StatusUnprocessableEntity, err.Error()), err
+	}
+
+	if testHasChanged {
+		updated.Version = test.Version + 1
+	}
+
 	err = c.testDB.UpdateTest(ctx, updated)
 	if err != nil {
 		return handleDBError(err), err
@@ -312,4 +322,35 @@ func (c *controller) DryRunAssertion(ctx context.Context, _, runID string, def o
 	})
 
 	return openapi.Response(200, res), nil
+}
+
+func (c *controller) testHasChanged(oldTest model.Test, newTest model.Test) (bool, error) {
+	definitionHasChanged, err := c.testFieldHasChanged(oldTest.Definition, newTest.Definition)
+	if err != nil {
+		return false, err
+	}
+
+	serviceUnderTestHasChanged, err := c.testFieldHasChanged(oldTest.ServiceUnderTest, newTest.ServiceUnderTest)
+	if err != nil {
+		return false, err
+	}
+
+	nameHasChanged := oldTest.Name != newTest.Name
+	descriptionHasChanged := oldTest.Description != newTest.Description
+
+	return definitionHasChanged || serviceUnderTestHasChanged || nameHasChanged || descriptionHasChanged, nil
+}
+
+func (c controller) testFieldHasChanged(oldField interface{}, newField interface{}) (bool, error) {
+	oldFieldJSON, err := json.Marshal(oldField)
+	if err != nil {
+		return false, err
+	}
+
+	newFieldJSON, err := json.Marshal(newField)
+	if err != nil {
+		return false, err
+	}
+
+	return string(oldFieldJSON) != string(newFieldJSON), nil
 }

--- a/server/http/mappings.go
+++ b/server/http/mappings.go
@@ -257,6 +257,7 @@ func (m modelMapper) Test(in openapi.Test) model.Test {
 		},
 		ReferenceRun: m.Run(in.ReferenceTestRun),
 		Definition:   m.Definition(in.Definition),
+		Version:      int(in.Version),
 	}
 }
 

--- a/server/http/mappings.go
+++ b/server/http/mappings.go
@@ -24,6 +24,7 @@ func (m openapiMapper) Test(in model.Test) openapi.Test {
 		},
 		Definition:       m.Definition(in.Definition),
 		ReferenceTestRun: m.Run(in.ReferenceRun),
+		Version:          int32(in.Version),
 	}
 }
 
@@ -226,6 +227,7 @@ func (m openapiMapper) Run(in *model.Run) openapi.TestRun {
 		CompletedAt:    in.CompletedAt,
 		Request:        m.HTTPRequest(in.Request),
 		Response:       m.HTTPResponse(in.Response),
+		TestVersion:    int32(in.TestVersion),
 		Trace:          m.Trace(in.Trace),
 		Result:         m.Result(in.Results),
 	}

--- a/server/migrations/4_test_version.down.sql
+++ b/server/migrations/4_test_version.down.sql
@@ -2,3 +2,10 @@ ALTER TABLE tests
 DROP COLUMN "version";
 
 DROP INDEX idx_unique_test_id_version;
+
+
+ALTER TABLE runs
+DROP COLUMN test_version;
+
+ALTER TABLE runs
+DROP CONSTRAINT test_id_version_fk;

--- a/server/migrations/4_test_version.down.sql
+++ b/server/migrations/4_test_version.down.sql
@@ -1,0 +1,4 @@
+ALTER TABLE tests
+DROP COLUMN "version";
+
+DROP INDEX idx_unique_test_id_version;

--- a/server/migrations/4_test_version.down.sql
+++ b/server/migrations/4_test_version.down.sql
@@ -1,11 +1,10 @@
-ALTER TABLE tests
-DROP COLUMN "version";
-
-DROP INDEX idx_unique_test_id_version;
-
+ALTER TABLE runs
+DROP CONSTRAINT test_id_version_fk;
 
 ALTER TABLE runs
 DROP COLUMN test_version;
 
-ALTER TABLE runs
-DROP CONSTRAINT test_id_version_fk;
+DROP INDEX idx_unique_test_id_version;
+
+ALTER TABLE tests
+DROP COLUMN "version";

--- a/server/migrations/4_test_version.down.sql
+++ b/server/migrations/4_test_version.down.sql
@@ -4,7 +4,11 @@ DROP CONSTRAINT test_id_version_fk;
 ALTER TABLE runs
 DROP COLUMN test_version;
 
-DROP INDEX idx_unique_test_id_version;
+ALTER TABLE tests
+DROP CONSTRAINT tests_pkey;
+
+ALTER TABLE tests
+ADD CONSTRAINT tests_pkey PRIMARY KEY (id);
 
 ALTER TABLE tests
 DROP COLUMN "version";

--- a/server/migrations/4_test_version.up.sql
+++ b/server/migrations/4_test_version.up.sql
@@ -2,3 +2,10 @@ ALTER TABLE tests
 ADD COLUMN "version" int NOT NULL DEFAULT 1;
 
 CREATE UNIQUE INDEX idx_unique_test_id_version ON tests (id, "version");
+
+ALTER TABLE runs
+ADD COLUMN test_version int NOT NULL;
+
+ALTER TABLE runs
+ADD CONSTRAINT test_id_version_fk
+FOREIGN KEY (test_id, test_version) REFERENCES tests(id, "version");

--- a/server/migrations/4_test_version.up.sql
+++ b/server/migrations/4_test_version.up.sql
@@ -1,0 +1,4 @@
+ALTER TABLE tests
+ADD COLUMN "version" int NOT NULL DEFAULT 1;
+
+CREATE UNIQUE INDEX idx_unique_test_id_version ON tests (id, "version");

--- a/server/migrations/4_test_version.up.sql
+++ b/server/migrations/4_test_version.up.sql
@@ -1,7 +1,11 @@
 ALTER TABLE tests
 ADD COLUMN "version" int NOT NULL DEFAULT 1;
 
-CREATE UNIQUE INDEX idx_unique_test_id_version ON tests (id, "version");
+ALTER TABLE tests
+DROP CONSTRAINT tests_pkey;
+
+ALTER TABLE tests
+ADD CONSTRAINT tests_pkey PRIMARY KEY (id, "version");
 
 ALTER TABLE runs
 ADD COLUMN test_version int NOT NULL;

--- a/server/model/repository.go
+++ b/server/model/repository.go
@@ -9,6 +9,7 @@ import (
 
 type TestRepository interface {
 	CreateTest(context.Context, Test) (Test, error)
+	CreateTestVersion(context.Context, Test) (Test, error)
 	UpdateTest(context.Context, Test) error
 	DeleteTest(context.Context, Test) error
 	GetLatestTestVersion(context.Context, uuid.UUID) (Test, error)

--- a/server/model/repository.go
+++ b/server/model/repository.go
@@ -11,7 +11,7 @@ type TestRepository interface {
 	CreateTest(context.Context, Test) (Test, error)
 	UpdateTest(context.Context, Test) error
 	DeleteTest(context.Context, Test) error
-	GetTest(context.Context, uuid.UUID) (Test, error)
+	GetLatestTestVersion(context.Context, uuid.UUID) (Test, error)
 	GetTests(_ context.Context, take, skip int32) ([]Test, error)
 }
 

--- a/server/model/repository.go
+++ b/server/model/repository.go
@@ -9,8 +9,8 @@ import (
 
 type TestRepository interface {
 	CreateTest(context.Context, Test) (Test, error)
-	CreateTestVersion(context.Context, Test) (Test, error)
-	UpdateTest(context.Context, Test) error
+	UpdateTest(context.Context, Test) (Test, error)
+	UpdateTestVersion(context.Context, Test) error
 	DeleteTest(context.Context, Test) error
 	GetLatestTestVersion(context.Context, uuid.UUID) (Test, error)
 	GetTests(_ context.Context, take, skip int32) ([]Test, error)

--- a/server/model/test_changes.go
+++ b/server/model/test_changes.go
@@ -1,0 +1,49 @@
+package model
+
+import (
+	"encoding/json"
+)
+
+func BumpTestVersionIfNeeded(in, updated Test) (Test, error) {
+	testHasChanged, err := testHasChanged(in, updated)
+	if err != nil {
+		return Test{}, err
+	}
+
+	if testHasChanged {
+		updated.Version = in.Version + 1
+	}
+
+	return updated, nil
+}
+
+func testHasChanged(oldTest Test, newTest Test) (bool, error) {
+	definitionHasChanged, err := testFieldHasChanged(oldTest.Definition, newTest.Definition)
+	if err != nil {
+		return false, err
+	}
+
+	serviceUnderTestHasChanged, err := testFieldHasChanged(oldTest.ServiceUnderTest, newTest.ServiceUnderTest)
+	if err != nil {
+		return false, err
+	}
+
+	nameHasChanged := oldTest.Name != newTest.Name
+	descriptionHasChanged := oldTest.Description != newTest.Description
+
+	return definitionHasChanged || serviceUnderTestHasChanged || nameHasChanged || descriptionHasChanged, nil
+}
+
+func testFieldHasChanged(oldField interface{}, newField interface{}) (bool, error) {
+	oldFieldJSON, err := json.Marshal(oldField)
+	if err != nil {
+		return false, err
+	}
+
+	newFieldJSON, err := json.Marshal(newField)
+	if err != nil {
+		return false, err
+	}
+
+	return string(oldFieldJSON) != string(newFieldJSON), nil
+}

--- a/server/model/tests.go
+++ b/server/model/tests.go
@@ -17,6 +17,7 @@ type (
 		ID               uuid.UUID
 		Name             string
 		Description      string
+		Version          int
 		ServiceUnderTest ServiceUnderTest
 		ReferenceRun     *Run
 		Definition       Definition

--- a/server/model/tests.go
+++ b/server/model/tests.go
@@ -48,6 +48,7 @@ type (
 		Response    HTTPResponse
 		Trace       *traces.Trace
 		Results     *RunResults
+		TestVersion int
 	}
 
 	RunResults struct {

--- a/server/openapi/model_test_.go
+++ b/server/openapi/model_test_.go
@@ -16,6 +16,9 @@ type Test struct {
 
 	Description string `json:"description,omitempty"`
 
+	// version number of the test
+	Version string `json:"version,omitempty"`
+
 	ServiceUnderTest TestServiceUnderTest `json:"serviceUnderTest,omitempty"`
 
 	Definition TestDefinition `json:"definition,omitempty"`

--- a/server/openapi/model_test_.go
+++ b/server/openapi/model_test_.go
@@ -17,7 +17,7 @@ type Test struct {
 	Description string `json:"description,omitempty"`
 
 	// version number of the test
-	Version string `json:"version,omitempty"`
+	Version int32 `json:"version,omitempty"`
 
 	ServiceUnderTest TestServiceUnderTest `json:"serviceUnderTest,omitempty"`
 

--- a/server/openapi/model_test_run.go
+++ b/server/openapi/model_test_run.go
@@ -21,7 +21,7 @@ type TestRun struct {
 	SpanId string `json:"spanId,omitempty"`
 
 	// Test version used when running this test run
-	TestVersion string `json:"testVersion,omitempty"`
+	TestVersion int32 `json:"testVersion,omitempty"`
 
 	// Current execution state
 	State string `json:"state,omitempty"`

--- a/server/openapi/model_test_run.go
+++ b/server/openapi/model_test_run.go
@@ -20,6 +20,9 @@ type TestRun struct {
 
 	SpanId string `json:"spanId,omitempty"`
 
+	// Test version used when running this test run
+	TestVersion string `json:"testVersion,omitempty"`
+
 	// Current execution state
 	State string `json:"state,omitempty"`
 

--- a/server/testdb/mock.go
+++ b/server/testdb/mock.go
@@ -21,12 +21,12 @@ func (m *MockRepository) CreateTest(_ context.Context, test model.Test) (model.T
 	return args.Get(0).(model.Test), args.Error(1)
 }
 
-func (m *MockRepository) CreateTestVersion(_ context.Context, test model.Test) (model.Test, error) {
+func (m *MockRepository) UpdateTest(_ context.Context, test model.Test) (model.Test, error) {
 	args := m.Called(test)
 	return args.Get(0).(model.Test), args.Error(1)
 }
 
-func (m *MockRepository) UpdateTest(_ context.Context, test model.Test) error {
+func (m *MockRepository) UpdateTestVersion(_ context.Context, test model.Test) error {
 	args := m.Called(test)
 	return args.Error(0)
 }

--- a/server/testdb/mock.go
+++ b/server/testdb/mock.go
@@ -31,7 +31,7 @@ func (m *MockRepository) DeleteTest(_ context.Context, test model.Test) error {
 	return args.Error(0)
 }
 
-func (m *MockRepository) GetTest(_ context.Context, id uuid.UUID) (model.Test, error) {
+func (m *MockRepository) GetLatestTestVersion(_ context.Context, id uuid.UUID) (model.Test, error) {
 	args := m.Called(id)
 	return args.Get(0).(model.Test), args.Error(1)
 }

--- a/server/testdb/mock.go
+++ b/server/testdb/mock.go
@@ -21,6 +21,11 @@ func (m *MockRepository) CreateTest(_ context.Context, test model.Test) (model.T
 	return args.Get(0).(model.Test), args.Error(1)
 }
 
+func (m *MockRepository) CreateTestVersion(_ context.Context, test model.Test) (model.Test, error) {
+	args := m.Called(test)
+	return args.Get(0).(model.Test), args.Error(1)
+}
+
 func (m *MockRepository) UpdateTest(_ context.Context, test model.Test) error {
 	args := m.Called(test)
 	return args.Error(0)

--- a/server/testdb/runs.go
+++ b/server/testdb/runs.go
@@ -22,13 +22,14 @@ func (td *postgresDB) CreateRun(ctx context.Context, test model.Test, run model.
 
 	run.ID = IDGen.UUID()
 	run.State = model.RunStateCreated
+	run.TestVersion = test.Version
 
 	encoded, err := encodeRun(run)
 	if err != nil {
 		return model.Run{}, fmt.Errorf("encoding error: %w", err)
 	}
 
-	_, err = stmt.ExecContext(ctx, run.ID, test.ID, test.Version, encoded)
+	_, err = stmt.ExecContext(ctx, run.ID, test.ID, run.TestVersion, encoded)
 	if err != nil {
 		return model.Run{}, fmt.Errorf("sql exec: %w", err)
 	}

--- a/server/testdb/runs.go
+++ b/server/testdb/runs.go
@@ -14,7 +14,7 @@ import (
 var _ model.RunRepository = &postgresDB{}
 
 func (td *postgresDB) CreateRun(ctx context.Context, test model.Test, run model.Run) (model.Run, error) {
-	stmt, err := td.db.Prepare("INSERT INTO runs(id, test_id, run) VALUES( $1, $2, $3 )")
+	stmt, err := td.db.Prepare("INSERT INTO runs(id, test_id, test_version, run) VALUES( $1, $2, $3, $4 )")
 	if err != nil {
 		return model.Run{}, fmt.Errorf("sql prepare: %w", err)
 	}
@@ -28,7 +28,7 @@ func (td *postgresDB) CreateRun(ctx context.Context, test model.Test, run model.
 		return model.Run{}, fmt.Errorf("encoding error: %w", err)
 	}
 
-	_, err = stmt.ExecContext(ctx, run.ID, test.ID, encoded)
+	_, err = stmt.ExecContext(ctx, run.ID, test.ID, test.Version, encoded)
 	if err != nil {
 		return model.Run{}, fmt.Errorf("sql exec: %w", err)
 	}

--- a/server/testdb/tests.go
+++ b/server/testdb/tests.go
@@ -14,7 +14,7 @@ import (
 var _ model.TestRepository = &postgresDB{}
 
 func (td *postgresDB) CreateTest(ctx context.Context, test model.Test) (model.Test, error) {
-	stmt, err := td.db.Prepare("INSERT INTO tests(id, test) VALUES( $1, $2 )")
+	stmt, err := td.db.Prepare("INSERT INTO tests(id, test, version) VALUES( $1, $2, $3 )")
 	if err != nil {
 		return model.Test{}, fmt.Errorf("sql prepare: %w", err)
 	}
@@ -22,12 +22,13 @@ func (td *postgresDB) CreateTest(ctx context.Context, test model.Test) (model.Te
 
 	test.ID = IDGen.UUID()
 	test.ReferenceRun = nil
+	test.Version = 1
 
 	b, err := encodeTest(test)
 	if err != nil {
 		return model.Test{}, fmt.Errorf("encoding error: %w", err)
 	}
-	_, err = stmt.ExecContext(ctx, test.ID, b)
+	_, err = stmt.ExecContext(ctx, test.ID, b, test.Version)
 	if err != nil {
 		return model.Test{}, fmt.Errorf("sql exec: %w", err)
 	}

--- a/server/testdb/tests.go
+++ b/server/testdb/tests.go
@@ -67,21 +67,21 @@ func (td *postgresDB) UpdateTest(ctx context.Context, test model.Test) (model.Te
 	}
 	defer stmt.Close()
 
-	b, err := encodeTest(test)
+	b, err := encodeTest(testToUpdate)
 	if err != nil {
 		return model.Test{}, fmt.Errorf("encoding error: %w", err)
 	}
-	_, err = stmt.ExecContext(ctx, test.ID, b, test.Version)
+	_, err = stmt.ExecContext(ctx, testToUpdate.ID, b, testToUpdate.Version)
 	if err != nil {
 		return model.Test{}, fmt.Errorf("sql exec: %w", err)
 	}
 
-	err = td.SetDefiniton(ctx, test, test.Definition)
+	err = td.SetDefiniton(ctx, testToUpdate, testToUpdate.Definition)
 	if err != nil {
 		return model.Test{}, fmt.Errorf("setDefinition error: %w", err)
 	}
 
-	return test, nil
+	return testToUpdate, nil
 }
 
 func (td *postgresDB) UpdateTestVersion(ctx context.Context, test model.Test) error {

--- a/server/testdb/tests.go
+++ b/server/testdb/tests.go
@@ -18,10 +18,14 @@ func (td *postgresDB) CreateTest(ctx context.Context, test model.Test) (model.Te
 	test.ReferenceRun = nil
 	test.Version = 1
 
-	return td.createTest(ctx, test)
+	return td.CreateTestVersion(ctx, test)
 }
 
-func (td *postgresDB) createTest(ctx context.Context, test model.Test) (model.Test, error) {
+func (td *postgresDB) CreateTestVersion(ctx context.Context, test model.Test) (model.Test, error) {
+	if test.Version == 0 {
+		test.Version = 1
+	}
+
 	stmt, err := td.db.Prepare("INSERT INTO tests(id, test, version) VALUES( $1, $2, $3 )")
 	if err != nil {
 		return model.Test{}, fmt.Errorf("sql prepare: %w", err)

--- a/server/testdb/tests_test.go
+++ b/server/testdb/tests_test.go
@@ -80,6 +80,7 @@ func TestGetLatestTestVersion(t *testing.T) {
 	latestTest, err := db.GetLatestTestVersion(context.TODO(), test.ID)
 	assert.NoError(t, err)
 	assert.Equal(t, "1 v2", latestTest.Name)
+	assert.Equal(t, 2, latestTest.Version)
 }
 
 func TestGetTests(t *testing.T) {

--- a/server/testdb/tests_test.go
+++ b/server/testdb/tests_test.go
@@ -66,6 +66,22 @@ func TestDeleteTest(t *testing.T) {
 
 }
 
+func TestGetLatestTestVersion(t *testing.T) {
+	db, clean := getDB()
+	defer clean()
+
+	test := createTestWithName(t, db, "1")
+	test.Name = "1 v2"
+	test.Version = 2
+
+	_, err := db.CreateTestVersion(context.TODO(), test)
+	require.NoError(t, err)
+
+	latestTest, err := db.GetLatestTestVersion(context.TODO(), test.ID)
+	assert.NoError(t, err)
+	assert.Equal(t, "1 v2", latestTest.Name)
+}
+
 func TestGetTests(t *testing.T) {
 	db, clean := getDB()
 	defer clean()
@@ -90,14 +106,14 @@ func TestGetTestsWithMultipleVersions(t *testing.T) {
 	test1.Name = "1 v2"
 	test1.Version = 2
 
-	err := db.UpdateTest(context.TODO(), test1)
+	_, err := db.CreateTestVersion(context.TODO(), test1)
 	require.NoError(t, err)
 
 	test2 := createTestWithName(t, db, "2")
 	test2.Name = "2 v2"
 	test2.Version = 2
 
-	err = db.UpdateTest(context.TODO(), test2)
+	_, err = db.CreateTestVersion(context.TODO(), test2)
 	require.NoError(t, err)
 
 	tests, err := db.GetTests(context.TODO(), 20, 0)

--- a/server/testdb/tests_test.go
+++ b/server/testdb/tests_test.go
@@ -48,7 +48,7 @@ func TestUpdateTest(t *testing.T) {
 
 	actual, err := db.GetLatestTestVersion(context.TODO(), test.ID)
 	require.NoError(t, err)
-	assert.NotEqual(t, test, actual)
+	assert.Equal(t, test, actual)
 }
 
 func TestDeleteTest(t *testing.T) {
@@ -88,11 +88,14 @@ func TestGetTestsWithMultipleVersions(t *testing.T) {
 
 	test1 := createTestWithName(t, db, "1")
 	test1.Name = "1 v2"
-	test2 := createTestWithName(t, db, "2")
-	test2.Name = "2 v2"
+	test1.Version = 2
 
 	err := db.UpdateTest(context.TODO(), test1)
 	require.NoError(t, err)
+
+	test2 := createTestWithName(t, db, "2")
+	test2.Name = "2 v2"
+	test2.Version = 2
 
 	err = db.UpdateTest(context.TODO(), test2)
 	require.NoError(t, err)

--- a/server/testdb/tests_test.go
+++ b/server/testdb/tests_test.go
@@ -43,7 +43,7 @@ func TestUpdateTest(t *testing.T) {
 	test := createTest(t, db)
 	test.Name = "updated test"
 
-	err := db.UpdateTest(context.TODO(), test)
+	err := db.UpdateTestVersion(context.TODO(), test)
 	require.NoError(t, err)
 
 	actual, err := db.GetLatestTestVersion(context.TODO(), test.ID)
@@ -74,7 +74,7 @@ func TestGetLatestTestVersion(t *testing.T) {
 	test.Name = "1 v2"
 	test.Version = 2
 
-	_, err := db.CreateTestVersion(context.TODO(), test)
+	_, err := db.UpdateTest(context.TODO(), test)
 	require.NoError(t, err)
 
 	latestTest, err := db.GetLatestTestVersion(context.TODO(), test.ID)
@@ -106,14 +106,14 @@ func TestGetTestsWithMultipleVersions(t *testing.T) {
 	test1.Name = "1 v2"
 	test1.Version = 2
 
-	_, err := db.CreateTestVersion(context.TODO(), test1)
+	_, err := db.UpdateTest(context.TODO(), test1)
 	require.NoError(t, err)
 
 	test2 := createTestWithName(t, db, "2")
 	test2.Name = "2 v2"
 	test2.Version = 2
 
-	_, err = db.CreateTestVersion(context.TODO(), test2)
+	_, err = db.UpdateTest(context.TODO(), test2)
 	require.NoError(t, err)
 
 	tests, err := db.GetTests(context.TODO(), 20, 0)

--- a/server/testdb/tests_test.go
+++ b/server/testdb/tests_test.go
@@ -104,14 +104,12 @@ func TestGetTestsWithMultipleVersions(t *testing.T) {
 
 	test1 := createTestWithName(t, db, "1")
 	test1.Name = "1 v2"
-	test1.Version = 2
 
 	_, err := db.UpdateTest(context.TODO(), test1)
 	require.NoError(t, err)
 
 	test2 := createTestWithName(t, db, "2")
 	test2.Name = "2 v2"
-	test2.Version = 2
 
 	_, err = db.UpdateTest(context.TODO(), test2)
 	require.NoError(t, err)


### PR DESCRIPTION
This PR adds versioning to both tests and references the test in the `test run` as well. So now we know which test definition was used to create a specific run.

## Changes

- add `version` field to test
- add `testVersion` field to run

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [x] added a test
