### PR TITLE
🪟 618 add assertion and copy buttons do not show next to attributes at all screen sizes

### DIFF
--- a/web/src/components/AttributeRow/AttributeRow.styled.ts
+++ b/web/src/components/AttributeRow/AttributeRow.styled.ts
@@ -4,7 +4,7 @@ import styled from 'styled-components';
 
 export const AttributeRow = styled.div`
   display: grid;
-  grid-template-columns: 190px 1fr 60px;
+  grid-template-columns: 160px 1fr 60px;
   gap: 14px;
   align-items: start;
   padding: 8px;
@@ -20,6 +20,7 @@ export const AttributeRow = styled.div`
 
 export const AttributeValueRow = styled.div`
   display: flex;
+  word-break: break-word;
 `;
 
 export const CopyIcon = styled(CopyOutlined)`

--- a/web/src/constants/SemanticGroupNames.constants.ts
+++ b/web/src/constants/SemanticGroupNames.constants.ts
@@ -31,7 +31,6 @@ export const SemanticGroupNameNodeMap: Record<SemanticGroupNames, {primary: stri
     primary: [
       Attributes.DB_MONGODB_COLLECTION,
       Attributes.DB_SQL_TABLE,
-      Attributes.DB_REDIS_DATABASE_INDEX,
       Attributes.DB_CASSANDRA_TABLE,
       Attributes.SERVICE_NAME,
     ],


### PR DESCRIPTION
This PR fixes the issue with small screens not showing the copy and add assertion button for attributes with long values.

## Changes

- attribute row styling

## Fixes

- https://github.com/kubeshop/tracetest/issues/618

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

https://www.loom.com/share/85841d3590de4f7a97d3f485c35865e4