### PR TITLE
Add assertion feedback endpoint

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -207,6 +207,38 @@ paths:
                 type: array
                 items:
                   type: string
+  /tests/{testId}/run/{runId}/dry-run:
+    put:
+      tags:
+        - api
+      parameters:
+        - in: path
+          name: testId
+          schema:
+            type: string
+            format: uuid
+          required: true
+        - in: path
+          name: runId
+          schema:
+            type: string
+            format: uuid
+          required: true
+      summary: "run given assertions agains the traces from the given run without persisting anything"
+      description: "use this method to test a definition agains an actual trace without creating a new version or persisting anything"
+      operationId: assertionDryRun
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "./tests.yaml#/components/schemas/TestDefinition"
+      responses:
+        200:
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                $ref: "./tests.yaml#/components/schemas/AssertionResults"
   /tests/{testId}/run/{runId}/rerun:
     post:
       tags:

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -225,7 +225,7 @@ paths:
             format: uuid
           required: true
       summary: "run given assertions against the traces from the given run without persisting anything"
-      description: "use this method to test a definition agains an actual trace without creating a new version or persisting anything"
+      description: "use this method to test a definition against an actual trace without creating a new version or persisting anything"
       operationId: assertionDryRun
       requestBody:
         content:

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -226,7 +226,7 @@ paths:
           required: true
       summary: "run given assertions against the traces from the given run without persisting anything"
       description: "use this method to test a definition against an actual trace without creating a new version or persisting anything"
-      operationId: assertionDryRun
+      operationId: dryRunAssertion
       requestBody:
         content:
           application/json:

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -224,7 +224,7 @@ paths:
             type: string
             format: uuid
           required: true
-      summary: "run given assertions agains the traces from the given run without persisting anything"
+      summary: "run given assertions against the traces from the given run without persisting anything"
       description: "use this method to test a definition agains an actual trace without creating a new version or persisting anything"
       operationId: assertionDryRun
       requestBody:

--- a/server/http/controller.go
+++ b/server/http/controller.go
@@ -290,7 +290,7 @@ func (c *controller) UpdateTest(ctx context.Context, testID string, in openapi.T
 	return openapi.Response(204, nil), nil
 }
 
