### PR TITLE
Improve headers in the Trace and Test areas

### DIFF
--- a/web/src/components/Diagram/components/TimelineChart.styled.ts
+++ b/web/src/components/Diagram/components/TimelineChart.styled.ts
@@ -2,7 +2,7 @@ import styled, {css} from 'styled-components';
 
 export const Container = styled.div<{$barHeight: number; $showAffected: boolean}>`
   overflow-y: scroll;
-  
+
   .rect-svg {
     width: 100%;
     height: ${({$barHeight}) => `${$barHeight}px`};

--- a/web/src/components/TestHeader/Info.tsx
+++ b/web/src/components/TestHeader/Info.tsx
@@ -1,0 +1,47 @@
+import {Button, Popover, Typography} from 'antd';
+import {InfoCircleOutlined} from '@ant-design/icons';
+
+import Date from 'utils/Date';
+
+interface IProps {
+  date: string;
+  executionTime: number;
+  totalSpans: number;
+  traceId: string;
+}
+
+const Info = ({date, executionTime, totalSpans, traceId}: IProps) => {
+  const content = (
+    <>
+      <div>
+        <Typography.Text strong>Trace ID: </Typography.Text>
+        <Typography.Text>{traceId}</Typography.Text>
+      </div>
+      <div>
+        <Typography.Text strong>Trace transaction occurred: </Typography.Text>
+        <Typography.Text>{Date.format(date, "yyyy/MM/dd 'at' HH:mm:ss")}</Typography.Text>
+      </div>
+      <div>
+        <Typography.Text strong>Execution time: </Typography.Text>
+        <Typography.Text>{executionTime} s</Typography.Text>
+      </div>
+      <div>
+        <Typography.Text strong>Total spans: </Typography.Text>
+        <Typography.Text>{totalSpans}</Typography.Text>
+      </div>
+    </>
+  );
+
+  return (
+    <Popover placement="right" content={content}>
+      <Button
+        icon={<InfoCircleOutlined style={{color: 'rgba(3, 24, 73, 0.6)'}} />}
+        shape="circle"
+        size="small"
+        type="text"
+      />
+    </Popover>
+  );
+};
+
+export default Info;

--- a/web/src/components/TestHeader/TestHeader.styled.ts
+++ b/web/src/components/TestHeader/TestHeader.styled.ts
@@ -18,8 +18,7 @@ export const TestName = styled(Typography.Title).attrs({
 })`
   && {
     margin: 0;
-    font-weight: 400;
-    font-size: 18px;
+    font-size: 16px;
   }
 `;
 
@@ -28,7 +27,6 @@ export const TestUrl = styled(Typography.Text).attrs({
 })`
   && {
     margin: 0;
-    align-self: flex-end;
     font-size: 12px;
   }
 `;
@@ -56,4 +54,8 @@ export const StateContainer = styled.div`
   display: flex;
   justify-self: flex-end;
   cursor: pointer;
