### PR TITLE
Fix contains comparator not matching

### DIFF
--- a/server/assertions/assertions.go
+++ b/server/assertions/assertions.go
@@ -44,11 +44,12 @@ func assert(a model.Assertion, spans []traces.Span) model.AssertionResult {
 }
 
 func apply(a model.Assertion, span traces.Span) model.SpanAssertionResult {
-	attr := span.Attributes.Get(a.Attribute)
+	expected := a.Value
+	actual := span.Attributes.Get(a.Attribute)
 	return model.SpanAssertionResult{
 		SpanID:        trace.SpanID(span.ID),
-		ObservedValue: attr,
-		CompareErr:    a.Comparator.Compare(attr, a.Value),
+		ObservedValue: actual,
+		CompareErr:    a.Comparator.Compare(expected, actual),
 	}
 }
 

--- a/server/assertions/assetions_test.go
+++ b/server/assertions/assetions_test.go
@@ -67,13 +67,19 @@ func TestAssertion(t *testing.T) {
 					Comparator: comparator.Contains,
 					Value:      "52",
 				},
+				{
+					Attribute:  "tracetest.span.duration",
+					Comparator: comparator.Lt,
+					Value:      "2001",
+				},
 			}),
 			trace: traces.Trace{
 				RootSpan: traces.Span{
 					ID: spanID,
 					Attributes: traces.Attributes{
-						"service.name":       "Pokeshop",
-						"http.response.body": `{"id":52}`,
+						"service.name":            "Pokeshop",
+						"http.response.body":      `{"id":52}`,
+						"tracetest.span.duration": "2000",
 					},
 				},
 			},
@@ -89,6 +95,20 @@ func TestAssertion(t *testing.T) {
 						{
 							SpanID:        spanID,
 							ObservedValue: `{"id":52}`,
+							CompareErr:    nil,
+						},
+					},
+				},
+				{
+					Assertion: model.Assertion{
+						Attribute:  "tracetest.span.duration",
+						Comparator: comparator.Lt,
+						Value:      "2001",
+					},
+					Results: []model.SpanAssertionResult{
+						{
+							SpanID:        spanID,
+							ObservedValue: "2000",
 							CompareErr:    nil,
 						},
 					},

--- a/server/assertions/assetions_test.go
+++ b/server/assertions/assetions_test.go
@@ -58,6 +58,43 @@ func TestAssertion(t *testing.T) {
 				},
 			}),
 		},
