### PR TITLE
feat: export tests using the CLI

### DIFF
--- a/cli/actions/export_test_action.go
+++ b/cli/actions/export_test_action.go
@@ -1,0 +1,81 @@
+package actions
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/kubeshop/tracetest/cli/config"
+	"github.com/kubeshop/tracetest/cli/conversion"
+	"github.com/kubeshop/tracetest/cli/definition"
+	"github.com/kubeshop/tracetest/cli/file"
+	"github.com/kubeshop/tracetest/cli/openapi"
+	"go.uber.org/zap"
+)
+
+type ExportTestConfig struct {
+	TestId     string
+	OutputFile string
+}
+
+type exportTestAction struct {
+	config config.Config
+	logger *zap.Logger
+	client *openapi.APIClient
+}
+
+var _ Action[ExportTestConfig] = &exportTestAction{}
+
+func NewExportTestAction(config config.Config, logger *zap.Logger, client *openapi.APIClient) exportTestAction {
+	return exportTestAction{
+		config: config,
+		logger: logger,
+		client: client,
+	}
+}
+
+func (a exportTestAction) Run(ctx context.Context, args ExportTestConfig) error {
+	if args.OutputFile == "" {
+		return fmt.Errorf("output file must be provided")
+	}
+
+	if args.TestId == "" {
+		return fmt.Errorf("test id must be provided")
+	}
+
+	a.logger.Debug("exporting test", zap.String("testID", args.TestId), zap.String("outputFile", args.OutputFile))
+	definition, err := a.getDefinitionFromServer(ctx, args.TestId)
+	if err != nil {
+		return fmt.Errorf("could not get definition from server: %w", err)
+	}
+
+	err = file.SaveDefinition(args.OutputFile, definition)
+	if err != nil {
+		return fmt.Errorf("could not save exported definition into file: %w", err)
+	}
+
+	return nil
+}
+
+func (a exportTestAction) getDefinitionFromServer(ctx context.Context, testID string) (definition.Test, error) {
+	openapiTest, err := a.getTestFromServer(ctx, testID)
+	if err != nil {
+		return definition.Test{}, fmt.Errorf("could not get test from server: %w", err)
+	}
+
+	testDefinition, err := conversion.ConvertOpenAPITestIntoDefinitionObject(openapiTest)
+	if err != nil {
+		return definition.Test{}, fmt.Errorf("could not convert openapi object into a defintion object: %w", err)
+	}
+
+	return testDefinition, nil
+}
+
+func (a exportTestAction) getTestFromServer(ctx context.Context, testID string) (openapi.Test, error) {
+	req := a.client.ApiApi.GetTest(ctx, testID)
+	openapiTest, _, err := a.client.ApiApi.GetTestExecute(req)
+	if err != nil {
+		return openapi.Test{}, fmt.Errorf("could not execute getTest request: %w", err)
+	}
+
+	return *openapiTest, nil
+}

--- a/cli/cmd/test_export_cmd.go
+++ b/cli/cmd/test_export_cmd.go
@@ -1,0 +1,46 @@
+package cmd
+
+import (
+	"context"
+
+	"github.com/kubeshop/tracetest/cli/actions"
+	"github.com/spf13/cobra"
+	"go.uber.org/zap"
+)
+
+var (
+	exportTestId         string
+	exportTestOutputFile string
+)
+
+var testExportCmd = &cobra.Command{
+	Use:    "export",
+	Short:  "export a test",
+	Long:   "export a test",
+	PreRun: setupCommand,
+	Run: func(cmd *cobra.Command, args []string) {
+		ctx := context.Background()
+		cliLogger.Debug("Exporting test", zap.String("testID", exportTestId))
+		client := getAPIClient()
+		exportTestAction := actions.NewExportTestAction(cliConfig, cliLogger, client)
+
+		actionArgs := actions.ExportTestConfig{
+			TestId:     exportTestId,
+			OutputFile: exportTestOutputFile,
+		}
+
+		err := exportTestAction.Run(ctx, actionArgs)
+		if err != nil {
+			cliLogger.Error("could not get tests", zap.Error(err))
+			return
+		}
+	},
+	PostRun: teardownCommand,
+}
+
+func init() {
+	testExportCmd.PersistentFlags().StringVarP(&exportTestId, "id", "", "", "tracetest test export --id <id>")
+	testExportCmd.PersistentFlags().StringVarP(&exportTestOutputFile, "output", "o", "", "tracetest test export --output file")
+
+	testCmd.AddCommand(testExportCmd)
+}

