### PR TITLE
feat: rerun test run creates a new run and copy data from original one

### DIFF
--- a/server/http/controller.go
+++ b/server/http/controller.go
@@ -13,11 +13,14 @@ import (
 	"github.com/kubeshop/tracetest/assertions/comparator"
 	"github.com/kubeshop/tracetest/assertions/selectors"
 	"github.com/kubeshop/tracetest/executor"
+	"github.com/kubeshop/tracetest/id"
 	"github.com/kubeshop/tracetest/model"
 	"github.com/kubeshop/tracetest/openapi"
 	"github.com/kubeshop/tracetest/testdb"
 	"github.com/kubeshop/tracetest/tracedb"
 )
+
+var IDGen = id.NewRandGenerator()
 
 type controller struct {
 	testDB          model.Repository
@@ -214,15 +217,23 @@ func (c *controller) RerunTestRun(ctx context.Context, testID string, runID stri
 		return handleDBError(err), err
 	}
 
-	run.State = model.RunStateAwaitingTestResults
-	err = c.testDB.UpdateRun(ctx, run)
+	newTestRun := run
+	newTestRun.Results = nil
+
+	newTestRun, err = c.testDB.CreateRun(ctx, test, newTestRun)
+	if err != nil {
+		return openapi.Response(http.StatusUnprocessableEntity, err.Error()), err
+	}
+
+	newTestRun.State = model.RunStateAwaitingTestResults
+	err = c.testDB.UpdateRun(ctx, newTestRun)
 	if err != nil {
 		return openapi.Response(http.StatusInternalServerError, err.Error()), err
 	}
 
 	assertionRequest := executor.AssertionRequest{
 		Test: test,
-		Run:  run,
+		Run:  newTestRun,
 	}
 
 	c.assertionRunner.RunAssertions(assertionRequest)

--- a/server/http/controller.go
+++ b/server/http/controller.go
@@ -219,6 +219,7 @@ func (c *controller) RerunTestRun(ctx context.Context, testID string, runID stri
 
 	newTestRun := run
 	newTestRun.Results = nil
+	newTestRun.TestVersion = test.Version
 
 	newTestRun, err = c.testDB.CreateRun(ctx, test, newTestRun)
 	if err != nil {


### PR DESCRIPTION
This PR creates a new test run when a run is rerun instead of updating the same run. It also uses the latest test version to run the assertions.

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
