### PR TITLE
feat: support env variables in definition file

### DIFF
--- a/cli/file/definition.go
+++ b/cli/file/definition.go
@@ -3,6 +3,8 @@ package file
 import (
 	"fmt"
 	"os"
+	"regexp"
+	"strings"
 
 	"github.com/kubeshop/tracetest/cli/definition"
 	"gopkg.in/yaml.v2"
@@ -12,6 +14,11 @@ func LoadDefinition(file string) (definition.Test, error) {
 	fileBytes, err := os.ReadFile(file)
 	if err != nil {
 		return definition.Test{}, fmt.Errorf("could not read test definition file %s: %w", file, err)
+	}
+
+	fileBytes, err = injectEnvVariables(fileBytes)
+	if err != nil {
+		return definition.Test{}, fmt.Errorf("could not inject env variables into definition file: %w", err)
 	}
 
 	test := definition.Test{}
@@ -35,4 +42,23 @@ func SaveDefinition(file string, definition definition.Test) error {
 	}
 
 	return nil
+}
+
+func injectEnvVariables(fileBytes []byte) ([]byte, error) {
+	envVarRegex, err := regexp.Compile(`\$\{\w+\}`)
+	if err != nil {
+		return []byte{}, fmt.Errorf("could not compile env variable regex: %w", err)
+	}
+
+	fileString := string(fileBytes)
+	allEnvVariables := envVarRegex.FindAllString(fileString, -1)
+
+	for _, envVariableExpression := range allEnvVariables {
+		envVarName := envVariableExpression[2 : len(envVariableExpression)-1] // removes '${' and '}'
+		envVarValue := os.Getenv(envVarName)
+
+		fileString = strings.Replace(fileString, envVariableExpression, envVarValue, -1)
+	}
+
+	return []byte(fileString), nil
 }

--- a/cli/file/definition_test.go
+++ b/cli/file/definition_test.go
@@ -170,14 +170,13 @@ func TestLoadDefinition(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
-		envVariables := testCase.EnvVariables
 		t.Run(testCase.Name, func(t *testing.T) {
-			for key, value := range envVariables {
+			for key, value := range testCase.EnvVariables {
 				os.Setenv(key, value)
 			}
 
 			t.Cleanup(func() {
-				for key, _ := range envVariables {
+				for key := range testCase.EnvVariables {
 					os.Unsetenv(key)
 				}
 			})

--- a/cli/testdata/definitions/valid_http_test_definition_with_env_variables.yml
+++ b/cli/testdata/definitions/valid_http_test_definition_with_env_variables.yml
@@ -1,0 +1,19 @@
+name: POST import pokemon
+description: Import a pokemon using its ID
+trigger:
+  type: http
+  http_request:
+    url: http://pokemon-demo.tracetest.io/pokemon/import
+    method: POST
+    headers:
+    - key: Content-Type
+      value: application/json
+    authentication:
+      type: apiKey
+      apiKey:
+        key: X-Key
+        value: ${POKEMON_APP_API_KEY}
+        in: header
+    body:
+      type: raw
+      raw: '{ "id": 52 }'


### PR DESCRIPTION
This PR enables users to define env variables in the definition file. Those variables will be replaced when the file is read from disk and its values are retrieved from the machine the CLI is running on.

Variables are declared as: `value: ${MY_VARIABLE}`. If the variable doesn't exist in the machine, it will be replaced with an empty string.

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [x] added a test