--- a/cli/cmd/test_export_cmd_test.go
+++ b/cli/cmd/test_export_cmd_test.go
@@ -1,0 +1,31 @@
+package cmd_test
+
+import (
+	"testing"
+
+	"github.com/kubeshop/tracetest/cli/cmd/e2e"
+	"github.com/kubeshop/tracetest/cli/file"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTestExportCmd(t *testing.T) {
+	cli := e2e.NewCLI()
+
+	definitionFile := "definition_file.yml"
+	t.Cleanup(func() {
+		deleteFile(definitionFile)
+	})
+
+	output, err := cli.RunCommand("test", "export", "--config", "e2e/config.yml", "--id", "a6074714-e986-4747-a399-b87748143884", "--output", definitionFile)
+	assert.NoError(t, err)
+	assert.Empty(t, output)
+
+	definition, err := file.LoadDefinition(definitionFile)
+	require.NoError(t, err)
+
+	assert.NotEmpty(t, definition.Id)
+	assert.NotEmpty(t, definition.Name)
+	assert.NotEmpty(t, definition.Trigger.Type)
+	assert.NotEmpty(t, definition.Trigger.HTTPRequest.URL)
+}

--- a/cli/conversion/openapi_definition_conversion.go
+++ b/cli/conversion/openapi_definition_conversion.go
@@ -1,0 +1,120 @@
+package conversion
+
+import (
+	"fmt"
+
+	"github.com/kubeshop/tracetest/cli/definition"
+	"github.com/kubeshop/tracetest/cli/openapi"
+)
+
+func ConvertOpenAPITestIntoDefinitionObject(test openapi.Test) (definition.Test, error) {
+	trigger := convertServiceUnderTestIntoTrigger(test.ServiceUnderTest)
+	testDefinition := convertOpenAPITestDefinitionIntoDefinitionArray(test.Definition)
+	description := ""
+	if test.Description != nil {
+		description = *test.Description
+	}
+
+	return definition.Test{
+		Id:             *test.Id,
+		Name:           *test.Name,
+		Description:    description,
+		Trigger:        trigger,
+		TestDefinition: testDefinition,
+	}, nil
+}
+
+func convertServiceUnderTestIntoTrigger(serviceUnderTest *openapi.TestServiceUnderTest) definition.TestTrigger {
+	if serviceUnderTest == nil || serviceUnderTest.Request == nil {
+		return definition.TestTrigger{}
+	}
+
+	headers := make([]definition.HTTPHeader, 0, len(serviceUnderTest.Request.Headers))
+	for _, header := range serviceUnderTest.Request.Headers {
+		headers = append(headers, definition.HTTPHeader{
+			Key:   *header.Key,
+			Value: *header.Value,
+		})
+	}
+
+	auth := getAuthDefinition(serviceUnderTest.Request.Auth)
+
+	body := definition.HTTPBody{}
+	if serviceUnderTest.Request.Body != nil {
+		body = definition.HTTPBody{
+			// we only support raw for now
+			Type: "raw",
+			Raw:  *serviceUnderTest.Request.Body,
+		}
+	}
+
+	return definition.TestTrigger{
+		// we only support http for now
+		Type: "http",
+		HTTPRequest: definition.HttpRequest{
+			URL:            *serviceUnderTest.Request.Url,
+			Method:         *serviceUnderTest.Request.Method,
+			Headers:        headers,
+			Body:           body,
+			Authentication: auth,
+		},
+	}
+}
+
+func getAuthDefinition(auth *openapi.HTTPAuth) definition.HTTPAuthentication {
+	if auth == nil || auth.Type == nil {
+		return definition.HTTPAuthentication{}
+	}
+
+	switch *auth.Type {
+	case "basic":
+		return definition.HTTPAuthentication{
+			Type: "basic",
+			BasicAuth: definition.HTTPBasicAuth{
+				User:     *auth.Basic.Username,
+				Password: *auth.Basic.Password,
+			},
+		}
+	case "apikey":
+		return definition.HTTPAuthentication{
+			Type: "apikey",
+			ApiKey: definition.HTTPAPIKeyAuth{
+				Key:   *auth.ApiKey.Key,
+				Value: *auth.ApiKey.Value,
+				In:    *auth.ApiKey.In,
+			},
+		}
+	case "bearer":
+		return definition.HTTPAuthentication{
+			Type: "bearer",
+			Bearer: definition.HTTPBearerAuth{
+				Token: *auth.Bearer.Token,
+			},
+		}
+	default:
+		return definition.HTTPAuthentication{}
+	}
+}
+
+func convertOpenAPITestDefinitionIntoDefinitionArray(testDefinition *openapi.TestDefinition) []definition.TestDefinition {
+	if testDefinition == nil {
+		return []definition.TestDefinition{}
+	}
+
+	definitionArray := make([]definition.TestDefinition, 0, len(testDefinition.Definitions))
+	for _, def := range testDefinition.Definitions {
+		assertions := make([]string, 0, len(def.Assertions))
+		for _, assertion := range def.Assertions {
+			assertionString := fmt.Sprintf("%s %s %s", *assertion.Attribute, *assertion.Comparator, *assertion.Expected)
+			assertions = append(assertions, assertionString)
+		}
+
+		newDefinition := definition.TestDefinition{
+			Selector:   *def.Selector,
+			Assertions: assertions,
+		}
+		definitionArray = append(definitionArray, newDefinition)
+	}
+
+	return definitionArray
+}

--- a/cli/conversion/openapi_definition_conversion_test.go
+++ b/cli/conversion/openapi_definition_conversion_test.go
@@ -1,0 +1,328 @@
+package conversion_test
+
+import (
+	"testing"
+
+	"github.com/kubeshop/tracetest/cli/conversion"
+	"github.com/kubeshop/tracetest/cli/definition"
+	"github.com/kubeshop/tracetest/cli/openapi"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func openApiInt(in int32) *int32 {
+	return &in
+}
+
+func TestOpenAPIToDefinitionConversion(t *testing.T) {
+	testCases := []struct {
+		Name           string
+		Input          openapi.Test
+		ExpectedOutput definition.Test
+	}{
+		{
+			Name: "Should_convert_basic_test_information",
+			Input: openapi.Test{
+				Id:               openAPIStr("624a8dea-f152-48d4-a742-30b210094959"),
+				Name:             openAPIStr("my test"),
+				Description:      openAPIStr("my test description"),
+				Version:          openApiInt(3),
+				ServiceUnderTest: &openapi.TestServiceUnderTest{},
+				Definition:       &openapi.TestDefinition{},
+				ReferenceTestRun: &openapi.TestRun{},
+			},
+			ExpectedOutput: definition.Test{
+				Id:             "624a8dea-f152-48d4-a742-30b210094959",
+				Name:           "my test",
+				Description:    "my test description",
+				Trigger:        definition.TestTrigger{},
+				TestDefinition: []definition.TestDefinition{},
+			},
+		},
+		{
+			Name: "should_convert_service_under_test_information_with_no_authentication",
+			Input: openapi.Test{
+				Id:          openAPIStr("624a8dea-f152-48d4-a742-30b210094959"),
+				Name:        openAPIStr("my test"),
+				Description: openAPIStr("my test description"),
+				Version:     openApiInt(3),
+				ServiceUnderTest: &openapi.TestServiceUnderTest{
+					Request: &openapi.HTTPRequest{
+						Url:    openAPIStr("http://localhost:1234"),
+						Method: openAPIStr("POST"),
+						Headers: []openapi.HTTPHeader{
+							{Key: openAPIStr("Content-Type"), Value: openAPIStr("application/json")},
+						},
+						Body: openAPIStr(`{ "id": 52 }`),
+						Auth: &openapi.HTTPAuth{},
+					},
+				},
+			},
+			ExpectedOutput: definition.Test{
+				Id:          "624a8dea-f152-48d4-a742-30b210094959",
+				Name:        "my test",
+				Description: "my test description",
+				Trigger: definition.TestTrigger{
+					Type: "http",
+					HTTPRequest: definition.HttpRequest{
+						URL:    "http://localhost:1234",
+						Method: "POST",
+						Headers: []definition.HTTPHeader{
+							{Key: "Content-Type", Value: "application/json"},
+						},
+						Authentication: definition.HTTPAuthentication{},
+						Body: definition.HTTPBody{
+							Type: "raw",
+							Raw:  `{ "id": 52 }`,
+						},
+					},
+				},
+				TestDefinition: []definition.TestDefinition{},
+			},
+		},
+		{
+			Name: "should_convert_service_under_test_information_with_no_body",
+			Input: openapi.Test{
+				Id:          openAPIStr("624a8dea-f152-48d4-a742-30b210094959"),
+				Name:        openAPIStr("my test"),
+				Description: openAPIStr("my test description"),
+				Version:     openApiInt(3),
+				ServiceUnderTest: &openapi.TestServiceUnderTest{
+					Request: &openapi.HTTPRequest{
+						Url:    openAPIStr("http://localhost:1234"),
+						Method: openAPIStr("POST"),
+						Headers: []openapi.HTTPHeader{
+							{Key: openAPIStr("Content-Type"), Value: openAPIStr("application/json")},
+						},
+						Body: nil,
+						Auth: &openapi.HTTPAuth{},
+					},
+				},
+			},
+			ExpectedOutput: definition.Test{
+				Id:          "624a8dea-f152-48d4-a742-30b210094959",
+				Name:        "my test",
+				Description: "my test description",
+				Trigger: definition.TestTrigger{
+					Type: "http",
+					HTTPRequest: definition.HttpRequest{
+						URL:    "http://localhost:1234",
+						Method: "POST",
+						Headers: []definition.HTTPHeader{
+							{Key: "Content-Type", Value: "application/json"},
+						},
+						Authentication: definition.HTTPAuthentication{},
+					},
+				},
+				TestDefinition: []definition.TestDefinition{},
+			},
+		},
+		{
+			Name: "should_convert_service_under_test_information_with_basic_authentication",
+			Input: openapi.Test{
+				Id:          openAPIStr("624a8dea-f152-48d4-a742-30b210094959"),
+				Name:        openAPIStr("my test"),
+				Description: openAPIStr("my test description"),
+				Version:     openApiInt(3),
+				ServiceUnderTest: &openapi.TestServiceUnderTest{
+					Request: &openapi.HTTPRequest{
+						Url:    openAPIStr("http://localhost:1234"),
+						Method: openAPIStr("POST"),
+						Headers: []openapi.HTTPHeader{
+							{Key: openAPIStr("Content-Type"), Value: openAPIStr("application/json")},
+						},
+						Body: openAPIStr(`{ "id": 52 }`),
+						Auth: &openapi.HTTPAuth{
+							Type: openAPIStr("basic"),
+							Basic: &openapi.HTTPAuthBasic{
+								Username: openAPIStr("my username"),
+								Password: openAPIStr("my password"),
+							},
+						},
+					},
+				},
+			},
+			ExpectedOutput: definition.Test{
+				Id:          "624a8dea-f152-48d4-a742-30b210094959",
+				Name:        "my test",
+				Description: "my test description",
+				Trigger: definition.TestTrigger{
+					Type: "http",
+					HTTPRequest: definition.HttpRequest{
+						URL:    "http://localhost:1234",
+						Method: "POST",
+						Headers: []definition.HTTPHeader{
+							{Key: "Content-Type", Value: "application/json"},
+						},
+						Authentication: definition.HTTPAuthentication{
+							Type: "basic",
+							BasicAuth: definition.HTTPBasicAuth{
+								User:     "my username",
+								Password: "my password",
+							},
+						},
+						Body: definition.HTTPBody{
+							Type: "raw",
+							Raw:  `{ "id": 52 }`,
+						},
+					},
+				},
+				TestDefinition: []definition.TestDefinition{},
+			},
+		},
+		{
+			Name: "should_convert_service_under_test_information_with_apikey_authentication",
+			Input: openapi.Test{
+				Id:          openAPIStr("624a8dea-f152-48d4-a742-30b210094959"),
+				Name:        openAPIStr("my test"),
+				Description: openAPIStr("my test description"),
+				Version:     openApiInt(3),
+				ServiceUnderTest: &openapi.TestServiceUnderTest{
+					Request: &openapi.HTTPRequest{
+						Url:    openAPIStr("http://localhost:1234"),
+						Method: openAPIStr("POST"),
+						Headers: []openapi.HTTPHeader{
+							{Key: openAPIStr("Content-Type"), Value: openAPIStr("application/json")},
+						},
+						Body: openAPIStr(`{ "id": 52 }`),
+						Auth: &openapi.HTTPAuth{
+							Type: openAPIStr("apikey"),
+							ApiKey: &openapi.HTTPAuthApiKey{
+								Key:   openAPIStr("X-Key"),
+								Value: openAPIStr("my-key"),
+								In:    openAPIStr("header"),
+							},
+						},
+					},
+				},
+			},
+			ExpectedOutput: definition.Test{
+				Id:          "624a8dea-f152-48d4-a742-30b210094959",
+				Name:        "my test",
+				Description: "my test description",
+				Trigger: definition.TestTrigger{
+					Type: "http",
+					HTTPRequest: definition.HttpRequest{
+						URL:    "http://localhost:1234",
+						Method: "POST",
+						Headers: []definition.HTTPHeader{
+							{Key: "Content-Type", Value: "application/json"},
+						},
+						Authentication: definition.HTTPAuthentication{
+							Type: "apikey",
+							ApiKey: definition.HTTPAPIKeyAuth{
+								Key:   "X-Key",
+								Value: "my-key",
+								In:    "header",
+							},
+						},
+						Body: definition.HTTPBody{
+							Type: "raw",
+							Raw:  `{ "id": 52 }`,
+						},
+					},
+				},
+				TestDefinition: []definition.TestDefinition{},
+			},
+		},
+		{
+			Name: "should_convert_service_under_test_information_with_bearer_authentication",
+			Input: openapi.Test{
+				Id:          openAPIStr("624a8dea-f152-48d4-a742-30b210094959"),
+				Name:        openAPIStr("my test"),
+				Description: openAPIStr("my test description"),
+				Version:     openApiInt(3),
+				ServiceUnderTest: &openapi.TestServiceUnderTest{
+					Request: &openapi.HTTPRequest{
+						Url:    openAPIStr("http://localhost:1234"),
+						Method: openAPIStr("POST"),
+						Headers: []openapi.HTTPHeader{
+							{Key: openAPIStr("Content-Type"), Value: openAPIStr("application/json")},
+						},
+						Body: openAPIStr(`{ "id": 52 }`),
+						Auth: &openapi.HTTPAuth{
+							Type: openAPIStr("bearer"),
+							Bearer: &openapi.HTTPAuthBearer{
+								Token: openAPIStr("my token"),
+							},
+						},
+					},
+				},
+			},
+			ExpectedOutput: definition.Test{
+				Id:          "624a8dea-f152-48d4-a742-30b210094959",
+				Name:        "my test",
+				Description: "my test description",
+				Trigger: definition.TestTrigger{
+					Type: "http",
+					HTTPRequest: definition.HttpRequest{
+						URL:    "http://localhost:1234",
+						Method: "POST",
+						Headers: []definition.HTTPHeader{
+							{Key: "Content-Type", Value: "application/json"},
+						},
+						Authentication: definition.HTTPAuthentication{
+							Type: "bearer",
+							Bearer: definition.HTTPBearerAuth{
+								Token: "my token",
+							},
+						},
+						Body: definition.HTTPBody{
+							Type: "raw",
+							Raw:  `{ "id": 52 }`,
+						},
+					},
+				},
+				TestDefinition: []definition.TestDefinition{},
+			},
+		},
+		{
+			Name: "Should_convert_test_definition",
+			Input: openapi.Test{
+				Id:               openAPIStr("624a8dea-f152-48d4-a742-30b210094959"),
+				Name:             openAPIStr("my test"),
+				Description:      openAPIStr("my test description"),
+				Version:          openApiInt(3),
+				ServiceUnderTest: &openapi.TestServiceUnderTest{},
+				Definition: &openapi.TestDefinition{
+					Definitions: []openapi.TestDefinitionDefinitions{
+						{
+							Selector: openAPIStr(`span[name = "my span name"]`),
+							Assertions: []openapi.Assertion{
+								{
+									Attribute:  openAPIStr("tracetest.span.duration"),
+									Comparator: openAPIStr("<="),
+									Expected:   openAPIStr("200"),
+								},
+							},
+						},
+					},
+				},
+				ReferenceTestRun: &openapi.TestRun{},
+			},
+			ExpectedOutput: definition.Test{
+				Id:          "624a8dea-f152-48d4-a742-30b210094959",
+				Name:        "my test",
+				Description: "my test description",
+				Trigger:     definition.TestTrigger{},
+				TestDefinition: []definition.TestDefinition{
+					{
+						Selector: `span[name = "my span name"]`,
+						Assertions: []string{
+							"tracetest.span.duration <= 200",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.Name, func(t *testing.T) {
+			output, err := conversion.ConvertOpenAPITestIntoDefinitionObject(testCase.Input)
+
+			require.NoError(t, err)
+			assert.Equal(t, testCase.ExpectedOutput, output)
+		})
+	}
+}

--- a/cli/file/definition.go
+++ b/cli/file/definition.go
@@ -29,7 +29,7 @@ func SaveDefinition(file string, definition definition.Test) error {
 		return fmt.Errorf("could not marshal definition into YAML: %w", err)
 	}
 
-	err = os.WriteFile(file, yamlContent, 0)
+	err = os.WriteFile(file, yamlContent, 0755)
 	if err != nil {
 		return fmt.Errorf("could not write file: %w", err)
 	}

--- a/cli/openapi/model_test_run.go
+++ b/cli/openapi/model_test_run.go
@@ -25,7 +25,9 @@ type TestRun struct {
 	// Current execution state
 	State *string `json:"state,omitempty"`
 	// Details of the cause for the last `FAILED` state
-	LastErrorState            *string           `json:"lastErrorState,omitempty"`
+	LastErrorState *string `json:"lastErrorState,omitempty"`
+	// time it took for the test to complete, either success or fail. If the test is still running, it will show the time up to the time of the request
+	ExectutionTime            *int32            `json:"exectutionTime,omitempty"`
 	CreatedAt                 *time.Time        `json:"createdAt,omitempty"`
 	ServiceTriggeredAt        *time.Time        `json:"serviceTriggeredAt,omitempty"`
 	ServiceTriggerCompletedAt *time.Time        `json:"serviceTriggerCompletedAt,omitempty"`
@@ -244,6 +246,38 @@ func (o *TestRun) HasLastErrorState() bool {
 // SetLastErrorState gets a reference to the given string and assigns it to the LastErrorState field.
 func (o *TestRun) SetLastErrorState(v string) {
 	o.LastErrorState = &v
+}
+
+// GetExectutionTime returns the ExectutionTime field value if set, zero value otherwise.
+func (o *TestRun) GetExectutionTime() int32 {
+	if o == nil || o.ExectutionTime == nil {
+		var ret int32
+		return ret
+	}
+	return *o.ExectutionTime
+}
+
+// GetExectutionTimeOk returns a tuple with the ExectutionTime field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *TestRun) GetExectutionTimeOk() (*int32, bool) {
+	if o == nil || o.ExectutionTime == nil {
+		return nil, false
+	}
+	return o.ExectutionTime, true
+}
+
+// HasExectutionTime returns a boolean if a field has been set.
+func (o *TestRun) HasExectutionTime() bool {
+	if o != nil && o.ExectutionTime != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetExectutionTime gets a reference to the given int32 and assigns it to the ExectutionTime field.
+func (o *TestRun) SetExectutionTime(v int32) {
+	o.ExectutionTime = &v
 }
 
 // GetCreatedAt returns the CreatedAt field value if set, zero value otherwise.
@@ -553,6 +587,9 @@ func (o TestRun) MarshalJSON() ([]byte, error) {
 	}
 	if o.LastErrorState != nil {
 		toSerialize["lastErrorState"] = o.LastErrorState
+	}
+	if o.ExectutionTime != nil {
+		toSerialize["exectutionTime"] = o.ExectutionTime
 	}
 	if o.CreatedAt != nil {
 		toSerialize["createdAt"] = o.CreatedAt


### PR DESCRIPTION
This PR add a new command to the CLI: `tracetest test export --id <id> --output <output-file.yml>`

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [x] added a test
