### PR TITLE
🤖  493 integrate backend assertions

### DIFF
--- a/web/cypress/integration/Trace/CreateAssertion.spec.ts
+++ b/web/cypress/integration/Trace/CreateAssertion.spec.ts
@@ -1,6 +1,9 @@
 import {createTest, deleteTest, testId} from '../utils/common';
 
-describe('Create Assertion', () => {
+const getAttributeListId = (number: number) => `#assertion-form_assertionList_${number}_attribute_list`;
+const getComparatorListId = (number: number) => `#assertion-form_assertionList_${number}_comparator_list`;
+
+describe.only('Create Assertion', () => {
   before(() => {
     createTest();
   });
@@ -30,10 +33,14 @@ describe('Create Assertion', () => {
 
     cy.get('[data-cy=assertion-check-attribute]').type('db');
     cy.wait(500);
-    cy.get('#assertion-form_assertionList_0_key_list + div .ant-select-item').first().click();
+    cy.get(`${getAttributeListId(0)} + div .ant-select-item`)
+      .first()
+      .click();
 
     cy.get('[data-cy=assertion-check-operator]').click();
-    cy.get('#assertion-form_assertionList_0_compareOp_list + div .ant-select-item').last().click();
+    cy.get(`${getComparatorListId(0)} + div .ant-select-item`)
+      .last()
+      .click();
     cy.get('[data-cy=assertion-check-operator] .ant-select-selection-item').should('have.text', 'Contains');
 
     cy.get('[data-cy=assertion-form-submit-button]').click();
@@ -59,20 +66,28 @@ describe('Create Assertion', () => {
 
     cy.get('[data-cy=assertion-check-attribute]').type('db');
     cy.wait(500);
-    cy.get('#assertion-form_assertionList_0_key_list + div .ant-select-item').first().click();
+    cy.get(`${getAttributeListId(0)} + div .ant-select-item`)
+      .first()
+      .click();
 
     cy.get('[data-cy=assertion-check-operator]').click();
-    cy.get('#assertion-form_assertionList_0_compareOp_list + div .ant-select-item').first().click();
+    cy.get(`${getComparatorListId(0)} + div .ant-select-item`)
+      .first()
+      .click();
     cy.get('[data-cy=assertion-check-operator] .ant-select-selection-item').first().should('have.text', 'Equals');
 
     cy.get('[data-cy=add-assertion-form-add-check]').click();
 
     cy.get('[data-cy=assertion-check-attribute]').last().type('service');
     cy.wait(500);
-    cy.get('#assertion-form_assertionList_1_key_list + div .ant-select-item').first().click();
+    cy.get(`${getAttributeListId(1)} + div .ant-select-item`)
+      .first()
+      .click();
 
     cy.get('[data-cy=assertion-check-operator]').last().click();
-    cy.get('#assertion-form_assertionList_1_compareOp_list + div .ant-select-item').last().click();
+    cy.get(`${getComparatorListId(1)} + div .ant-select-item`)
+      .last()
+      .click();
     cy.get('[data-cy=assertion-check-operator] .ant-select-selection-item').last().should('have.text', 'Contains');
     cy.get('[data-cy=assertion-form-submit-button]').click();
 
@@ -81,21 +96,27 @@ describe('Create Assertion', () => {
   });
 
   it('should update an assertion', () => {
-    cy.get('[data-cy=edit-assertion-button]').last().click();
+    cy.get('[data-cy=edit-assertion-button]').first().click();
     cy.get('[data-cy=assertion-form]').should('be.visible');
 
     cy.get('[data-cy=assertion-check-operator]').first().click();
-    cy.get('#assertion-form_assertionList_0_compareOp_list + div .ant-select-item:nth-child(2)').first().click();
-    cy.get('[data-cy=assertion-check-operator] .ant-select-selection-item').first().should('have.text', 'Not equals');
+    cy.get(`${getComparatorListId(0)} + div .ant-select-item`)
+      .first()
+      .click();
+    cy.get('[data-cy=assertion-check-operator] .ant-select-selection-item').first().should('have.text', 'Equals');
 
     cy.get('[data-cy=add-assertion-form-add-check]').click();
 
     cy.get('[data-cy=assertion-check-attribute]').last().type('service');
     cy.wait(500);
-    cy.get('#assertion-form_assertionList_2_key_list + div .ant-select-item').first().click();
+    cy.get(`${getAttributeListId(2)} + div .ant-select-item`)
+      .first()
+      .click();
 
     cy.get('[data-cy=assertion-check-operator]').last().click();
-    cy.get('#assertion-form_assertionList_2_compareOp_list + div .ant-select-item').last().click();
+    cy.get(`${getComparatorListId(2)} + div .ant-select-item`)
+      .last()
+      .click();
     cy.get('[data-cy=assertion-check-operator] .ant-select-selection-item').last().should('have.text', 'Contains');
     cy.get('[data-cy=assertion-form-submit-button]').click();
 

--- a/web/src/components/AssertionCard/AssertionCard.tsx
+++ b/web/src/components/AssertionCard/AssertionCard.tsx
@@ -1,20 +1,18 @@
 import {useCallback, useMemo} from 'react';
 import {useStore} from 'react-flow-renderer';
-import {TAssertionResultEntry, TSpanSelector} from '../../types/Assertion.types';
+import {TAssertionResultEntry} from '../../types/Assertion.types';
 import AssertionCheckRow from '../AssertionCheckRow';
 import * as S from './AssertionCard.styled';
 
 interface TAssertionCardProps {
   assertionResult: TAssertionResultEntry;
-  selectorList: TSpanSelector[];
   onSelectSpan(spanId: string): void;
-  onDelete(assertionId: string): void;
+  onDelete(selector: string): void;
   onEdit(assertionResult: TAssertionResultEntry): void;
 }
 
 const AssertionCard: React.FC<TAssertionCardProps> = ({
-  assertionResult: {resultList, id: assertionId},
-  selectorList,
+  assertionResult: {selector, resultList, selectorList, pseudoSelector, spanCount},
   assertionResult,
   onSelectSpan,
   onDelete,
@@ -22,11 +20,7 @@ const AssertionCard: React.FC<TAssertionCardProps> = ({
 }) => {
   const store = useStore();
 
-  const spanCountText = useMemo(() => {
-    const spanCount = resultList.length;
-
-    return `${spanCount} ${spanCount > 1 ? 'spans' : 'span'}`;
-  }, [resultList.length]);
+  const spanCountText = useMemo(() => `${spanCount} ${spanCount > 1 ? 'spans' : 'span'}`, [spanCount]);
 
   const getIsSelectedSpan = useCallback(
     (id: string): boolean => {
@@ -42,12 +36,15 @@ const AssertionCard: React.FC<TAssertionCardProps> = ({
     <S.AssertionCard data-cy="assertion-card">
       <S.Header>
         <div>
-          <S.SelectorListText>{selectorList.map(({value}) => value).join(' ')}</S.SelectorListText>
+          <S.SelectorListText>
+            {selectorList.map(({value}) => value).join(' ')} {pseudoSelector?.selector}
+            {pseudoSelector?.number && `(${pseudoSelector?.number})`}
+          </S.SelectorListText>
           <S.SpanCountText>{spanCountText}</S.SpanCountText>
         </div>
         <div>
           <S.EditIcon data-cy="edit-assertion-button" onClick={() => onEdit(assertionResult)} />
-          <S.DeleteIcon onClick={() => onDelete(assertionId)} />
+          <S.DeleteIcon onClick={() => onDelete(selector)} />
         </div>
       </S.Header>
       <S.Body>

--- a/web/src/components/AssertionCardList/AssertionCardList.tsx
+++ b/web/src/components/AssertionCardList/AssertionCardList.tsx
@@ -1,6 +1,7 @@
 import {Typography} from 'antd';
 import {useCallback} from 'react';
-import {TAssertionResults} from '../../types/Assertion.types';
+import {useTestDefinition} from '../../providers/TestDefinition/TestDefinition.provider';
+import {TAssertionResultEntry, TAssertionResults} from '../../types/Assertion.types';
 import AssertionCard from '../AssertionCard/AssertionCard';
 import {useAssertionForm} from '../AssertionForm/AssertionFormProvider';
 import * as S from './AssertionCardList.styled';
@@ -11,16 +12,31 @@ interface TAssertionCardListProps {
   testId: string;
 }
 
-const AssertionCardList: React.FC<TAssertionCardListProps> = ({
-  assertionResults: {resultList},
-  onSelectSpan,
-  testId,
-}) => {
+const AssertionCardList: React.FC<TAssertionCardListProps> = ({assertionResults: {resultList}, onSelectSpan}) => {
   const {open} = useAssertionForm();
+  const {remove} = useTestDefinition();
 
-  const handleEdit = useCallback(data => {
-    console.log('@@onEditAssertion', data);
-  }, []);
+  const handleEdit = useCallback(
+    ({selector, resultList: list, selectorList, pseudoSelector}: TAssertionResultEntry) => {
+      open({
+        isEditing: true,
+        selector,
+        defaultValues: {
+          assertionList: list.map(({assertion}) => assertion),
+          selectorList,
+          pseudoSelector,
+        },
+      });
+    },
+    [open]
+  );
+
+  const handleDelete = useCallback(
+    (selector: string) => {
+      remove(selector);
+    },
+    [remove]
+  );
 
   return (
     <S.AssertionCardList data-cy="assertion-card-list">
@@ -31,9 +47,8 @@ const AssertionCardList: React.FC<TAssertionCardListProps> = ({
               key={assertionResult.id}
               assertionResult={assertionResult}
               onSelectSpan={onSelectSpan}
-              selectorList={[]}
               onEdit={handleEdit}
-              onDelete={assertionId => console.log('@@onDeleteAssertion', assertionId)}
+              onDelete={handleDelete}
             />
           ) : null
         )

--- a/web/src/components/AssertionCheckRow/AssertionCheckRow.tsx
+++ b/web/src/components/AssertionCheckRow/AssertionCheckRow.tsx
@@ -1,9 +1,11 @@
 import {useMemo} from 'react';
-import {difference} from 'lodash';
+import {capitalize, difference} from 'lodash';
 import {TAssertion, TAssertionSpanResult} from '../../types/Assertion.types';
 import * as S from './AssertionCheckRow.styled';
 import AttributeValue from '../AttributeValue';
 import {useTestRun} from '../../providers/TestRun/TestRun.provider';
+import OperatorService from '../../services/Operator.service';
+import {TCompareOperatorSymbol} from '../../types/Operator.types';
 
 interface TAssertionCheckRowProps {
   result: TAssertionSpanResult;
@@ -52,7 +54,7 @@ const AssertionCheckRow: React.FC<TAssertionCheckRowProps> = ({
       </S.Entry>
       <S.Entry>
         <S.Label>Assertion Type</S.Label>
-        <S.Value>{comparator}</S.Value>
+        <S.Value>{capitalize(OperatorService.getNameFromSymbol(comparator as TCompareOperatorSymbol))}</S.Value>
       </S.Entry>
       <S.Entry>
         <S.Label>Expected Value</S.Label>

--- a/web/src/components/AssertionForm/AssertionForm.styled.ts
+++ b/web/src/components/AssertionForm/AssertionForm.styled.ts
@@ -63,6 +63,12 @@ export const AssertionFormTitle = styled(Typography.Text).attrs({
   font-weight: 600;
 `;
 
+export const AssertionFormHeader = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+`;
+
 export const AssertionFromActions = styled.div`
   display: flex;
   justify-content: flex-end;

--- a/web/src/components/AssertionForm/AssertionForm.tsx
+++ b/web/src/components/AssertionForm/AssertionForm.tsx
@@ -7,24 +7,26 @@ import {Typography, Form, Button} from 'antd';
 import GuidedTourService, {GuidedTours} from 'services/GuidedTour.service';
 import useGuidedTour from 'hooks/useGuidedTour';
 import CreateAssertionModalAnalyticsService from '../../services/Analytics/CreateAssertionModalAnalytics.service';
-import {CompareOperator, PseudoSelector} from '../../constants/Operator.constants';
+import {CompareOperator} from '../../constants/Operator.constants';
 import {Steps} from '../GuidedTour/assertionStepList';
 import * as S from './AssertionForm.styled';
 import AssertionSelectors from '../../selectors/Assertion.selectors';
 import AssertionFormSelectorInput from './AssertionFormSelectorInput';
-import {TAssertion, TSpanSelector} from '../../types/Assertion.types';
+import {TAssertion, TPseudoSelector, TSpanSelector} from '../../types/Assertion.types';
 import AssertionFormPseudoSelectorInput from './AssertionFormPseudoSelectorInput';
 import AssertionFormCheckList from './AssertionFormCheckList';
+import {useGetSelectedSpansQuery} from '../../redux/apis/TraceTest.api';
+import {RootState} from '../../redux/store';
+import {TSpanFlatAttribute} from '../../types/Span.types';
+import OperatorService from '../../services/Operator.service';
+import SelectorService from '../../services/Selector.service';
 
 const {onChecksChange, onSelectorChange} = CreateAssertionModalAnalyticsService;
 
 export interface IValues {
   assertionList: TAssertion[];
   selectorList: TSpanSelector[];
-  pseudoSelector?: {
-    selector: PseudoSelector;
-    number?: number;
-  };
+  pseudoSelector?: TPseudoSelector;
 }
 
 interface TAssertionFormProps {
@@ -40,12 +42,11 @@ const AssertionForm: React.FC<TAssertionFormProps> = ({
   defaultValues: {
     assertionList = [
       {
-        key: '',
-        compareOp: CompareOperator.EQUALS,
-        value: '',
+        comparator: OperatorService.getOperatorSymbol(CompareOperator.EQUALS),
       },
     ],
     selectorList = [],
+    pseudoSelector,
   } = {},
   onSubmit,
   onCancel,
@@ -54,12 +55,19 @@ const AssertionForm: React.FC<TAssertionFormProps> = ({
   runId,
 }) => {
   const [form] = Form.useForm<IValues>();
-
   useGuidedTour(GuidedTours.Assertion);
 
   const currentSelectorList = Form.useWatch('selectorList', form) || [];
   const currentAssertionList = Form.useWatch('assertionList', form) || [];
-  const attributeList = useSelector(AssertionSelectors.selectAttributeList(testId, runId, currentSelectorList));
+  const {data: spanIdList = []} = useGetSelectedSpansQuery({
+    query: SelectorService.getSelectorString(currentSelectorList),
+    testId,
+    runId,
+  });
+
+  const attributeList = useSelector<RootState, TSpanFlatAttribute[]>(state =>
+    AssertionSelectors.selectAttributeList(state, testId, runId, spanIdList)
+  );
 
   const onFieldsChange = useCallback(
     (changedFields: FieldData[]) => {
@@ -70,7 +78,7 @@ const AssertionForm: React.FC<TAssertionFormProps> = ({
       if (fieldName === 'selectorList') onSelectorChange(JSON.stringify(selectorList));
       if (fieldName === 'assertionList') onChecksChange(JSON.stringify(form.getFieldValue('assertionList') || []));
 
-      if (fieldName === 'assertionList' && keyName === 'key' && field.value) {
+      if (fieldName === 'assertionList' && keyName === 'attribute' && field.value) {
         const list: TAssertion[] = form.getFieldValue('assertionList') || [];
 
         form.setFieldsValue({
@@ -92,7 +100,10 @@ const AssertionForm: React.FC<TAssertionFormProps> = ({
 
   return (
     <S.AssertionForm>
-      <S.AssertionFormTitle strong>{isEditing ? 'Edit Assertion' : 'Add New Assertion'}</S.AssertionFormTitle>
+      <S.AssertionFormHeader>
+        <S.AssertionFormTitle strong>{isEditing ? 'Edit Assertion' : 'Add New Assertion'}</S.AssertionFormTitle>
+        <Typography.Text type="secondary">Affects {spanIdList.length} span(s)</Typography.Text>
+      </S.AssertionFormHeader>
       <Form
         name="assertion-form"
         form={form}
@@ -100,6 +111,7 @@ const AssertionForm: React.FC<TAssertionFormProps> = ({
           remember: true,
           assertionList,
           selectorList,
+          pseudoSelector,
         }}
         onFinish={onSubmit}
         autoComplete="off"

--- a/web/src/components/AssertionForm/AssertionForm.tsx
+++ b/web/src/components/AssertionForm/AssertionForm.tsx
@@ -59,8 +59,10 @@ const AssertionForm: React.FC<TAssertionFormProps> = ({
 
   const currentSelectorList = Form.useWatch('selectorList', form) || [];
   const currentAssertionList = Form.useWatch('assertionList', form) || [];
+  const currentPseudoSelector = Form.useWatch('pseudoSelector', form) || undefined;
+
   const {data: spanIdList = []} = useGetSelectedSpansQuery({
-    query: SelectorService.getSelectorString(currentSelectorList),
+    query: SelectorService.getSelectorString(currentSelectorList, currentPseudoSelector),
     testId,
     runId,
   });

--- a/web/src/components/AssertionForm/AssertionFormCheckList.tsx
+++ b/web/src/components/AssertionForm/AssertionFormCheckList.tsx
@@ -19,7 +19,7 @@ interface IProps {
 }
 
 const operatorList = Object.values(CompareOperator).map(value => ({
-  value,
+  value: OperatorService.getOperatorSymbol(value),
   label: capitalize(OperatorService.getOperatorName(value)),
 }));
 

--- a/web/src/components/AssertionForm/AssertionFormPseudoSelectorInput.tsx
+++ b/web/src/components/AssertionForm/AssertionFormPseudoSelectorInput.tsx
@@ -22,7 +22,7 @@ interface IProps {
 
 const AssertionFormPseudoSelectorInput: React.FC<IProps> = ({
   value: pseudoSelector = {
-    selector: PseudoSelector.FIRST,
+    selector: PseudoSelector.ALL,
     number: 0,
   },
   onChange = noop,
@@ -53,7 +53,13 @@ const AssertionFormPseudoSelectorInput: React.FC<IProps> = ({
         {optionList}
       </Select>
       {pseudoSelector?.selector === PseudoSelector.NTH && (
-        <Input placeholder="number" style={{width: '100px'}} type="number" onChange={handleNumberChange} />
+        <Input
+          placeholder="number"
+          style={{width: '100px'}}
+          type="number"
+          value={pseudoSelector.number}
+          onChange={handleNumberChange}
+        />
       )}
     </S.PseudoSelector>
   );

--- a/web/src/components/AssertionForm/AssertionFormSelectorInput.tsx
+++ b/web/src/components/AssertionForm/AssertionFormSelectorInput.tsx
@@ -1,7 +1,9 @@
 import {noop, uniqBy} from 'lodash';
 import React, {useCallback, useMemo, useState} from 'react';
 import {CompareOperator} from '../../constants/Operator.constants';
+import OperatorService from '../../services/Operator.service';
 import {TSpanSelector} from '../../types/Assertion.types';
+import {TCompareOperatorSymbol} from '../../types/Operator.types';
 import {TSpanFlatAttribute} from '../../types/Span.types';
 import MultiSelectInput, {SEPARATOR} from '../MultiSelectInput/MultiSelectInput';
 import * as S from './AssertionForm.styled';
@@ -15,12 +17,11 @@ type TItemSelectorDropdownProps = {
 const operatorOptionList = [
   {
     key: '=',
-    value: CompareOperator.EQUALS,
+    value: OperatorService.getOperatorSymbol(CompareOperator.EQUALS),
   },
-  // this will be added when we add the query language parser
   // {
   //   key: 'contains',
-  //   value: CompareOperator.CONTAINS,
+  //   value: OperatorService.getOperatorSymbol(CompareOperator.CONTAINS),
   // },
 ];
 
@@ -66,7 +67,7 @@ const AssertionFormSelectorInput: React.FC<TItemSelectorDropdownProps> = ({
       const selector: TSpanSelector = {
         key: attribute,
         value,
-        operator: operator as CompareOperator,
+        operator: operator as TCompareOperatorSymbol,
       };
 
       onChange([...selectorList, selector]);

--- a/web/src/components/AssertionForm/__tests__/AssertionForm.test.tsx
+++ b/web/src/components/AssertionForm/__tests__/AssertionForm.test.tsx
@@ -1,0 +1,19 @@
+import {render} from '@testing-library/react';
+import AssertionForm from '../AssertionForm';
+import {ReduxWrapperProvider} from '../../../redux/ReduxWrapperProvider';
+
+const defaultProps = {
+  onSubmit: jest.fn(),
+  onCancel: jest.fn(),
+  testId: 'testId',
+  runId: 'runId',
+};
+
+describe('AssertionForm', () => {
+  it('should render correctly', () => {
+    fetchMock.mockResponse(JSON.stringify(['spanId']));
+    const {container} = render(<AssertionForm {...defaultProps} />, {wrapper: ReduxWrapperProvider}); 
+
+    expect(container.querySelector('form')).toBeInTheDocument();
+  });
+});

--- a/web/src/components/LoadingSpinner/LoadingSpinner.tsx
+++ b/web/src/components/LoadingSpinner/LoadingSpinner.tsx
@@ -1,0 +1,8 @@
+import {Spin} from 'antd';
+import {LoadingOutlined} from '@ant-design/icons';
+
+const antIcon = <LoadingOutlined style={{fontSize: 40}} spin />;
+
+const LoadingSpinner: React.FC = () => <Spin indicator={antIcon} />;
+
+export default LoadingSpinner;

--- a/web/src/components/LoadingSpinner/index.ts
+++ b/web/src/components/LoadingSpinner/index.ts
@@ -1,0 +1,2 @@
+// eslint-disable-next-line no-restricted-exports
+export {default} from './LoadingSpinner';

--- a/web/src/components/Navigation/Router.tsx
+++ b/web/src/components/Navigation/Router.tsx
@@ -8,8 +8,8 @@ const Router = (): JSX.Element => {
     <BrowserRouter>
       <Routes>
         <Route path="/" element={<Home path="home" />} />
-        <Route path="/test/:id" element={<Test path="test-details" />} />
-        <Route path="/test/:testId/result/:resultId" element={<Trace path="trace" />} />
+        <Route path="/test/:testId" element={<Test path="test-details" />} />
+        <Route path="/test/:testId/result/:runId" element={<Trace path="trace" />} />
         <Route path="*" element={<Navigate to="/" />} />
       </Routes>
     </BrowserRouter>

--- a/web/src/components/SpanDetail/SpanDetail.tsx
+++ b/web/src/components/SpanDetail/SpanDetail.tsx
@@ -8,7 +8,8 @@ import Http from './components/Http';
 import SpanHeader from './SpanHeader';
 import * as S from './SpanDetail.styled';
 import {useAssertionForm} from '../AssertionForm/AssertionFormProvider';
-import {CompareOperator} from '../../constants/Operator.constants';
+import {CompareOperator, PseudoSelector} from '../../constants/Operator.constants';
+import OperatorService from '../../services/Operator.service';
 
 export interface TSpanDetailProps {
   testId?: string;
@@ -43,18 +44,26 @@ const SpanDetail: React.FC<TSpanDetailProps> = ({span}) => {
       open({
         isEditing: false,
         defaultValues: {
+          pseudoSelector: {
+            selector: PseudoSelector.FIRST,
+          },
           assertionList: [
             {
-              comparator: CompareOperator.EQUALS,
+              comparator: OperatorService.getOperatorSymbol(CompareOperator.EQUALS),
               expected: value,
               attribute: key,
             },
           ],
-          selectorList: [],
+          selectorList:
+            span?.signature.map(attribute => ({
+              value: attribute.value,
+              key: attribute.key,
+              operator: OperatorService.getOperatorSymbol(CompareOperator.EQUALS),
+            })) || [],
         },
       });
     },
-    [open]
+    [open, span?.signature]
   );
 
   return (

--- a/web/src/components/TestCard/__stories__/TestCard.stories.tsx
+++ b/web/src/components/TestCard/__stories__/TestCard.stories.tsx
@@ -1,6 +1,7 @@
 import faker from '@faker-js/faker';
 import {ComponentStory, ComponentMeta} from '@storybook/react';
 import {HTTP_METHOD} from '../../../constants/Common.constants';
+import TestDefinition from '../../../models/TestDefinition.model';
 
 import TestCard from '../TestCard';
 
@@ -16,6 +17,7 @@ export const Default = Template.bind({});
 Default.args = {
   test: {
     id: faker.datatype.uuid(),
+    definition: TestDefinition({}),
     name: `${faker.name.firstName()} ${faker.name.lastName()}`,
     description: faker.lorem.sentences(),
     serviceUnderTest: {

--- a/web/src/components/TestHeader/__stories__/TestHeader.stories.tsx
+++ b/web/src/components/TestHeader/__stories__/TestHeader.stories.tsx
@@ -1,7 +1,8 @@
 import faker from '@faker-js/faker';
 import {ComponentStory, ComponentMeta} from '@storybook/react';
 import {HTTP_METHOD} from '../../../constants/Common.constants';
-import {TestState} from '../../../constants/TestRun.constants';
+import { TestState } from '../../../constants/TestRun.constants';
+import TestDefinition from '../../../models/TestDefinition.model';
 
 import TestHeader from '../TestHeader';
 
@@ -19,6 +20,7 @@ Default.args = {
     id: faker.datatype.uuid(),
     name: `${faker.name.firstName()} ${faker.name.lastName()}`,
     description: faker.lorem.sentences(),
+    definition: TestDefinition({}),
     serviceUnderTest: {
       request: {
         url: faker.internet.url(),
@@ -34,6 +36,7 @@ WithState.args = {
     id: faker.datatype.uuid(),
     name: `${faker.name.firstName()} ${faker.name.lastName()}`,
     description: faker.lorem.sentences(),
+    definition: TestDefinition({}),
     serviceUnderTest: {
       request: {
         url: faker.internet.url(),

--- a/web/src/components/TraceDrawer/TraceDrawer.styled.ts
+++ b/web/src/components/TraceDrawer/TraceDrawer.styled.ts
@@ -49,3 +49,11 @@ export const AddAssertionButton = styled(Button).attrs({
     font-weight: 600;
   }
 `;
+
+export const LoadingSpinnerContainer = styled.div`
+  height: 100%;
+  width: 100%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+`;

--- a/web/src/components/TraceDrawer/TraceDrawer.tsx
+++ b/web/src/components/TraceDrawer/TraceDrawer.tsx
@@ -6,6 +6,8 @@ import * as S from './TraceDrawer.styled';
 import TraceDrawerHeader from './TraceDrawerHeader';
 import {useAssertionForm} from '../AssertionForm/AssertionFormProvider';
 import AssertionForm from '../AssertionForm';
+import {useTestDefinition} from '../../providers/TestDefinition/TestDefinition.provider';
+import LoadingSpinner from '../LoadingSpinner';
 
 interface IProps {
   visiblePortion: number;
@@ -17,6 +19,7 @@ interface IProps {
 const TraceDrawer: React.FC<IProps> = ({run: {id: runId}, run, testId, visiblePortion, onSelectSpan}) => {
   const [isCollapsed, setIsCollapsed] = useState(false);
   const {isOpen: isAssertionFormOpen, formProps, onSubmit, close} = useAssertionForm();
+  const {isLoading} = useTestDefinition();
 
   useEffect(() => {
     if (isAssertionFormOpen) setIsCollapsed(true);
@@ -40,14 +43,17 @@ const TraceDrawer: React.FC<IProps> = ({run: {id: runId}, run, testId, visiblePo
         visiblePortion={visiblePortion}
       />
       <S.Content>
-        {isAssertionFormOpen ? (
+        {isLoading ? (
+          <S.LoadingSpinnerContainer>
+            <LoadingSpinner />
+          </S.LoadingSpinnerContainer>
+        ) : isAssertionFormOpen ? (
           <AssertionForm
             runId={runId}
             onSubmit={onSubmit}
             testId={testId}
             {...formProps}
             onCancel={() => {
-              setIsCollapsed(false);
               close();
             }}
           />

--- a/web/src/constants/Operator.constants.ts
+++ b/web/src/constants/Operator.constants.ts
@@ -30,9 +30,19 @@ export const CompareOperatorSymbolMap: Record<CompareOperator, TCompareOperatorS
   [CompareOperator.CONTAINS]: 'contains',
 };
 
+export const CompareOperatorSymbolNameMap: Record<TCompareOperatorSymbol, TCompareOperatorName> = {
+  '=': 'equals',
+  '<': 'not equals',
+  '>': 'less than',
+  '!=': 'greater than',
+  '>=': 'greater or equals',
+  '<=': 'less or equals',
+  contains: 'contains',
+};
+
 export enum PseudoSelector {
   FIRST = ':first',
   LAST = ':last',
-  NTH = ':nth',
-  ALL = ':all',
+  NTH = ':nth_child',
+  ALL = '',
 }

--- a/web/src/models/AssertionResults.model.ts
+++ b/web/src/models/AssertionResults.model.ts
@@ -1,4 +1,6 @@
 import {uniqueId} from 'lodash';
+import AssertionService from '../services/Assertion.service';
+import SelectorService from '../services/Selector.service';
 import {TAssertionResults, TRawAssertionResults} from '../types/Assertion.types';
 import AssertionResult from './AssertionResult.model';
 
@@ -8,6 +10,9 @@ const AssertionResults = ({allPassed = false, results = []}: TRawAssertionResult
     resultList: results.map(({selector = '', results: resultList = []}) => ({
       id: uniqueId(),
       selector,
+      spanCount: AssertionService.getSpanCount(resultList),
+      pseudoSelector: SelectorService.getPseudoSelector(selector),
+      selectorList: SelectorService.getSpanSelectorList(selector),
       resultList: resultList.map(assertionResult => AssertionResult(assertionResult)),
     })),
   };

--- a/web/src/models/Test.model.ts
+++ b/web/src/models/Test.model.ts
@@ -13,7 +13,7 @@ const Test = ({
     id,
     name,
     description,
-    definition: definition ? TestDefinition(definition) : undefined,
+    definition: TestDefinition(definition || {}),
     serviceUnderTest,
     referenceTestRun,
   };

--- a/web/src/models/__mocks__/Assertion.mock.ts
+++ b/web/src/models/__mocks__/Assertion.mock.ts
@@ -1,0 +1,22 @@
+import faker from '@faker-js/faker';
+import {TAssertion, TRawAssertion} from '../../types/Assertion.types';
+import {IMockFactory} from '../../types/Common.types';
+import Assertion from '../Assertion.model';
+
+const operatorSymbolList = ['=', '<', '>', '!=', '>=', '<=', 'contains'];
+
+const AssertionMock: IMockFactory<TAssertion, TRawAssertion> = () => ({
+  raw(data = {}) {
+    return {
+      attribute: faker.random.word(),
+      comparator: operatorSymbolList[faker.datatype.number({min: 0, max: operatorSymbolList.length - 1})],
+      expected: faker.random.word(),
+      ...data,
+    };
+  },
+  model(data = {}) {
+    return Assertion(this.raw(data));
+  },
+});
+
+export default AssertionMock();

--- a/web/src/models/__mocks__/AssertionResult.mock.ts
+++ b/web/src/models/__mocks__/AssertionResult.mock.ts
@@ -1,0 +1,22 @@
+import faker from '@faker-js/faker';
+import {TAssertionResult, TRawAssertionResult} from '../../types/Assertion.types';
+import {IMockFactory} from '../../types/Common.types';
+import AssertionResult from '../AssertionResult.model';
+import AssertionMock from './Assertion.mock';
+import AssertionSpanResultMock from './AssertionSpanResult.mock';
+
+const AssertionResultMock: IMockFactory<TAssertionResult, TRawAssertionResult> = () => ({
+  raw(data = {}) {
+    return {
+      allPassed: faker.datatype.boolean(),
+      assertion: AssertionMock.raw(),
+      spanResults: new Array(4).fill(null).map(() => AssertionSpanResultMock.raw()),
+      ...data,
+    };
+  },
+  model(data = {}) {
+    return AssertionResult(this.raw(data));
+  },
+});
+
+export default AssertionResultMock();

--- a/web/src/models/__mocks__/AssertionSpanResult.mock.ts
+++ b/web/src/models/__mocks__/AssertionSpanResult.mock.ts
@@ -1,0 +1,21 @@
+import faker from '@faker-js/faker';
+import {TAssertionSpanResult, TRawAssertionSpanResult} from '../../types/Assertion.types';
+import {IMockFactory} from '../../types/Common.types';
+import AssertionSpanResult from '../AssertionSpanResult.model';
+
+const AssertionSpanResultMock: IMockFactory<TAssertionSpanResult, TRawAssertionSpanResult> = () => ({
+  raw(data = {}) {
+    return {
+      spanId: faker.datatype.uuid(),
+      observedValue: faker.random.word(),
+      passed: faker.datatype.boolean(),
+      error: faker.random.word(),
+      ...data,
+    };
+  },
+  model(data = {}) {
+    return AssertionSpanResult(this.raw(data));
+  },
+});
+
+export default AssertionSpanResultMock();

--- a/web/src/models/__mocks__/Test.mock.ts
+++ b/web/src/models/__mocks__/Test.mock.ts
@@ -2,13 +2,21 @@ import faker from '@faker-js/faker';
 import {IMockFactory} from '../../types/Common.types';
 import {TRawTest, TTest} from '../../types/Test.types';
 import Test from '../Test.model';
+import AssertionResultMock from './AssertionResult.mock';
 
 const TestMock: IMockFactory<TTest, TRawTest> = () => ({
   raw(data = {}) {
     return {
       id: faker.datatype.uuid(),
       name: faker.name.firstName(),
-      definition: undefined,
+      definition: {
+        definitions: [
+          {
+            selector: faker.random.word(),
+            assertionList: [AssertionResultMock.raw()],
+          },
+        ],
+      },
       ...data,
     };
   },

--- a/web/src/pages/Test/Test.tsx
+++ b/web/src/pages/Test/Test.tsx
@@ -11,14 +11,14 @@ import TestHeader from '../../components/TestHeader';
 
 const TestPage: React.FC = () => {
   const navigate = useNavigate();
-  const {id} = useParams();
-  const {data: test} = useGetTestByIdQuery({testId: id as string});
+  const {testId = ''} = useParams();
+  const {data: test} = useGetTestByIdQuery({testId});
 
   const handleSelectTestResult = useCallback(
     (result: TTestRun) => {
-      navigate(`/test/${id}/result/${result.id}`);
+      navigate(`/test/${testId}/result/${result.id}`);
     },
-    [id, navigate]
+    [navigate, testId]
   );
 
   // TODO: Add proper loading states

--- a/web/src/pages/Trace/Trace.tsx
+++ b/web/src/pages/Trace/Trace.tsx
@@ -4,6 +4,7 @@ import {ReactFlowProvider} from 'react-flow-renderer';
 import Layout from 'components/Layout';
 import AssertionFormProvider from '../../components/AssertionForm/AssertionFormProvider';
 import TestRunProvider from '../../providers/TestRun';
+import TestDefinitionProvider from '../../providers/TestDefinition';
 import TraceContent from './TraceContent';
 
 const TracePage = () => {
@@ -11,13 +12,15 @@ const TracePage = () => {
 
   return (
     <ReactFlowProvider>
-      <AssertionFormProvider testId={testId}>
-        <TestRunProvider testId={testId} runId={runId}>
-          <Layout>
-            <TraceContent />
-          </Layout>
-        </TestRunProvider>
-      </AssertionFormProvider>
+      <TestDefinitionProvider testId={testId} runId={runId}>
+        <AssertionFormProvider testId={testId}>
+          <TestRunProvider testId={testId} runId={runId}>
+            <Layout>
+              <TraceContent />
+            </Layout>
+          </TestRunProvider>
+        </AssertionFormProvider>
+      </TestDefinitionProvider>
     </ReactFlowProvider>
   );
 };

--- a/web/src/providers/TestDefinition/TestDefinition.provider.tsx
+++ b/web/src/providers/TestDefinition/TestDefinition.provider.tsx
@@ -1,0 +1,67 @@
+import {noop} from 'lodash';
+import {useCallback, createContext, useContext, useMemo} from 'react';
+import TestDefinitionActions from '../../redux/actions/TestDefinition.actions';
+import {useReRunMutation} from '../../redux/apis/TraceTest.api';
+import {useAppDispatch} from '../../redux/hooks';
+import {TTestDefinitionEntry} from '../../types/TestDefinition.types';
+
+interface IContext {
+  add(testDefinition: TTestDefinitionEntry): void;
+  update(selector: string, testDefinition: TTestDefinitionEntry): void;
+  remove(selector: string): void;
+  isLoading: boolean;
+  isError: boolean;
+}
+
+export const Context = createContext<IContext>({
+  add: noop,
+  update: noop,
+  remove: noop,
+  isLoading: false,
+  isError: false,
+});
+
+interface IProps {
+  testId: string;
+  runId: string;
+}
+
+export const useTestDefinition = () => useContext(Context);
+
+const TestDefinitionProvider: React.FC<IProps> = ({children, testId, runId}) => {
+  const [rerun, {isLoading, isError}] = useReRunMutation();
+  const dispatch = useAppDispatch();
+
+  const add = useCallback(
+    async (definition: TTestDefinitionEntry) => {
+      await dispatch(TestDefinitionActions.add({testId, definition}));
+      await rerun({testId, runId});
+    },
+    [dispatch, rerun, runId, testId]
+  );
+
+  const update = useCallback(
+    async (selector: string, definition: TTestDefinitionEntry) => {
+      await dispatch(TestDefinitionActions.update({testId, definition, selector}));
+      await rerun({testId, runId});
+    },
+    [dispatch, rerun, runId, testId]
+  );
+
+  const remove = useCallback(
+    async (selector: string) => {
+      await dispatch(TestDefinitionActions.remove({testId, selector}));
+      await rerun({testId, runId});
+    },
+    [dispatch, rerun, runId, testId]
+  );
+
+  const value = useMemo<IContext>(
+    () => ({add, remove, update, isLoading, isError}),
+    [add, isError, isLoading, remove, update]
+  );
+
+  return <Context.Provider value={value}>{children}</Context.Provider>;
+};
+
+export default TestDefinitionProvider;

--- a/web/src/providers/TestDefinition/__tests__/TestDefinition.provider.test.tsx
+++ b/web/src/providers/TestDefinition/__tests__/TestDefinition.provider.test.tsx
@@ -1,0 +1,16 @@
+import {render} from '@testing-library/react';
+import TestDefinitionProvider from '../TestDefinition.provider';
+
+describe('TestDefinitionProvider', () => {
+  it('should render with the proper values', () => {
+    const {getByText} = render(
+      <TestDefinitionProvider testId="testId" runId="runId">
+        <div>
+          <p>Hello</p>
+        </div>
+      </TestDefinitionProvider>
+    );
+
+    expect(getByText('Hello')).toBeInTheDocument();
+  });
+});

--- a/web/src/providers/TestDefinition/index.ts
+++ b/web/src/providers/TestDefinition/index.ts
@@ -1,0 +1,2 @@
+// eslint-disable-next-line no-restricted-exports
+export {default} from './TestDefinition.provider';

--- a/web/src/providers/TestRun/TestRun.provider.tsx
+++ b/web/src/providers/TestRun/TestRun.provider.tsx
@@ -27,7 +27,7 @@ const TestRunProvider: React.FC<IProps> = ({children, testId, runId}) => {
 
   const value = useMemo(() => ({run, refetch, isError}), [refetch, run, isError]) as IContext;
 
-  return run ? <Context.Provider value={value}>{children}</Context.Provider> : <div data-cy="not_initialized" />;
+  return run ? <Context.Provider value={value}>{children}</Context.Provider> : <div data-cy="loading_test_run" />;
 };
 
 export default TestRunProvider;

--- a/web/src/redux/actions/TestDefinition.actions.ts
+++ b/web/src/redux/actions/TestDefinition.actions.ts
@@ -1,0 +1,55 @@
+import {createAsyncThunk} from '@reduxjs/toolkit';
+import TestDefinitionGateway from '../../gateways/TestDefinition.gateway';
+import TestSelectors from '../../selectors/Test.selectors';
+import TestDefinitionService from '../../services/TestDefinition.service';
+import {TTestDefinitionEntry} from '../../types/TestDefinition.types';
+import {RootState} from '../store';
+
+const TestDefinitionActions = () => ({
+  add: createAsyncThunk<void, {testId: string; definition: TTestDefinitionEntry}>(
+    'testDefinition/add',
+    async ({testId, definition}, {dispatch, getState}) => {
+      const test = TestSelectors.selectTest(getState() as RootState, testId);
+
+      const rawDefinitionList = test.definition.definitionList.map(def => TestDefinitionService.toRaw(def));
+
+      await dispatch(
+        TestDefinitionGateway.set(testId, {
+          definitions: [...rawDefinitionList, TestDefinitionService.toRaw(definition)],
+        })
+      );
+    }
+  ),
+  update: createAsyncThunk<void, {testId: string; selector: string; definition: TTestDefinitionEntry}>(
+    'testDefinition/update',
+    async ({testId, definition, selector}, {dispatch, getState}) => {
+      const test = TestSelectors.selectTest(getState() as RootState, testId);
+      const rawDefinitionList = test.definition.definitionList.map(def => TestDefinitionService.toRaw(def));
+
+      await dispatch(
+        TestDefinitionGateway.set(testId, {
+          definitions: rawDefinitionList.map(def => {
+            if (def.selector === selector) return TestDefinitionService.toRaw(definition);
+
+            return def;
+          }),
+        })
+      );
+    }
+  ),
+  remove: createAsyncThunk<void, {testId: string; selector: string}>(
+    'testDefinition/remove',
+    async ({testId, selector}, {dispatch, getState}) => {
+      const test = TestSelectors.selectTest(getState() as RootState, testId);
+      const rawDefinitionList = test.definition.definitionList.map(def => TestDefinitionService.toRaw(def));
+
+      await dispatch(
+        TestDefinitionGateway.set(testId, {
+          definitions: rawDefinitionList.filter(definition => definition.selector !== selector),
+        })
+      );
+    }
+  ),
+});
+
+export default TestDefinitionActions();

--- a/web/src/redux/actions/__tests_/TestDefinition.actions.test.ts
+++ b/web/src/redux/actions/__tests_/TestDefinition.actions.test.ts
@@ -1,0 +1,66 @@
+import TestDefinitionActions from '../TestDefinition.actions';
+import TestSelectors from '../../../selectors/Test.selectors';
+import {store} from '../../store';
+import TestMock from '../../../models/__mocks__/Test.mock';
+import {HTTP_METHOD} from '../../../constants/Common.constants';
+
+jest.mock('../../../selectors/Test.selectors', () => ({
+  selectTest: jest.fn(),
+}));
+
+const selectTestMock = TestSelectors.selectTest as unknown as jest.Mock;
+
+describe('TestDefinitionActions', () => {
+  beforeEach(() => {
+    fetchMock.resetMocks();
+  });
+
+  describe('add', () => {
+    it('should add a new definition by triggering the request to the backend', async () => {
+      selectTestMock.mockImplementationOnce(() => TestMock.model());
+
+      fetchMock.mockResponse(JSON.stringify({}));
+      await store.dispatch(
+        TestDefinitionActions.add({testId: 'testId', definition: {selector: 'selector', assertionList: []}})
+      );
+
+      const request = fetchMock.mock.calls[0][0] as Request;
+
+      expect(request.url).toEqual('http://localhost/api/tests/testId/definition');
+      expect(request.method).toEqual(HTTP_METHOD.PUT);
+      expect(fetchMock.mock.calls.length).toBe(1);
+    });
+  });
+
+  describe('update', () => {
+    it('should update a definition by triggering the request to the backend', async () => {
+      selectTestMock.mockImplementationOnce(() => TestMock.model());
+
+      fetchMock.mockResponse(JSON.stringify({}));
+      await store.dispatch(
+        TestDefinitionActions.add({testId: 'testId', definition: {selector: 'selector', assertionList: []}})
+      );
+
+      const request = fetchMock.mock.calls[0][0] as Request;
+
+      expect(request.url).toEqual('http://localhost/api/tests/testId/definition');
+      expect(request.method).toEqual(HTTP_METHOD.PUT);
+      expect(fetchMock.mock.calls.length).toBe(1);
+    });
+  });
+
+  describe('remove', () => {
+    it('should remove a definition by triggering the request to the backend', async () => {
+      selectTestMock.mockImplementationOnce(() => TestMock.model());
+
+      fetchMock.mockResponse(JSON.stringify({}));
+      await store.dispatch(TestDefinitionActions.remove({testId: 'testId', selector: 'selector'}));
+
+      const request = fetchMock.mock.calls[0][0] as Request;
+
+      expect(request.url).toEqual('http://localhost/api/tests/testId/definition');
+      expect(request.method).toEqual(HTTP_METHOD.PUT);
+      expect(fetchMock.mock.calls.length).toBe(1);
+    });
+  });
+});

--- a/web/src/redux/apis/TraceTest.api.ts
+++ b/web/src/redux/apis/TraceTest.api.ts
@@ -81,14 +81,12 @@ const TraceTestAPI = createApi({
       ],
       transformResponse: (rawTestRun: TRawTestRun) => TestRun(rawTestRun),
     }),
-
     getRunList: build.query<TTestRun[], {testId: string; take?: number; skip?: number}>({
       query: ({testId, take = 25, skip = 0}) => `/tests/${testId}/run?take=${take}&skip=${skip}`,
       providesTags: (result, error, {testId}) => [{type: Tags.TEST_RUN, id: `${testId}-LIST`}],
       transformResponse: (rawTestResultList: TRawTestRun[]) =>
         rawTestResultList.map(rawTestResult => TestRun(rawTestResult)),
     }),
-
     getRunById: build.query<TTestRun, {runId: string; testId: string}>({
       query: ({testId, runId}) => `/tests/${testId}/run/${runId}`,
       providesTags: result => (result ? [{type: Tags.TEST_RUN, id: result?.id}] : []),

--- a/web/src/selectors/Test.selectors.ts
+++ b/web/src/selectors/Test.selectors.ts
@@ -1,0 +1,18 @@
+import {createSelector} from '@reduxjs/toolkit';
+
+import {endpoints} from 'redux/apis/TraceTest.api';
+import {RootState} from '../redux/store';
+
+const stateSelector = (state: RootState) => state;
+
+const testIdSelector = (state: RootState, testId: string) => testId;
+
+const TestSelectors = () => ({
+  selectTest: createSelector(stateSelector, testIdSelector, (state, testId) => {
+    const {data: test} = endpoints.getTestById.select({testId})(state);
+
+    return test!;
+  }),
+});
+
+export default TestSelectors();

--- a/web/src/services/Assertion.service.ts
+++ b/web/src/services/Assertion.service.ts
@@ -1,35 +1,18 @@
-import {isNumber} from 'lodash';
-import {CompareOperator} from '../constants/Operator.constants';
-import {TSpanSelector} from '../types/Assertion.types';
-import {escapeString, isJson} from '../utils/Common';
-import OperatorService from './Operator.service';
-
-const getValue = (value: string): string => {
-  if (isNumber(value)) {
-    return value;
-  }
-
-  if (isJson(value)) {
-    return escapeString(value);
-  }
-
-  return value;
-};
-
-const getFilters = (selectors: TSpanSelector[]) =>
-  selectors.map(
-    ({key, operator = CompareOperator.EQUALS, value}) =>
-      `${key}${OperatorService.getOperatorSymbol(operator)}${getValue(value)}`
-  );
+import {TRawAssertionResult} from '../types/Assertion.types';
 
 const AssertionService = () => ({
-  getSelectorString(selectorList: TSpanSelector[]): string {
-    return selectorList.length ? `span[${getFilters(selectorList).join(' ')}]` : '';
-  },
+  getSpanCount(resultList: TRawAssertionResult[]): number {
+    const spanIdList = resultList.reduce<string[]>((list, {spanResults}) => {
+      const tmpList: string[] = [];
 
-  getSpanSelectorList(selectorString: string): TSpanSelector[] {
-    console.log('@@selectorString', selectorString);
-    return [];
+      spanResults?.forEach(({spanId = ''}) => {
+        if (!tmpList.includes(spanId)) tmpList.push(spanId);
+      });
+
+      return list.concat(tmpList);
+    }, []);
+
+    return spanIdList.length;
   },
 });
 

--- a/web/src/services/Operator.service.ts
+++ b/web/src/services/Operator.service.ts
@@ -1,4 +1,9 @@
-import {CompareOperator, CompareOperatorNameMap, CompareOperatorSymbolMap} from '../constants/Operator.constants';
+import {
+  CompareOperator,
+  CompareOperatorNameMap,
+  CompareOperatorSymbolMap,
+  CompareOperatorSymbolNameMap,
+} from '../constants/Operator.constants';
 import {TCompareOperatorName, TCompareOperatorSymbol} from '../types/Operator.types';
 
 const OperatorService = () => ({
@@ -7,6 +12,9 @@ const OperatorService = () => ({
   },
   getOperatorSymbol(op: CompareOperator): TCompareOperatorSymbol {
     return CompareOperatorSymbolMap[op];
+  },
+  getNameFromSymbol(symbol: TCompareOperatorSymbol): TCompareOperatorName {
+    return CompareOperatorSymbolNameMap[symbol];
   },
 });
 

--- a/web/src/services/Selector.service.ts
+++ b/web/src/services/Selector.service.ts
@@ -1,0 +1,87 @@
+import {isNumber} from 'lodash';
+import {PseudoSelector} from '../constants/Operator.constants';
+import {TPseudoSelector, TSpanSelector} from '../types/Assertion.types';
+import {TCompareOperatorSymbol} from '../types/Operator.types';
+import {escapeString, isJson} from '../utils/Common';
+
+const getValue = (value: string): string => {
+  if (isNumber(value)) {
+    return value;
+  }
+
+  if (isJson(value)) {
+    return escapeString(value);
+  }
+
+  return `"${value}"`;
+};
+
+const selectorRegex = /span\[(.*)\]/i;
+const nthChildNumberRegex = /\((.*)\)/i;
+const operationRegex = /([=]+|contains)/;
+
+const getFilters = (selectors: TSpanSelector[]) =>
+  selectors.map(({key, operator, value}) => `${key}${operator}${getValue(value)}`);
+
+const getCleanValue = (value: string): string => {
+  if (value.includes('"')) {
+    return value.replace(/"/g, '');
+  }
+
+  return value;
+};
+
+const getPseudoSelectorString = (pseudoSelector?: TPseudoSelector): string => {
+  if (!pseudoSelector) return '';
+
+  const {selector, number} = pseudoSelector;
+
+  if (selector === PseudoSelector.NTH) {
+    return `${pseudoSelector.selector}(${number})`;
+  }
+
+  return selector;
+};
+
+const SelectorService = () => ({
+  getSelectorString(selectorList: TSpanSelector[], pseudoSelector?: TPseudoSelector): string {
+    return selectorList.length
+      ? `span[${getFilters(selectorList).join(' ')}]${getPseudoSelectorString(pseudoSelector)}`
+      : '';
+  },
+
+  getSpanSelectorList(selectorString: string): TSpanSelector[] {
+    const [matchString] = (selectorString.match(selectorRegex) || []).reverse();
+
+    if (!matchString) return [];
+
+    const selectorList = matchString.split(' ').map(operation => {
+      const [key, operator, value] = operation.split(operationRegex);
+
+      return {key, operator: operator as TCompareOperatorSymbol, value: getCleanValue(value)};
+    });
+
+    return selectorList;
+  },
+
+  getPseudoSelector(selectorString: string): TPseudoSelector | undefined {
+    const index = selectorString.indexOf(']:');
+    if (index === -1) return;
+
+    const pseudoSelector = selectorString.substring(selectorString.indexOf(']:') + 1);
+
+    if (pseudoSelector.includes('nth_child')) {
+      const [number] = (pseudoSelector.match(nthChildNumberRegex) || []).reverse();
+
+      return {selector: PseudoSelector.NTH, number: Number(number)};
+    }
+
+    return pseudoSelector
+      ? {
+          selector: pseudoSelector as PseudoSelector,
+        }
+      : undefined;
+  },
+});
+
+export default SelectorService();

--- a/web/src/services/TestDefinition.service.ts
+++ b/web/src/services/TestDefinition.service.ts
@@ -1,0 +1,13 @@
+import {TTestDefinitionEntry} from '../types/TestDefinition.types';
+
+const TestDefinitionService = () => ({
+  toRaw({selector, assertionList}: TTestDefinitionEntry) {
+
+    return {
+      selector,
+      assertions: assertionList,
+    };
+  },
+});
+
+export default TestDefinitionService();

--- a/web/src/services/__tests__/Assertion.service.test.ts
+++ b/web/src/services/__tests__/Assertion.service.test.ts
@@ -1,38 +1,28 @@
-import {CompareOperator} from '../../constants/Operator.constants';
+import faker from '@faker-js/faker';
 import AssertionService from '../Assertion.service';
+import AssertionResultMock from '../../models/__mocks__/AssertionResult.mock';
+import AssertionSpanResultMock from '../../models/__mocks__/AssertionSpanResult.mock';
 
 describe('AssertionService', () => {
-  describe('getSelectorString', () => {
-    test('empty selectorList', () => {
-      const result = AssertionService.getSelectorString([]);
-      expect(result).toBe('');
-    });
+  describe('getSpanCount', () => {
+    test('should returning the number of spans', () => {
+      const id = faker.datatype.uuid();
+      const assertionResult = AssertionResultMock.model({
+        spanResults: [
+          AssertionSpanResultMock.raw({
+            spanId: id,
+          }),
+          AssertionSpanResultMock.raw({
+            spanId: id,
+          }),
+          AssertionSpanResultMock.raw(),
+          AssertionSpanResultMock.raw(),
+        ],
+      });
 
-    test('single selectorList', () => {
-      const result = AssertionService.getSelectorString([
-        {
-          operator: CompareOperator.EQUALS,
-          key: 'service.name',
-          value: 'pokeshop',
-        },
-      ]);
-      expect(result).toStrictEqual(`span[service.name="pokeshop"]`);
-    });
+      const result = AssertionService.getSpanCount([assertionResult]);
 
-    test('double selectorList', () => {
-      const result = AssertionService.getSelectorString([
-        {
-          operator: CompareOperator.EQUALS,
-          key: 'service.name',
-          value: 'pokeshop',
-        },
-        {
-          operator: CompareOperator.CONTAINS,
-          key: 'tracetest.span.type',
-          value: 'http',
-        },
-      ]);
-      expect(result).toStrictEqual(`span[service.name="pokeshop" tracetest.span.type contains "http"]`);
+      expect(result).toBe(3);
     });
   });
 });

--- a/web/src/services/__tests__/Operator.service.test.ts
+++ b/web/src/services/__tests__/Operator.service.test.ts
@@ -13,4 +13,10 @@ describe('OperatorService', () => {
 
     expect(symbol).toEqual('==');
   });
+
+  it('should return the name of an operator from the symbol', () =>{
+    const name = OperatorService.getNameFromSymbol('=');
+
+    expect(name).toEqual('equals');
+  });
 });

--- a/web/src/services/__tests__/Selector.service.test.ts
+++ b/web/src/services/__tests__/Selector.service.test.ts
@@ -1,0 +1,95 @@
+import {PseudoSelector} from '../../constants/Operator.constants';
+import SelectorService from '../Selector.service';
+
+describe('AssertionService', () => {
+  describe('getSelectorString', () => {
+    test('empty selectorList', () => {
+      const result = SelectorService.getSelectorString([]);
+      expect(result).toBe('');
+    });
+
+    test('single selectorList', () => {
+      const result = SelectorService.getSelectorString([
+        {
+          operator: '=',
+          key: 'service.name',
+          value: 'pokeshop',
+        },
+      ]);
+      expect(result).toStrictEqual(`span[service.name="pokeshop"]`);
+    });
+
+    test('double selectorList', () => {
+      const result = SelectorService.getSelectorString([
+        {
+          operator: '=',
+          key: 'service.name',
+          value: 'pokeshop',
+        },
+        {
+          operator: 'contains',
+          key: 'tracetest.span.type',
+          value: 'http',
+        },
+      ]);
+      expect(result).toStrictEqual(`span[service.name="pokeshop" tracetest.span.typecontains"http"]`);
+    });
+  });
+
+  describe('getSpanSelectorList', () => {
+    it('should get a list of selector objects from the selector string', () => {
+      const selectorString = 'span[service.name="pokeshop"]';
+
+      const result = SelectorService.getSpanSelectorList(selectorString);
+      expect(result).toStrictEqual([
+        {
+          key: 'service.name',
+          operator: '=',
+          value: 'pokeshop',
+        },
+      ]);
+    });
+
+    it('should get a list of selector objects from the selector string with multiple filters', () => {
+      const selectorString = 'span[service.name="pokeshop" tracetest.span.type="http"]';
+
+      const result = SelectorService.getSpanSelectorList(selectorString);
+      expect(result).toStrictEqual([
+        {
+          key: 'service.name',
+          operator: '=',
+          value: 'pokeshop',
+        },
+        {
+          key: 'tracetest.span.type',
+          operator: '=',
+          value: 'http',
+        },
+      ]);
+    });
+  });
+
+  describe('getPseudoSelectorString', () => {
+    it('should get a pseudo selector object from a selector string', () => {
+      const selector = 'span[service.name="pokeshop" tracetest.span.type="http"]';
+      const result = SelectorService.getPseudoSelector(selector);
+      expect(result?.selector).toStrictEqual(undefined);
+    });
+
+    it('should get a pseudo selector object from a selector string', () => {
+      const selector = 'span[service.name="pokeshop" tracetest.span.type="http"]:first';
+      const result = SelectorService.getPseudoSelector(selector);
+      expect(result?.selector).toStrictEqual(PseudoSelector.FIRST);
+    });
+
+    it('should get a selector object from a nth_child selector', () => {
+      const selector = 'span[service.name="pokeshop" tracetest.span.type="http"]:nth_child(2)';
+
+      const result = SelectorService.getPseudoSelector(selector);
+      expect(result).toStrictEqual({
+        selector: PseudoSelector.NTH,
+        number: 2,
+      });
+    });
+  });
+});

--- a/web/src/types/Assertion.types.ts
+++ b/web/src/types/Assertion.types.ts
@@ -1,5 +1,6 @@
-import {CompareOperator} from 'constants/Operator.constants';
+import {PseudoSelector} from '../constants/Operator.constants';
 import {Model, TTestSchemas} from './Common.types';
+import {TCompareOperatorSymbol} from './Operator.types';
 import {TSpanFlatAttribute} from './Span.types';
 
 export type TRawAssertion = TTestSchemas['Assertion'];
@@ -9,15 +10,23 @@ export type TAssertion = Model<TRawAssertion, {}>;
 export type TSpanSelector = Model<
   TSpanFlatAttribute,
   {
-    operator: CompareOperator;
+    operator: TCompareOperatorSymbol;
   }
 >;
+
+export type TPseudoSelector = {
+  selector: PseudoSelector;
+  number?: number;
+};
 
 export type TRawAssertionResults = TTestSchemas['AssertionResults'];
 
 export type TAssertionResultEntry = {
   id: string;
   selector: string;
+  spanCount: number;
+  pseudoSelector?: TPseudoSelector;
+  selectorList: TSpanSelector[];
   resultList: TAssertionResult[];
 };
 

--- a/web/src/types/Test.types.ts
+++ b/web/src/types/Test.types.ts
@@ -6,7 +6,7 @@ export type TRawTest = TTestSchemas['Test'];
 export type TTest = Model<
   TRawTest,
   {
-    definition?: TTestDefinition;
+    definition: TTestDefinition;
     serviceUnderTest?: {
       request?: THttpSchemas['HTTPRequest'];
     };


### PR DESCRIPTION
This PR moves the assertions logic to the backend.

## Changes

- Adds TestDefinition concept and provider.
- Adds more mocks for models.
- Includes API calls for setting and querying spans.

## Fixes

- https://github.com/kubeshop/tracetest/issues/493

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [x] added a test