+		// https://github.com/kubeshop/tracetest/issues/617
+		{
+			name: "ContainsWithJSON",
+			testDef: (model.OrderedMap[model.SpanQuery, []model.Assertion]{}).MustAdd(`span[service.name="Pokeshop"]`, []model.Assertion{
+				{
+					Attribute:  "http.response.body",
+					Comparator: comparator.Contains,
+					Value:      "52",
+				},
+			}),
+			trace: traces.Trace{
+				RootSpan: traces.Span{
+					ID: spanID,
+					Attributes: traces.Attributes{
+						"service.name":       "Pokeshop",
+						"http.response.body": `{"id":52}`,
+					},
+				},
+			},
+			expectedAllPassed: true,
+			expectedResult: (model.OrderedMap[model.SpanQuery, []model.AssertionResult]{}).MustAdd(`span[service.name="Pokeshop"]`, []model.AssertionResult{
+				{
+					Assertion: model.Assertion{
+						Attribute:  "http.response.body",
+						Comparator: comparator.Contains,
+						Value:      "52",
+					},
+					Results: []model.SpanAssertionResult{
+						{
+							SpanID:        spanID,
+							ObservedValue: `{"id":52}`,
+							CompareErr:    nil,
+						},
+					},
+				},
+			}),
+		},
 	}
 
 	for _, c := range cases {

--- a/server/assertions/comparator/basic.go
+++ b/server/assertions/comparator/basic.go
@@ -26,7 +26,7 @@ var Eq Comparator = eq{}
 type eq struct{}
 
 func (c eq) Compare(expected, actual string) error {
-	if expected == actual {
+	if actual == expected {
 		return nil
 	}
 
@@ -43,7 +43,7 @@ var Neq Comparator = neq{}
 type neq struct{}
 
 func (c neq) Compare(expected, actual string) error {
-	if expected != actual {
+	if actual != expected {
 		return nil
 	}
 
@@ -62,13 +62,13 @@ func parseNumber(s string) (int64, error) {
 	return n, nil
 }
 
-func parseNumbers(expected, actual string) (a, b int64, err error) {
-	a, err = parseNumber(expected)
+func parseNumbers(expected, actual string) (e, a int64, err error) {
+	e, err = parseNumber(expected)
 	if err != nil {
 		return
 	}
 
-	b, err = parseNumber(actual)
+	a, err = parseNumber(actual)
 	if err != nil {
 		return
 	}
@@ -82,11 +82,11 @@ var Gt Comparator = gt{}
 type gt struct{}
 
 func (c gt) Compare(expected, actual string) error {
-	a, b, err := parseNumbers(expected, actual)
+	e, a, err := parseNumbers(expected, actual)
 	if err != nil {
 		return err
 	}
-	if a > b {
+	if a > e {
 		return nil
 	}
 
@@ -103,11 +103,11 @@ var Gte Comparator = gte{}
 type gte struct{}
 
 func (c gte) Compare(expected, actual string) error {
-	a, b, err := parseNumbers(expected, actual)
+	e, a, err := parseNumbers(expected, actual)
 	if err != nil {
 		return err
 	}
-	if a >= b {
+	if a >= e {
 		return nil
 	}
 
@@ -124,11 +124,11 @@ var Lt Comparator = lt{}
 type lt struct{}
 
 func (c lt) Compare(expected, actual string) error {
-	a, b, err := parseNumbers(expected, actual)
+	e, a, err := parseNumbers(expected, actual)
 	if err != nil {
 		return err
 	}
-	if a < b {
+	if a < e {
 		return nil
 	}
 
@@ -145,11 +145,11 @@ var Lte Comparator = lte{}
 type lte struct{}
 
 func (c lte) Compare(expected, actual string) error {
-	a, b, err := parseNumbers(expected, actual)
+	e, a, err := parseNumbers(expected, actual)
 	if err != nil {
 		return err
 	}
-	if a <= b {
+	if a <= e {
 		return nil
 	}
 

--- a/server/assertions/comparator/basic_test.go
+++ b/server/assertions/comparator/basic_test.go
@@ -8,8 +8,8 @@ import (
 )
 
 func TestComparators(t *testing.T) {
-	type compInput struct{ expected, actual string }
-	type compErr struct{ expected, actual, err string }
+	type compInput struct{ actual, expected string }
+	type compErr struct{ actual, expected, err string }
 	comps := []struct {
 		name          string
 		symbol        string
@@ -23,6 +23,7 @@ func TestComparators(t *testing.T) {
 			name:       "Equal",
 			symbol:     "=",
 			comparator: comparator.Eq,
+			// actual = expected
 			expectSuccess: []compInput{
 				{"a", "a"},
 				{"1", "1"},
@@ -38,6 +39,7 @@ func TestComparators(t *testing.T) {
 			name:       "NotEqual",
 			symbol:     "!=",
 			comparator: comparator.Neq,
+			// actual != expected
 			expectSuccess: []compInput{
 				{"", "2"},
 				{"a", "b"},
@@ -53,6 +55,7 @@ func TestComparators(t *testing.T) {
 			name:       "Gt",
 			symbol:     ">",
 			comparator: comparator.Gt,
+			// actual > expected
 			expectSuccess: []compInput{
 				{"2", "1"},
 				{"10", "2"},
@@ -71,6 +74,7 @@ func TestComparators(t *testing.T) {
 			name:       "Gte",
 			symbol:     ">=",
 			comparator: comparator.Gte,
+			// actual >= expected
 			expectSuccess: []compInput{
 				{"2", "1"},
 				{"2", "2"},
@@ -88,6 +92,7 @@ func TestComparators(t *testing.T) {
 			name:       "Lt",
 			symbol:     "<",
 			comparator: comparator.Lt,
+			// actual < expected
 			expectSuccess: []compInput{
 				{"1", "2"},
 				{"2", "10"},
@@ -106,6 +111,7 @@ func TestComparators(t *testing.T) {
 			name:       "Lte",
 			symbol:     "<=",
 			comparator: comparator.Lte,
+			// actual <= expected
 			expectSuccess: []compInput{
 				{"1", "2"},
 				{"1", "1"},
@@ -123,16 +129,17 @@ func TestComparators(t *testing.T) {
 			name:       "Contains",
 			symbol:     "contains",
 			comparator: comparator.Contains,
+			// actual CONTAINS expected
 			expectSuccess: []compInput{
-				{"he", "hello"},
-				{"ll", "hello"},
-				{"lo", "hello"},
+				{"hello", "he"},
+				{"hello", "ll"},
+				{"hello", "lo"},
 
 				// https://github.com/kubeshop/tracetest/issues/617
-				{"52", `{"id":52}`},
+				{`{"id":52}`, "52"},
 			},
 			expectNoMatch: []compInput{
-				{"nop", "hello"},
+				{"hello", "nop"},
 			},
 		},
 
@@ -142,12 +149,12 @@ func TestComparators(t *testing.T) {
 			symbol:     "startsWith",
 			comparator: comparator.StartsWith,
 			expectSuccess: []compInput{
-				{"he", "hello"},
+				{"hello", "he"},
 			},
 			expectNoMatch: []compInput{
-				{"nop", "hello"},
-				{"ll", "hello"},
-				{"lo", "hello"},
+				{"hello", "nop"},
+				{"hello", "ll"},
+				{"hello", "lo"},
 			},
 		},
 
@@ -157,12 +164,12 @@ func TestComparators(t *testing.T) {
 			symbol:     "endsWith",
 			comparator: comparator.EndsWith,
 			expectSuccess: []compInput{
-				{"lo", "hello"},
+				{"hello", "lo"},
 			},
 			expectNoMatch: []compInput{
-				{"nop", "hello"},
-				{"he", "hello"},
-				{"ll", "hello"},
+				{"hello", "nop"},
+				{"hello", "he"},
+				{"hello", "ll"},
 			},
 		},
 	}

--- a/server/assertions/comparator/basic_test.go
+++ b/server/assertions/comparator/basic_test.go
@@ -127,6 +127,9 @@ func TestComparators(t *testing.T) {
 				{"he", "hello"},
 				{"ll", "hello"},
 				{"lo", "hello"},
+
+				// https://github.com/kubeshop/tracetest/issues/617
+				{"52", `{"id":52}`},
 			},
 			expectNoMatch: []compInput{
 				{"nop", "hello"},

--- a/server/http/controller_test.go
+++ b/server/http/controller_test.go
@@ -1,0 +1,108 @@
+package http_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/kubeshop/tracetest/server/http"
+	"github.com/kubeshop/tracetest/server/model"
+	"github.com/kubeshop/tracetest/server/openapi"
+	"github.com/kubeshop/tracetest/server/testdb"
+	"github.com/kubeshop/tracetest/server/traces"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+var (
+	exampleRun = model.Run{
+		ID:      http.IDGen.UUID(),
+		TraceID: http.IDGen.TraceID(),
+		Trace: &traces.Trace{
+			ID: http.IDGen.TraceID(),
+			RootSpan: traces.Span{
+				ID:   http.IDGen.SpanID(),
+				Name: "POST /pokemon/import",
+				Attributes: traces.Attributes{
+					"tracetest.span.type": "http",
+					"service.name":        "pokeshop",
+					"http.response.body":  `{"id":52}`,
+				},
+			},
+		},
+	}
+)
+
+// https://github.com/kubeshop/tracetest/issues/617
+func TestContains_Issue617(t *testing.T) {
+
+	definition := openapi.TestDefinition{
+		Definitions: []openapi.TestDefinitionDefinitions{
+			{
+				Selector: "span[tracetest.span.type = \"http\"  service.name = \"pokeshop\"  name = \"POST /pokemon/import\"]",
+				Assertions: []openapi.Assertion{
+					{
+						Attribute:  "http.response.body",
+						Comparator: "contains",
+						Expected:   "52",
+					},
+				},
+			},
+		},
+	}
+
+	expected := openapi.AssertionResults{
+		AllPassed: true,
+		Results: []openapi.AssertionResultsResults{
+			{
+				Selector: "span[tracetest.span.type = \"http\"  service.name = \"pokeshop\"  name = \"POST /pokemon/import\"]",
+				Results: []openapi.AssertionResult{
+					{
+						AllPassed: true,
+						Assertion: openapi.Assertion{
+							Attribute:  "http.response.body",
+							Comparator: "contains",
+							Expected:   "52",
+						},
+						SpanResults: []openapi.AssertionSpanResult{
+							{
+								SpanId:        exampleRun.Trace.RootSpan.ID.String(),
+								ObservedValue: `{"id":52}`,
+								Passed:        true,
+								Error:         "",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	f := setupController(t)
+	f.expectGetRun(exampleRun)
+
+	actual, err := f.c.DryRunAssertion(context.TODO(), "", exampleRun.ID.String(), definition)
+	require.NoError(t, err)
+
+	assert.Equal(t, 200, actual.Code)
+	assert.Equal(t, expected, actual.Body)
+}
+
+func setupController(t *testing.T) controllerFixture {
+	mdb := new(testdb.MockRepository)
+	mdb.Test(t)
+	return controllerFixture{
+		db: mdb,
+		c:  http.NewController(mdb, nil, nil),
+	}
+}
+
+type controllerFixture struct {
+	db *testdb.MockRepository
+	c  openapi.ApiApiServicer
+}
+
+func (f controllerFixture) expectGetRun(r model.Run) {
+	f.db.
+		On("GetRun", r.ID).
+		Return(r, nil)
+}

--- a/server/http/mappings.go
+++ b/server/http/mappings.go
@@ -182,6 +182,7 @@ func (m OpenAPIMapper) Result(in *model.RunResults) openapi.AssertionResults {
 				}
 			}
 			res[j] = openapi.AssertionResult{
+				AllPassed:   r.AllPassed,
 				Assertion:   m.Assertion(r.Assertion),
 				SpanResults: sres,
 			}


### PR DESCRIPTION
This PR fixes a bug detected when using the `contains` operator. The error was we were doing the comparations in the incorrect order (`expected < actual` instead of `actual < expected`), but we were also passing the conditions in an inverted order, so the error cancelled out. When using `contains`, we use the go `strings.Contains` function, and here the error doesn't cancel out.

## Fixes

- Fix expected/actual comparation order 

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [x] added a test
