### PR TITLE
fix: test definition versioning

### DIFF
--- a/server/http/controller.go
+++ b/server/http/controller.go
@@ -287,11 +287,6 @@ func (c *controller) SetTestDefinition(ctx context.Context, testID string, def o
 		return openapi.Response(http.StatusInternalServerError, err.Error()), err
 	}
 
-	err = c.testDB.SetDefiniton(ctx, newTest, c.model.Definition(def))
-	if err != nil {
-		return handleDBError(err), err
-	}
-
 	return openapi.Response(204, nil), nil
 }
 

--- a/server/http/controller.go
+++ b/server/http/controller.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
-	"time"
 
 	"github.com/google/uuid"
 	"github.com/kubeshop/tracetest/server/analytics"
@@ -219,8 +218,6 @@ func (c *controller) RerunTestRun(ctx context.Context, testID string, runID stri
 	newTestRun := run
 	newTestRun.Results = nil
 	newTestRun.TestVersion = test.Version
-	newTestRun.CreatedAt = time.Now()
-	newTestRun.CompletedAt = time.Now()
 
 	newTestRun, err = c.testDB.CreateRun(ctx, test, newTestRun)
 	if err != nil {

--- a/server/integration/add_assertion_test.go
+++ b/server/integration/add_assertion_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 func TestAddAssertionToTest(t *testing.T) {
-	test, err := testfixtures.GetPokemonTest()
+	test, err := testfixtures.GetPokemonTest(testfixtures.WithCacheDisabled())
 	require.NoError(t, err)
 
 	setDefinition(t, test)

--- a/server/integration/add_assertion_test.go
+++ b/server/integration/add_assertion_test.go
@@ -1,0 +1,71 @@
+package integration_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"testing"
+
+	"github.com/kubeshop/tracetest/server/openapi"
+	"github.com/kubeshop/tracetest/server/testfixtures"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAddAssertionToTest(t *testing.T) {
+	test, err := testfixtures.GetPokemonTest()
+	require.NoError(t, err)
+
+	setDefinition(t, test)
+
+	updatedTest := getTest(t, test.Id)
+	assert.Equal(t, test.Version+1, updatedTest.Version)
+}
+
+func setDefinition(t *testing.T, test *openapi.Test) {
+	url := fmt.Sprintf("%s/api/tests/%s/definition", endpointUrl, test.Id)
+	body := openapi.TestDefinition{
+		Definitions: []openapi.TestDefinitionDefinitions{
+			{
+				Selector: `span[tracetest.span.type="http"]`,
+				Assertions: []openapi.Assertion{
+					{
+						Attribute:  "http.status_code",
+						Comparator: "=",
+						Expected:   "200",
+					},
+				},
+			},
+		},
+	}
+	bodyJson, err := json.Marshal(body)
+	require.NoError(t, err)
+
+	bodyBuffer := bytes.NewBuffer(bodyJson)
+	req, err := http.NewRequest(http.MethodPut, url, bodyBuffer)
+	require.NoError(t, err)
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+
+	if resp.StatusCode != 204 {
+		require.Fail(t, fmt.Sprintf("expected status 204, got %d", resp.StatusCode))
+	}
+}
+
+func getTest(t *testing.T, id string) openapi.Test {
+	url := fmt.Sprintf("%s/api/tests/%s", endpointUrl, id)
+	req, err := http.Get(url)
+	require.NoError(t, err)
+
+	bodyJsonBytes, err := ioutil.ReadAll(req.Body)
+	require.NoError(t, err)
+
+	var test openapi.Test
+	err = json.Unmarshal(bodyJsonBytes, &test)
+	require.NoError(t, err)
+
+	return test
+}

--- a/server/integration/add_assertion_test.go
+++ b/server/integration/add_assertion_test.go
@@ -50,9 +50,7 @@ func setDefinition(t *testing.T, test *openapi.Test) {
 	resp, err := http.DefaultClient.Do(req)
 	require.NoError(t, err)
 
-	if resp.StatusCode != 204 {
-		require.Fail(t, fmt.Sprintf("expected status 204, got %d", resp.StatusCode))
-	}
+	require.Equal(t, 204, resp.StatusCode)
 }
 
 func getTest(t *testing.T, id string) openapi.Test {

--- a/server/integration/run_and_assert_pokemon_app_test.go
+++ b/server/integration/run_and_assert_pokemon_app_test.go
@@ -11,7 +11,7 @@ import (
 const endpointUrl = "http://localhost:8080"
 
 func TestExecutorIntegration(t *testing.T) {
-	testRun, err := testfixtures.GetPokemonTestRun()
+	testRun, err := testfixtures.GetPokemonTestRun(testfixtures.WithCacheDisabled())
 	assert.NoError(t, err)
 
 	assert.Equal(t, string(model.RunStateFinished), testRun.State)

--- a/server/migrations/5_test_definition_version.down.sql
+++ b/server/migrations/5_test_definition_version.down.sql
@@ -1,0 +1,11 @@
+ALTER TABLE definitions
+DROP CONSTRAINT definitions_pkey;
+
+ALTER TABLE definitions
+ADD CONSTRAINT definitions_pkey PRIMARY KEY (test_id);
+
+ALTER TABLE definitions
+DROP CONSTRAINT definition_test_id_version_fk;
+
+ALTER TABLE definitions
+DROP COLUMN test_version;

--- a/server/migrations/5_test_definition_version.up.sql
+++ b/server/migrations/5_test_definition_version.up.sql
@@ -1,0 +1,12 @@
+ALTER TABLE definitions
+ADD COLUMN test_version int not null default 1;
+
+ALTER TABLE definitions
+ADD CONSTRAINT definition_test_id_version_fk
+FOREIGN KEY (test_id, test_version) REFERENCES tests(id, "version");
+
+ALTER TABLE definitions
+DROP CONSTRAINT definitions_pkey;
+
+ALTER TABLE definitions
+ADD CONSTRAINT definitions_pkey PRIMARY KEY (test_id, test_version);

--- a/server/migrations/migration_test.go
+++ b/server/migrations/migration_test.go
@@ -17,11 +17,15 @@ func TestMigrations(t *testing.T) {
 	db, err := testmock.GetRawTestingDatabase()
 	require.NoError(t, err)
 
-	_, err = testdb.Postgres(testdb.WithMigrations("file://../migrations"), testdb.WithDB(db))
-	require.NoError(t, err, "postgres migrations up should not fail")
+	t.Run("applying migrations", func(t *testing.T) {
+		_, err = testdb.Postgres(testdb.WithMigrations("file://../migrations"), testdb.WithDB(db))
+		require.NoError(t, err, "postgres migrations up should not fail")
+	})
 
-	err = rollback(db)
-	assert.NoError(t, err, "rollback should not fail")
+	t.Run("rolling back migrations", func(t *testing.T) {
+		err = rollback(db)
+		assert.NoError(t, err, "rollback should not fail")
+	})
 }
 
 func rollback(db *sql.DB) error {

--- a/server/model/test_changes.go
+++ b/server/model/test_changes.go
@@ -17,6 +17,19 @@ func BumpTestVersionIfNeeded(in, updated Test) (Test, error) {
 	return updated, nil
 }
 
+func BumpVersionIfDefinitionChanged(test Test, newDef Definition) (Test, error) {
+	definitionHasChanged, err := testFieldHasChanged(test.Definition, newDef)
+	if err != nil {
+		return test, err
+	}
+
+	if definitionHasChanged {
+		test.Version = test.Version + 1
+	}
+
+	return test, nil
+}
+
 func testHasChanged(oldTest Test, newTest Test) (bool, error) {
 	definitionHasChanged, err := testFieldHasChanged(oldTest.Definition, newTest.Definition)
 	if err != nil {

--- a/server/model/tests.go
+++ b/server/model/tests.go
@@ -82,6 +82,21 @@ const (
 	RunStateAwaitingTestResults RunState = "AWAITING_TEST_RESULTS"
 )
 
+func (t Test) Copy() (Test, error) {
+	testJSON, err := json.Marshal(t)
+	if err != nil {
+		return Test{}, fmt.Errorf("could not copy test: %w", err)
+	}
+
+	var newTest Test
+	err = json.Unmarshal(testJSON, &newTest)
+	if err != nil {
+		return Test{}, fmt.Errorf("could not copy test: %w", err)
+	}
+
+	return newTest, nil
+}
+
 func (sar SpanAssertionResult) MarshalJSON() ([]byte, error) {
 	return json.Marshal(&struct {
 		SpanID        string

--- a/server/model/tests.go
+++ b/server/model/tests.go
@@ -82,21 +82,6 @@ const (
 	RunStateAwaitingTestResults RunState = "AWAITING_TEST_RESULTS"
 )
 
-func (t Test) Copy() (Test, error) {
-	testJSON, err := json.Marshal(t)
-	if err != nil {
-		return Test{}, fmt.Errorf("could not copy test: %w", err)
-	}
-
-	var newTest Test
-	err = json.Unmarshal(testJSON, &newTest)
-	if err != nil {
-		return Test{}, fmt.Errorf("could not copy test: %w", err)
-	}
-
-	return newTest, nil
-}
-
 func (sar SpanAssertionResult) MarshalJSON() ([]byte, error) {
 	return json.Marshal(&struct {
 		SpanID        string

--- a/server/testfixtures/fixture_test.go
+++ b/server/testfixtures/fixture_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestFixture(t *testing.T) {
-	testfixtures.RegisterFixture("uuid", func(args ...interface{}) (string, error) {
+	testfixtures.RegisterFixture("uuid", func(options testfixtures.FixtureOptions) (string, error) {
 		return uuid.NewString(), nil
 	})
 

--- a/server/testfixtures/import_pokemon_test_fixture.go
+++ b/server/testfixtures/import_pokemon_test_fixture.go
@@ -18,17 +18,17 @@ func init() {
 	RegisterFixture(IMPORT_POKEMON_TEST, getImportPokemonTest)
 }
 
-func GetPokemonTest() (*openapi.Test, error) {
-	return GetFixtureValue[*openapi.Test](IMPORT_POKEMON_TEST)
+func GetPokemonTest(options ...Option) (*openapi.Test, error) {
+	return GetFixtureValue[*openapi.Test](IMPORT_POKEMON_TEST, options...)
 }
 
-func getImportPokemonTest(args ...interface{}) (*openapi.Test, error) {
-	pokeshopApp, err := GetFixtureValue[*testmock.DemoApp](POKESHOP_APP)
+func getImportPokemonTest(options FixtureOptions) (*openapi.Test, error) {
+	pokeshopApp, err := GetPokeshopApp()
 	if err != nil {
 		return nil, fmt.Errorf("could not get pokeshop app: %w", err)
 	}
 
-	tracetestApp, err := GetFixtureValue[*app.App](TRACETEST_APP)
+	tracetestApp, err := GetTracetestApp()
 	if err != nil {
 		return nil, fmt.Errorf("could not get tracetest app: %w", err)
 	}

--- a/server/testfixtures/import_pokemon_test_run.go
+++ b/server/testfixtures/import_pokemon_test_run.go
@@ -16,17 +16,17 @@ func init() {
 	RegisterFixture(IMPORT_POKEMON_TEST_RUN, getImportPokemonTestRun)
 }
 
-func GetPokemonTestRun() (*openapi.TestRun, error) {
-	return GetFixtureValue[*openapi.TestRun](IMPORT_POKEMON_TEST_RUN)
+func GetPokemonTestRun(options ...Option) (*openapi.TestRun, error) {
+	return GetFixtureValue[*openapi.TestRun](IMPORT_POKEMON_TEST_RUN, options...)
 }
 
-func getImportPokemonTestRun(args ...interface{}) (*openapi.TestRun, error) {
-	tracetestApp, err := GetFixtureValue[*app.App](TRACETEST_APP)
+func getImportPokemonTestRun(options FixtureOptions) (*openapi.TestRun, error) {
+	tracetestApp, err := GetTracetestApp()
 	if err != nil {
 		return nil, fmt.Errorf("could not get tracetest app: %w", err)
 	}
 
-	importPokemonTest, err := GetFixtureValue[*openapi.Test](IMPORT_POKEMON_TEST)
+	importPokemonTest, err := GetPokemonTest()
 	if err != nil {
 		return nil, fmt.Errorf("could not get import pokemon test: %w", err)
 	}

--- a/server/testfixtures/options.go
+++ b/server/testfixtures/options.go
@@ -1,0 +1,7 @@
+package testfixtures
+
+func WithCacheDisabled() Option {
+	return func(opt *FixtureOptions) {
+		opt.DisableCache = true
+	}
+}

--- a/server/testfixtures/pokeshop_app_fixture.go
+++ b/server/testfixtures/pokeshop_app_fixture.go
@@ -12,6 +12,6 @@ func GetPokeshopApp() (*testmock.DemoApp, error) {
 	return GetFixtureValue[*testmock.DemoApp](POKESHOP_APP)
 }
 
-func getPokeshopApp(args ...interface{}) (*testmock.DemoApp, error) {
+func getPokeshopApp(options FixtureOptions) (*testmock.DemoApp, error) {
 	return testmock.GetDemoApplicationInstance()
 }

--- a/server/testfixtures/tracetest_app_fixture.go
+++ b/server/testfixtures/tracetest_app_fixture.go
@@ -12,7 +12,11 @@ func GetTracetestApp() (*app.App, error) {
 	return GetFixtureValue[*app.App](TRACETEST_APP)
 }
 
-func getTracetestApp(args ...interface{}) (*app.App, error) {
+func init() {
+	RegisterFixture(TRACETEST_APP, getTracetestApp)
+}
+
+func getTracetestApp(options FixtureOptions) (*app.App, error) {
 	demoApp, err := GetFixtureValue[*testmock.DemoApp](POKESHOP_APP)
 	if err != nil {
 		return nil, fmt.Errorf("could not get pokeshop app: %w", err)
@@ -28,10 +32,4 @@ func getTracetestApp(args ...interface{}) (*app.App, error) {
 	time.Sleep(1 * time.Second)
 
 	return tracetestApp, nil
-}
-
-var _ Generator[*app.App] = getTracetestApp
-
-func init() {
-	RegisterFixture(TRACETEST_APP, getTracetestApp)
 }


### PR DESCRIPTION
This PR fixes the issue of updating the test definition and the test is on the same 

## Changes
- Version test definition
- Added option to disable cache in fixtures
- Added field to definitions table

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [x] added a test
