### PR TITLE
map parentID in flat structure

### DIFF
--- a/server/http/mappings.go
+++ b/server/http/mappings.go
@@ -127,6 +127,7 @@ func (m openapiMapper) Trace(in *traces.Trace) openapi.Trace {
 		flat[id.String()] = openapi.Span{
 			Id:         span.ID.String(),
 			Attributes: map[string]string(span.Attributes),
+			ParentId:   span.Parent.ID.String(),
 		}
 	}
 

--- a/server/http/mappings.go
+++ b/server/http/mappings.go
@@ -124,12 +124,16 @@ func (m openapiMapper) Trace(in *traces.Trace) openapi.Trace {
 
 	flat := map[string]openapi.Span{}
 	for id, span := range in.Flat {
+		parentID := ""
+		if span.Parent != nil {
+			parentID = span.Parent.ID.String()
+		}
 		flat[id.String()] = openapi.Span{
 			Id:         span.ID.String(),
 			Attributes: map[string]string(span.Attributes),
 			StartTime:  span.StartTime,
 			EndTime:    span.EndTime,
-			ParentId:   span.Parent.ID.String(),
+			ParentId:   parentID,
 		}
 	}
 

--- a/server/http/mappings.go
+++ b/server/http/mappings.go
@@ -127,6 +127,8 @@ func (m openapiMapper) Trace(in *traces.Trace) openapi.Trace {
 		flat[id.String()] = openapi.Span{
 			Id:         span.ID.String(),
 			Attributes: map[string]string(span.Attributes),
+			StartTime:  span.StartTime,
+			EndTime:    span.EndTime,
 			ParentId:   span.Parent.ID.String(),
 		}
 	}


### PR DESCRIPTION
This PR maps the `parentID` field to the response object

## Checklist

- [ ] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
