### PR TITLE
fix: test deletion

### DIFF
--- a/server/testdb/tests.go
+++ b/server/testdb/tests.go
@@ -106,9 +106,9 @@ func (td *postgresDB) UpdateTestVersion(ctx context.Context, test model.Test) er
 
 func (td *postgresDB) DeleteTest(ctx context.Context, test model.Test) error {
 	queries := []string{
-		"DELETE FROM tests WHERE id = $1",
-		"DELETE FROM definitions WHERE test_id = $1",
 		"DELETE FROM runs WHERE test_id = $1",
+		"DELETE FROM definitions WHERE test_id = $1",
+		"DELETE FROM tests WHERE id = $1",
 	}
 
 	for _, sql := range queries {


### PR DESCRIPTION
This PR solves the issue of deleting a test due to the wrong order of queries.


## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
