### PR TITLE
513 simple ux issues

### DIFF
--- a/web/cypress/support/index.js
+++ b/web/cypress/support/index.js
@@ -14,7 +14,7 @@
 // ***********************************************************
 
 // Import commands.js using ES2015 syntax:
-import './commands'
+import './commands';
 
 // Alternatively you can use CommonJS syntax:
 // require('./commands')

--- a/web/package.json
+++ b/web/package.json
@@ -41,6 +41,7 @@
   },
   "scripts": {
     "start": "craco start",
+    "port-forward": "kubectl -n tracetest-beta port-forward svc/tracetest-beta 8080:8080",
     "build": "craco build",
     "test": "npm run test:unit",
     "test:integration": "npm run cy:run",

--- a/web/src/components/AssertionForm/AssertionForm.tsx
+++ b/web/src/components/AssertionForm/AssertionForm.tsx
@@ -153,7 +153,7 @@ const AssertionForm: React.FC<TAssertionFormProps> = ({
         <S.AssertionFromActions>
           <Button onClick={onCancel}>Cancel</Button>
           <Button type="primary" onClick={form.submit} data-cy="assertion-form-submit-button">
-            Add
+            {isEditing ? 'Save' : 'Add'}
           </Button>
         </S.AssertionFromActions>
       </Form>

--- a/web/src/components/AssertionForm/AssertionFormCheckList.tsx
+++ b/web/src/components/AssertionForm/AssertionFormCheckList.tsx
@@ -13,8 +13,11 @@ import * as S from './AssertionForm.styled';
 interface IProps {
   fields: FormListFieldData[];
   assertionList: TAssertion[];
+
   add(): void;
+
   remove(name: number): void;
+
   attributeList: TSpanFlatAttribute[];
 }
 
@@ -77,13 +80,12 @@ const AssertionFormCheckList: React.FC<IProps> = ({fields, add, remove, attribut
           >
             <Input placeholder="Expected Value" />
           </Form.Item>
+
           <S.CheckActions>
             <S.DeleteCheckIcon
               onClick={() => {
-                if (index !== 0) {
-                  CreateAssertionModalAnalyticsService.onRemoveCheck();
-                  remove(name);
-                }
+                CreateAssertionModalAnalyticsService.onRemoveCheck();
+                remove(name);
               }}
             />
             {index === fields.length - 1 && (

--- a/web/src/components/AssertionForm/AssertionFormProvider.tsx
+++ b/web/src/components/AssertionForm/AssertionFormProvider.tsx
@@ -1,5 +1,5 @@
 import {noop} from 'lodash';
-import {useState, createContext, useCallback, useMemo, useContext} from 'react';
+import {useState, createContext, useCallback, useMemo, useContext, Dispatch, SetStateAction} from 'react';
 import {useTestDefinition} from '../../providers/TestDefinition/TestDefinition.provider';
 import SelectorService from '../../services/Selector.service';
 import {TTestDefinitionEntry} from '../../types/TestDefinition.types';
@@ -12,10 +12,18 @@ interface IFormProps {
 }
 
 interface ICreateAssertionModalProviderContext {
+  isCollapsed: boolean;
+
+  setIsCollapsed: Dispatch<SetStateAction<boolean>>;
+
   isOpen: boolean;
+
   open(props?: IFormProps): void;
+
   close(): void;
+
   onSubmit(values: IValues): void;
+
   formProps: IFormProps;
 }
 
@@ -24,6 +32,8 @@ const initialFormProps = {
 };
 
 export const Context = createContext<ICreateAssertionModalProviderContext>({
+  isCollapsed: false,
+  setIsCollapsed: noop,
   isOpen: false,
   open: noop,
   close: noop,
@@ -34,6 +44,7 @@ export const Context = createContext<ICreateAssertionModalProviderContext>({
 export const useAssertionForm = () => useContext(Context);
 
 const AssertionFormProvider: React.FC<{testId: string}> = ({children}) => {
+  const [isCollapsed, setIsCollapsed] = useState(false);
   const [isOpen, setIsOpen] = useState(false);
   const [formProps, setFormProps] = useState<IFormProps>(initialFormProps);
   const {update, add} = useTestDefinition();
@@ -66,8 +77,8 @@ const AssertionFormProvider: React.FC<{testId: string}> = ({children}) => {
   );
 
   const contextValue = useMemo(
-    () => ({isOpen, open, close, formProps, onSubmit}),
-    [isOpen, open, close, formProps, onSubmit]
+    () => ({isOpen, open, close, formProps, onSubmit, isCollapsed, setIsCollapsed}),
+    [isOpen, open, close, formProps, onSubmit, isCollapsed, setIsCollapsed]
   );
 
   return <Context.Provider value={contextValue}>{children}</Context.Provider>;

--- a/web/src/components/TestHeader/TestHeader.tsx
+++ b/web/src/components/TestHeader/TestHeader.tsx
@@ -1,5 +1,6 @@
 import {TTest} from '../../types/Test.types';
 import {TTestRunState} from '../../types/TestRun.types';
+import {useAssertionForm} from '../AssertionForm/AssertionFormProvider';
 import TestState from '../TestState';
 import * as S from './TestHeader.styled';
 
@@ -10,6 +11,7 @@ interface TTestHeaderProps {
 }
 
 const TestHeader: React.FC<TTestHeaderProps> = ({test: {name, serviceUnderTest}, onBack, testState}) => {
+  const {setIsCollapsed} = useAssertionForm();
   return (
     <S.TestHeader>
       <S.Content>
@@ -20,7 +22,7 @@ const TestHeader: React.FC<TTestHeaderProps> = ({test: {name, serviceUnderTest},
         </S.TestUrl>
       </S.Content>
       {testState && (
-        <S.StateContainer data-cy="test-run-result-status">
+        <S.StateContainer onClick={() => setIsCollapsed(o => !o)} data-cy="test-run-result-status">
           <S.StateText>Test status:</S.StateText>
           <TestState testState={testState} />
         </S.StateContainer>

--- a/web/src/components/TraceDrawer/TraceDrawer.tsx
+++ b/web/src/components/TraceDrawer/TraceDrawer.tsx
@@ -1,13 +1,13 @@
 import {Drawer} from 'antd';
-import {useState, useEffect} from 'react';
+import {useEffect} from 'react';
 import {TTestRun} from 'types/TestRun.types';
+import {useTestDefinition} from '../../providers/TestDefinition/TestDefinition.provider';
+import AssertionForm from '../AssertionForm';
+import {useAssertionForm} from '../AssertionForm/AssertionFormProvider';
+import LoadingSpinner from '../LoadingSpinner';
 import TestResults from '../TestResults';
 import * as S from './TraceDrawer.styled';
 import TraceDrawerHeader from './TraceDrawerHeader';
-import {useAssertionForm} from '../AssertionForm/AssertionFormProvider';
-import AssertionForm from '../AssertionForm';
-import {useTestDefinition} from '../../providers/TestDefinition/TestDefinition.provider';
-import LoadingSpinner from '../LoadingSpinner';
 
 interface IProps {
   visiblePortion: number;
@@ -17,13 +17,12 @@ interface IProps {
 }
 
 const TraceDrawer: React.FC<IProps> = ({run: {id: runId}, run, testId, visiblePortion, onSelectSpan}) => {
-  const [isCollapsed, setIsCollapsed] = useState(false);
-  const {isOpen: isAssertionFormOpen, formProps, onSubmit, close} = useAssertionForm();
+  const {isOpen: isAssertionFormOpen, formProps, onSubmit, close, isCollapsed, setIsCollapsed} = useAssertionForm();
   const {isLoading} = useTestDefinition();
 
   useEffect(() => {
     if (isAssertionFormOpen) setIsCollapsed(true);
-  }, [isAssertionFormOpen]);
+  }, [isAssertionFormOpen, setIsCollapsed]);
 
   return (
     <Drawer


### PR DESCRIPTION
This PR solves a couple of issues found on #513 

## Changes

- We want to be able to click on 'Test Status: Finished' and have the bottom test area expand (we watch somebody do this... might as well help get them to the test if they do not see it at the bottom) ✅ 

- When editing an assertion, the 'Add' button should say 'Save' ✅ 

- If you add a second check line (ie add check), there is no way to delete that line. Should have a trash can next to it. ✅ 


## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
