### PR TITLE
Fix: ensure consistent ordering of test definitions

### DIFF
--- a/server/assertions/assertions.go
+++ b/server/assertions/assertions.go
@@ -10,7 +10,7 @@ import (
 func Assert(defs model.Definition, trace traces.Trace) (model.Results, bool) {
 	testResult := model.Results{}
 	allPassed := true
-	for spanQuery, asserts := range defs {
+	defs.Map(func(spanQuery model.SpanQuery, asserts []model.Assertion) {
 		spans := selector(spanQuery).Filter(trace)
 		assertionResults := make([]model.AssertionResult, 0)
 		for _, assertion := range asserts {
@@ -21,7 +21,7 @@ func Assert(defs model.Definition, trace traces.Trace) (model.Results, bool) {
 			assertionResults = append(assertionResults, res)
 		}
 		testResult[spanQuery] = assertionResults
-	}
+	})
 
 	return testResult, allPassed
 }

--- a/server/assertions/assertions.go
+++ b/server/assertions/assertions.go
@@ -7,8 +7,8 @@ import (
 	"go.opentelemetry.io/otel/trace"
 )
 
-func Assert(defs model.Definition, trace traces.Trace) (model.Results, bool) {
-	testResult := model.Results{}
+func Assert(defs model.OrderedMap[model.SpanQuery, []model.Assertion], trace traces.Trace) (model.OrderedMap[model.SpanQuery, []model.AssertionResult], bool) {
+	testResult := model.OrderedMap[model.SpanQuery, []model.AssertionResult]{}
 	allPassed := true
 	defs.Map(func(spanQuery model.SpanQuery, asserts []model.Assertion) {
 		spans := selector(spanQuery).Filter(trace)
@@ -20,7 +20,7 @@ func Assert(defs model.Definition, trace traces.Trace) (model.Results, bool) {
 			}
 			assertionResults = append(assertionResults, res)
 		}
-		testResult[spanQuery] = assertionResults
+		testResult, _ = testResult.Add(spanQuery, assertionResults)
 	})
 
 	return testResult, allPassed

--- a/server/assertions/assetions_test.go
+++ b/server/assertions/assetions_test.go
@@ -24,15 +24,13 @@ func TestAssertion(t *testing.T) {
 	}{
 		{
 			name: "CanAssert",
-			testDef: model.Definition{
-				`span[service.name="Pokeshop"]`: []model.Assertion{
-					{
-						Attribute:  "tracetest.span.duration",
-						Comparator: comparator.Eq,
-						Value:      "2000",
-					},
+			testDef: (model.Definition{}).MustAdd(`span[service.name="Pokeshop"]`, []model.Assertion{
+				{
+					Attribute:  "tracetest.span.duration",
+					Comparator: comparator.Eq,
+					Value:      "2000",
 				},
-			},
+			}),
 			trace: traces.Trace{
 				RootSpan: traces.Span{
 					ID: spanID,

--- a/server/executor/assertion_runner_test.go
+++ b/server/executor/assertion_runner_test.go
@@ -70,14 +70,13 @@ func TestExecutorSuccessfulExecution(t *testing.T) {
 			require.NotNil(t, dbResult.Results)
 			if testCase.ShouldPass {
 				assert.Equal(t, model.RunStateFinished, dbResult.State)
-				for _, results := range dbResult.Results.Results {
+				dbResult.Results.Results.Map(func(_ model.SpanQuery, results []model.AssertionResult) {
 					for _, assertRes := range results {
 						for _, spanAssertionRes := range assertRes.Results {
 							assert.NoError(t, spanAssertionRes.CompareErr)
 						}
 					}
-
-				}
+				})
 				assert.True(t, dbResult.Results.AllPassed)
 			} else {
 				assert.False(t, dbResult.Results.AllPassed)

--- a/server/http/controller.go
+++ b/server/http/controller.go
@@ -26,8 +26,8 @@ type controller struct {
 	runner          executor.Runner
 	assertionRunner executor.AssertionRunner
 
-	openapi openapiMapper
-	model   modelMapper
+	openapi OpenAPIMapper
+	model   ModelMapper
 }
 
 func NewController(
@@ -39,8 +39,8 @@ func NewController(
 		testDB:          testDB,
 		runner:          runner,
 		assertionRunner: assertionRunner,
-		openapi:         openapiMapper{},
-		model:           modelMapper{Comparators: comparator.DefaultRegistry()},
+		openapi:         OpenAPIMapper{},
+		model:           ModelMapper{Comparators: comparator.DefaultRegistry()},
 	}
 }
 

--- a/server/http/mappings.go
+++ b/server/http/mappings.go
@@ -98,21 +98,21 @@ func (m OpenAPIMapper) Tests(in []model.Test) []openapi.Test {
 
 func (m OpenAPIMapper) Definition(in model.Definition) openapi.TestDefinition {
 
-	defs := make([]openapi.TestDefinitionDefinitions, len(in))
+	defs := make([]openapi.TestDefinitionDefinitions, in.Len())
 
 	i := 0
-	for sel, def := range in {
-		assertions := make([]openapi.Assertion, len(def))
-		for j, a := range def {
+	in.Map(func(spanQuery model.SpanQuery, asserts []model.Assertion) {
+		assertions := make([]openapi.Assertion, len(asserts))
+		for j, a := range asserts {
 			assertions[j] = m.Assertion(a)
 		}
 
 		defs[i] = openapi.TestDefinitionDefinitions{
-			Selector:   string(sel),
+			Selector:   string(spanQuery),
 			Assertions: assertions,
 		}
 		i++
-	}
+	})
 
 	return openapi.TestDefinition{
 		Definitions: defs,
@@ -339,7 +339,7 @@ func (m ModelMapper) Definition(in openapi.TestDefinition) model.Definition {
 		for i, a := range d.Assertions {
 			asserts[i] = m.Assertion(a)
 		}
-		defs[model.SpanQuery(d.Selector)] = asserts
+		defs, _ = defs.Add(model.SpanQuery(d.Selector), asserts)
 	}
 
 	return defs

--- a/server/http/mappings.go
+++ b/server/http/mappings.go
@@ -13,9 +13,9 @@ import (
 	"go.opentelemetry.io/otel/trace"
 )
 
-type openapiMapper struct{}
+type OpenAPIMapper struct{}
 
-func (m openapiMapper) Test(in model.Test) openapi.Test {
+func (m OpenAPIMapper) Test(in model.Test) openapi.Test {
 	return openapi.Test{
 		Id:          in.ID.String(),
 		Name:        in.Name,
@@ -29,7 +29,7 @@ func (m openapiMapper) Test(in model.Test) openapi.Test {
 	}
 }
 
-func (m openapiMapper) HTTPHeaders(in []model.HTTPHeader) []openapi.HttpHeader {
+func (m OpenAPIMapper) HTTPHeaders(in []model.HTTPHeader) []openapi.HttpHeader {
 	headers := make([]openapi.HttpHeader, len(in))
 	for i, h := range in {
 		headers[i] = openapi.HttpHeader{Key: h.Key, Value: h.Value}
@@ -38,7 +38,7 @@ func (m openapiMapper) HTTPHeaders(in []model.HTTPHeader) []openapi.HttpHeader {
 	return headers
 }
 
-func (m openapiMapper) HTTPRequest(in model.HTTPRequest) openapi.HttpRequest {
+func (m OpenAPIMapper) HTTPRequest(in model.HTTPRequest) openapi.HttpRequest {
 	return openapi.HttpRequest{
 		Url:     in.URL,
 		Method:  string(in.Method),
@@ -48,7 +48,7 @@ func (m openapiMapper) HTTPRequest(in model.HTTPRequest) openapi.HttpRequest {
 	}
 }
 
-func (m openapiMapper) HTTPResponse(in model.HTTPResponse) openapi.HttpResponse {
+func (m OpenAPIMapper) HTTPResponse(in model.HTTPResponse) openapi.HttpResponse {
 
 	return openapi.HttpResponse{
 		Status:     in.Status,
@@ -58,7 +58,7 @@ func (m openapiMapper) HTTPResponse(in model.HTTPResponse) openapi.HttpResponse 
 	}
 }
 
-func (m openapiMapper) Auth(in *model.HTTPAuthenticator) openapi.HttpAuth {
+func (m OpenAPIMapper) Auth(in *model.HTTPAuthenticator) openapi.HttpAuth {
 	if in == nil {
 		return openapi.HttpAuth{}
 	}
@@ -87,7 +87,7 @@ func (m openapiMapper) Auth(in *model.HTTPAuthenticator) openapi.HttpAuth {
 	return auth
 }
 
-func (m openapiMapper) Tests(in []model.Test) []openapi.Test {
+func (m OpenAPIMapper) Tests(in []model.Test) []openapi.Test {
 	tests := make([]openapi.Test, len(in))
 	for i, t := range in {
 		tests[i] = m.Test(t)
@@ -96,7 +96,7 @@ func (m openapiMapper) Tests(in []model.Test) []openapi.Test {
 	return tests
 }
 
-func (m openapiMapper) Definition(in model.Definition) openapi.TestDefinition {
+func (m OpenAPIMapper) Definition(in model.Definition) openapi.TestDefinition {
 
 	defs := make([]openapi.TestDefinitionDefinitions, len(in))
 
@@ -119,7 +119,7 @@ func (m openapiMapper) Definition(in model.Definition) openapi.TestDefinition {
 	}
 }
 
-func (m openapiMapper) Trace(in *traces.Trace) openapi.Trace {
+func (m OpenAPIMapper) Trace(in *traces.Trace) openapi.Trace {
 	if in == nil {
 		return openapi.Trace{}
 	}
@@ -136,7 +136,7 @@ func (m openapiMapper) Trace(in *traces.Trace) openapi.Trace {
 	}
 }
 
-func (m openapiMapper) Span(in traces.Span) openapi.Span {
+func (m OpenAPIMapper) Span(in traces.Span) openapi.Span {
 	parentID := ""
 	if in.Parent != nil {
 		parentID = in.Parent.ID.String()
@@ -152,7 +152,7 @@ func (m openapiMapper) Span(in traces.Span) openapi.Span {
 	}
 }
 
-func (m openapiMapper) Spans(in []*traces.Span) []openapi.Span {
+func (m OpenAPIMapper) Spans(in []*traces.Span) []openapi.Span {
 	spans := make([]openapi.Span, len(in))
 	for i, s := range in {
 		spans[i] = m.Span(*s)
@@ -161,7 +161,7 @@ func (m openapiMapper) Spans(in []*traces.Span) []openapi.Span {
 	return spans
 }
 
-func (m openapiMapper) Result(in *model.RunResults) openapi.AssertionResults {
+func (m OpenAPIMapper) Result(in *model.RunResults) openapi.AssertionResults {
 	if in == nil {
 		return openapi.AssertionResults{}
 	}
@@ -196,7 +196,7 @@ func (m openapiMapper) Result(in *model.RunResults) openapi.AssertionResults {
 		Results:   results,
 	}
 }
-func (m openapiMapper) Assertion(in model.Assertion) openapi.Assertion {
+func (m OpenAPIMapper) Assertion(in model.Assertion) openapi.Assertion {
 	return openapi.Assertion{
 		Attribute:  in.Attribute,
 		Comparator: in.Comparator.String(),
@@ -204,7 +204,7 @@ func (m openapiMapper) Assertion(in model.Assertion) openapi.Assertion {
 	}
 }
 
-func (m openapiMapper) Run(in *model.Run) openapi.TestRun {
+func (m OpenAPIMapper) Run(in *model.Run) openapi.TestRun {
 	if in == nil {
 		return openapi.TestRun{}
 	}
@@ -228,7 +228,7 @@ func (m openapiMapper) Run(in *model.Run) openapi.TestRun {
 	}
 }
 
-func (m openapiMapper) Runs(in []model.Run) []openapi.TestRun {
+func (m OpenAPIMapper) Runs(in []model.Run) []openapi.TestRun {
 	runs := make([]openapi.TestRun, len(in))
 	for i, t := range in {
 		runs[i] = m.Run(&t)
@@ -237,11 +237,11 @@ func (m openapiMapper) Runs(in []model.Run) []openapi.TestRun {
 	return runs
 }
 
-type modelMapper struct {
+type ModelMapper struct {
 	Comparators comparator.Registry
 }
 
-func (m modelMapper) Test(in openapi.Test) model.Test {
+func (m ModelMapper) Test(in openapi.Test) model.Test {
 	id, _ := uuid.Parse(in.Id)
 	return model.Test{
 		ID:          id,
@@ -256,7 +256,7 @@ func (m modelMapper) Test(in openapi.Test) model.Test {
 	}
 }
 
-func (m modelMapper) HTTPHeaders(in []openapi.HttpHeader) []model.HTTPHeader {
+func (m ModelMapper) HTTPHeaders(in []openapi.HttpHeader) []model.HTTPHeader {
 	headers := make([]model.HTTPHeader, len(in))
 	for i, h := range in {
 		headers[i] = model.HTTPHeader{Key: h.Key, Value: h.Value}
@@ -265,7 +265,7 @@ func (m modelMapper) HTTPHeaders(in []openapi.HttpHeader) []model.HTTPHeader {
 	return headers
 }
 
-func (m modelMapper) HTTPRequest(in openapi.HttpRequest) model.HTTPRequest {
+func (m ModelMapper) HTTPRequest(in openapi.HttpRequest) model.HTTPRequest {
 	return model.HTTPRequest{
 		URL:     in.Url,
 		Method:  model.HTTPMethod(in.Method),
@@ -275,7 +275,7 @@ func (m modelMapper) HTTPRequest(in openapi.HttpRequest) model.HTTPRequest {
 	}
 }
 
-func (m modelMapper) HTTPResponse(in openapi.HttpResponse) model.HTTPResponse {
+func (m ModelMapper) HTTPResponse(in openapi.HttpResponse) model.HTTPResponse {
 	return model.HTTPResponse{
 		Status:     in.Status,
 		StatusCode: int(in.StatusCode),
@@ -284,7 +284,7 @@ func (m modelMapper) HTTPResponse(in openapi.HttpResponse) model.HTTPResponse {
 	}
 }
 
-func (m modelMapper) Auth(in openapi.HttpAuth) *model.HTTPAuthenticator {
+func (m ModelMapper) Auth(in openapi.HttpAuth) *model.HTTPAuthenticator {
 	var props map[string]string
 	switch in.Type {
 	case "apiKey":
@@ -310,7 +310,7 @@ func (m modelMapper) Auth(in openapi.HttpAuth) *model.HTTPAuthenticator {
 	}
 }
 
-func (m modelMapper) Tests(in []openapi.Test) []model.Test {
+func (m ModelMapper) Tests(in []openapi.Test) []model.Test {
 	tests := make([]model.Test, len(in))
 	for i, t := range in {
 		tests[i] = m.Test(t)
@@ -319,7 +319,7 @@ func (m modelMapper) Tests(in []openapi.Test) []model.Test {
 	return tests
 }
 
-func (m modelMapper) ValidateDefinition(in openapi.TestDefinition) error {
+func (m ModelMapper) ValidateDefinition(in openapi.TestDefinition) error {
 	selectors := map[string]bool{}
 	for _, d := range in.Definitions {
 		if _, exists := selectors[d.Selector]; exists {
@@ -332,7 +332,7 @@ func (m modelMapper) ValidateDefinition(in openapi.TestDefinition) error {
 	return nil
 }
 
-func (m modelMapper) Definition(in openapi.TestDefinition) model.Definition {
+func (m ModelMapper) Definition(in openapi.TestDefinition) model.Definition {
 	defs := model.Definition{}
 	for _, d := range in.Definitions {
 		asserts := make([]model.Assertion, len(d.Assertions))
@@ -345,7 +345,7 @@ func (m modelMapper) Definition(in openapi.TestDefinition) model.Definition {
 	return defs
 }
 
-func (m modelMapper) Run(in openapi.TestRun) *model.Run {
+func (m ModelMapper) Run(in openapi.TestRun) *model.Run {
 	id, _ := uuid.Parse(in.Id)
 	tid, _ := trace.TraceIDFromHex(in.TraceId)
 	sid, _ := trace.SpanIDFromHex(in.SpanId)
@@ -368,7 +368,7 @@ func (m modelMapper) Run(in openapi.TestRun) *model.Run {
 	}
 }
 
-func (m modelMapper) Result(in openapi.AssertionResults) *model.RunResults {
+func (m ModelMapper) Result(in openapi.AssertionResults) *model.RunResults {
 	results := model.Results{}
 
 	for _, res := range in.Results {
@@ -398,7 +398,7 @@ func (m modelMapper) Result(in openapi.AssertionResults) *model.RunResults {
 	}
 }
 
-func (m modelMapper) Assertion(in openapi.Assertion) model.Assertion {
+func (m ModelMapper) Assertion(in openapi.Assertion) model.Assertion {
 	comp, _ := m.Comparators.Get(in.Comparator)
 	return model.Assertion{
 		Attribute:  in.Attribute,
@@ -407,7 +407,7 @@ func (m modelMapper) Assertion(in openapi.Assertion) model.Assertion {
 	}
 }
 
-func (m modelMapper) Trace(in openapi.Trace) *traces.Trace {
+func (m ModelMapper) Trace(in openapi.Trace) *traces.Trace {
 	tid, _ := trace.TraceIDFromHex(in.TraceId)
 	return &traces.Trace{
 		ID:       tid,
@@ -415,7 +415,7 @@ func (m modelMapper) Trace(in openapi.Trace) *traces.Trace {
 	}
 }
 
-func (m modelMapper) Span(in openapi.Span, parent *traces.Span) traces.Span {
+func (m ModelMapper) Span(in openapi.Span, parent *traces.Span) traces.Span {
 	sid, _ := trace.SpanIDFromHex(in.Id)
 	span := traces.Span{
 		ID:         sid,
@@ -430,7 +430,7 @@ func (m modelMapper) Span(in openapi.Span, parent *traces.Span) traces.Span {
 	return span
 }
 
-func (m modelMapper) Spans(in []openapi.Span, parent *traces.Span) []*traces.Span {
+func (m ModelMapper) Spans(in []openapi.Span, parent *traces.Span) []*traces.Span {
 	spans := make([]*traces.Span, len(in))
 	for i, s := range in {
 		span := m.Span(s, parent)
@@ -440,7 +440,7 @@ func (m modelMapper) Spans(in []openapi.Span, parent *traces.Span) []*traces.Spa
 	return spans
 }
 
-func (m modelMapper) Runs(in []openapi.TestRun) []model.Run {
+func (m ModelMapper) Runs(in []openapi.TestRun) []model.Run {
 	runs := make([]model.Run, len(in))
 	for i, r := range in {
 		runs[i] = *m.Run(r)

--- a/server/http/mappings_test.go
+++ b/server/http/mappings_test.go
@@ -1,0 +1,98 @@
+package http_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/kubeshop/tracetest/server/assertions/comparator"
+	"github.com/kubeshop/tracetest/server/http"
+	"github.com/kubeshop/tracetest/server/openapi"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDefinitionsOrder(t *testing.T) {
+	input := openapi.TestDefinition{
+		Definitions: []openapi.TestDefinitionDefinitions{
+			{
+				Selector: "selector 1",
+				Assertions: []openapi.Assertion{
+					{
+						Attribute:  "attr 1",
+						Comparator: "=",
+						Expected:   "1",
+					},
+					{
+						Attribute:  "attr 2",
+						Comparator: "=",
+						Expected:   "2",
+					},
+				},
+			},
+			{
+				Selector: "selector 2",
+				Assertions: []openapi.Assertion{
+					{
+						Attribute:  "attr 3",
+						Comparator: "=",
+						Expected:   "3",
+					},
+					{
+						Attribute:  "attr 4",
+						Comparator: "=",
+						Expected:   "4",
+					},
+				},
+			},
+		},
+	}
+
+	expectedJSON := `{
+		"definitions": [{
+				"selector": "selector 1",
+				"assertions": [{
+						"attribute": "attr 1",
+						"comparator": "=",
+						"expected": "1"
+					},
+					{
+						"attribute": "attr 2",
+						"comparator": "=",
+						"expected": "2"
+					}
+				]
+			},
+			{
+				"selector": "selector 2",
+				"assertions": [{
+						"attribute": "attr 3",
+						"comparator": "=",
+						"expected": "3"
+					},
+					{
+						"attribute": "attr 4",
+						"comparator": "=",
+						"expected": "4"
+					}
+				]
+			}
+		]
+	}`
+
+	// try multiple times to hit the map iteration randomization
+	attempts := 50
+	for i := 0; i < attempts; i++ {
+		m := http.ModelMapper{
+			Comparators: comparator.DefaultRegistry(),
+		}
+		oapi := http.OpenAPIMapper{}
+
+		actual := oapi.Definition(m.Definition(input))
+		actualJSON, err := json.Marshal(actual)
+
+		require.NoError(t, err)
+		// we just need this to fail once to detect a regression,
+		// so we don't even care in which attempt we failed.
+		// just treat this as a unique test fail
+		require.JSONEq(t, expectedJSON, string(actualJSON))
+	}
+}

--- a/server/http/mappings_test.go
+++ b/server/http/mappings_test.go
@@ -96,3 +96,109 @@ func TestDefinitionsOrder(t *testing.T) {
 		require.JSONEq(t, expectedJSON, string(actualJSON))
 	}
 }
+
+func TestResultsOrder(t *testing.T) {
+	input := openapi.AssertionResults{
+		Results: []openapi.AssertionResultsResults{
+			{
+				Selector: "selector 1",
+				Results: []openapi.AssertionResult{
+					{
+						Assertion: openapi.Assertion{
+							Attribute:  "attr 1",
+							Comparator: "=",
+							Expected:   "1",
+						},
+					},
+					{
+						Assertion: openapi.Assertion{
+							Attribute:  "attr 2",
+							Comparator: "=",
+							Expected:   "2",
+						},
+					},
+				},
+			},
+			{
+				Selector: "selector 2",
+				Results: []openapi.AssertionResult{
+					{
+						Assertion: openapi.Assertion{
+							Attribute:  "attr 3",
+							Comparator: "=",
+							Expected:   "3",
+						},
+					},
+					{
+						Assertion: openapi.Assertion{
+							Attribute:  "attr 4",
+							Comparator: "=",
+							Expected:   "4",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	expectedJSON := `{
+		"results": [
+			{
+				"selector": "selector 1",
+				"results": [
+					{
+						"assertion": {
+							"attribute":  "attr 1",
+							"comparator": "=",
+							"expected":   "1"
+						}
+					},
+					{
+						"assertion": {
+							"attribute":  "attr 2",
+							"comparator": "=",
+							"expected":   "2"
+						}
+					}
+				]
+			},
+			{
+				"selector": "selector 2",
+				"results": [
+					{
+						"assertion": {
+							"attribute":  "attr 3",
+							"comparator": "=",
+							"expected":   "3"
+						}
+					},
+					{
+						"assertion": {
+							"attribute":  "attr 4",
+							"comparator": "=",
+							"expected":   "4"
+						}
+					}
+				]
+			}
+		]
+	}`
+
+	// try multiple times to hit the map iteration randomization
+	attempts := 50
+	for i := 0; i < attempts; i++ {
+		m := http.ModelMapper{
+			Comparators: comparator.DefaultRegistry(),
+		}
+		oapi := http.OpenAPIMapper{}
+
+		actual := oapi.Result(m.Result(input))
+		actualJSON, err := json.Marshal(actual)
+
+		require.NoError(t, err)
+		// we just need this to fail once to detect a regression,
+		// so we don't even care in which attempt we failed.
+		// just treat this as a unique test fail
+		require.JSONEq(t, expectedJSON, string(actualJSON))
+	}
+}

--- a/server/model/ordered_map.go
+++ b/server/model/ordered_map.go
@@ -1,0 +1,99 @@
+package model
+
+import (
+	"encoding/json"
+	"errors"
+)
+
+type OrderedMap[K comparable, V any] struct {
+	list        []V
+	keyPosition map[K]int
+	positionKey map[int]K
+}
+
+func (om *OrderedMap[K, V]) replace(om2 *OrderedMap[K, V]) {
+	*om = *om2
+}
+
+type jsonOrderedMapEntry[K comparable, V any] struct {
+	Key   K
+	Value V
+}
+
+func (om OrderedMap[K, V]) MarshalJSON() ([]byte, error) {
+	j := []jsonOrderedMapEntry[K, V]{}
+	om.Map(func(key K, asserts V) {
+		j = append(j, jsonOrderedMapEntry[K, V]{key, asserts})
+	})
+
+	return json.Marshal(j)
+}
+
+func (om *OrderedMap[K, V]) UnmarshalJSON(data []byte) error {
+	aux := []jsonOrderedMapEntry[K, V]{}
+	if err := json.Unmarshal(data, &aux); err != nil {
+		return err
+	}
+
+	newMap := OrderedMap[K, V]{}
+	var err error
+	for _, s := range aux {
+		newMap, err = newMap.Add(s.Key, s.Value)
+		if err != nil {
+			return err
+		}
+	}
+
+	om.replace(&newMap)
+
+	return nil
+}
+
+func (om OrderedMap[K, V]) MustAdd(key K, asserts V) OrderedMap[K, V] {
+	def, err := om.Add(key, asserts)
+	if err != nil {
+		panic(err)
+	}
+	return def
+}
+
+func (om OrderedMap[K, V]) Add(key K, asserts V) (OrderedMap[K, V], error) {
+	if om.keyPosition == nil {
+		om.keyPosition = make(map[K]int)
+	}
+	if om.positionKey == nil {
+		om.positionKey = make(map[int]K)
+	}
+
+	if _, exists := om.keyPosition[key]; exists {
+		return OrderedMap[K, V]{}, errors.New("selector already exists")
+	}
+
+	om.list = append(om.list, asserts)
+	ix := len(om.list) - 1
+	om.keyPosition[key] = ix
+	om.positionKey[ix] = key
+
+	return om, nil
+}
+
+func (om OrderedMap[K, V]) Len() int {
+	return len(om.list)
+}
+
+func (om OrderedMap[K, V]) Get(key K) V {
+	ix, exists := om.keyPosition[key]
+	if !exists {
+		var result V
+		return result
+	}
+
+	return om.list[ix]
+}
+
+func (om *OrderedMap[K, V]) Map(fn func(key K, val V)) {
+	for ix, asserts := range om.list {
+		K := om.positionKey[ix]
+		fn(K, asserts)
+	}
+}

--- a/server/model/repository.go
+++ b/server/model/repository.go
@@ -17,8 +17,8 @@ type TestRepository interface {
 }
 
 type DefinitionRepository interface {
-	GetDefiniton(context.Context, Test) (Definition, error)
-	SetDefiniton(context.Context, Test, Definition) error
+	GetDefiniton(context.Context, Test) (OrderedMap[SpanQuery, []Assertion], error)
+	SetDefiniton(context.Context, Test, OrderedMap[SpanQuery, []Assertion]) error
 }
 
 type RunRepository interface {

--- a/server/model/run.go
+++ b/server/model/run.go
@@ -52,7 +52,7 @@ func (r Run) SuccessfullyPolledTraces(t *traces.Trace) Run {
 	return r
 }
 
-func (r Run) SuccessfullyAsserted(res Results, allPassed bool) Run {
+func (r Run) SuccessfullyAsserted(res OrderedMap[SpanQuery, []AssertionResult], allPassed bool) Run {
 	r.Results = &RunResults{
 		AllPassed: allPassed,
 		Results:   res,

--- a/server/model/test_changes.go
+++ b/server/model/test_changes.go
@@ -17,7 +17,7 @@ func BumpTestVersionIfNeeded(in, updated Test) (Test, error) {
 	return updated, nil
 }
 
-func BumpVersionIfDefinitionChanged(test Test, newDef Definition) (Test, error) {
+func BumpVersionIfDefinitionChanged(test Test, newDef OrderedMap[SpanQuery, []Assertion]) (Test, error) {
 	definitionHasChanged, err := testFieldHasChanged(test.Definition, newDef)
 	if err != nil {
 		return test, err

--- a/server/model/tests.go
+++ b/server/model/tests.go
@@ -118,6 +118,14 @@ func (d *Definition) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (d Definition) MustAdd(key SpanQuery, asserts []Assertion) Definition {
+	def, err := d.Add(key, asserts)
+	if err != nil {
+		panic(err)
+	}
+	return def
+}
+
 func (d Definition) Add(key SpanQuery, asserts []Assertion) (Definition, error) {
 	if d.keyPosition == nil {
 		d.keyPosition = make(map[SpanQuery]int)

--- a/server/model/tests_test.go
+++ b/server/model/tests_test.go
@@ -12,7 +12,7 @@ import (
 
 func TestDefinition(t *testing.T) {
 	t.Run("Add", func(t *testing.T) {
-		def := model.Definition{}
+		def := (model.Test{}).Definition
 
 		def, err := def.Add(model.SpanQuery("1"), []model.Assertion{{"1", comparator.Eq, "1"}})
 		require.NoError(t, err)
@@ -27,8 +27,8 @@ func TestDefinition(t *testing.T) {
 
 	})
 
-	generateDef := func() model.Definition {
-		def := model.Definition{}
+	generateDef := func() model.OrderedMap[model.SpanQuery, []model.Assertion] {
+		def := (model.Test{}).Definition
 
 		def, _ = def.Add(model.SpanQuery("1"), []model.Assertion{{"1", comparator.Eq, "1"}})
 		def, _ = def.Add(model.SpanQuery("2"), []model.Assertion{{"2", comparator.Eq, "2"}})
@@ -74,7 +74,80 @@ func TestDefinition(t *testing.T) {
 		encoded, err := json.Marshal(def)
 		require.NoError(t, err)
 
-		decoded := model.Definition{}
+		decoded := model.OrderedMap[model.SpanQuery, []model.Assertion]{}
+		err = json.Unmarshal(encoded, &decoded)
+		require.NoError(t, err)
+
+		assert.Equal(t, def, decoded)
+	})
+
+}
+
+func TestResults(t *testing.T) {
+	t.Run("Add", func(t *testing.T) {
+		def := (model.RunResults{}).Results
+
+		def, err := def.Add(model.SpanQuery("1"), []model.AssertionResult{{Assertion: model.Assertion{"1", comparator.Eq, "1"}}})
+		require.NoError(t, err)
+
+		def, err = def.Add(model.SpanQuery("2"), []model.AssertionResult{{Assertion: model.Assertion{"2", comparator.Eq, "2"}}})
+		require.NoError(t, err)
+		assert.Equal(t, 2, def.Len())
+
+		def, err = def.Add(model.SpanQuery("2"), []model.AssertionResult{{Assertion: model.Assertion{"2", comparator.Eq, "2"}}})
+		assert.ErrorContains(t, err, "selector already exists")
+		assert.Equal(t, 0, def.Len())
+
+	})
+
+	generateDef := func() model.OrderedMap[model.SpanQuery, []model.AssertionResult] {
+		def := (model.RunResults{}).Results
+
+		def, _ = def.Add(model.SpanQuery("1"), []model.AssertionResult{{Assertion: model.Assertion{"1", comparator.Eq, "1"}}})
+		def, _ = def.Add(model.SpanQuery("2"), []model.AssertionResult{{Assertion: model.Assertion{"2", comparator.Eq, "2"}}})
+
+		return def
+	}
+
+	t.Run("Map", func(t *testing.T) {
+
+		def := generateDef()
+
+		expected := map[string][]model.AssertionResult{
+			"1": {{Assertion: model.Assertion{"1", comparator.Eq, "1"}}},
+			"2": {{Assertion: model.Assertion{"2", comparator.Eq, "2"}}},
+		}
+
+		actual := map[string][]model.AssertionResult{}
+		def.Map(func(spanQuery model.SpanQuery, asserts []model.AssertionResult) {
+			actual[string(spanQuery)] = asserts
+		})
+
+		assert.Equal(t, expected, actual)
+
+	})
+
+	t.Run("Get", func(t *testing.T) {
+
+		def := generateDef()
+
+		expected := []model.AssertionResult{{Assertion: model.Assertion{"1", comparator.Eq, "1"}}}
+		actual := def.Get(model.SpanQuery("1"))
+
+		assert.Equal(t, expected, actual)
+
+		assert.Empty(t, def.Get(model.SpanQuery("3")))
+
+	})
+
+	t.Run("JSON", func(t *testing.T) {
+
+		def := generateDef()
+
+		encoded, err := json.Marshal(def)
+		require.NoError(t, err)
+
+		decoded := model.OrderedMap[model.SpanQuery, []model.AssertionResult]{}
 		err = json.Unmarshal(encoded, &decoded)
 		require.NoError(t, err)
 

--- a/server/model/tests_test.go
+++ b/server/model/tests_test.go
@@ -1,6 +1,7 @@
 package model_test
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/kubeshop/tracetest/server/assertions/comparator"
@@ -64,6 +65,20 @@ func TestDefinition(t *testing.T) {
 
 		assert.Empty(t, def.Get(model.SpanQuery("3")))
 
+	})
+
+	t.Run("JSON", func(t *testing.T) {
+
+		def := generateDef()
+
+		encoded, err := json.Marshal(def)
+		require.NoError(t, err)
+
+		decoded := model.Definition{}
+		err = json.Unmarshal(encoded, &decoded)
+		require.NoError(t, err)
+
+		assert.Equal(t, def, decoded)
 	})
 
 }

--- a/server/model/tests_test.go
+++ b/server/model/tests_test.go
@@ -1,0 +1,69 @@
+package model_test
+
+import (
+	"testing"
+
+	"github.com/kubeshop/tracetest/server/assertions/comparator"
+	"github.com/kubeshop/tracetest/server/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDefinition(t *testing.T) {
+	t.Run("Add", func(t *testing.T) {
+		def := model.Definition{}
+
+		def, err := def.Add(model.SpanQuery("1"), []model.Assertion{{"1", comparator.Eq, "1"}})
+		require.NoError(t, err)
+
+		def, err = def.Add(model.SpanQuery("2"), []model.Assertion{{"2", comparator.Eq, "2"}})
+		require.NoError(t, err)
+		assert.Equal(t, 2, def.Len())
+
+		def, err = def.Add(model.SpanQuery("2"), []model.Assertion{{"2", comparator.Eq, "2"}})
+		assert.ErrorContains(t, err, "selector already exists")
+		assert.Equal(t, 0, def.Len())
+
+	})
+
+	generateDef := func() model.Definition {
+		def := model.Definition{}
+
+		def, _ = def.Add(model.SpanQuery("1"), []model.Assertion{{"1", comparator.Eq, "1"}})
+		def, _ = def.Add(model.SpanQuery("2"), []model.Assertion{{"2", comparator.Eq, "2"}})
+
+		return def
+	}
+
+	t.Run("Map", func(t *testing.T) {
+
+		def := generateDef()
+
+		expected := map[string][]model.Assertion{
+			"1": {{"1", comparator.Eq, "1"}},
+			"2": {{"2", comparator.Eq, "2"}},
+		}
+
+		actual := map[string][]model.Assertion{}
+		def.Map(func(spanQuery model.SpanQuery, asserts []model.Assertion) {
+			actual[string(spanQuery)] = asserts
+		})
+
+		assert.Equal(t, expected, actual)
+
+	})
+
+	t.Run("Get", func(t *testing.T) {
+
+		def := generateDef()
+
+		expected := []model.Assertion{{"1", comparator.Eq, "1"}}
+		actual := def.Get(model.SpanQuery("1"))
+
+		assert.Equal(t, expected, actual)
+
+		assert.Empty(t, def.Get(model.SpanQuery("3")))
+
+	})
+
+}

--- a/server/testdb/definitions_test.go
+++ b/server/testdb/definitions_test.go
@@ -16,15 +16,13 @@ func TestDefinitions(t *testing.T) {
 
 	test := createTest(t, db)
 
-	def := model.Definition{
-		`span[service.name="Pokeshop"]`: []model.Assertion{
-			{
-				Attribute:  "tracetest.span.duration",
-				Comparator: comparator.Eq,
-				Value:      "2000",
-			},
+	def := (model.Definition{}).MustAdd(`span[service.name="Pokeshop"]`, []model.Assertion{
+		{
+			Attribute:  "tracetest.span.duration",
+			Comparator: comparator.Eq,
+			Value:      "2000",
 		},
-	}
+	})
 
 	err := db.SetDefiniton(context.TODO(), test, def)
 	require.NoError(t, err)

--- a/server/testdb/definitions_test.go
+++ b/server/testdb/definitions_test.go
@@ -16,7 +16,7 @@ func TestDefinitions(t *testing.T) {
 
 	test := createTest(t, db)
 
-	def := (model.Definition{}).MustAdd(`span[service.name="Pokeshop"]`, []model.Assertion{
+	def := (model.OrderedMap[model.SpanQuery, []model.Assertion]{}).MustAdd(`span[service.name="Pokeshop"]`, []model.Assertion{
 		{
 			Attribute:  "tracetest.span.duration",
 			Comparator: comparator.Eq,

--- a/server/testdb/mock.go
+++ b/server/testdb/mock.go
@@ -46,12 +46,12 @@ func (m *MockRepository) GetTests(_ context.Context, take int32, skip int32) ([]
 	return args.Get(0).([]model.Test), args.Error(1)
 }
 
-func (m *MockRepository) GetDefiniton(_ context.Context, test model.Test) (model.Definition, error) {
+func (m *MockRepository) GetDefiniton(_ context.Context, test model.Test) (model.OrderedMap[model.SpanQuery, []model.Assertion], error) {
 	args := m.Called(test)
-	return args.Get(0).(model.Definition), args.Error(1)
+	return args.Get(0).(model.OrderedMap[model.SpanQuery, []model.Assertion]), args.Error(1)
 }
 
-func (m *MockRepository) SetDefiniton(_ context.Context, test model.Test, def model.Definition) error {
+func (m *MockRepository) SetDefiniton(_ context.Context, test model.Test, def model.OrderedMap[model.SpanQuery, []model.Assertion]) error {
 	args := m.Called(test, def)
 	return args.Error(0)
 }

--- a/server/testdb/runs_test.go
+++ b/server/testdb/runs_test.go
@@ -62,24 +62,22 @@ func TestUpdateRun(t *testing.T) {
 	}
 	run.Results = &model.RunResults{
 		AllPassed: true,
-		Results: model.Results{
-			`span[service.name="Pokeshop"]`: []model.AssertionResult{
-				{
-					Assertion: model.Assertion{
-						Attribute:  "tracetest.span.duration",
-						Comparator: comparator.Eq,
-						Value:      "2000",
-					},
-					Results: []model.SpanAssertionResult{
-						{
-							SpanID:        run.Trace.RootSpan.ID,
-							ObservedValue: "2000",
-							CompareErr:    nil,
-						},
+		Results: (model.OrderedMap[model.SpanQuery, []model.AssertionResult]{}).MustAdd(`span[service.name="Pokeshop"]`, []model.AssertionResult{
+			{
+				Assertion: model.Assertion{
+					Attribute:  "tracetest.span.duration",
+					Comparator: comparator.Eq,
+					Value:      "2000",
+				},
+				Results: []model.SpanAssertionResult{
+					{
+						SpanID:        run.Trace.RootSpan.ID,
+						ObservedValue: "2000",
+						CompareErr:    nil,
 					},
 				},
 			},
-		},
+		}),
 	}
 
 	err := db.UpdateRun(context.TODO(), run)

--- a/server/testmock/data/pokeshop_import_pokemon.json
+++ b/server/testmock/data/pokeshop_import_pokemon.json
@@ -17,8 +17,8 @@
         },
         "Definition": [
           {
-            "Selector": "span[service.name=\"pokeshop\" tracetest.span.type=\"http\" name=\"POST /pokemon/import\"]",
-            "Assertions": [
+            "Key": "span[service.name=\"pokeshop\" tracetest.span.type=\"http\" name=\"POST /pokemon/import\"]",
+            "Value": [
               {
                 "attribute": "http.status_code",
                 "comparator": "=",
@@ -27,8 +27,8 @@
             ]
           },
           {
-            "Selector": "span[service.name=\"pokeshop-worker\" tracetest.span.type=\"database\" db.statement contains \"INSERT INTO\"]",
-            "Assertions": [
+            "Key": "span[service.name=\"pokeshop-worker\" tracetest.span.type=\"database\" db.statement contains \"INSERT INTO\"]",
+            "Value": [
               {
                 "attribute": "tracetest.span.duration",
                 "comparator": "<",
@@ -37,8 +37,8 @@
             ]
           },
           {
-            "Selector": "span[service.name=\"pokeshop-worker\" tracetest.span.type=\"messaging\" messaging.destination=\"/queue/syncronizePokemon\"]",
-            "Assertions": [
+            "Key": "span[service.name=\"pokeshop-worker\" tracetest.span.type=\"messaging\" messaging.destination=\"/queue/syncronizePokemon\"]",
+            "Value": [
               {
                 "attribute": "tracetest.span.duration",
                 "comparator": "<",

--- a/server/testmock/data/pokeshop_import_pokemon.json
+++ b/server/testmock/data/pokeshop_import_pokemon.json
@@ -15,29 +15,38 @@
                 "Body": "{ \"id\": 52 }"
             }
         },
-        "Definition": {
-          "span[service.name=\"pokeshop\" tracetest.span.type=\"http\" name=\"POST /pokemon/import\"]": [
-            {
-              "attribute": "http.status_code",
-              "comparator": "=",
-              "value": "200"
-            }
-          ],
-          "span[service.name=\"pokeshop-worker\" tracetest.span.type=\"database\" db.statement contains \"INSERT INTO\"]": [
-            {
-              "attribute": "tracetest.span.duration",
-              "comparator": "<",
-              "value": "100"
-            }
-          ],
-          "span[service.name=\"pokeshop-worker\" tracetest.span.type=\"messaging\" messaging.destination=\"/queue/syncronizePokemon\"]": [
-            {
-              "attribute": "tracetest.span.duration",
-              "comparator": "<",
-              "value": "1000"
-            }
-          ]
-        }
+        "Definition": [
+          {
+            "Selector": "span[service.name=\"pokeshop\" tracetest.span.type=\"http\" name=\"POST /pokemon/import\"]",
+            "Assertions": [
+              {
+                "attribute": "http.status_code",
+                "comparator": "=",
+                "value": "200"
+              }
+            ]
+          },
+          {
+            "Selector": "span[service.name=\"pokeshop-worker\" tracetest.span.type=\"database\" db.statement contains \"INSERT INTO\"]",
+            "Assertions": [
+              {
+                "attribute": "tracetest.span.duration",
+                "comparator": "<",
+                "value": "100"
+              }
+            ]
+          },
+          {
+            "Selector": "span[service.name=\"pokeshop-worker\" tracetest.span.type=\"messaging\" messaging.destination=\"/queue/syncronizePokemon\"]",
+            "Assertions": [
+              {
+                "attribute": "tracetest.span.duration",
+                "comparator": "<",
+                "value": "1000"
+              }
+            ]
+          }
+        ]
     },
     "run": {
         "ID": "0841f905-4d9e-4049-815c-7e348c10e182",

--- a/server/testmock/data/pokeshop_import_pokemon_failed_assertions.json
+++ b/server/testmock/data/pokeshop_import_pokemon_failed_assertions.json
@@ -15,29 +15,38 @@
               "Body": "{ \"id\": 52 }"
           }
       },
-      "Definition": {
-        "span[service.name=\"pokeshop\" tracetest.span.type=\"http\" name=\"POST /pokemon/import\"]": [
-          {
-            "attrib": "http.status_code",
-            "comparator": "=",
-            "value": "400"
-          }
-        ],
-        "span[service.name=\"pokeshop-worker\" tracetest.span.type=\"database\" db.statement contains \"INSERT INTO\"]": [
-          {
-            "attribute": "tracetest.span.duration",
-            "comparator": "<",
-            "value": "100"
-          }
-        ],
-        "span[service.name=\"pokeshop-worker\" tracetest.span.type=\"messaging\" messaging.destination=\"/queue/syncronizePokemon\"]": [
-          {
-            "attribute": "tracetest.span.duration",
-            "comparator": "<",
-            "value": "1000"
-          }
-        ]
-      }
+      "Definition": [
+        {
+          "Selector": "span[service.name=\"pokeshop\" tracetest.span.type=\"http\" name=\"POST /pokemon/import\"]",
+          "Assertions": [
+            {
+              "attribute": "http.status_code",
+              "comparator": "=",
+              "value": "400"
+            }
+          ]
+        },
+        {
+          "Selector": "span[service.name=\"pokeshop-worker\" tracetest.span.type=\"database\" db.statement contains \"INSERT INTO\"]",
+          "Assertions": [
+            {
+              "attribute": "tracetest.span.duration",
+              "comparator": "<",
+              "value": "100"
+            }
+          ]
+        },
+        {
+          "Selector": "span[service.name=\"pokeshop-worker\" tracetest.span.type=\"messaging\" messaging.destination=\"/queue/syncronizePokemon\"]",
+          "Assertions": [
+            {
+              "attribute": "tracetest.span.duration",
+              "comparator": "<",
+              "value": "1000"
+            }
+          ]
+        }
+      ]
   },
   "run": {
       "ID": "0841f905-4d9e-4049-815c-7e348c10e182",

--- a/server/testmock/data/pokeshop_import_pokemon_failed_assertions.json
+++ b/server/testmock/data/pokeshop_import_pokemon_failed_assertions.json
@@ -17,8 +17,8 @@
       },
       "Definition": [
         {
-          "Selector": "span[service.name=\"pokeshop\" tracetest.span.type=\"http\" name=\"POST /pokemon/import\"]",
-          "Assertions": [
+          "Key": "span[service.name=\"pokeshop\" tracetest.span.type=\"http\" name=\"POST /pokemon/import\"]",
+          "Value": [
             {
               "attribute": "http.status_code",
               "comparator": "=",
@@ -27,8 +27,8 @@
           ]
         },
         {
-          "Selector": "span[service.name=\"pokeshop-worker\" tracetest.span.type=\"database\" db.statement contains \"INSERT INTO\"]",
-          "Assertions": [
+          "Key": "span[service.name=\"pokeshop-worker\" tracetest.span.type=\"database\" db.statement contains \"INSERT INTO\"]",
+          "Value": [
             {
               "attribute": "tracetest.span.duration",
               "comparator": "<",
@@ -37,8 +37,8 @@
           ]
         },
         {
-          "Selector": "span[service.name=\"pokeshop-worker\" tracetest.span.type=\"messaging\" messaging.destination=\"/queue/syncronizePokemon\"]",
-          "Assertions": [
+          "Key": "span[service.name=\"pokeshop-worker\" tracetest.span.type=\"messaging\" messaging.destination=\"/queue/syncronizePokemon\"]",
+          "Value": [
             {
               "attribute": "tracetest.span.duration",
               "comparator": "<",


### PR DESCRIPTION
This PR ensures consistent ordering of tests definition and results. The issue comes from go's map implementation, which we use as the internal representation. I've implemented an `OrderedMap` that allows us to keep using the map approach but maintaining the order.

I think this is the smallest change possible, since we are keeping the internal concepts untouched, it just updates the implementation.

NOTE: this is a **VERY** backwards incompatible change. All saved tests/results are unparseable now.

## Changes

- Change internal model `Definition` and `Result` representation from maps to `OrderedMaps`
- Update consumers implementations, including tests
- Add tests to ensure order is consistent

## Fixes

- Inconsistent definition and results order

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [x] added a test
