### PR TITLE
🔀  562 when creating or editing an assertion validate that the selector is unique

### DIFF
--- a/web/src/components/AssertionCardList/AssertionCardList.tsx
+++ b/web/src/components/AssertionCardList/AssertionCardList.tsx
@@ -12,11 +12,7 @@ interface TAssertionCardListProps {
   testId: string;
 }
 
-const AssertionCardList: React.FC<TAssertionCardListProps> = ({
-  assertionResults: {resultList},
-  onSelectSpan,
-  testId,
-}) => {
+const AssertionCardList: React.FC<TAssertionCardListProps> = ({assertionResults: {resultList}, onSelectSpan}) => {
   const {open} = useAssertionForm();
   const {remove} = useTestDefinition();
 

--- a/web/src/components/AssertionForm/AssertionForm.tsx
+++ b/web/src/components/AssertionForm/AssertionForm.tsx
@@ -10,6 +10,7 @@ import {CompareOperator} from '../../constants/Operator.constants';
 import {Steps} from '../GuidedTour/assertionStepList';
 import * as S from './AssertionForm.styled';
 import AssertionSelectors from '../../selectors/Assertion.selectors';
+import TestDefinitionSelectors from '../../selectors/TestDefinition.selectors';
 import AssertionFormSelectorInput from './AssertionFormSelectorInput';
 import {TAssertion, TPseudoSelector, TSpanSelector} from '../../types/Assertion.types';
 import AssertionFormPseudoSelectorInput from './AssertionFormPseudoSelectorInput';
@@ -45,8 +46,7 @@ const AssertionForm: React.FC<TAssertionFormProps> = ({
     ],
     selectorList = [],
     pseudoSelector,
-  } = {
-  },
+  } = {},
   onSubmit,
   onCancel,
   isEditing = false,
@@ -69,6 +69,7 @@ const AssertionForm: React.FC<TAssertionFormProps> = ({
   const attributeList = useAppSelector(state =>
     AssertionSelectors.selectAttributeList(state, testId, runId, spanIdList)
   );
+  const definitionSelectorList = useAppSelector(state => TestDefinitionSelectors.selectDefinitionSelectorList(state));
 
   const onFieldsChange = useCallback(
     (changedFields: FieldData[]) => {
@@ -126,7 +127,20 @@ const AssertionForm: React.FC<TAssertionFormProps> = ({
         <S.SelectorInputContainer>
           <Form.Item
             name="selectorList"
-            rules={[{required: true, message: 'At least one selector is required'}]}
+            rules={[
+              {required: true, message: 'At least one selector is required'},
+              {
+                validator: (_, value: TSpanSelector[]) =>
+                  SelectorService.validateSelector(
+                    definitionSelectorList,
+                    isEditing,
+                    selectorList,
+                    value,
+                    currentPseudoSelector,
+                    pseudoSelector
+                  ),
+              },
+            ]}
             data-tour={GuidedTourService.getStep(GuidedTours.Assertion, Steps.Selectors)}
           >
             <AssertionFormSelectorInput attributeList={attributeList} />

--- a/web/src/components/SpanDetail/SpanDetail.tsx
+++ b/web/src/components/SpanDetail/SpanDetail.tsx
@@ -8,7 +8,7 @@ import Http from './components/Http';
 import SpanHeader from './SpanHeader';
 import * as S from './SpanDetail.styled';
 import {useAssertionForm} from '../AssertionForm/AssertionFormProvider';
-import {CompareOperator, PseudoSelector} from '../../constants/Operator.constants';
+import {CompareOperator} from '../../constants/Operator.constants';
 import OperatorService from '../../services/Operator.service';
 
 export interface TSpanDetailProps {
@@ -41,12 +41,12 @@ const SpanDetail: React.FC<TSpanDetailProps> = ({span}) => {
 
   const onCreateAssertion = useCallback(
     ({value, key}: TSpanFlatAttribute) => {
+      const {selectorList, pseudoSelector} = SpanService.getSelectorInformation(span!);
+
       open({
         isEditing: false,
         defaultValues: {
-          pseudoSelector: {
-            selector: PseudoSelector.FIRST,
-          },
+          pseudoSelector,
           assertionList: [
             {
               comparator: OperatorService.getOperatorSymbol(CompareOperator.EQUALS),
@@ -54,16 +54,11 @@ const SpanDetail: React.FC<TSpanDetailProps> = ({span}) => {
               attribute: key,
             },
           ],
-          selectorList:
-            span?.signature.map(attribute => ({
-              value: attribute.value,
-              key: attribute.key,
-              operator: OperatorService.getOperatorSymbol(CompareOperator.EQUALS),
-            })) || [],
+          selectorList,
         },
       });
     },
-    [open, span?.signature]
+    [open, span]
   );
 
   return (

--- a/web/src/components/TestCard/__tests__/__snapshots__/TestActions.test.tsx.snap
+++ b/web/src/components/TestCard/__tests__/__snapshots__/TestActions.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`TestCardActions 1`] = `
 <div>
   <span
     class="ant-dropdown-trigger ant-dropdown-link"
-    data-cy="test-actions-button-e2b2fb7a-1a42-4726-85b3-d35a353b00f0"
+    data-cy="test-actions-button-dbe439ad-ead4-4379-bf14-fca81e316889"
   >
     <span
       aria-label="more"

--- a/web/src/components/TestCard/__tests__/__snapshots__/TestCard.test.tsx.snap
+++ b/web/src/components/TestCard/__tests__/__snapshots__/TestCard.test.tsx.snap
@@ -11,7 +11,7 @@ exports[`TestCard 1`] = `
       <span
         aria-label="right"
         class="anticon anticon-right"
-        data-cy="collapse-test-1dc446cf-83c8-4daf-b972-47ad00475d9a"
+        data-cy="collapse-test-c79502a8-4828-4993-9bea-4265f78cbc96"
         role="img"
         tabindex="-1"
       >
@@ -35,7 +35,7 @@ exports[`TestCard 1`] = `
         <span
           class="ant-typography sc-hBUSln fEhLhq"
         >
-          Brent
+          Jamarcus
         </span>
       </div>
       <div
@@ -47,7 +47,7 @@ exports[`TestCard 1`] = `
       </div>
       <div
         class="sc-bqiRlB ghwjXk"
-        data-cy="test-url-1dc446cf-83c8-4daf-b972-47ad00475d9a"
+        data-cy="test-url-c79502a8-4828-4993-9bea-4265f78cbc96"
       >
         <span
           class="ant-typography sc-fotOHu"
@@ -61,7 +61,7 @@ exports[`TestCard 1`] = `
       >
         <button
           class="ant-btn ant-btn-primary ant-btn-background-ghost"
-          data-cy="test-run-button-1dc446cf-83c8-4daf-b972-47ad00475d9a"
+          data-cy="test-run-button-c79502a8-4828-4993-9bea-4265f78cbc96"
           type="button"
         >
           <span>
@@ -71,7 +71,7 @@ exports[`TestCard 1`] = `
       </div>
       <span
         class="ant-dropdown-trigger ant-dropdown-link ant-dropdown-open"
-        data-cy="test-actions-button-1dc446cf-83c8-4daf-b972-47ad00475d9a"
+        data-cy="test-actions-button-c79502a8-4828-4993-9bea-4265f78cbc96"
       >
         <span
           aria-label="more"

--- a/web/src/components/TestHeader/__tests__/__snapshots__/TestHeader.test.tsx.snap
+++ b/web/src/components/TestHeader/__tests__/__snapshots__/TestHeader.test.tsx.snap
@@ -33,7 +33,7 @@ exports[`SpanAttributesTable 1`] = `
         class="ant-typography sc-hKwDye gXTdui"
         data-cy="test-details-name"
       >
-        Josephine
+        Anabel
          (v
         )
       </h4>

--- a/web/src/components/TraceDrawer/TraceDrawerHeader.tsx
+++ b/web/src/components/TraceDrawer/TraceDrawerHeader.tsx
@@ -1,11 +1,10 @@
 import {PlusOutlined} from '@ant-design/icons';
 import {Badge} from 'antd';
 import {format, parseISO} from 'date-fns';
-import {useMemo} from 'react';
+import {MouseEventHandler, useCallback, useMemo} from 'react';
 import {TTestRun} from 'types/TestRun.types';
-import {CompareOperator} from '../../constants/Operator.constants';
 import GuidedTourService, {GuidedTours} from '../../services/GuidedTour.service';
-import OperatorService from '../../services/Operator.service';
+import SpanService from '../../services/Span.service';
 import TraceService from '../../services/Trace.service';
 import {TAssertionResults} from '../../types/Assertion.types';
 import {TSpan} from '../../types/Span.types';
@@ -41,6 +40,22 @@ const TraceDrawerHeader: React.FC<IProps> = ({
 
   const startDate = useMemo(() => format(parseISO(createdAt), "EEEE, do MMMM yyyy 'at' HH:mm:ss"), [createdAt]);
 
+  const handleAssertionClick: MouseEventHandler<HTMLElement> = useCallback(
+    event => {
+      event.stopPropagation();
+      const {selectorList, pseudoSelector} = SpanService.getSelectorInformation(selectedSpan!);
+
+      open({
+        isEditing: false,
+        defaultValues: {
+          pseudoSelector,
+          selectorList,
+        },
+      });
+    },
+    [open, selectedSpan]
+  );
+
   return (
     <S.Header
       visiblePortion={visiblePortion}
@@ -63,20 +78,7 @@ const TraceDrawerHeader: React.FC<IProps> = ({
           data-cy="add-assertion-button"
           icon={<PlusOutlined />}
           disabled={isDisabled}
-          onClick={event => {
-            event.stopPropagation();
-            open({
-              isEditing: false,
-              defaultValues: {
-                selectorList:
-                  selectedSpan?.signature.map(attribute => ({
-                    value: attribute.value,
-                    key: attribute.key,
-                    operator: OperatorService.getOperatorSymbol(CompareOperator.EQUALS),
-                  })) || [],
-              },
-            });
-          }}
+          onClick={handleAssertionClick}
         >
           Add Assertion
         </S.AddAssertionButton>

--- a/web/src/providers/TestDefinition/hooks/useDraftMode.ts
+++ b/web/src/providers/TestDefinition/hooks/useDraftMode.ts
@@ -8,6 +8,12 @@ const useDraftMode = (isDefaultDraftMode = false) => {
     else window.onbeforeunload = null;
   }, [isDraftMode]);
 
+  useEffect(() => {
+    return () => {
+      window.onbeforeunload = null;
+    };
+  }, []);
+
   return {isDraftMode, setIsDraftMode};
 };
 

--- a/web/src/selectors/TestDefinition.selectors.ts
+++ b/web/src/selectors/TestDefinition.selectors.ts
@@ -5,9 +5,16 @@ const stateSelector = (state: RootState) => state.testDefinition;
 const selectorSelector = (state: RootState, selector: string) => selector;
 
 const selectDefinitionList = createSelector(stateSelector, ({definitionList}) => definitionList);
+const selectDefinitionSelectorList = createSelector(selectDefinitionList, definitionList =>
+  definitionList.map(({selector}) => selector)
+);
 
-const TestSelectors = () => ({
+const TestDefinitionSelectors = () => ({
   selectDefinitionList,
+  selectDefinitionSelectorList,
+  selectIsSelectorExist: createSelector(selectDefinitionSelectorList, selectorSelector, (selectorList, selector) =>
+    selectorList.includes(selector)
+  ),
   selectIsLoading: createSelector(stateSelector, ({isLoading}) => isLoading),
   selectIsInitialized: createSelector(stateSelector, ({isInitialized}) => isInitialized),
   selectAssertionResults: createSelector(stateSelector, ({assertionResults}) => assertionResults),
@@ -16,4 +23,4 @@ const TestSelectors = () => ({
   ),
 });
 
-export default TestSelectors();
+export default TestDefinitionSelectors();

--- a/web/src/services/Selector.service.ts
+++ b/web/src/services/Selector.service.ts
@@ -89,6 +89,22 @@ const SelectorService = () => ({
         }
       : undefined;
   },
+
+  validateSelector(
+    definitionSelectorList: string[],
+    isEditing: boolean,
+    initialSelectorList: TSpanSelector[],
+    selectorList: TSpanSelector[],
+    initialPseudoSelector?: TPseudoSelector,
+    pseudoSelector?: TPseudoSelector
+  ): Promise<boolean> {
+    const initialSelectorString = this.getSelectorString(initialSelectorList, initialPseudoSelector);
+    const selectorString = this.getSelectorString(selectorList, pseudoSelector);
+
+    if (!definitionSelectorList.includes(selectorString) || (isEditing && initialSelectorString === selectorString))
+      return Promise.resolve(true);
+    return Promise.reject(new Error('Selector already exists'));
+  },
 });
 
 export default SelectorService();

--- a/web/src/services/Span.service.ts
+++ b/web/src/services/Span.service.ts
@@ -1,6 +1,8 @@
 import {differenceBy, intersectionBy} from 'lodash';
+import {CompareOperator, PseudoSelector} from '../constants/Operator.constants';
 import {SELECTOR_DEFAULT_ATTRIBUTES, SemanticGroupNameNodeMap} from '../constants/SemanticGroupNames.constants';
 import {TSpan, TSpanFlatAttribute} from '../types/Span.types';
+import OperatorService from './Operator.service';
 
 const itemSelectorKeys = SELECTOR_DEFAULT_ATTRIBUTES.flatMap(el => el.attributes);
 
@@ -36,6 +38,21 @@ const SpanService = () => ({
       intersectedList: intersectedAttributeList,
       differenceList: differenceBy(selectedSpanAttributeList, intersectedAttributeList, 'key'),
     };
+  },
+
+  getSelectorInformation(span: TSpan) {
+    const selectorList =
+      span?.signature.map(attribute => ({
+        value: attribute.value,
+        key: attribute.key,
+        operator: OperatorService.getOperatorSymbol(CompareOperator.EQUALS),
+      })) || [];
+
+    const pseudoSelector = {
+      selector: PseudoSelector.FIRST,
+    };
+
+    return {selectorList, pseudoSelector};
   },
 });
 

--- a/web/src/services/__tests__/Selector.service.test.ts
+++ b/web/src/services/__tests__/Selector.service.test.ts
@@ -1,4 +1,5 @@
 import {PseudoSelector} from '../../constants/Operator.constants';
+import {TSpanSelector} from '../../types/Assertion.types';
 import SelectorService from '../Selector.service';
 
 describe('AssertionService', () => {
@@ -90,6 +91,67 @@ describe('AssertionService', () => {
         selector: PseudoSelector.NTH,
         number: 2,
       });
+    });
+  });
+
+  describe('validateSelector', () => {
+    it('should return true for a valid selector', async () => {
+      const selector: TSpanSelector = {
+        key: 'service.name',
+        operator: '=',
+        value: 'pokeshop',
+      };
+
+      const result = await SelectorService.validateSelector([], false, [], [selector]);
+      expect(result).toEqual(true);
+    });
+
+    it('should return true when editing and the selector match with the initial', async () => {
+      const selector: TSpanSelector = {
+        key: 'service.name',
+        operator: '=',
+        value: 'pokeshop',
+      };
+
+      const selectorString = 'span[service.name = "pokeshop"]';
+
+      const result = await SelectorService.validateSelector([selectorString], true, [selector], [selector]);
+      expect(result).toEqual(true);
+    });
+
+    it('should return an error when editing and the selector does not match with the initial', done => {
+      expect.assertions(2);
+      const selector: TSpanSelector = {
+        key: 'service.name',
+        operator: '=',
+        value: 'pokeshop',
+      };
+
+      const selectorString = 'span[service.name = "pokeshop"]';
+
+      SelectorService.validateSelector([selectorString], true, [], [selector]).catch((error: Error) => {
+        expect(error).toBeInstanceOf(Error);
+        expect(error.message).toBe('Selector already exists');
+        done();
+      });
+    });
+  });
+
+  it('should return an error when not editing and the selector is already part of the list', done => {
+    expect.assertions(2);
+    const selector: TSpanSelector = {
+      key: 'service.name',
+      operator: '=',
+      value: 'pokeshop',
+    };
+
+    const selectorString = 'span[service.name = "pokeshop"]';
+
+    SelectorService.validateSelector([selectorString], false, [selector], [selector]).catch((error: Error) => {
+      expect(error).toBeInstanceOf(Error);
+      expect(error.message).toBe('Selector already exists');
+
+      done();
     });
   });
 });

--- a/web/src/services/__tests__/Span.service.test.ts
+++ b/web/src/services/__tests__/Span.service.test.ts
@@ -1,3 +1,4 @@
+import {PseudoSelector} from '../../constants/Operator.constants';
 import SpanMock from '../../models/__mocks__/Span.mock';
 import SpanService from '../Span.service';
 
@@ -39,12 +40,31 @@ describe('SpanService', () => {
 
     it('should return the selected span list attributes with different sizes', () => {
       const span = SpanMock.model();
-      const spanList = [SpanMock.model(), SpanMock.model()];
+      const spanList = [
+        SpanMock.model(),
+        SpanMock.model({
+          attributes: {
+            'db.system': 'mysql',
+            'service.name': 'mock',
+          },
+        }),
+      ];
 
       const {differenceList, intersectedList} = SpanService.getSelectedSpanListAttributes(span, spanList);
 
       expect(intersectedList.length).toBeGreaterThan(0);
       expect(differenceList.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('getSelectorInformation', () => {
+    it('should return the selector information', () => {
+      const span = SpanMock.model();
+
+      const selectorInfo = SpanService.getSelectorInformation(span);
+
+      expect(selectorInfo.selectorList).toHaveLength(2);
+      expect(selectorInfo.pseudoSelector).toEqual({selector: PseudoSelector.FIRST});
     });
   });
 });


### PR DESCRIPTION
This PR blocks the user from adding the same selector twice. 
The behavior is the following:
1. If the user selects a span in which a test definition already exists.
2. The app will concatenate the new set of checks the user might want to add.
3. And the assertion form will be opened in edit mode.

1. If the user selects a span or configures the selection in a way that the result already exists.
2. A FE validation error would be displayed telling the user that the selector already exists blocking him from submitting the form.

## Changes

- New find selector logic.

## Fixes

- https://github.com/kubeshop/tracetest/issues/562

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [x] added a test
