### PR TITLE
✨ 549 fixing tooltip alignment

### DIFF
--- a/web/src/components/AttributeRow/AttributeRow.styled.ts
+++ b/web/src/components/AttributeRow/AttributeRow.styled.ts
@@ -4,12 +4,17 @@ import styled from 'styled-components';
 
 export const AttributeRow = styled.div`
   display: grid;
-  grid-template-columns: 200px 1fr 50px;
+  grid-template-columns: 190px 1fr 60px;
   gap: 14px;
   align-items: start;
+  padding: 8px;
 
   .ant-tooltip-inner {
     color: yellow;
+  }
+
+  &:hover {
+    background-color: #fbfbff;
   }
 `;
 
@@ -37,8 +42,11 @@ export const IconContainer = styled.div`
   display: flex;
   gap: 14px;
   align-items: center;
+  align-self: center;
 `;
 
 export const CustomTooltip = styled(Tooltip).attrs({
   color: '#FBFBFF',
+  placement: 'top',
+  arrowPointAtCenter: true,
 })``;

--- a/web/src/components/AttributeRow/AttributeRow.tsx
+++ b/web/src/components/AttributeRow/AttributeRow.tsx
@@ -1,4 +1,4 @@
-import {useCallback} from 'react';
+import {useCallback, useEffect, useState} from 'react';
 import useHover from '../../hooks/useHover';
 import {TSpanFlatAttribute} from '../../types/Span.types';
 import * as S from './AttributeRow.styled';
@@ -11,10 +11,16 @@ interface IAttributeRowProps {
 
 const AttributeRow: React.FC<IAttributeRowProps> = ({attribute: {key, value}, attribute, onCreateAssertion}) => {
   const {isHovering, onMouseEnter, onMouseLeave} = useHover();
+  const [isCopy, setIsCopy] = useState(false);
 
   const onCopy = useCallback(() => {
     navigator.clipboard.writeText(value);
+    setIsCopy(true);
   }, [value]);
+
+  useEffect(() => {
+    if (!isHovering) setIsCopy(false);
+  }, [isHovering]);
 
   return (
     <S.AttributeRow onMouseEnter={onMouseEnter} onMouseLeave={onMouseLeave}>
@@ -25,8 +31,10 @@ const AttributeRow: React.FC<IAttributeRowProps> = ({attribute: {key, value}, at
       <S.IconContainer>
         {isHovering && (
           <>
-            <S.CopyIcon onClick={onCopy} />
-            <S.CustomTooltip placement="top" title="Add Assertion">
+            <S.CustomTooltip title={isCopy ? 'Copied' : 'Copy'}>
+              <S.CopyIcon onClick={onCopy} />
+            </S.CustomTooltip>
+            <S.CustomTooltip title="Add Assertion">
               <S.AddAssertionIcon onClick={() => onCreateAssertion(attribute)} />
             </S.CustomTooltip>
           </>

--- a/web/src/components/AttributeRow/__tests__/AttributeRow.test.tsx
+++ b/web/src/components/AttributeRow/__tests__/AttributeRow.test.tsx
@@ -1,0 +1,19 @@
+import {render} from '../../../test-utils';
+import {TSpanFlatAttribute} from '../../../types/Span.types';
+import AttributeRow from '../AttributeRow';
+
+const attribute: TSpanFlatAttribute = {
+  key: 'key',
+  value: 'value',
+};
+
+const onCreateAssertion = jest.fn();
+
+describe('AttributeRow', () => {
+  it('should render correctly', () => {
+    const {getByText} = render(<AttributeRow attribute={attribute} onCreateAssertion={onCreateAssertion} />);
+
+    expect(getByText(attribute.key)).toBeInTheDocument();
+    expect(getByText(attribute.value)).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
This PR fixes the alignment issue we had with the add assertion tooltip, it also adds a tooltip for the copy action.

## Changes

- Copy action tooltip.

## Fixes

- https://github.com/kubeshop/tracetest/issues/549

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [x] added a test

<img width="222" alt="Screen Shot 2022-05-27 at 11 31 32 a m" src="https://user-images.githubusercontent.com/11051031/170740998-cff0208a-7da7-42fc-97a4-bccb2b3bf030.png">
<img width="171" alt="Screen Shot 2022-05-27 at 11 31 35 a m" src="https://user-images.githubusercontent.com/11051031/170741000-ac79449d-e16f-4e08-818f-7e2d0e9321ba.png">
<img width="144" alt="Screen Shot 2022-05-27 at 11 31 39 a m" src="https://user-images.githubusercontent.com/11051031/170741002-0679aa81-01a4-4bf1-8d2d-2ae01d7009aa.png">