-func (c *controller) AssertionDryRun(ctx context.Context, _, runID string, def openapi.TestDefinition) (openapi.ImplResponse, error) {
+func (c *controller) DryRunAssertion(ctx context.Context, _, runID string, def openapi.TestDefinition) (openapi.ImplResponse, error) {
 	rid, err := uuid.Parse(runID)
 	if err != nil {
 		return openapi.Response(http.StatusUnprocessableEntity, err.Error()), err

--- a/server/http/controller.go
+++ b/server/http/controller.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/hex"
 	"errors"
+	"fmt"
 	"net/http"
 
 	"github.com/google/uuid"
@@ -301,7 +302,7 @@ func (c *controller) AssertionDryRun(ctx context.Context, _, runID string, def o
 	}
 
 	if run.Trace == nil {
-		return openapi.Response(http.StatusInternalServerError, "given run has no trace associated"), nil
+		return openapi.Response(http.StatusUnprocessableEntity, fmt.Sprintf(`run "%s" has no trace associated`, runID)), nil
 	}
 
 	results, allPassed := assertions.Assert(c.model.Definition(def), *run.Trace)

--- a/server/openapi/api.go
+++ b/server/openapi/api.go
@@ -18,6 +18,7 @@ import (
 // The ApiApiRouter implementation should parse necessary information from the http request,
 // pass the data to a ApiApiServicer to perform the required actions, then write the service results to the http response.
 type ApiApiRouter interface {
+	AssertionDryRun(http.ResponseWriter, *http.Request)
 	CreateTest(http.ResponseWriter, *http.Request)
 	DeleteTest(http.ResponseWriter, *http.Request)
 	GetTest(http.ResponseWriter, *http.Request)
@@ -37,6 +38,7 @@ type ApiApiRouter interface {
 // while the service implementation can ignored with the .openapi-generator-ignore file
 // and updated with the logic required for the API.
 type ApiApiServicer interface {
+	AssertionDryRun(context.Context, string, string, TestDefinition) (ImplResponse, error)
 	CreateTest(context.Context, Test) (ImplResponse, error)
 	DeleteTest(context.Context, string) (ImplResponse, error)
 	GetTest(context.Context, string) (ImplResponse, error)

--- a/server/openapi/api.go
+++ b/server/openapi/api.go
@@ -18,9 +18,9 @@ import (
 // The ApiApiRouter implementation should parse necessary information from the http request,
 // pass the data to a ApiApiServicer to perform the required actions, then write the service results to the http response.
 type ApiApiRouter interface {
-	AssertionDryRun(http.ResponseWriter, *http.Request)
 	CreateTest(http.ResponseWriter, *http.Request)
 	DeleteTest(http.ResponseWriter, *http.Request)
+	DryRunAssertion(http.ResponseWriter, *http.Request)
 	GetTest(http.ResponseWriter, *http.Request)
 	GetTestDefinition(http.ResponseWriter, *http.Request)
 	GetTestResultSelectedSpans(http.ResponseWriter, *http.Request)
@@ -38,9 +38,9 @@ type ApiApiRouter interface {
 // while the service implementation can ignored with the .openapi-generator-ignore file
 // and updated with the logic required for the API.
 type ApiApiServicer interface {
-	AssertionDryRun(context.Context, string, string, TestDefinition) (ImplResponse, error)
 	CreateTest(context.Context, Test) (ImplResponse, error)
 	DeleteTest(context.Context, string) (ImplResponse, error)
+	DryRunAssertion(context.Context, string, string, TestDefinition) (ImplResponse, error)
 	GetTest(context.Context, string) (ImplResponse, error)
 	GetTestDefinition(context.Context, string) (ImplResponse, error)
 	GetTestResultSelectedSpans(context.Context, string, string, string) (ImplResponse, error)

--- a/server/openapi/api_api.go
+++ b/server/openapi/api_api.go
@@ -51,6 +51,12 @@ func NewApiApiController(s ApiApiServicer, opts ...ApiApiOption) Router {
 func (c *ApiApiController) Routes() Routes {
 	return Routes{
 		{
+			"AssertionDryRun",
+			strings.ToUpper("Put"),
+			"/api/tests/{testId}/run/{runId}/dry-run",
+			c.AssertionDryRun,
+		},
+		{
 			"CreateTest",
 			strings.ToUpper("Post"),
 			"/api/tests",
@@ -123,6 +129,35 @@ func (c *ApiApiController) Routes() Routes {
 			c.UpdateTest,
 		},
 	}
+}
+
+// AssertionDryRun - run given assertions agains the traces from the given run without persisting anything
+func (c *ApiApiController) AssertionDryRun(w http.ResponseWriter, r *http.Request) {
+	params := mux.Vars(r)
+	testIdParam := params["testId"]
+
+	runIdParam := params["runId"]
+
+	testDefinitionParam := TestDefinition{}
+	d := json.NewDecoder(r.Body)
+	d.DisallowUnknownFields()
+	if err := d.Decode(&testDefinitionParam); err != nil {
+		c.errorHandler(w, r, &ParsingError{Err: err}, nil)
+		return
+	}
+	if err := AssertTestDefinitionRequired(testDefinitionParam); err != nil {
+		c.errorHandler(w, r, err, nil)
+		return
+	}
+	result, err := c.service.AssertionDryRun(r.Context(), testIdParam, runIdParam, testDefinitionParam)
+	// If an error occurred, encode the error with the status code
+	if err != nil {
+		c.errorHandler(w, r, err, &result)
+		return
+	}
+	// If no error, encode the body and the result code
+	EncodeJSONResponse(result.Body, &result.Code, w)
+
 }
 
 // CreateTest - Create new test

--- a/server/openapi/model_test_.go
+++ b/server/openapi/model_test_.go
@@ -28,6 +28,9 @@ func AssertTestRequired(obj Test) error {
 	if err := AssertTestServiceUnderTestRequired(obj.ServiceUnderTest); err != nil {
 		return err
 	}
+	if err := AssertTestDefinitionRequired(obj.Definition); err != nil {
+		return err
+	}
 	if err := AssertTestRunRequired(obj.ReferenceTestRun); err != nil {
 		return err
 	}


### PR DESCRIPTION
This PR adds and endpoint to try test definitions against existing results without modifying the DB.

Example requests (works against beta db):

## Success

```bash
curl "http://localhost:8080/api/tests/f04330f2-56e8-4db4-8af5-2fbb4bf5d4c3/run/28c97b89-e5e9-4235-adc3-01ceddecf886/dry-run" \
    -X PUT \
    -H "Content-Type: application/json" \
    -d '{
        "definitions":[
            {
                "selector": "span[name=\"POST /pokemon/import\"]",
                "assertions": [
                    {
                        "attribute": "tracetest.response.status",
                        "comparator": "=",
                        "expected": "200"
                    }
                ]
            }
        ]
    }'
```

**Result**:

```json
{
  "allPassed": true,
  "results": [
    {
      "selector": "span[name=\"POST /pokemon/import\"]",
      "results": [
        {
          "assertion": {
            "attribute": "tracetest.response.status",
            "comparator": "=",
            "expected": "200"
          },
          "spanResults": [
            {
              "spanId": "36888225769c0b39",
              "observedValue": "200",
              "passed": true
            }
          ]
        }
      ]
    }
  ]
}
```

## Failing

```bash
curl "http://localhost:8080/api/tests/f04330f2-56e8-4db4-8af5-2fbb4bf5d4c3/run/28c97b89-e5e9-4235-adc3-01ceddecf886/dry-run" \
    -X PUT \
    -H "Content-Type: application/json" \
    -d '{
        "definitions":[
            {
                "selector": "span[name=\"POST /pokemon/import\"]",
                "assertions": [
                    {
                        "attribute": "tracetest.response.status",
                        "comparator": "=",
                        "expected": "201"
                    }
                ]
            }
        ]
    }'
```

**Result**:

```json
{
  "results": [
    {
      "selector": "span[name=\"POST /pokemon/import\"]",
      "results": [
        {
          "assertion": {
            "attribute": "tracetest.response.status",
            "comparator": "=",
            "expected": "201"
          },
          "spanResults": [
            {
              "spanId": "36888225769c0b39",
              "observedValue": "200",
              "error": "no match"
            }
          ]
        }
      ]
    }
  ]
}
```

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
