### PR TITLE
add test fixtures to improve test setup

### DIFF
--- a/server/executor/integration_test.go
+++ b/server/executor/integration_test.go
@@ -1,61 +1,26 @@
 package executor_test
 
 import (
-	"bytes"
-	"encoding/json"
-	"fmt"
-	"io/ioutil"
-	"net/http"
 	"testing"
-	"time"
 
-	"github.com/kubeshop/tracetest/server/app"
 	"github.com/kubeshop/tracetest/server/model"
 	"github.com/kubeshop/tracetest/server/openapi"
-	"github.com/kubeshop/tracetest/server/testmock"
+	"github.com/kubeshop/tracetest/server/testfixtures"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 const appEndpoint = "http://localhost:8080"
 
 func TestExecutorIntegration(t *testing.T) {
-	demoApp, err := testmock.GetDemoApplicationInstance()
-	require.NoError(t, err)
-	defer demoApp.Stop()
-
-	tracetestApp, err := testmock.GetTestingApp(demoApp)
-	require.NoError(t, err)
-
-	go tracetestApp.Start()
-
-	time.Sleep(1 * time.Second)
-
-	t.Run("HappyPath", func(t *testing.T) {
-		happyPath(t, tracetestApp, demoApp)
-	})
-}
-
-func happyPath(t *testing.T, app *app.App, demoApp *testmock.DemoApp) {
-	testID, err := createImportPokemonTest(app, demoApp)
+	testRun, err := testfixtures.GetFixtureValue[*openapi.TestRun](testfixtures.IMPORT_POKEMON_TEST_RUN)
 	assert.NoError(t, err)
-	assert.NotEmpty(t, testID)
 
-	createTestDefinition(testID)
-
-	runID, err := runTest(app, testID)
-	assert.NoError(t, err)
-	assert.NotEmpty(t, runID)
-
-	run := waitForRunState(app, testID, runID, string(model.RunStateFinished), 30*time.Second)
-	require.NotNil(t, run)
-
-	assert.Equal(t, string(model.RunStateFinished), run.State)
-	assert.Greater(t, len(run.Result.Results), 0)
-	assert.True(t, run.Result.AllPassed)
+	assert.Equal(t, string(model.RunStateFinished), testRun.State)
+	assert.Greater(t, len(testRun.Result.Results), 0)
+	assert.True(t, testRun.Result.AllPassed)
 
 	count := 0
-	for _, res := range run.Result.Results {
+	for _, res := range testRun.Result.Results {
 		for _, assertionResult := range res.Results {
 			for _, spanRes := range assertionResult.SpanResults {
 				assert.True(t, spanRes.Passed)
@@ -65,179 +30,4 @@ func happyPath(t *testing.T, app *app.App, demoApp *testmock.DemoApp) {
 	}
 
 	assert.Equal(t, 2, count)
-}
-
-func createImportPokemonTest(app *app.App, demoApp *testmock.DemoApp) (string, error) {
-	body := openapi.Test{
-		Name:        "Import Pokemon",
-		Description: "Import a pokemon into the api",
-		ServiceUnderTest: openapi.TestServiceUnderTest{
-			Request: openapi.HttpRequest{
-				Url:    fmt.Sprintf("http://%s/pokemon/import", demoApp.Endpoint()),
-				Method: "POST",
-				Headers: []openapi.HttpHeader{
-					{
-						Key:   "Content-Type",
-						Value: "application/json",
-					},
-				},
-				Body: `{ "id": 52 }`,
-			},
-		},
-	}
-	jsonBytes, err := json.Marshal(body)
-	if err != nil {
-		return "", fmt.Errorf("could not convert body into json: %w", err)
-	}
-	bytesBuffer := bytes.NewBuffer(jsonBytes)
-	url := fmt.Sprintf("%s/api/tests", appEndpoint)
-
-	response, err := http.Post(url, "application/json", bytesBuffer)
-	if err != nil {
-		return "", fmt.Errorf("could not create test: %w", err)
-	}
-
-	if response.StatusCode != 200 {
-		return "", fmt.Errorf("could not create test. Expected status 200, got %d", response.StatusCode)
-	}
-
-	bodyBytes, err := ioutil.ReadAll(response.Body)
-	if err != nil {
-		return "", fmt.Errorf("could not read response body: %w", err)
-	}
-
-	test := openapi.Test{}
-	err = json.Unmarshal(bodyBytes, &test)
-	if err != nil {
-		return "", fmt.Errorf("could not unmarshal response body: %w", err)
-	}
-
-	return test.Id, nil
-}
-
-func createTestDefinition(testID string) {
-	body := openapi.TestDefinition{
-		Definitions: []openapi.TestDefinitionDefinitions{
-			{
-				Selector: `span[service.name="pokeshop" tracetest.span.type="http" name="POST /pokemon/import"]`,
-				Assertions: []openapi.Assertion{
-					{
-						Attribute:  "http.status_code",
-						Comparator: "=",
-						Expected:   "200",
-					},
-					{
-						Attribute:  "tracetest.span.duration",
-						Comparator: "<",
-						Expected:   "200",
-					},
-				},
-			},
-		},
-	}
-	jsonBytes, err := json.Marshal(body)
-	if err != nil {
-		panic(fmt.Errorf("could not convert body into json: %w", err))
-	}
-	bytesBuffer := bytes.NewBuffer(jsonBytes)
-	url := fmt.Sprintf("%s/api/tests/%s/definition", appEndpoint, testID)
-
-	req, _ := http.NewRequest("PUT", url, bytesBuffer)
-	req.Header.Set("Content-Type", "application/json")
-	response, err := http.DefaultClient.Do(req)
-	if err != nil {
-		panic(fmt.Errorf("could not send request to create assertion: %w", err))
-	}
-
-	if response.StatusCode != 204 {
-		panic(fmt.Errorf("could not create definition. Expected status 201, got %d", response.StatusCode))
-	}
-}
-
-func runTest(app *app.App, testID string) (string, error) {
-	url := fmt.Sprintf("%s/api/tests/%s/run", appEndpoint, testID)
-	response, err := http.Post(url, "application/json", nil)
-	if err != nil {
-		return "", fmt.Errorf("could not send request to run test: %w", err)
-	}
-
-	if response.StatusCode != 200 {
-		return "", fmt.Errorf("could not run test. Expected status 200, got %d", response.StatusCode)
-	}
-
-	bodyBytes, err := ioutil.ReadAll(response.Body)
-	if err != nil {
-		return "", fmt.Errorf("could not read response body: %w", err)
-	}
-
-	testRun := openapi.TestRun{}
-	err = json.Unmarshal(bodyBytes, &testRun)
-	if err != nil {
-		return "", fmt.Errorf("could not unmarshal response body: %w", err)
-	}
-
-	return testRun.Id, nil
-}
-
-func waitForRunState(app *app.App, testID, runID, state string, timeout time.Duration) *openapi.TestRun {
-	timeoutTicker := time.NewTicker(timeout)
-	executionTicker := time.NewTicker(1 * time.Second)
-	outputChannel := make(chan *openapi.TestRun, 1)
-	go func() {
-		for {
-			select {
-			case <-timeoutTicker.C:
-				outputChannel <- nil
-				return
-			case <-executionTicker.C:
-				testRun := getRunInState(app, testID, runID, state)
-				if testRun != nil {
-					outputChannel <- testRun
-					return
-				}
-			}
-		}
-	}()
-
-	testRun := <-outputChannel
-	return testRun
-}
-
-func getRunInState(app *app.App, testID, resultID, state string) *openapi.TestRun {
-	run, err := getRun(app, testID, resultID)
-	if err != nil {
-		return nil
-	}
-
-	if run.State != state {
-		return nil
-
-	}
-
-	return &run
-}
-
-func getRun(app *app.App, testID, runID string) (openapi.TestRun, error) {
-	url := fmt.Sprintf("%s/api/tests/%s/run/%s", appEndpoint, testID, runID)
-	response, err := http.Get(url)
-	if err != nil {
-		return openapi.TestRun{}, fmt.Errorf("could not send request to run test: %w", err)
-	}
-
-	if response.StatusCode != 200 {
-		return openapi.TestRun{}, fmt.Errorf("could not run test. Expected status 200, got %d", response.StatusCode)
-	}
-
-	bodyBytes, err := ioutil.ReadAll(response.Body)
-	if err != nil {
-		return openapi.TestRun{}, fmt.Errorf("could not read response body: %w", err)
-	}
-
-	run := openapi.TestRun{}
-	err = json.Unmarshal(bodyBytes, &run)
-	if err != nil {
-		return openapi.TestRun{}, fmt.Errorf("could not unmarshal response body: %w", err)
-	}
-
-	return run, nil
 }

--- a/server/executor/integration_test.go
+++ b/server/executor/integration_test.go
@@ -4,7 +4,6 @@ import (
 	"testing"
 
 	"github.com/kubeshop/tracetest/server/model"
-	"github.com/kubeshop/tracetest/server/openapi"
 	"github.com/kubeshop/tracetest/server/testfixtures"
 	"github.com/stretchr/testify/assert"
 )
@@ -12,7 +11,7 @@ import (
 const appEndpoint = "http://localhost:8080"
 
 func TestExecutorIntegration(t *testing.T) {
-	testRun, err := testfixtures.GetFixtureValue[*openapi.TestRun](testfixtures.IMPORT_POKEMON_TEST_RUN)
+	testRun, err := testfixtures.GetPokemonTestRun()
 	assert.NoError(t, err)
 
 	assert.Equal(t, string(model.RunStateFinished), testRun.State)

--- a/server/http/controller_integration_test.go
+++ b/server/http/controller_integration_test.go
@@ -1,0 +1,57 @@
+package http_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"testing"
+
+	"github.com/kubeshop/tracetest/openapi"
+	"github.com/kubeshop/tracetest/testfixtures"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+var endpointUrl = "http://localhost:8080"
+
+func TestRerun(t *testing.T) {
+	importPokemonTest, err := testfixtures.GetPokemonTest()
+	require.NoError(t, err)
+
+	importPokemonTestRun, err := testfixtures.GetPokemonTestRun()
+	require.NoError(t, err)
+
+	newTestRun, err := rerunTestRun(importPokemonTest, importPokemonTestRun)
+	assert.NoError(t, err)
+
+	assert.NotEqual(t, importPokemonTestRun.Id, newTestRun.Id)
+	assert.Equal(t, importPokemonTestRun.Request, newTestRun.Request)
+	assert.Equal(t, importPokemonTestRun.Response, newTestRun.Response)
+	assert.Equal(t, importPokemonTestRun.Trace, newTestRun.Trace)
+}
+
+func rerunTestRun(test *openapi.Test, testRun *openapi.TestRun) (*openapi.TestRun, error) {
+	url := fmt.Sprintf("%s/api/tests/%s/run/%s/rerun", endpointUrl, test.Id, testRun.Id)
+	response, err := http.Post(url, "application/json", nil)
+	if err != nil {
+		return nil, err
+	}
+
+	if response.StatusCode != 200 {
+		return nil, fmt.Errorf("expected status 200, got %d", response.StatusCode)
+	}
+
+	responseBody := openapi.TestRun{}
+	bodyContent, err := ioutil.ReadAll(response.Body)
+	if err != nil {
+		return nil, fmt.Errorf("could not read response body: %w", err)
+	}
+
+	err = json.Unmarshal(bodyContent, &responseBody)
+	if err != nil {
+		return nil, fmt.Errorf("could not unmarshal body: %w", err)
+	}
+
+	return &responseBody, nil
+}

--- a/server/http/controller_integration_test.go
+++ b/server/http/controller_integration_test.go
@@ -7,8 +7,8 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/kubeshop/tracetest/openapi"
-	"github.com/kubeshop/tracetest/testfixtures"
+	"github.com/kubeshop/tracetest/server/openapi"
+	"github.com/kubeshop/tracetest/server/testfixtures"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/server/integration/rerun_test_run_test.go
+++ b/server/integration/rerun_test_run_test.go
@@ -20,7 +20,7 @@ func TestRerun(t *testing.T) {
 	importPokemonTestRun, err := testfixtures.GetPokemonTestRun()
 	require.NoError(t, err)
 
-	newTestRun, err := rerunTestRun(importPokemonTest, importPokemonTestRun)
+	newTestRun := rerunTestRun(t, importPokemonTest, importPokemonTestRun)
 	assert.NoError(t, err)
 
 	assert.NotEqual(t, importPokemonTestRun.Id, newTestRun.Id)
@@ -29,27 +29,21 @@ func TestRerun(t *testing.T) {
 	assert.Equal(t, importPokemonTestRun.Trace, newTestRun.Trace)
 }
 
-func rerunTestRun(test *openapi.Test, testRun *openapi.TestRun) (*openapi.TestRun, error) {
+func rerunTestRun(t *testing.T, test *openapi.Test, testRun *openapi.TestRun) *openapi.TestRun {
 	url := fmt.Sprintf("%s/api/tests/%s/run/%s/rerun", endpointUrl, test.Id, testRun.Id)
 	response, err := http.Post(url, "application/json", nil)
-	if err != nil {
-		return nil, err
-	}
+	require.NoError(t, err)
 
 	if response.StatusCode != 200 {
-		return nil, fmt.Errorf("expected status 200, got %d", response.StatusCode)
+		require.Fail(t, fmt.Sprintf("expected status 200, got %d", response.StatusCode))
 	}
 
 	responseBody := openapi.TestRun{}
 	bodyContent, err := ioutil.ReadAll(response.Body)
-	if err != nil {
-		return nil, fmt.Errorf("could not read response body: %w", err)
-	}
+	require.NoError(t, err)
 
 	err = json.Unmarshal(bodyContent, &responseBody)
-	if err != nil {
-		return nil, fmt.Errorf("could not unmarshal body: %w", err)
-	}
+	require.NoError(t, err)
 
-	return &responseBody, nil
+	return &responseBody
 }

--- a/server/integration/rerun_test_run_test.go
+++ b/server/integration/rerun_test_run_test.go
@@ -1,4 +1,4 @@
-package http_test
+package integration_test
 
 import (
 	"encoding/json"
@@ -12,8 +12,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
-
-var endpointUrl = "http://localhost:8080"
 
 func TestRerun(t *testing.T) {
 	importPokemonTest, err := testfixtures.GetPokemonTest()

--- a/server/integration/run_and_assert_pokemon_app_test.go
+++ b/server/integration/run_and_assert_pokemon_app_test.go
@@ -1,4 +1,4 @@
-package executor_test
+package integration_test
 
 import (
 	"testing"
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-const appEndpoint = "http://localhost:8080"
+const endpointUrl = "http://localhost:8080"
 
 func TestExecutorIntegration(t *testing.T) {
 	testRun, err := testfixtures.GetPokemonTestRun()

--- a/server/testfixtures/fixture.go
+++ b/server/testfixtures/fixture.go
@@ -1,0 +1,54 @@
+package testfixtures
+
+import (
+	"fmt"
+	"sync"
+)
+
+type Fixture[T comparable] struct {
+	mutex     *sync.Mutex
+	value     T
+	generator Generator[T]
+}
+
+type Generator[T comparable] func(args ...interface{}) (T, error)
+
+var fixtures = make(map[string]interface{}, 0)
+
+func emptyValue[T any]() T {
+	var empty T
+	return empty
+}
+
+func RegisterFixture[T comparable](name string, generator Generator[T]) {
+	fixture := Fixture[T]{
+		mutex:     &sync.Mutex{},
+		value:     emptyValue[T](),
+		generator: generator,
+	}
+
+	fixtures[name] = fixture
+}
+
+func GetFixtureValue[T comparable](name string, args ...interface{}) (T, error) {
+	obj := fixtures[name]
+	fixture, ok := obj.(Fixture[T])
+	if !ok {
+		return emptyValue[T](), fmt.Errorf("fixture \"%s\": conflict between configured and requested types", name)
+	}
+
+	if fixture.value != emptyValue[T]() {
+		return fixture.value, nil
+	}
+
+	fixture.mutex.Lock()
+	defer fixture.mutex.Unlock()
+
+	value, err := fixture.generator(args)
+	if err != nil {
+		return emptyValue[T](), fmt.Errorf("fixture \"%s\": could not get value from generator: %w", name, err)
+	}
+
+	fixture.value = value
+	return value, nil
+}

--- a/server/testfixtures/fixture.go
+++ b/server/testfixtures/fixture.go
@@ -15,7 +15,7 @@ type Generator[T comparable] func(args ...interface{}) (T, error)
 
 var fixtures = make(map[string]interface{}, 0)
 
-func emptyValue[T any]() T {
+func emptyValue[T comparable]() T {
 	var empty T
 	return empty
 }
@@ -50,5 +50,6 @@ func GetFixtureValue[T comparable](name string, args ...interface{}) (T, error) 
 	}
 
 	fixture.value = value
+	fixtures[name] = fixture
 	return value, nil
 }

--- a/server/testfixtures/fixture_names.go
+++ b/server/testfixtures/fixture_names.go
@@ -1,0 +1,8 @@
+package testfixtures
+
+const (
+	POKESHOP_APP            = "pokeshop_app"
+	TRACETEST_APP           = "tracetest_app"
+	IMPORT_POKEMON_TEST     = "import_pokemon_test"
+	IMPORT_POKEMON_TEST_RUN = "import_pokemon_test_run"
+)

--- a/server/testfixtures/fixture_test.go
+++ b/server/testfixtures/fixture_test.go
@@ -1,0 +1,39 @@
+package testfixtures_test
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/kubeshop/tracetest/server/testfixtures"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFixture(t *testing.T) {
+	testfixtures.RegisterFixture("uuid", func(args ...interface{}) (string, error) {
+		return uuid.NewString(), nil
+	})
+
+	var uuid1, uuid2 string
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	go func() {
+		uuid, err := testfixtures.GetFixtureValue[string]("uuid")
+		require.NoError(t, err)
+		uuid1 = uuid
+		wg.Done()
+	}()
+
+	go func() {
+		uuid, err := testfixtures.GetFixtureValue[string]("uuid")
+		require.NoError(t, err)
+		uuid2 = uuid
+		wg.Done()
+	}()
+
+	wg.Wait()
+
+	assert.Equal(t, uuid1, uuid2)
+}

--- a/server/testfixtures/import_pokemon_test_fixture.go
+++ b/server/testfixtures/import_pokemon_test_fixture.go
@@ -1,0 +1,167 @@
+package testfixtures
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+
+	"github.com/kubeshop/tracetest/app"
+	"github.com/kubeshop/tracetest/openapi"
+	"github.com/kubeshop/tracetest/testmock"
+)
+
+const appEndpoint = "http://localhost:8080"
+
+func init() {
+	RegisterFixture(IMPORT_POKEMON_TEST, getImportPokemonTest)
+}
+
+func getImportPokemonTest(args ...interface{}) (*openapi.Test, error) {
+	pokeshopApp, err := GetFixtureValue[*testmock.DemoApp](POKESHOP_APP)
+	if err != nil {
+		return nil, fmt.Errorf("could not get pokeshop app: %w", err)
+	}
+
+	tracetestApp, err := GetFixtureValue[*app.App](TRACETEST_APP)
+	if err != nil {
+		return nil, fmt.Errorf("could not get tracetest app: %w", err)
+	}
+
+	test, err := createImportPokemonTest(tracetestApp, pokeshopApp)
+	if err != nil {
+		return nil, fmt.Errorf("could not create import pokemon test: %w", err)
+	}
+
+	if test.Id == "" {
+		return nil, fmt.Errorf("testID cannot be empty")
+	}
+
+	err = createTestDefinition(test.Id)
+	if err != nil {
+		return nil, fmt.Errorf("could not create test definition: %w", err)
+	}
+
+	updatedTest, err := getTest(test.Id)
+	if err != nil {
+		return nil, fmt.Errorf("could not get test: %w", err)
+	}
+
+	return &updatedTest, nil
+}
+
+func createImportPokemonTest(app *app.App, demoApp *testmock.DemoApp) (openapi.Test, error) {
+	body := openapi.Test{
+		Name:        "Import Pokemon",
+		Description: "Import a pokemon into the api",
+		ServiceUnderTest: openapi.TestServiceUnderTest{
+			Request: openapi.HttpRequest{
+				Url:    fmt.Sprintf("http://%s/pokemon/import", demoApp.Endpoint()),
+				Method: "POST",
+				Headers: []openapi.HttpHeader{
+					{
+						Key:   "Content-Type",
+						Value: "application/json",
+					},
+				},
+				Body: `{ "id": 52 }`,
+			},
+		},
+	}
+	jsonBytes, err := json.Marshal(body)
+	if err != nil {
+		return openapi.Test{}, fmt.Errorf("could not convert body into json: %w", err)
+	}
+	bytesBuffer := bytes.NewBuffer(jsonBytes)
+	url := fmt.Sprintf("%s/api/tests", appEndpoint)
+
+	response, err := http.Post(url, "application/json", bytesBuffer)
+	if err != nil {
+		return openapi.Test{}, fmt.Errorf("could not create test: %w", err)
+	}
+
+	if response.StatusCode != 200 {
+		return openapi.Test{}, fmt.Errorf("could not create test. Expected status 200, got %d", response.StatusCode)
+	}
+
+	bodyBytes, err := ioutil.ReadAll(response.Body)
+	if err != nil {
+		return openapi.Test{}, fmt.Errorf("could not read response body: %w", err)
+	}
+
+	test := openapi.Test{}
+	err = json.Unmarshal(bodyBytes, &test)
+	if err != nil {
+		return openapi.Test{}, fmt.Errorf("could not unmarshal response body: %w", err)
+	}
+
+	return test, nil
+}
+
+func createTestDefinition(testID string) error {
+	body := openapi.TestDefinition{
+		Definitions: []openapi.TestDefinitionDefinitions{
+			{
+				Selector: `span[service.name="pokeshop" tracetest.span.type="http" name="POST /pokemon/import"]`,
+				Assertions: []openapi.Assertion{
+					{
+						Attribute:  "http.status_code",
+						Comparator: "=",
+						Expected:   "200",
+					},
+					{
+						Attribute:  "tracetest.span.duration",
+						Comparator: "<",
+						Expected:   "200",
+					},
+				},
+			},
+		},
+	}
+	jsonBytes, err := json.Marshal(body)
+	if err != nil {
+		return fmt.Errorf("could not convert body into json: %w", err)
+	}
+	bytesBuffer := bytes.NewBuffer(jsonBytes)
+	url := fmt.Sprintf("%s/api/tests/%s/definition", appEndpoint, testID)
+
+	req, _ := http.NewRequest("PUT", url, bytesBuffer)
+	req.Header.Set("Content-Type", "application/json")
+	response, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("could not send request to create assertion: %w", err)
+	}
+
+	if response.StatusCode != 204 {
+		return fmt.Errorf("could not create definition. Expected status 201, got %d", response.StatusCode)
+	}
+
+	return nil
+}
+
+func getTest(testID string) (openapi.Test, error) {
+	url := fmt.Sprintf("%s/api/tests/%s", appEndpoint, testID)
+
+	response, err := http.Get(url)
+	if err != nil {
+		return openapi.Test{}, fmt.Errorf("could not send request to create assertion: %w", err)
+	}
+
+	if response.StatusCode != 200 {
+		return openapi.Test{}, fmt.Errorf("could not create definition. Expected status 201, got %d", response.StatusCode)
+	}
+
+	bodyBytes, err := ioutil.ReadAll(response.Body)
+	if err != nil {
+		return openapi.Test{}, fmt.Errorf("could not read response body: %w", err)
+	}
+
+	test := openapi.Test{}
+	err = json.Unmarshal(bodyBytes, &test)
+	if err != nil {
+		return openapi.Test{}, fmt.Errorf("could not unmarshal response body: %w", err)
+	}
+
+	return test, nil
+}

--- a/server/testfixtures/import_pokemon_test_fixture.go
+++ b/server/testfixtures/import_pokemon_test_fixture.go
@@ -7,15 +7,19 @@ import (
 	"io/ioutil"
 	"net/http"
 
-	"github.com/kubeshop/tracetest/app"
-	"github.com/kubeshop/tracetest/openapi"
-	"github.com/kubeshop/tracetest/testmock"
+	"github.com/kubeshop/tracetest/server/app"
+	"github.com/kubeshop/tracetest/server/openapi"
+	"github.com/kubeshop/tracetest/server/testmock"
 )
 
 const appEndpoint = "http://localhost:8080"
 
 func init() {
 	RegisterFixture(IMPORT_POKEMON_TEST, getImportPokemonTest)
+}
+
+func GetPokemonTest() (*openapi.Test, error) {
+	return GetFixtureValue[*openapi.Test](IMPORT_POKEMON_TEST)
 }
 
 func getImportPokemonTest(args ...interface{}) (*openapi.Test, error) {

--- a/server/testfixtures/import_pokemon_test_run.go
+++ b/server/testfixtures/import_pokemon_test_run.go
@@ -7,13 +7,17 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/kubeshop/tracetest/app"
-	"github.com/kubeshop/tracetest/model"
-	"github.com/kubeshop/tracetest/openapi"
+	"github.com/kubeshop/tracetest/server/app"
+	"github.com/kubeshop/tracetest/server/model"
+	"github.com/kubeshop/tracetest/server/openapi"
 )
 
 func init() {
 	RegisterFixture(IMPORT_POKEMON_TEST_RUN, getImportPokemonTestRun)
+}
+
+func GetPokemonTestRun() (*openapi.TestRun, error) {
+	return GetFixtureValue[*openapi.TestRun](IMPORT_POKEMON_TEST_RUN)
 }
 
 func getImportPokemonTestRun(args ...interface{}) (*openapi.TestRun, error) {

--- a/server/testfixtures/import_pokemon_test_run.go
+++ b/server/testfixtures/import_pokemon_test_run.go
@@ -1,0 +1,133 @@
+package testfixtures
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"time"
+
+	"github.com/kubeshop/tracetest/app"
+	"github.com/kubeshop/tracetest/model"
+	"github.com/kubeshop/tracetest/openapi"
+)
+
+func init() {
+	RegisterFixture(IMPORT_POKEMON_TEST_RUN, getImportPokemonTestRun)
+}
+
+func getImportPokemonTestRun(args ...interface{}) (*openapi.TestRun, error) {
+	tracetestApp, err := GetFixtureValue[*app.App](TRACETEST_APP)
+	if err != nil {
+		return nil, fmt.Errorf("could not get tracetest app: %w", err)
+	}
+
+	importPokemonTest, err := GetFixtureValue[*openapi.Test](IMPORT_POKEMON_TEST)
+	if err != nil {
+		return nil, fmt.Errorf("could not get import pokemon test: %w", err)
+	}
+
+	runID, err := runTest(tracetestApp, importPokemonTest.Id)
+	if err != nil {
+		return nil, fmt.Errorf("could not run test: %w", err)
+	}
+
+	if runID == "" {
+		return nil, fmt.Errorf("run id must not be empty")
+	}
+
+	run := waitForRunState(tracetestApp, importPokemonTest.Id, runID, string(model.RunStateFinished), 30*time.Second)
+	if run == nil {
+		return nil, fmt.Errorf("test run must not be nil")
+	}
+
+	return run, nil
+}
+
+func runTest(app *app.App, testID string) (string, error) {
+	url := fmt.Sprintf("%s/api/tests/%s/run", appEndpoint, testID)
+	response, err := http.Post(url, "application/json", nil)
+	if err != nil {
+		return "", fmt.Errorf("could not send request to run test: %w", err)
+	}
+
+	if response.StatusCode != 200 {
+		return "", fmt.Errorf("could not run test. Expected status 200, got %d", response.StatusCode)
+	}
+
+	bodyBytes, err := ioutil.ReadAll(response.Body)
+	if err != nil {
+		return "", fmt.Errorf("could not read response body: %w", err)
+	}
+
+	testRun := openapi.TestRun{}
+	err = json.Unmarshal(bodyBytes, &testRun)
+	if err != nil {
+		return "", fmt.Errorf("could not unmarshal response body: %w", err)
+	}
+
+	return testRun.Id, nil
+}
+
+func waitForRunState(app *app.App, testID, runID, state string, timeout time.Duration) *openapi.TestRun {
+	timeoutTicker := time.NewTicker(timeout)
+	executionTicker := time.NewTicker(1 * time.Second)
+	outputChannel := make(chan *openapi.TestRun, 1)
+	go func() {
+		for {
+			select {
+			case <-timeoutTicker.C:
+				outputChannel <- nil
+				return
+			case <-executionTicker.C:
+				testRun := getRunInState(app, testID, runID, state)
+				if testRun != nil {
+					outputChannel <- testRun
+					return
+				}
+			}
+		}
+	}()
+
+	testRun := <-outputChannel
+	return testRun
+}
+
+func getRunInState(app *app.App, testID, resultID, state string) *openapi.TestRun {
+	run, err := getRun(app, testID, resultID)
+	if err != nil {
+		return nil
+	}
+
+	if run.State != state {
+		return nil
+
+	}
+
+	return &run
+}
+
+func getRun(app *app.App, testID, runID string) (openapi.TestRun, error) {
+	url := fmt.Sprintf("%s/api/tests/%s/run/%s", appEndpoint, testID, runID)
+	response, err := http.Get(url)
+	if err != nil {
+		return openapi.TestRun{}, fmt.Errorf("could not send request to run test: %w", err)
+	}
+
+	if response.StatusCode != 200 {
+		return openapi.TestRun{}, fmt.Errorf("could not run test. Expected status 200, got %d", response.StatusCode)
+	}
+
+	bodyBytes, err := ioutil.ReadAll(response.Body)
+	if err != nil {
+		return openapi.TestRun{}, fmt.Errorf("could not read response body: %w", err)
+	}
+
+	run := openapi.TestRun{}
+	err = json.Unmarshal(bodyBytes, &run)
+	if err != nil {
+		return openapi.TestRun{}, fmt.Errorf("could not unmarshal response body: %w", err)
+	}
+
+	return run, nil
+}

--- a/server/testfixtures/pokeshop_app_fixture.go
+++ b/server/testfixtures/pokeshop_app_fixture.go
@@ -1,0 +1,13 @@
+package testfixtures
+
+import (
+	"github.com/kubeshop/tracetest/testmock"
+)
+
+func getPokeshopApp(args ...interface{}) (*testmock.DemoApp, error) {
+	return testmock.GetDemoApplicationInstance()
+}
+
+func init() {
+	RegisterFixture(POKESHOP_APP, getPokeshopApp)
+}

--- a/server/testfixtures/pokeshop_app_fixture.go
+++ b/server/testfixtures/pokeshop_app_fixture.go
@@ -1,13 +1,17 @@
 package testfixtures
 
 import (
-	"github.com/kubeshop/tracetest/testmock"
+	"github.com/kubeshop/tracetest/server/testmock"
 )
-
-func getPokeshopApp(args ...interface{}) (*testmock.DemoApp, error) {
-	return testmock.GetDemoApplicationInstance()
-}
 
 func init() {
 	RegisterFixture(POKESHOP_APP, getPokeshopApp)
+}
+
+func GetPokeshopApp() (*testmock.DemoApp, error) {
+	return GetFixtureValue[*testmock.DemoApp](POKESHOP_APP)
+}
+
+func getPokeshopApp(args ...interface{}) (*testmock.DemoApp, error) {
+	return testmock.GetDemoApplicationInstance()
 }

--- a/server/testfixtures/tracetest_app_fixture.go
+++ b/server/testfixtures/tracetest_app_fixture.go
@@ -4,9 +4,13 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/kubeshop/tracetest/app"
-	"github.com/kubeshop/tracetest/testmock"
+	"github.com/kubeshop/tracetest/server/app"
+	"github.com/kubeshop/tracetest/server/testmock"
 )
+
+func GetTracetestApp() (*app.App, error) {
+	return GetFixtureValue[*app.App](TRACETEST_APP)
+}
 
 func getTracetestApp(args ...interface{}) (*app.App, error) {
 	demoApp, err := GetFixtureValue[*testmock.DemoApp](POKESHOP_APP)

--- a/server/testfixtures/tracetest_app_fixture.go
+++ b/server/testfixtures/tracetest_app_fixture.go
@@ -1,0 +1,33 @@
+package testfixtures
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/kubeshop/tracetest/app"
+	"github.com/kubeshop/tracetest/testmock"
+)
+
+func getTracetestApp(args ...interface{}) (*app.App, error) {
+	demoApp, err := GetFixtureValue[*testmock.DemoApp](POKESHOP_APP)
+	if err != nil {
+		return nil, fmt.Errorf("could not get pokeshop app: %w", err)
+	}
+
+	tracetestApp, err := testmock.GetTestingApp(demoApp)
+	if err != nil {
+		return nil, err
+	}
+
+	go tracetestApp.Start()
+
+	time.Sleep(1 * time.Second)
+
+	return tracetestApp, nil
+}
+
+var _ Generator[*app.App] = getTracetestApp
+
+func init() {
+	RegisterFixture(TRACETEST_APP, getTracetestApp)
+}


### PR DESCRIPTION
This PR introduces a new testing structure called `fixtures` based on Python's pytest.

Fixtures are a way of obtaining a specific value that can be reused by tests. Fixtures also cache their value, so if you call a fixture twice, it will only generate the value once and all subsequent calls will use the cache.

## Why did I do that? 

1. Our integration test was complex
2. I wanted to be able to write more integration tests to prevent our changes from breaking things (versioning did that a couple of times and integration tests would have allowed us to see that during development). However, adding more tests that relied on the pokemon demo, the more our test suite would take to run. Thus, by adding a mechanism that would automatically cache those values and only run things once, we reduce this overhead.

## What can be improved?

One idea is to enable fixtures to turn off the cache mechanism: for example, we might want to have a new `test run` everytime we need one instead of reusing the same one. It could be achieved by calling the `rerun` method to clone the test run and return it. By disabling the cache, we would ensure that all calls to that fixture would return a clone of the run instead of reusing it.

## Side effects
Because integration tests need to be in a separated package, code coverage is not reflecting its real value, but I prefer to have tests ensuring everything works than having a high code coverage metric anyway.

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [x] added a test
