### PR TITLE
Fix: Incorrect update behaviour when updating definition

### DIFF
--- a/server/http/controller.go
+++ b/server/http/controller.go
@@ -215,7 +215,7 @@ func (c *controller) RerunTestRun(ctx context.Context, testID string, runID stri
 		return handleDBError(err), err
 	}
 
-	newTestRun, err := c.testDB.CreateRun(ctx, test, run.Copy(test.Version))
+	newTestRun, err := c.testDB.CreateRun(ctx, test, run.Copy())
 	if err != nil {
 		return openapi.Response(http.StatusUnprocessableEntity, err.Error()), err
 	}

--- a/server/model/run.go
+++ b/server/model/run.go
@@ -4,6 +4,7 @@ import (
 	"math"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/kubeshop/tracetest/server/traces"
 )
 
@@ -13,9 +14,14 @@ var (
 	}
 )
 
-func (r Run) Copy(testVersion int) Run {
+func (r Run) Copy() Run {
+	r.ID = uuid.UUID{}
 	r.Results = nil
-	r.TestVersion = testVersion
+	r.CreatedAt = Now()
+	r.ServiceTriggeredAt = time.Time{}
+	r.ServiceTriggerCompletedAt = time.Time{}
+	r.ObtainedTraceAt = time.Time{}
+	r.CompletedAt = time.Time{}
 
 	return r
 }


### PR DESCRIPTION
When rerunning a test after updating its definition, the new copied run kept some field values from the original, like dates and version. This caused the update to match a version it shouldn't.

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