+`;
+
+export const Row = styled.div`
+  display: flex;
 `;

--- a/web/src/components/TestHeader/TestHeader.tsx
+++ b/web/src/components/TestHeader/TestHeader.tsx
@@ -1,35 +1,56 @@
-import {TTest} from '../../types/Test.types';
-import {TTestRunState} from '../../types/TestRun.types';
-import {useSetIsCollapsedCallback} from '../ResizableDrawer/useSetIsCollapsedCallback';
-import TestState from '../TestState';
+import {useSetIsCollapsedCallback} from 'components/ResizableDrawer/useSetIsCollapsedCallback';
+import TestState from 'components/TestState';
+import {TTest} from 'types/Test.types';
+import {TTestRunState} from 'types/TestRun.types';
+import Info from './Info';
 import * as S from './TestHeader.styled';
 
-interface TTestHeaderProps {
-  test: TTest;
+interface IProps {
+  executionTime?: number;
+  extraContent?: React.ReactElement;
   onBack(): void;
+  showInfo: boolean;
+  test: TTest;
   testState?: TTestRunState;
   testVersion: number;
-  extraContent?: React.ReactElement;
+  totalSpans?: number;
 }
 
-const TestHeader: React.FC<TTestHeaderProps> = ({
-  test: {name, serviceUnderTest},
-  onBack,
-  testState,
+const TestHeader = ({
+  executionTime,
   extraContent,
+  onBack,
+  showInfo,
+  test: {name, referenceTestRun, serviceUnderTest},
+  test,
+  testState,
   testVersion,
-}) => {
+  totalSpans,
+}: IProps) => {
   const onClick = useSetIsCollapsedCallback();
+
   return (
     <S.TestHeader>
       <S.Content>
         <S.BackIcon data-cy="test-header-back-button" onClick={onBack} />
-        <S.TestName data-cy="test-details-name">
-          {name} (v{testVersion})
-        </S.TestName>
-        <S.TestUrl>
-          {serviceUnderTest?.request?.method?.toUpperCase()} - {serviceUnderTest?.request?.url}
-        </S.TestUrl>
+        <div>
+          <S.Row>
+            <S.TestName data-cy="test-details-name">
+              {name} (v{testVersion})
+            </S.TestName>
+            {showInfo && (
+              <Info
+                date={referenceTestRun?.createdAt ?? ''}
+                executionTime={executionTime ?? 0}
+                totalSpans={totalSpans ?? 0}
+                traceId={referenceTestRun?.traceId ?? ''}
+              />
+            )}
+          </S.Row>
+          <S.TestUrl>
+            {serviceUnderTest?.request?.method?.toUpperCase()} - {serviceUnderTest?.request?.url}
+          </S.TestUrl>
+        </div>
       </S.Content>
       {extraContent}
       {testState && !extraContent && (

--- a/web/src/components/TestHeader/__tests__/TestHeader.test.tsx
+++ b/web/src/components/TestHeader/__tests__/TestHeader.test.tsx
@@ -5,7 +5,13 @@ import TestHeader from '../TestHeader';
 
 test('SpanAttributesTable', () => {
   const {getByTestId} = render(
-    <TestHeader onBack={jest.fn()} test={TestMock.model()} testState={TestState.CREATED} testVersion={1} />
+    <TestHeader
+      onBack={jest.fn()}
+      showInfo={false}
+      test={TestMock.model()}
+      testState={TestState.CREATED}
+      testVersion={1}
+    />
   );
   expect(getByTestId('test-details-name')).toBeInTheDocument();
 });

--- a/web/src/components/TraceDrawer/TraceDrawerHeader.tsx
+++ b/web/src/components/TraceDrawer/TraceDrawerHeader.tsx
@@ -1,9 +1,9 @@
 import {PlusOutlined} from '@ant-design/icons';
 import {Badge} from 'antd';
-import {format, parseISO} from 'date-fns';
 import * as React from 'react';
 import {MouseEventHandler, useCallback, useMemo} from 'react';
 import {TTestRun} from 'types/TestRun.types';
+import Date from 'utils/Date';
 import GuidedTourService, {GuidedTours} from '../../services/GuidedTour.service';
 import SpanService from '../../services/Span.service';
 import TraceService from '../../services/Trace.service';
@@ -39,15 +39,12 @@ const TraceDrawerHeader: React.FC<IProps> = ({
   const $isCollapsed = useChevronDirectionMemo(height, max, min);
   const onClick = useSetIsCollapsedCallbackDirection($isCollapsed);
   const {open} = useAssertionForm();
-  const totalSpanCount = trace?.spans.length;
   const totalAssertionCount = assertionResults?.resultList.length || 0;
 
   const {totalPassedCount, totalFailedCount} = useMemo(
     () => TraceService.getTestResultCount(assertionResults!),
     [assertionResults]
   );
-
-  const startDate = useMemo(() => format(parseISO(createdAt), "EEEE, do MMMM yyyy 'at' HH:mm:ss"), [createdAt]);
 
   const handleAssertionClick: MouseEventHandler<HTMLElement> = useCallback(
     event => {
@@ -72,12 +69,11 @@ const TraceDrawerHeader: React.FC<IProps> = ({
       onClick={onClick}
     >
       <div>
-        <S.HeaderText strong>Test Results</S.HeaderText>
-        <S.StartDateText>Trace Start {startDate}</S.StartDateText>
+        <S.HeaderText strong>Test Result</S.HeaderText>
+        <S.StartDateText>{Date.format(createdAt)}</S.StartDateText>
         <S.HeaderText strong>
-          {totalSpanCount} total span(s) • {totalAssertionCount} assertion(s) • {totalPassedCount + totalFailedCount}{' '}
-          check(s) • <Badge count="P" style={{backgroundColor: '#49AA19'}} />{' '}
-          <S.CountNumber>{totalPassedCount}</S.CountNumber>
+          {totalAssertionCount} assertion(s) • {totalPassedCount + totalFailedCount} check(s) •{' '}
+          <Badge count="P" style={{backgroundColor: '#49AA19'}} /> <S.CountNumber>{totalPassedCount}</S.CountNumber>
           <Badge count="F" /> <S.CountNumber>{totalFailedCount}</S.CountNumber>
         </S.HeaderText>
       </div>

--- a/web/src/models/TestRun.model.ts
+++ b/web/src/models/TestRun.model.ts
@@ -1,14 +1,7 @@
-import {differenceInSeconds} from 'date-fns';
 import {TRawAssertionResults} from '../types/Assertion.types';
 import {TRawTestRun, TTestRun} from '../types/TestRun.types';
 import AssertionResults from './AssertionResults.model';
 import Trace from './Trace.model';
-
-const getExecutionTime = (createdAt?: string, completedAt?: string) => {
-  if (!createdAt || !completedAt) return 0;
-
-  return differenceInSeconds(new Date(completedAt), new Date(createdAt)) + 1;
-};
 
 const getTestResultCount = (
   {results: resultList = []}: TRawAssertionResults = {},
@@ -47,8 +40,17 @@ const TestRun = ({
   request,
   response,
   testVersion = 1,
+  exectutionTime = 0,
+  obtainedTraceAt = '',
+  serviceTriggerCompletedAt = '',
+  serviceTriggeredAt = '',
 }: TRawTestRun): TTestRun => {
   return {
+    obtainedTraceAt,
+    serviceTriggerCompletedAt,
+    serviceTriggeredAt,
+    executionTime: exectutionTime,
+    exectutionTime,
     lastErrorState,
     request,
     response,
@@ -64,7 +66,6 @@ const TestRun = ({
     totalAssertionCount: getTestResultCount(result),
     failedAssertionCount: getTestResultCount(result, 'failed'),
     passedAssertionCount: getTestResultCount(result, 'passed'),
-    executionTime: getExecutionTime(createdAt, completedAt),
   };
 };
 

--- a/web/src/pages/Test/Test.tsx
+++ b/web/src/pages/Test/Test.tsx
@@ -24,7 +24,7 @@ const TestPage: React.FC = () => {
   // TODO: Add proper loading states
   return test ? (
     <Layout>
-      <TestHeader test={test} onBack={() => navigate('/')} testVersion={test.version} />
+      <TestHeader onBack={() => navigate('/')} showInfo={false} test={test} testVersion={test.version} />
       <S.Wrapper>
         <TestDetails testId={test.id} onSelectResult={handleSelectTestResult} />
       </S.Wrapper>

--- a/web/src/pages/Trace/TraceContent.tsx
+++ b/web/src/pages/Trace/TraceContent.tsx
@@ -32,11 +32,14 @@ const TraceContent = () => {
   return test ? (
     <S.Wrapper>
       <TestHeader
-        test={test}
+        executionTime={run?.executionTime}
         extraContent={isDraftMode ? <TraceActions /> : undefined}
         onBack={() => navigate(`/test/${testId}`)}
+        showInfo
+        test={test}
         testState={run.state}
         testVersion={run.testVersion}
+        totalSpans={run?.trace?.spans?.length}
       />
       <FailedTrace
         onRunTest={onRunTest}

--- a/web/src/types/Generated.types.ts
+++ b/web/src/types/Generated.types.ts
@@ -399,8 +399,16 @@ export interface external {
             | "FAILED";
           /** @description Details of the cause for the last `FAILED` state */
           lastErrorState?: string;
+          /** @description time it took for the test to complete, either success or fail. If the test is still running, it will show the time up to the time of the request */
+          exectutionTime?: number;
           /** Format: date-time */
           createdAt?: string;
+          /** Format: date-time */
+          serviceTriggeredAt?: string;
+          /** Format: date-time */
+          serviceTriggerCompletedAt?: string;
+          /** Format: date-time */
+          obtainedTraceAt?: string;
           /** Format: date-time */
           completedAt?: string;
           request?: external["http.yaml"]["components"]["schemas"]["HTTPRequest"];

--- a/web/src/utils/Date.ts
+++ b/web/src/utils/Date.ts
@@ -1,0 +1,13 @@
+import {format, isValid, parseISO} from 'date-fns';
+
+const Date = {
+  format(date: string, dateFormat = "EEEE, yyyy/MM/dd 'at' HH:mm:ss") {
+    const isoDate = parseISO(date);
+    if (!isValid(isoDate)) {
+      return '';
+    }
+    return format(isoDate, dateFormat);
+  },
+};
+
+export default Date;

--- a/web/src/utils/__tests__/Date.test.ts
+++ b/web/src/utils/__tests__/Date.test.ts
@@ -1,0 +1,20 @@
+import Date from '../Date';
+
+describe('Date', () => {
+  describe('format', () => {
+    it('should handle empty value', () => {
+      const date = '';
+      expect(Date.format(date)).toBe('');
+    });
+
+    it('should handle invalid value', () => {
+      const date = 'invalid-date';
+      expect(Date.format(date)).toBe('');
+    });
+
+    it('should handle valid value', () => {
+      const date = '2022-06-02T17:28:48';
+      expect(Date.format(date, 'yyyy/MM/dd')).toBe('2022/06/02');
+    });
+  });
+});


### PR DESCRIPTION
This PR adds a couple of improvements to the Trace/Test areas.

## Changes

- Add new Popover with test info.
- Remove not-needed fields in the test result header.

## Fixes

- #629 

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [x] added a test

## Loom

## Coverage

<img width="436" alt="Screen Shot 2022-06-02 at 13 22 51" src="https://user-images.githubusercontent.com/3879892/171700577-a503a8df-2f98-4473-92a8-0553b26ac917.png">