### PR TITLE
feat: add deleteTestRun endpoint

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -293,6 +293,28 @@ paths:
             application/json:
               schema:
                 $ref: "./tests.yaml#/components/schemas/TestRun"
+    delete:
+      tags:
+        - api
+      parameters:
+        - in: path
+          name: testId
+          schema:
+            type: string
+            format: uuid
+          required: true
+        - in: path
+          name: runId
+          schema:
+            type: string
+            format: uuid
+          required: true
+      summary: "delete a test run"
+      description: "delete a test run"
+      operationId: deleteTestRun
+      responses:
+        "204":
+          description: OK
   /tests/{testId}/definition:
     get:
       tags:

--- a/server/model/repository.go
+++ b/server/model/repository.go
@@ -24,6 +24,7 @@ type DefinitionRepository interface {
 type RunRepository interface {
 	CreateRun(context.Context, Test, Run) (Run, error)
 	UpdateRun(context.Context, Run) error
+	DeleteRun(context.Context, Run) error
 	GetRun(context.Context, uuid.UUID) (Run, error)
 	GetTestRuns(_ context.Context, _ Test, take, skip int32) ([]Run, error)
 	GetRunByTraceID(context.Context, Test, trace.TraceID) (Run, error)

--- a/server/openapi/api.go
+++ b/server/openapi/api.go
@@ -20,6 +20,7 @@ import (
 type ApiApiRouter interface {
 	CreateTest(http.ResponseWriter, *http.Request)
 	DeleteTest(http.ResponseWriter, *http.Request)
+	DeleteTestRun(http.ResponseWriter, *http.Request)
 	DryRunAssertion(http.ResponseWriter, *http.Request)
 	GetTest(http.ResponseWriter, *http.Request)
 	GetTestDefinition(http.ResponseWriter, *http.Request)
@@ -40,6 +41,7 @@ type ApiApiRouter interface {
 type ApiApiServicer interface {
 	CreateTest(context.Context, Test) (ImplResponse, error)
 	DeleteTest(context.Context, string) (ImplResponse, error)
+	DeleteTestRun(context.Context, string, string) (ImplResponse, error)
 	DryRunAssertion(context.Context, string, string, TestDefinition) (ImplResponse, error)
 	GetTest(context.Context, string) (ImplResponse, error)
 	GetTestDefinition(context.Context, string) (ImplResponse, error)

--- a/server/openapi/api_api.go
+++ b/server/openapi/api_api.go
@@ -63,6 +63,12 @@ func (c *ApiApiController) Routes() Routes {
 			c.DeleteTest,
 		},
 		{
+			"DeleteTestRun",
+			strings.ToUpper("Delete"),
+			"/api/tests/{testId}/run/{runId}",
+			c.DeleteTestRun,
+		},
+		{
 			"DryRunAssertion",
 			strings.ToUpper("Put"),
 			"/api/tests/{testId}/run/{runId}/dry-run",
@@ -161,6 +167,24 @@ func (c *ApiApiController) DeleteTest(w http.ResponseWriter, r *http.Request) {
 	testIdParam := params["testId"]
 
 	result, err := c.service.DeleteTest(r.Context(), testIdParam)
+	// If an error occurred, encode the error with the status code
+	if err != nil {
+		c.errorHandler(w, r, err, &result)
+		return
+	}
+	// If no error, encode the body and the result code
+	EncodeJSONResponse(result.Body, &result.Code, w)
+
+}
+
+// DeleteTestRun - delete a test run
+func (c *ApiApiController) DeleteTestRun(w http.ResponseWriter, r *http.Request) {
+	params := mux.Vars(r)
+	testIdParam := params["testId"]
+
+	runIdParam := params["runId"]
+
+	result, err := c.service.DeleteTestRun(r.Context(), testIdParam, runIdParam)
 	// If an error occurred, encode the error with the status code
 	if err != nil {
 		c.errorHandler(w, r, err, &result)

--- a/server/testdb/mock.go
+++ b/server/testdb/mock.go
@@ -66,6 +66,11 @@ func (m *MockRepository) UpdateRun(_ context.Context, run model.Run) error {
 	return args.Error(0)
 }
 
+func (m *MockRepository) DeleteRun(_ context.Context, run model.Run) error {
+	args := m.Called(run)
+	return args.Error(0)
+}
+
 func (m *MockRepository) GetRun(_ context.Context, id uuid.UUID) (model.Run, error) {
 	args := m.Called(id)
 	return args.Get(0).(model.Run), args.Error(1)

--- a/server/testdb/runs.go
+++ b/server/testdb/runs.go
@@ -56,6 +56,21 @@ func (td *postgresDB) UpdateRun(ctx context.Context, r model.Run) error {
 	return nil
 }
 
+func (td *postgresDB) DeleteRun(ctx context.Context, r model.Run) error {
+	stmt, err := td.db.Prepare("DELETE FROM runs WHERE id = $1")
+	if err != nil {
+		return fmt.Errorf("prepare: %w", err)
+	}
+	defer stmt.Close()
+
+	_, err = stmt.ExecContext(ctx, r.ID)
+	if err != nil {
+		return fmt.Errorf("sql exec: %w", err)
+	}
+
+	return nil
+}
+
 func (td *postgresDB) GetRun(ctx context.Context, id uuid.UUID) (model.Run, error) {
 	stmt, err := td.db.Prepare("SELECT run, test_version FROM runs WHERE id = $1")
 	if err != nil {


### PR DESCRIPTION
This PR adds an endpoint to delete TestRuns

## Changes

- update openapi definitions
- implement endpoint

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
