### PR TITLE
implement revert logic by using originalSelector

### DIFF
--- a/web/src/components/AssertionCard/AssertionCard.tsx
+++ b/web/src/components/AssertionCard/AssertionCard.tsx
@@ -1,12 +1,12 @@
-import {Tooltip} from 'antd';
-import {useCallback} from 'react';
-import {useStore} from 'react-flow-renderer';
+import {Button, Tooltip} from 'antd';
 
 import AssertionCheckRow from 'components/AssertionCheckRow';
 import {useTestDefinition} from 'providers/TestDefinition/TestDefinition.provider';
-import {useAppSelector} from 'redux/hooks';
+import {useCallback} from 'react';
+import {useStore} from 'react-flow-renderer';
 import TestDefinitionSelectors from 'selectors/TestDefinition.selectors';
-import {TAssertionResultEntry} from 'types/Assertion.types';
+import {useAppSelector} from '../../redux/hooks';
+import {TAssertionResultEntry} from '../../types/Assertion.types';
 import * as S from './AssertionCard.styled';
 import AssertionCardSelectorList from './AssertionCardSelectorList';
 
@@ -24,13 +24,16 @@ const AssertionCard: React.FC<TAssertionCardProps> = ({
   onDelete,
   onEdit,
 }) => {
-  const {setSelectedAssertion} = useTestDefinition();
+  const {setSelectedAssertion, revert} = useTestDefinition();
   const store = useStore();
   const {selectedElements} = store.getState();
 
   const selectedAssertion = useAppSelector(TestDefinitionSelectors.selectSelectedAssertion);
-  const {isDraft = false, isDeleted = false} =
-    useAppSelector(state => TestDefinitionSelectors.selectDefinitionBySelector(state, selector)) || {};
+  const {
+    isDraft = false,
+    isDeleted = false,
+    originalSelector = '',
+  } = useAppSelector(state => TestDefinitionSelectors.selectDefinitionBySelector(state, selector)) || {};
   const spanCountText = `${spanIds.length} ${spanIds.length > 1 ? 'spans' : 'span'}`;
 
   const getIsSelectedSpan = useCallback(
@@ -49,6 +52,13 @@ const AssertionCard: React.FC<TAssertionCardProps> = ({
     setSelectedAssertion(selector);
   };
 
+  const resetDefinition: React.MouseEventHandler = useCallback(
+    e => {
+      e.stopPropagation();
+      revert(originalSelector);
+    },
+    [revert, originalSelector]
+  );
   return (
     <S.AssertionCard
       $isSelected={selectedAssertion === selector}
@@ -60,7 +70,14 @@ const AssertionCard: React.FC<TAssertionCardProps> = ({
           <AssertionCardSelectorList selectorList={selectorList} pseudoSelector={pseudoSelector} />
         </div>
         <S.ActionsContainer>
-          {isDraft && <S.StatusTag>draft</S.StatusTag>}
+          {isDraft && (
+            <>
+              <S.StatusTag>draft</S.StatusTag>
+              <Button type="link" data-cy="assertion-action-revert" onClick={resetDefinition}>
+                Revert Assertion
+              </Button>
+            </>
+          )}
           {isDeleted && <S.StatusTag color="#61175E">deleted</S.StatusTag>}
           <S.SpanCountText>{spanCountText}</S.SpanCountText>
           <Tooltip color="white" title="Edit Assertion">

--- a/web/src/models/AssertionResults.model.ts
+++ b/web/src/models/AssertionResults.model.ts
@@ -11,6 +11,7 @@ const AssertionResults = ({allPassed = false, results = []}: TRawAssertionResult
       id: uniqueId(),
       selector,
       spanIds: AssertionService.getSpanIds(resultList),
+      originalSelector: selector,
       pseudoSelector: SelectorService.getPseudoSelector(selector),
       selectorList: SelectorService.getSpanSelectorList(selector),
       resultList: resultList.map(assertionResult => AssertionResult(assertionResult)),

--- a/web/src/providers/TestDefinition/hooks/useTestDefinitionCrud.ts
+++ b/web/src/providers/TestDefinition/hooks/useTestDefinitionCrud.ts
@@ -10,6 +10,7 @@ import {
   updateDefinition,
   reset as resetAction,
   clearAffectedSpans,
+  revertDefinition,
 } from '../../../redux/slices/TestDefinition.slice';
 import {TAssertionResults} from '../../../types/Assertion.types';
 import {TTestDefinitionEntry} from '../../../types/TestDefinition.types';
@@ -24,6 +25,13 @@ const useTestDefinitionCrud = ({runId, testId}: IProps) => {
   const {isDraftMode, setIsDraftMode} = useDraftMode();
   const dispatch = useAppDispatch();
   const navigate = useNavigate();
+
+  const revert = useCallback(
+    (originalSelector: string) => {
+      return dispatch(revertDefinition({originalSelector}));
+    },
+    [dispatch]
+  );
 
   const dryRun = useCallback(
     (definitionList: TTestDefinitionEntry[]) => {
@@ -80,7 +88,7 @@ const useTestDefinitionCrud = ({runId, testId}: IProps) => {
     dispatch(resetAction());
   }, [dispatch]);
 
-  return {init, reset, add, remove, update, publish, cancel, dryRun, isDraftMode};
+  return {revert, init, reset, add, remove, update, publish, cancel, dryRun, isDraftMode};
 };
 
 export default useTestDefinitionCrud;

--- a/web/src/redux/slices/__tests__/TestDefinition.slice.test.ts
+++ b/web/src/redux/slices/__tests__/TestDefinition.slice.test.ts
@@ -6,21 +6,26 @@ import TestRunMock from '../../../models/__mocks__/TestRun.mock';
 import {TTestDefinitionEntry} from '../../../types/TestDefinition.types';
 import Reducer, {
   addDefinition,
+  assertionResultsToDefinitionList,
   initDefinitionList,
-  resetDefinitionList,
+  initialState,
   removeDefinition,
   reset,
+  resetDefinitionList,
+  revertDefinition,
   setAssertionResults,
-  initialState,
-  assertionResultsToDefinitionList,
   updateDefinition,
 } from '../TestDefinition.slice';
 
 const {definitionList} = TestDefinitionMock.model();
+
+const definitionSelector = `span[http.status_code] = "304"]`;
+
 const definition: TTestDefinitionEntry = {
-  selector: `span[http.status_code] = "304"]`,
+  selector: definitionSelector,
   isDraft: true,
   assertionList: new Array(faker.datatype.number({min: 2, max: 10})).fill(null).map(() => AssertionMock.model()),
+  originalSelector: definitionSelector,
 };
 
 const state = {
@@ -98,6 +103,25 @@ describe('TestDefinitionReducer', () => {
         ...initialState,
         definitionList: [definition, ...definitionList.slice(1, definitionList.length)],
       });
+    });
+    it('should handle the revert definition action', () => {
+      const initialSelector = 'span[http.status_code] = "204"]';
+      const result = Reducer(
+        {
+          ...state,
+          definitionList: [
+            {
+              ...definition,
+              originalSelector: initialSelector,
+            },
+          ],
+        },
+        revertDefinition({
+          originalSelector: definitionSelector,
+        })
+      );
+
+      expect(result.definitionList[0].originalSelector).toEqual(initialSelector);
     });
 
     it('should handle the remove definition action', () => {

--- a/web/src/types/Assertion.types.ts
+++ b/web/src/types/Assertion.types.ts
@@ -24,6 +24,7 @@ export type TRawAssertionResults = TTestSchemas['AssertionResults'];
 export type TAssertionResultEntry = {
   id: string;
   selector: string;
+  originalSelector: string;
   spanIds: string[];
   pseudoSelector?: TPseudoSelector;
   selectorList: TSpanSelector[];

--- a/web/src/types/TestDefinition.types.ts
+++ b/web/src/types/TestDefinition.types.ts
@@ -4,6 +4,7 @@ import {Model, TTestSchemas} from './Common.types';
 export type TRawTestDefinition = TTestSchemas['TestDefinition'];
 
 export type TTestDefinitionEntry = {
+  originalSelector?: string;
   selector: string;
   assertionList: TAssertion[];
   isDraft: boolean;


### PR DESCRIPTION
This PR add revert logic to individual assertions

## Changes

- implement field originalSelector on assertions


## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [x] added a test
