### PR TITLE
ℹ️ 568 analyze how the selector items in title bar of an assertion should be shown

### DIFF
--- a/web/src/components/AssertionCard/AssertionCard.styled.ts
+++ b/web/src/components/AssertionCard/AssertionCard.styled.ts
@@ -23,15 +23,11 @@ export const Body = styled.div`
   gap: 9px;
 `;
 
-export const SelectorListText = styled(Typography.Text).attrs({
-  strong: true,
-})`
+export const SpanCountText = styled(Typography.Text)`
+  font-size: 12px;
   margin-right: 14px;
 `;
 
-export const SpanCountText = styled(Typography.Text)`
-  font-size: 12px;
-`;
 const baseIcon = css`
   font-size: 18px;
   color: #61175e;
@@ -55,3 +51,22 @@ export const ActionsContainer = styled.div`
 export const StatusTag = styled(Tag).attrs({
   color: '#61175E',
 })``;
+
+export const Selector = styled.div`
+  display: flex;
+  flex-direction: column;
+`;
+
+export const SelectorList = styled.div`
+  display: flex;
+  gap: 14px;
+`;
+
+export const SelectorValueText = styled(Typography.Text)``;
+
+export const SelectorAttributeText = styled(Typography.Text).attrs({
+  type: 'secondary',
+})`
+  font-size: 10px;
+  margin-bottom: -3px;
+`;

--- a/web/src/components/AssertionCard/AssertionCard.tsx
+++ b/web/src/components/AssertionCard/AssertionCard.tsx
@@ -6,14 +6,12 @@ import TestDefinitionSelectors from '../../selectors/TestDefinition.selectors';
 import {TAssertionResultEntry} from '../../types/Assertion.types';
 import AssertionCheckRow from '../AssertionCheckRow';
 import * as S from './AssertionCard.styled';
+import AssertionCardSelectorList from './AssertionCardSelectorList';
 
 interface TAssertionCardProps {
   assertionResult: TAssertionResultEntry;
-
   onSelectSpan(spanId: string): void;
-
   onDelete(selector: string): void;
-
   onEdit(assertionResult: TAssertionResultEntry): void;
 }
 
@@ -25,34 +23,29 @@ const AssertionCard: React.FC<TAssertionCardProps> = ({
   onEdit,
 }) => {
   const store = useStore();
+  const {selectedElements} = store.getState();
 
   const spanCountText = `${spanCount} ${spanCount > 1 ? 'spans' : 'span'}`;
-  const definition = useAppSelector(state => TestDefinitionSelectors.selectDefinitionBySelector(state, selector));
-  const {isDraft = false, isDeleted = false} = definition || {};
+  const {isDraft = false, isDeleted = false} =
+    useAppSelector(state => TestDefinitionSelectors.selectDefinitionBySelector(state, selector)) || {};
 
   const getIsSelectedSpan = useCallback(
     (id: string): boolean => {
-      const {selectedElements} = store.getState();
       const found = selectedElements ? selectedElements.find(element => element.id === id) : undefined;
 
       return Boolean(found);
     },
-    [store]
+    [selectedElements]
   );
 
   return (
     <S.AssertionCard data-cy="assertion-card" id={`assertion-${assertionResult.selector}`}>
       <S.Header>
-        <div>
-          <S.SelectorListText>
-            {selectorList.map(({value}) => value).join(' ')} {pseudoSelector?.selector}
-            {pseudoSelector?.number && `(${pseudoSelector?.number})`}
-          </S.SelectorListText>
-          <S.SpanCountText>{spanCountText}</S.SpanCountText>
-        </div>
+        <AssertionCardSelectorList selectorList={selectorList} pseudoSelector={pseudoSelector} />
         <S.ActionsContainer>
           {isDraft && <S.StatusTag>draft</S.StatusTag>}
           {isDeleted && <S.StatusTag color="#61175E">deleted</S.StatusTag>}
+          <S.SpanCountText>{spanCountText}</S.SpanCountText>
           <Tooltip color="white" title="Edit Assertion">
             <S.EditIcon data-cy="edit-assertion-button" onClick={() => onEdit(assertionResult)} />
           </Tooltip>
@@ -70,7 +63,6 @@ const AssertionCard: React.FC<TAssertionCardProps> = ({
               result={result}
               onSelectSpan={onSelectSpan}
               getIsSelectedSpan={getIsSelectedSpan}
-              assertionSelectorList={selectorList.map(({value}) => value)}
             />
           ))
         )}

--- a/web/src/components/AssertionCard/AssertionCardSelectorList.tsx
+++ b/web/src/components/AssertionCard/AssertionCardSelectorList.tsx
@@ -1,0 +1,33 @@
+import OperatorService from '../../services/Operator.service';
+import {TPseudoSelector, TSpanSelector} from '../../types/Assertion.types';
+import * as S from './AssertionCard.styled';
+
+interface IProps {
+  selectorList: TSpanSelector[];
+  pseudoSelector?: TPseudoSelector;
+}
+
+const AssertionCardSelectorList: React.FC<IProps> = ({selectorList, pseudoSelector}) => {
+  return (
+    <S.SelectorList>
+      {selectorList.map(({key, value, operator}) => (
+        <S.Selector key={key}>
+          <S.SelectorAttributeText>
+            {key} • {OperatorService.getNameFromSymbol(operator)}
+          </S.SelectorAttributeText>
+          <S.SelectorValueText>{value}</S.SelectorValueText>
+        </S.Selector>
+      ))}
+      {pseudoSelector && (
+        <S.Selector key="pseudo-selector">
+          <S.SelectorAttributeText>pseudo selector</S.SelectorAttributeText>
+          <S.SelectorValueText>
+            {pseudoSelector.selector} {pseudoSelector.number ? `(${pseudoSelector.number})` : ''}
+          </S.SelectorValueText>
+        </S.Selector>
+      )}
+    </S.SelectorList>
+  );
+};
+
+export default AssertionCardSelectorList;

--- a/web/src/components/AssertionCard/__tests__/AssertionCard.test.tsx
+++ b/web/src/components/AssertionCard/__tests__/AssertionCard.test.tsx
@@ -1,0 +1,29 @@
+import {ReactFlowProvider} from 'react-flow-renderer';
+import AssertionResultsMock from '../../../models/__mocks__/AssertionResults.mock';
+import {render} from '../../../test-utils';
+import AssertionCard from '../AssertionCard';
+
+const onSelectSpan = jest.fn();
+const onDelete = jest.fn();
+const onEdit = jest.fn();
+
+describe('AssertionCard', () => {
+  it('should render', () => {
+    const {
+      resultList: [assertionResult],
+    } = AssertionResultsMock.model();
+
+    const {getByTestId} = render(
+      <ReactFlowProvider>
+        <AssertionCard
+          assertionResult={assertionResult}
+          onDelete={onDelete}
+          onEdit={onEdit}
+          onSelectSpan={onSelectSpan}
+        />
+      </ReactFlowProvider>
+    );
+
+    expect(getByTestId('assertion-card')).toBeInTheDocument();
+  });
+});

--- a/web/src/components/AssertionCheckRow/AssertionCheckRow.styled.ts
+++ b/web/src/components/AssertionCheckRow/AssertionCheckRow.styled.ts
@@ -1,4 +1,4 @@
-import {Badge, Typography} from 'antd';
+import {Badge, Tooltip, Typography} from 'antd';
 import styled from 'styled-components';
 import {SemanticGroupNames} from '../../constants/SemanticGroupNames.constants';
 import {getNotchColor} from '../TraceNode/TraceNode.styled';
@@ -18,6 +18,12 @@ export const Entry = styled.div`
   overflow: hidden;
 `;
 
+export const SelectorEntry = styled.div`
+  display: flex;
+  flex-direction: column;
+  flex-wrap: wrap;
+`;
+
 export const Label = styled(Typography.Text).attrs({
   type: 'secondary',
 })`
