### PR TITLE
Latest drawer behaviour

### DIFF
--- a/web/src/components/ResizableDrawer/ResizableDrawer.tsx
+++ b/web/src/components/ResizableDrawer/ResizableDrawer.tsx
@@ -15,6 +15,7 @@ export enum DrawerState {
   CLOSE = 'CLOSE',
   INITIAL = 'INITIAL',
   FORM = 'FORM',
+  MAX = 'MAX',
 }
 
 const CustomDrawer = styled(Drawer)`
@@ -45,7 +46,7 @@ const ResizableDrawer: React.FC<IProps> = ({children, visiblePortion}: IProps) =
       if (isResizing) {
         const offsetRight =
           document.body.offsetHeight - ((e.clientY || document.body.offsetLeft) - document.body.offsetLeft);
-        if (offsetRight > visiblePortion && offsetRight < ref['OPEN']) {
+        if (offsetRight > visiblePortion && offsetRight < ref[DrawerState.MAX]) {
           setHeight(offsetRight);
         }
       }
@@ -104,7 +105,7 @@ const ResizableDrawer: React.FC<IProps> = ({children, visiblePortion}: IProps) =
         }}
         onPointerDown={onPointerDown}
       />
-      {children.map(child => React.cloneElement(child, {height, max: ref['OPEN'], min: visiblePortion}))}
+      {children.map(child => React.cloneElement(child, {height, max: ref[DrawerState.MAX], min: visiblePortion}))}
     </CustomDrawer>
   );
 };

--- a/web/src/components/ResizableDrawer/useReferenceMemo.tsx
+++ b/web/src/components/ResizableDrawer/useReferenceMemo.tsx
@@ -1,15 +1,18 @@
 import {useMemo} from 'react';
+import {DrawerState} from './ResizableDrawer';
 
 export function useReferenceMemo(visiblePortion: number) {
-  return useMemo(() => {
+  return useMemo<Record<DrawerState, number>>(() => {
     return {
       CLOSE: visiblePortion,
       // used when the page initially loads
       INITIAL: window.outerHeight * 0.2,
       // used when user open the assertion block form
       FORM: window.outerHeight * 0.4,
+      // used when drawer is opened by clicking the header
+      OPEN: window.outerHeight * 0.5,
       // used to limit drawer height
-      OPEN: window.outerHeight * 0.85,
+      MAX: window.outerHeight * 0.85,
     };
   }, [visiblePortion]);
 }

--- a/web/src/components/ResizableDrawer/useSetIsCollapsedCallback.tsx
+++ b/web/src/components/ResizableDrawer/useSetIsCollapsedCallback.tsx
@@ -3,6 +3,17 @@ import {useCallback} from 'react';
 import {useAssertionForm} from '../AssertionForm/AssertionFormProvider';
 import {DrawerState} from './ResizableDrawer';
 
+export function useSetIsCollapsedCallbackDirection(input: boolean) {
+  const {setDrawerState} = useAssertionForm();
+  return useCallback<React.MouseEventHandler<HTMLDivElement>>(
+    e => {
+      e.stopPropagation();
+      setDrawerState(input ? DrawerState.CLOSE : DrawerState.OPEN);
+    },
+    [setDrawerState, input]
+  );
+}
+
 export function useSetIsCollapsedCallback() {
   const {setDrawerState} = useAssertionForm();
   return useCallback<React.MouseEventHandler<HTMLDivElement>>(

--- a/web/src/components/TraceDrawer/TraceDrawer.tsx
+++ b/web/src/components/TraceDrawer/TraceDrawer.tsx
@@ -7,7 +7,6 @@ import {useAssertionForm} from '../AssertionForm/AssertionFormProvider';
 import LoadingSpinner from '../LoadingSpinner';
 import ResizableDrawer from '../ResizableDrawer';
 import {DrawerState} from '../ResizableDrawer/ResizableDrawer';
-import {useSetIsCollapsedCallback} from '../ResizableDrawer/useSetIsCollapsedCallback';
 import TestResults from '../TestResults';
 import * as S from './TraceDrawer.styled';
 import TraceDrawerHeader from './TraceDrawerHeader';
@@ -30,7 +29,6 @@ const TraceDrawer: React.FC<IProps> = ({run: {id: runId}, run, testId, visiblePo
   return (
     <ResizableDrawer visiblePortion={visiblePortion}>
       <TraceDrawerHeader
-        onClick={useSetIsCollapsedCallback()}
         run={run}
         assertionResults={assertionResults}
         isDisabled={isAssertionFormOpen}

--- a/web/src/components/TraceDrawer/TraceDrawerHeader.tsx
+++ b/web/src/components/TraceDrawer/TraceDrawerHeader.tsx
@@ -11,6 +11,7 @@ import {TAssertionResults} from '../../types/Assertion.types';
 import {TSpan} from '../../types/Span.types';
 import {useAssertionForm} from '../AssertionForm/AssertionFormProvider';
 import {Steps} from '../GuidedTour/traceStepList';
+import {useSetIsCollapsedCallbackDirection} from '../ResizableDrawer/useSetIsCollapsedCallback';
 import * as S from './TraceDrawer.styled';
 import {useChevronDirectionMemo} from './useChevronDirectionMemo';
 
@@ -18,7 +19,6 @@ interface IProps {
   visiblePortion: number;
   run: TTestRun;
   assertionResults?: TAssertionResults;
-  onClick: React.MouseEventHandler<HTMLDivElement>;
   isDisabled: boolean;
   selectedSpan: TSpan;
   height?: number;
@@ -30,13 +30,14 @@ const TraceDrawerHeader: React.FC<IProps> = ({
   run: {trace, createdAt},
   visiblePortion,
   assertionResults,
-  onClick,
   isDisabled,
   selectedSpan,
   height,
   max,
   min,
 }) => {
+  const $isCollapsed = useChevronDirectionMemo(height, max, min);
+  const onClick = useSetIsCollapsedCallbackDirection($isCollapsed);
   const {open} = useAssertionForm();
   const totalSpanCount = trace?.spans.length;
   const totalAssertionCount = assertionResults?.resultList.length || 0;
@@ -63,7 +64,6 @@ const TraceDrawerHeader: React.FC<IProps> = ({
     },
     [open, selectedSpan]
   );
-  const $isCollapsed = useChevronDirectionMemo(height, max, min);
   return (
     <S.Header
       visiblePortion={visiblePortion}

--- a/web/src/components/TraceDrawer/useChevronDirectionMemo.tsx
+++ b/web/src/components/TraceDrawer/useChevronDirectionMemo.tsx
@@ -8,6 +8,6 @@ export function useChevronDirectionMemo(height = 0, max = 0, min = 0) {
     if (isMin) {
       return false;
     }
-    return false;
+    return true;
   }, [height, max, min]);
 }


### PR DESCRIPTION
This PR make open drawerState not to be the max height the drawer can be set to

## Changes

- adds a DrawerState.MAX to the drawerState
-  default chevron orientation to match open/close action


## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
