### PR TITLE
change start and end time to unix milli

### DIFF
--- a/api/trace.yaml
+++ b/api/trace.yaml
@@ -27,11 +27,11 @@ components:
         name:
           type: string
         startTime:
-          type: string
-          format: date-time
+          type: integer
+          description: span start time in unix milli format
         endTime:
-          type: string
-          format: date-time
+          type: integer
+          description: span end time in unix milli format
         attributes:
           type: object
           description: Key-Value of span attributes

--- a/server/http/mappings.go
+++ b/server/http/mappings.go
@@ -3,6 +3,7 @@ package http
 import (
 	"errors"
 	"fmt"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/kubeshop/tracetest/server/assertions/comparator"
@@ -125,17 +126,7 @@ func (m openapiMapper) Trace(in *traces.Trace) openapi.Trace {
 
 	flat := map[string]openapi.Span{}
 	for id, span := range in.Flat {
-		parentID := ""
-		if span.Parent != nil {
-			parentID = span.Parent.ID.String()
-		}
-		flat[id.String()] = openapi.Span{
-			Id:         span.ID.String(),
-			Attributes: map[string]string(span.Attributes),
-			StartTime:  span.StartTime,
-			EndTime:    span.EndTime,
-			ParentId:   parentID,
-		}
+		flat[id.String()] = m.Span(*span)
 	}
 
 	return openapi.Trace{
@@ -154,8 +145,8 @@ func (m openapiMapper) Span(in traces.Span) openapi.Span {
 	return openapi.Span{
 		Id:         in.ID.String(),
 		ParentId:   parentID,
-		StartTime:  in.StartTime,
-		EndTime:    in.EndTime,
+		StartTime:  int32(in.StartTime.UnixMilli()),
+		EndTime:    int32(in.EndTime.UnixMilli()),
 		Attributes: map[string]string(in.Attributes),
 		Children:   m.Spans(in.Children),
 	}
@@ -409,8 +400,8 @@ func (m modelMapper) Span(in openapi.Span, parent *traces.Span) traces.Span {
 		ID:         sid,
 		Attributes: in.Attributes,
 		Name:       in.Name,
-		StartTime:  in.StartTime,
-		EndTime:    in.EndTime,
+		StartTime:  time.UnixMilli(int64(in.StartTime)),
+		EndTime:    time.UnixMilli(int64(in.EndTime)),
 		Parent:     parent,
 	}
 	span.Children = m.Spans(in.Children, &span)

--- a/server/openapi/model_span.go
+++ b/server/openapi/model_span.go
@@ -9,10 +9,6 @@
 
 package openapi
 
-import (
-	"time"
-)
-
 type Span struct {
 	Id string `json:"id,omitempty"`
 
@@ -20,9 +16,11 @@ type Span struct {
 
 	Name string `json:"name,omitempty"`
 
-	StartTime time.Time `json:"startTime,omitempty"`
+	// span start time in unix nano format
+	StartTime int32 `json:"startTime,omitempty"`
 
-	EndTime time.Time `json:"endTime,omitempty"`
+	// span end time in unix nano format
+	EndTime int32 `json:"endTime,omitempty"`
 
 	// Key-Value of span attributes
 	Attributes map[string]string `json:"attributes,omitempty"`


### PR DESCRIPTION
This PR changes the openapi span to use unix milli as the format for start and end time

## Changes

- update openapi to use integer for start and end time
- update mappings to use the new format

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
