### PR TITLE
Fix onClick propagation in assertion header

### DIFF
--- a/web/src/components/AssertionCard/AssertionCard.tsx
+++ b/web/src/components/AssertionCard/AssertionCard.tsx
@@ -66,10 +66,21 @@ const AssertionCard: React.FC<TAssertionCardProps> = ({
           {isDraft && <S.StatusTag>draft</S.StatusTag>}
           {isDeleted && <S.StatusTag color="#61175E">deleted</S.StatusTag>}
           <Tooltip color="white" title="Edit Assertion">
-            <S.EditIcon data-cy="edit-assertion-button" onClick={() => onEdit(assertionResult)} />
+            <S.EditIcon
+              data-cy="edit-assertion-button"
+              onClick={e => {
+                e.stopPropagation();
+                onEdit(assertionResult);
+              }}
+            />
           </Tooltip>
           <Tooltip color="white" title="Delete Assertion">
-            <S.DeleteIcon onClick={() => onDelete(selector)} />
+            <S.DeleteIcon
+              onClick={e => {
+                e.stopPropagation();
+                onDelete(selector);
+              }}
+            />
           </Tooltip>
         </S.ActionsContainer>
       </S.Header>


### PR DESCRIPTION
This PR fixes an issue with the onClick propagation in the assertion header.

## Changes

- Fix onClick event.

## Fixes

- #567 

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
