### PR TITLE
fix: don't validate description because our server doesn't use it

### DIFF
--- a/cli/definition/test.go
+++ b/cli/definition/test.go
@@ -15,10 +15,6 @@ func (t Test) Validate() error {
 		return fmt.Errorf("test name cannot be empty")
 	}
 
-	if t.Description == "" {
-		return fmt.Errorf("test description cannot be empty")
-	}
-
 	if err := t.Trigger.Validate(); err != nil {
 		return fmt.Errorf("test trigger must be valid: %w", err)
 	}


### PR DESCRIPTION
Our UI doesn't create a description, so by validating it, we automatically make all exported tests invalid because no test created via UI have this attribute.

## Checklist

- [X] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