@@ -34,8 +40,15 @@ export const LabelBadge = styled(Badge)<{spanType?: SemanticGroupNames}>`
     color: black;
     margin-right: 6px;
     border-radius: 2px;
+    margin-bottom: 8px;
   }
 `;
+
+export const LabelTooltip = styled(Tooltip).attrs({
+  color: '#FBFBFF',
+  placement: 'top',
+  arrowPointAtCenter: true,
+})``;
 
 export const SelectedLabelBadge = styled(LabelBadge)`
   > sup {

--- a/web/src/components/AssertionCheckRow/AssertionCheckRow.tsx
+++ b/web/src/components/AssertionCheckRow/AssertionCheckRow.tsx
@@ -1,4 +1,4 @@
-import {capitalize, difference} from 'lodash';
+import {capitalize} from 'lodash';
 import {useMemo} from 'react';
 import {useTestRun} from '../../providers/TestRun/TestRun.provider';
 import OperatorService from '../../services/Operator.service';
@@ -10,17 +10,13 @@ import * as S from './AssertionCheckRow.styled';
 interface TAssertionCheckRowProps {
   result: TAssertionSpanResult;
   assertion: TAssertion;
-  assertionSelectorList: string[];
-
   getIsSelectedSpan(spanId: string): boolean;
-
   onSelectSpan(spanId: string): void;
 }
 
 const AssertionCheckRow: React.FC<TAssertionCheckRowProps> = ({
   result: {observedValue, passed, spanId},
   assertion: {attribute, comparator, expected},
-  assertionSelectorList,
   getIsSelectedSpan,
   onSelectSpan,
 }) => {
@@ -29,25 +25,25 @@ const AssertionCheckRow: React.FC<TAssertionCheckRowProps> = ({
   } = useTestRun();
   const span = useMemo(() => trace?.spans.find(({id}) => id === spanId), [spanId, trace?.spans]);
 
-  const signatureSelectorList = span?.signature.map(({value}) => value);
-  const spanLabelList = difference(signatureSelectorList, assertionSelectorList);
   const badgeList = useMemo(() => {
     const isSelected = getIsSelectedSpan(spanId);
+    const signatureSelectorList = span?.signature || [];
 
     return (isSelected ? [<S.SelectedLabelBadge count="selected" key="selected" />] : []).concat(
-      spanLabelList.map((label, index) => (
-        // eslint-disable-next-line react/no-array-index-key
-        <S.LabelBadge spanType={!index ? span?.type : undefined} count={label} key={`${label}-${index}`} />
+      signatureSelectorList.map(({key, value}, index) => (
+        <S.LabelTooltip title={key} key={key}>
+          <S.LabelBadge spanType={!index ? span?.type : undefined} count={value} />
+        </S.LabelTooltip>
       ))
     );
-  }, [getIsSelectedSpan, spanId, spanLabelList, span?.type]);
+  }, [getIsSelectedSpan, spanId, span?.signature, span?.type]);
 
   return (
     <S.AssertionCheckRow onClick={() => onSelectSpan(spanId)}>
-      <S.Entry>
+      <S.SelectorEntry>
         <S.Label>Span Labels</S.Label>
         <S.Value>{badgeList}</S.Value>
-      </S.Entry>
+      </S.SelectorEntry>
       <S.Entry>
         <S.Label>Attribute</S.Label>
         <S.Value>{attribute}</S.Value>

--- a/web/src/components/AssertionCheckRow/__tests__/AssertionCheckRow.test.tsx
+++ b/web/src/components/AssertionCheckRow/__tests__/AssertionCheckRow.test.tsx
@@ -1,0 +1,25 @@
+import AssertionMock from '../../../models/__mocks__/Assertion.mock';
+import AssertionSpanResultMock from '../../../models/__mocks__/AssertionSpanResult.mock';
+import {render} from '../../../test-utils';
+import AssertionCheckRow from '../AssertionCheckRow';
+
+const onSelectSpan = jest.fn();
+const getIsSelectedSpan = jest.fn();
+
+describe('AssertionCheckRow', () => {
+  it('should render', () => {
+    const result = AssertionSpanResultMock.model();
+    const assertion = AssertionMock.model();
+
+    const {getByText} = render(
+      <AssertionCheckRow
+        result={result}
+        assertion={assertion}
+        getIsSelectedSpan={getIsSelectedSpan}
+        onSelectSpan={onSelectSpan}
+      />
+    );
+
+    expect(getByText(assertion.attribute)).toBeInTheDocument();
+  });
+});

--- a/web/src/components/AssertionForm/AssertionForm.tsx
+++ b/web/src/components/AssertionForm/AssertionForm.tsx
@@ -70,7 +70,7 @@ const AssertionForm: React.FC<TAssertionFormProps> = ({
     AssertionSelectors.selectAttributeList(state, testId, runId, spanIdList)
   );
   const selectorAttributeList = useAppSelector(state =>
-    AssertionSelectors.selectSelectorAttributeList(state, testId, runId, spanIdList)
+    AssertionSelectors.selectSelectorAttributeList(state, testId, runId, spanIdList, currentSelectorList)
   );
   const definitionSelectorList = useAppSelector(state => TestDefinitionSelectors.selectDefinitionSelectorList(state));
 

--- a/web/src/components/AssertionForm/AssertionForm.tsx
+++ b/web/src/components/AssertionForm/AssertionForm.tsx
@@ -69,6 +69,9 @@ const AssertionForm: React.FC<TAssertionFormProps> = ({
   const attributeList = useAppSelector(state =>
     AssertionSelectors.selectAttributeList(state, testId, runId, spanIdList)
   );
+  const selectorAttributeList = useAppSelector(state =>
+    AssertionSelectors.selectSelectorAttributeList(state, testId, runId, spanIdList)
+  );
   const definitionSelectorList = useAppSelector(state => TestDefinitionSelectors.selectDefinitionSelectorList(state));
 
   const onFieldsChange = useCallback(
@@ -143,7 +146,7 @@ const AssertionForm: React.FC<TAssertionFormProps> = ({
             ]}
             data-tour={GuidedTourService.getStep(GuidedTours.Assertion, Steps.Selectors)}
           >
-            <AssertionFormSelectorInput attributeList={attributeList} />
+            <AssertionFormSelectorInput attributeList={selectorAttributeList} />
           </Form.Item>
           <Form.Item name="pseudoSelector">
             <AssertionFormPseudoSelectorInput />

--- a/web/src/components/AssertionForm/AssertionFormSelectorInput.tsx
+++ b/web/src/components/AssertionForm/AssertionFormSelectorInput.tsx
@@ -76,8 +76,10 @@ const AssertionFormSelectorInput: React.FC<TItemSelectorDropdownProps> = ({
   );
 
   const handleDeleteItemSelector = useCallback(
-    (entryNumber: number) => {
-      onChange(selectorList.filter((item, index) => index !== entryNumber));
+    ([attribute, operator, value]: string[]) => {
+      onChange(
+        selectorList.filter(item => attribute !== item.key || operator !== item.operator || value !== item.value)
+      );
     },
     [onChange, selectorList]
   );

--- a/web/src/components/MultiSelectInput/MultiSelectInput.tsx
+++ b/web/src/components/MultiSelectInput/MultiSelectInput.tsx
@@ -10,7 +10,7 @@ interface IProps {
   }[];
   onEntry(entry: string[]): void;
   onStepEntry?(name: string, entry: string): void;
-  onDeselect(entryNumber: number): void;
+  onDeselect(entry: string[]): void;
   onClear(): void;
   placeholder?: string;
   defaultValueList?: LabeledValue[];
@@ -88,7 +88,12 @@ const MultiSelectInput: React.FC<IProps> = ({
         })
       );
 
-      onDeselect(entryNumber);
+      const deselectedEntry = selectedItemList.reduce<string[]>((list, {value, label}) => {
+        const [, , number] = String(value).split(SEPARATOR);
+
+        return Number(number) === entryNumber ? list.concat(label as string) : list;
+      }, []);
+      onDeselect(deselectedEntry);
     },
     [onDeselect, selectedItemList]
   );

--- a/web/src/constants/SemanticGroupNames.constants.ts
+++ b/web/src/constants/SemanticGroupNames.constants.ts
@@ -63,7 +63,7 @@ export const SemanticGroupNameNodeMap: Record<SemanticGroupNames, {primary: stri
   },
 };
 
-const BASE_ATTRIBUTES = [Attributes.NAME, Attributes.TRACETEST_SPAN_TYPE, Attributes.SERVICE_NAME];
+export const BASE_ATTRIBUTES = [Attributes.TRACETEST_SPAN_TYPE, Attributes.SERVICE_NAME, Attributes.NAME];
 
 export const SELECTOR_DEFAULT_ATTRIBUTES = [
   {

--- a/web/src/constants/Span.constants.ts
+++ b/web/src/constants/Span.constants.ts
@@ -1,5 +1,6 @@
-import {SemanticGroupNames} from './SemanticGroupNames.constants';
-import {Attributes} from './SpanAttribute.constants';
+import {uniq} from 'lodash';
+import {SemanticGroupNames, BASE_ATTRIBUTES, SemanticGroupsSignature} from './SemanticGroupNames.constants';
+import {Attributes, SemanticAttributes} from './SpanAttribute.constants';
 
 type TValueOfAttributes = typeof Attributes[keyof typeof Attributes];
 
@@ -13,6 +14,8 @@ export enum SectionNames {
   custom = 'custom',
   all = 'all',
 }
+
+export const SelectorAttributesBlackList = [SemanticAttributes.DB_STATEMENT, SemanticAttributes.DB_CONNECTION_STRING];
 
 export const SpanAttributeSections: Record<SemanticGroupNames, Record<string, TValueOfAttributes[]>> = {
   [SemanticGroupNames.Http]: {
@@ -80,9 +83,28 @@ export const SpanAttributeSections: Record<SemanticGroupNames, Record<string, TV
       Attributes.MESSAGING_KAFKA_CONSUMER_GROUP,
     ],
   },
-  [SemanticGroupNames.Rpc]: {},
-  [SemanticGroupNames.Exception]: {},
-  [SemanticGroupNames.General]: {},
-  [SemanticGroupNames.Compatibility]: {},
-  [SemanticGroupNames.Faas]: {},
+  [SemanticGroupNames.Rpc]: {
+    [SectionNames.metadata]: SemanticGroupsSignature.rpc,
+  },
+  [SemanticGroupNames.Exception]: {
+    [SectionNames.metadata]: SemanticGroupsSignature.exception,
+  },
+  [SemanticGroupNames.General]: {
+    [SectionNames.metadata]: SemanticGroupsSignature.general,
+  },
+  [SemanticGroupNames.Compatibility]: {
+    [SectionNames.metadata]: SemanticGroupsSignature.compatibility,
+  },
+  [SemanticGroupNames.Faas]: {
+    [SectionNames.metadata]: SemanticGroupsSignature.faas,
+  },
 };
+
+export const SelectorAttributesWhiteList = uniq([
+  ...BASE_ATTRIBUTES,
+  ...Object.values(SpanAttributeSections).flatMap(section => {
+    const sectionAttributes = Object.values(section).flatMap(attributes => attributes);
+
+    return sectionAttributes;
+  }),
+]);

--- a/web/src/models/__mocks__/AssertionResults.mock.ts
+++ b/web/src/models/__mocks__/AssertionResults.mock.ts
@@ -8,7 +8,10 @@ const AssertionResultsMock: IMockFactory<TAssertionResults, TRawAssertionResults
   raw(data = {}) {
     return {
       allPassed: faker.datatype.boolean(),
-      resultList: new Array(faker.datatype.number({min: 2, max: 10})).fill(null).map(() => AssertionResultMock.raw()),
+      results: new Array(faker.datatype.number({min: 2, max: 10})).fill(null).map((item, index) => ({
+        selector: `span[http.status_code] = "20${index}"]`,
+        results: new Array(faker.datatype.number({min: 2, max: 10})).fill(null).map(() => AssertionResultMock.raw()),
+      })),
       ...data,
     };
   },

--- a/web/src/providers/TestDefinition/__tests__/TestDefinition.provider.test.tsx
+++ b/web/src/providers/TestDefinition/__tests__/TestDefinition.provider.test.tsx
@@ -1,15 +1,18 @@
 import {render} from '@testing-library/react';
+import {BrowserRouter} from 'react-router-dom';
 import {ReduxWrapperProvider} from '../../../redux/ReduxWrapperProvider';
 import TestDefinitionProvider from '../TestDefinition.provider';
 
 describe('TestDefinitionProvider', () => {
   it('should render with the proper values', () => {
     const {getByText} = render(
-      <TestDefinitionProvider testId="testId" runId="runId">
-        <div>
-          <p>Hello</p>
-        </div>
-      </TestDefinitionProvider>,
+      <BrowserRouter>
+        <TestDefinitionProvider testId="testId" runId="runId">
+          <div>
+            <p>Hello</p>
+          </div>
+        </TestDefinitionProvider>
+      </BrowserRouter>,
       {wrapper: ReduxWrapperProvider}
     );
 

--- a/web/src/selectors/Assertion.selectors.ts
+++ b/web/src/selectors/Assertion.selectors.ts
@@ -2,6 +2,7 @@ import {createSelector} from '@reduxjs/toolkit';
 
 import {endpoints} from 'redux/apis/TraceTest.api';
 import {RootState} from 'redux/store';
+import SpanAttributeService from '../services/SpanAttribute.service';
 
 const stateSelector = (state: RootState) => state;
 const paramsSelector = (state: RootState, testId: string, runId: string, spanIdList: string[]) => ({
@@ -20,6 +21,9 @@ const selectAffectedSpanList = createSelector(stateSelector, paramsSelector, (st
 const AssertionSelectors = () => ({
   selectAffectedSpanList,
   selectAttributeList: createSelector(selectAffectedSpanList, spanList => spanList.flatMap(span => span.attributeList)),
+  selectSelectorAttributeList: createSelector(selectAffectedSpanList, spanList =>
+    SpanAttributeService.getFilteredSelectorAttributeList(spanList.flatMap(span => span.attributeList))
+  ),
 });
 
 export default AssertionSelectors();

--- a/web/src/selectors/Assertion.selectors.ts
+++ b/web/src/selectors/Assertion.selectors.ts
@@ -3,6 +3,7 @@ import {createSelector} from '@reduxjs/toolkit';
 import {endpoints} from 'redux/apis/TraceTest.api';
 import {RootState} from 'redux/store';
 import SpanAttributeService from '../services/SpanAttribute.service';
+import {TSpanSelector} from '../types/Assertion.types';
 
 const stateSelector = (state: RootState) => state;
 const paramsSelector = (state: RootState, testId: string, runId: string, spanIdList: string[]) => ({
@@ -10,6 +11,14 @@ const paramsSelector = (state: RootState, testId: string, runId: string, spanIdL
   testId,
   runId,
 });
+
+const currentSelectorListSelector = (
+  state: RootState,
+  testId: string,
+  runId: string,
+  spanIdList: string[],
+  currentSelectorList: TSpanSelector[]
+) => currentSelectorList.map(({key}) => key);
 
 const selectAffectedSpanList = createSelector(stateSelector, paramsSelector, (state, {spanIdList, testId, runId}) => {
   if (!spanIdList) return [];
@@ -21,8 +30,11 @@ const selectAffectedSpanList = createSelector(stateSelector, paramsSelector, (st
 const AssertionSelectors = () => ({
   selectAffectedSpanList,
   selectAttributeList: createSelector(selectAffectedSpanList, spanList => spanList.flatMap(span => span.attributeList)),
-  selectSelectorAttributeList: createSelector(selectAffectedSpanList, spanList =>
-    SpanAttributeService.getFilteredSelectorAttributeList(spanList.flatMap(span => span.attributeList))
+  selectSelectorAttributeList: createSelector(
+    selectAffectedSpanList,
+    currentSelectorListSelector,
+    (spanList, currentSelectorList) =>
+      SpanAttributeService.getFilteredSelectorAttributeList(spanList.flatMap(span => span.attributeList), currentSelectorList)
   ),
 });
 

--- a/web/src/services/Span.service.ts
+++ b/web/src/services/Span.service.ts
@@ -49,7 +49,7 @@ const SpanService = () => ({
       })) || [];
 
     const pseudoSelector = {
-      selector: PseudoSelector.FIRST,
+      selector: PseudoSelector.ALL,
     };
 
     return {selectorList, pseudoSelector};

--- a/web/src/services/SpanAttribute.service.ts
+++ b/web/src/services/SpanAttribute.service.ts
@@ -49,8 +49,12 @@ const SpanAttributeService = () => ({
     return sectionList.concat(defaultSectionList);
   },
 
-  getFilteredSelectorAttributeList(attributeList: TSpanFlatAttribute[]): TSpanFlatAttribute[] {
-    const whiteListFiltered = filterAttributeList(attributeList, SelectorAttributesWhiteList);
+  getFilteredSelectorAttributeList(
+    attributeList: TSpanFlatAttribute[],
+    currentSelectorList: string[]
+  ): TSpanFlatAttribute[] {
+    const duplicatedFiltered = removeFromAttributeList(attributeList, currentSelectorList);
+    const whiteListFiltered = filterAttributeList(duplicatedFiltered, SelectorAttributesWhiteList);
     const blackListFiltered = removeFromAttributeList(whiteListFiltered, SelectorAttributesBlackList);
     const customList = attributeList.filter(attr => !flatAttributes.includes(attr.key));
 

--- a/web/src/services/SpanAttribute.service.ts
+++ b/web/src/services/SpanAttribute.service.ts
@@ -1,17 +1,27 @@
+import {isEmpty, remove} from 'lodash';
 import {SemanticGroupNames} from '../constants/SemanticGroupNames.constants';
-import {SectionNames, SpanAttributeSections} from '../constants/Span.constants';
+import {
+  SectionNames,
+  SelectorAttributesBlackList,
+  SelectorAttributesWhiteList,
+  SpanAttributeSections,
+} from '../constants/Span.constants';
 import {Attributes} from '../constants/SpanAttribute.constants';
 import {TSpanFlatAttribute} from '../types/Span.types';
+import {isJson} from '../utils/Common';
 
 const flatAttributes = Object.values(Attributes);
 
 const filterAttributeList = (attributeList: TSpanFlatAttribute[], attrKeyList: string[]): TSpanFlatAttribute[] => {
   return attrKeyList.reduce<TSpanFlatAttribute[]>((list, key) => {
-    const foundAttr = attributeList.find(attr => attr.key === key);
+    const foundAttrList = attributeList.filter(attr => attr.key === key);
 
-    return foundAttr ? list.concat(foundAttr) : list;
+    return foundAttrList.length ? list.concat(foundAttrList) : list;
   }, []);
 };
+
+const removeFromAttributeList = (attributeList: TSpanFlatAttribute[], attrKeyList: string[]): TSpanFlatAttribute[] =>
+  remove(attributeList, attr => !attrKeyList.includes(attr.key));
 
 const SpanAttributeService = () => ({
   getSpanAttributeSectionsList(
@@ -37,6 +47,16 @@ const SpanAttributeService = () => ({
     );
 
     return sectionList.concat(defaultSectionList);
+  },
+
+  getFilteredSelectorAttributeList(attributeList: TSpanFlatAttribute[]): TSpanFlatAttribute[] {
+    const whiteListFiltered = filterAttributeList(attributeList, SelectorAttributesWhiteList);
+    const blackListFiltered = removeFromAttributeList(whiteListFiltered, SelectorAttributesBlackList);
+    const customList = attributeList.filter(attr => !flatAttributes.includes(attr.key));
+
+    const parsedList = blackListFiltered.concat(customList).filter(attr => !isJson(attr.value) && !isEmpty(attr));
+
+    return parsedList;
   },
 });
 

--- a/web/src/services/__tests__/Span.service.test.ts
+++ b/web/src/services/__tests__/Span.service.test.ts
@@ -64,7 +64,7 @@ describe('SpanService', () => {
       const selectorInfo = SpanService.getSelectorInformation(span);
 
       expect(selectorInfo.selectorList).toHaveLength(2);
-      expect(selectorInfo.pseudoSelector).toEqual({selector: PseudoSelector.FIRST});
+      expect(selectorInfo.pseudoSelector).toEqual({selector: PseudoSelector.ALL});
     });
   });
 });

--- a/web/src/services/__tests__/SpanAttribute.service.test.ts
+++ b/web/src/services/__tests__/SpanAttribute.service.test.ts
@@ -112,7 +112,7 @@ describe('SpanAttributeService', () => {
         },
       ];
 
-      expect(SpanAttributeService.getFilteredSelectorAttributeList(attributeList)).toEqual([
+      expect(SpanAttributeService.getFilteredSelectorAttributeList(attributeList, [])).toEqual([
         {
           key: Attributes.DB_NAME,
           value: 'pokeshop',

--- a/web/src/services/__tests__/SpanAttribute.service.test.ts
+++ b/web/src/services/__tests__/SpanAttribute.service.test.ts
@@ -2,6 +2,7 @@ import SpanAttributeService from '../SpanAttribute.service';
 import {SemanticGroupNames} from '../../constants/SemanticGroupNames.constants';
 import {SectionNames} from '../../constants/Span.constants';
 import {Attributes} from '../../constants/SpanAttribute.constants';
+import {TSpanFlatAttribute} from '../../types/Span.types';
 
 describe('SpanAttributeService', () => {
   describe('getFilteredSpanAttributeList', () => {
@@ -85,6 +86,40 @@ describe('SpanAttributeService', () => {
         {
           section: SectionNames.all,
           attributeList: [attribute, customAttribute],
+        },
+      ]);
+    });
+  });
+
+  describe('getFilteredSelectorAttributeList', () => {
+    it('should return the filtered list of attributes', () => {
+      const attributeList: TSpanFlatAttribute[] = [
+        {
+          key: Attributes.MESSAGING_SYSTEM,
+          value: 'kafka',
+        },
+        {
+          key: Attributes.DB_NAME,
+          value: 'pokeshop',
+        },
+        {
+          key: Attributes.DB_STATEMENT,
+          value: 'SELECT * FROM users',
+        },
+        {
+          key: Attributes.TRACETEST_RESPONSE_BODY,
+          value: '{"id": 1}',
+        },
+      ];
+
+      expect(SpanAttributeService.getFilteredSelectorAttributeList(attributeList)).toEqual([
+        {
+          key: Attributes.DB_NAME,
+          value: 'pokeshop',
+        },
+        {
+          key: Attributes.MESSAGING_SYSTEM,
+          value: 'kafka',
         },
       ]);
     });

--- a/web/src/utils/Common.ts
+++ b/web/src/utils/Common.ts
@@ -1,10 +1,9 @@
-export const filterBySpanId = (spanId: string = '') =>
-  `resourceSpans[?instrumentationLibrarySpans[?spans[?starts_with(spanId,'${spanId}')]]] | [].[instrumentationLibrarySpans[].spans[].attributes[].{key:key,value:value.*|[0],type:'span'},resource.attributes[].{key:key,value: value.*|[0],type:'resource'}]|[][]`;
-
 export const escapeString = (str: string): string => {
   // eslint-disable-next-line no-control-regex
   return str.replace(/[\\"']/g, '\\$&').replace(/\u0000/g, '\\0');
 };
+
+export const isBoolean = (value: string): boolean => value === 'true' || value === 'false';
 
 export const isJson = (str: string) => {
   try {
@@ -13,7 +12,7 @@ export const isJson = (str: string) => {
     return false;
   }
 
-  return Number.isNaN(Number(str)) && true;
+  return Number.isNaN(Number(str)) && !isBoolean(str) && true;
 };
 
 const visiblePortion = 64;


### PR DESCRIPTION
This PR adds more information to the assertion card header. Including the name of the attributes plus the operator.

## Changes

- Stablishes a sorting for the attributes to be always displayed in the same order.
- Cleans up attributes from the assertion form
- Adds tooltip for the selector labels.

## Fixes

- https://github.com/kubeshop/tracetest/issues/568

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [x] added a test
