### PR TITLE
fix: quote string values in assertions when exporting a test

### DIFF
--- a/cli/conversion/openapi_definition_conversion.go
+++ b/cli/conversion/openapi_definition_conversion.go
@@ -2,6 +2,7 @@ package conversion
 
 import (
 	"fmt"
+	"strconv"
 
 	"github.com/kubeshop/tracetest/cli/definition"
 	"github.com/kubeshop/tracetest/cli/openapi"
@@ -105,7 +106,11 @@ func convertOpenAPITestDefinitionIntoDefinitionArray(testDefinition *openapi.Tes
 	for _, def := range testDefinition.Definitions {
 		assertions := make([]string, 0, len(def.Assertions))
 		for _, assertion := range def.Assertions {
-			assertionString := fmt.Sprintf("%s %s %s", *assertion.Attribute, *assertion.Comparator, *assertion.Expected)
+			assertionFormat := `%s %s "%s"`
+			if isNumber(*assertion.Expected) {
+				assertionFormat = "%s %s %s"
+			}
+			assertionString := fmt.Sprintf(assertionFormat, *assertion.Attribute, *assertion.Comparator, *assertion.Expected)
 			assertions = append(assertions, assertionString)
 		}
 
@@ -117,4 +122,16 @@ func convertOpenAPITestDefinitionIntoDefinitionArray(testDefinition *openapi.Tes
 	}
 
 	return definitionArray
+}
+
+func isNumber(in string) bool {
+	if _, err := strconv.Atoi(in); err == nil {
+		return true
+	}
+
+	if _, err := strconv.ParseFloat(in, 64); err == nil {
+		return true
+	}
+
+	return false
 }

--- a/cli/conversion/openapi_definition_conversion_test.go
+++ b/cli/conversion/openapi_definition_conversion_test.go
@@ -294,6 +294,11 @@ func TestOpenAPIToDefinitionConversion(t *testing.T) {
 									Comparator: openAPIStr("<="),
 									Expected:   openAPIStr("200"),
 								},
+								{
+									Attribute:  openAPIStr("db.operation"),
+									Comparator: openAPIStr("="),
+									Expected:   openAPIStr("create"),
+								},
 							},
 						},
 					},
@@ -310,6 +315,7 @@ func TestOpenAPIToDefinitionConversion(t *testing.T) {
 						Selector: `span[name = "my span name"]`,
 						Assertions: []string{
 							"tracetest.span.duration <= 200",
+							`db.operation = "create"`,
 						},
 					},
 				},


### PR DESCRIPTION
This PR quote string values in assertions when exporting a test


## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [x] added a test
