### PR TITLE
feat: better CLI configuration setup

### DIFF
--- a/cli/.gitignore
+++ b/cli/.gitignore
@@ -1,2 +1,3 @@
 tracetest
 openapitools.json
+config.yml

--- a/cli/actions/configure_action.go
+++ b/cli/actions/configure_action.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path"
+	"path/filepath"
 	"strings"
 
 	"github.com/kubeshop/tracetest/cli/config"
@@ -34,8 +35,13 @@ func NewConfigureAction(config config.Config, logger *zap.Logger, client *openap
 }
 
 func (a configureAction) Run(ctx context.Context, args ConfigureConfig) error {
+	existingConfig := a.loadExistingConfig(args)
 	var serverURL string
-	fmt.Print("Enter your Tracetest server URL: ")
+	if existingConfig.Scheme != "" && existingConfig.Endpoint != "" {
+		fmt.Printf("Enter your Tracetest server URL (current value: %s://%s): ", existingConfig.Scheme, existingConfig.Endpoint)
+	} else {
+		fmt.Print("Enter your Tracetest server URL: ")
+	}
 	_, err := fmt.Fscanf(os.Stdin, "%s", &serverURL)
 	if err != nil {
 		return fmt.Errorf("could not read text from input: %w", err)
@@ -68,14 +74,24 @@ func (a configureAction) Run(ctx context.Context, args ConfigureConfig) error {
 	return nil
 }
 
+func (a configureAction) loadExistingConfig(args ConfigureConfig) config.Config {
+	configPath, err := a.getConfigurationPath(args)
+	if err != nil {
+		return config.Config{}
+	}
+
+	c, err := config.LoadConfig(configPath)
+	if err != nil {
+		return config.Config{}
+	}
+
+	return c
+}
+
 func (a configureAction) saveConfiguration(ctx context.Context, config config.Config, args ConfigureConfig) error {
-	configPath := "./config.yml"
-	if args.Global {
-		homePath, err := os.UserHomeDir()
-		if err != nil {
-			return fmt.Errorf("could not get user home dir: %w", err)
-		}
-		configPath = path.Join(homePath, ".tracetest/config.yml")
+	configPath, err := a.getConfigurationPath(args)
+	if err != nil {
+		return fmt.Errorf("could not get configuration path: %w", err)
 	}
 
 	configYml, err := yaml.Marshal(config)
@@ -83,10 +99,26 @@ func (a configureAction) saveConfiguration(ctx context.Context, config config.Co
 		return fmt.Errorf("could not marshal configuration into yml: %w", err)
 	}
 
+	if _, err := os.Stat(configPath); os.IsNotExist(err) {
+		os.MkdirAll(filepath.Dir(configPath), 0700) // Ensure folder exists
+	}
 	err = os.WriteFile(configPath, configYml, 0755)
 	if err != nil {
 		return fmt.Errorf("could not write file: %w", err)
 	}
 
 	return nil
+}
+
+func (a configureAction) getConfigurationPath(args ConfigureConfig) (string, error) {
+	configPath := "./config.yml"
+	if args.Global {
+		homePath, err := os.UserHomeDir()
+		if err != nil {
+			return "", fmt.Errorf("could not get user home dir: %w", err)
+		}
+		configPath = path.Join(homePath, ".tracetest/config.yml")
+	}
+
+	return configPath, nil
 }

--- a/cli/actions/configure_action.go
+++ b/cli/actions/configure_action.go
@@ -1,0 +1,92 @@
+package actions
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path"
+	"strings"
+
+	"github.com/kubeshop/tracetest/cli/config"
+	"github.com/kubeshop/tracetest/cli/openapi"
+	"go.uber.org/zap"
+	"gopkg.in/yaml.v3"
+)
+
+type ConfigureConfig struct {
+	Global bool
+}
+
+type configureAction struct {
+	config config.Config
+	logger *zap.Logger
+	client *openapi.APIClient
+}
+
+var _ Action[ExportTestConfig] = &exportTestAction{}
+
+func NewConfigureAction(config config.Config, logger *zap.Logger, client *openapi.APIClient) configureAction {
+	return configureAction{
+		config: config,
+		logger: logger,
+		client: client,
+	}
+}
+
+func (a configureAction) Run(ctx context.Context, args ConfigureConfig) error {
+	var serverURL string
+	fmt.Print("Enter your Tracetest server URL: ")
+	_, err := fmt.Fscanf(os.Stdin, "%s", &serverURL)
+	if err != nil {
+		return fmt.Errorf("could not read text from input: %w", err)
+	}
+
+	a.logger.Debug("user entered new server URL", zap.String("serverURL", serverURL))
+
+	if !strings.HasPrefix(serverURL, "http://") && !strings.HasPrefix(serverURL, "https://") {
+		return fmt.Errorf(`the server URL must start with the scheme, either "http://" or "https://"`)
+	}
+
+	urlParts := strings.Split(serverURL, "://")
+	if len(urlParts) != 2 {
+		return fmt.Errorf("invalid server url")
+	}
+
+	scheme := urlParts[0]
+	endpoint := urlParts[1]
+
+	config := config.Config{
+		Scheme:   scheme,
+		Endpoint: endpoint,
+	}
+
+	err = a.saveConfiguration(ctx, config, args)
+	if err != nil {
+		return fmt.Errorf("could not save configuration: %w", err)
+	}
+
+	return nil
+}
+
+func (a configureAction) saveConfiguration(ctx context.Context, config config.Config, args ConfigureConfig) error {
+	configPath := "./config.yml"
+	if args.Global {
+		homePath, err := os.UserHomeDir()
+		if err != nil {
+			return fmt.Errorf("could not get user home dir: %w", err)
+		}
+		configPath = path.Join(homePath, ".tracetest/config.yml")
+	}
+
+	configYml, err := yaml.Marshal(config)
+	if err != nil {
+		return fmt.Errorf("could not marshal configuration into yml: %w", err)
+	}
+
+	err = os.WriteFile(configPath, configYml, 0755)
+	if err != nil {
+		return fmt.Errorf("could not write file: %w", err)
+	}
+
+	return nil
+}

--- a/cli/cmd/configure_cmd.go
+++ b/cli/cmd/configure_cmd.go
@@ -1,0 +1,38 @@
+package cmd
+
+import (
+	"context"
+
+	"github.com/kubeshop/tracetest/cli/actions"
+	"github.com/spf13/cobra"
+	"go.uber.org/zap"
+)
+
+var global bool
+
+var configureCmd = &cobra.Command{
+	Use:    "configure",
+	Short:  "Configure your tracetest CLI",
+	Long:   "Configure your tracetest CLI",
+	PreRun: setupLogger,
+	Run: func(cmd *cobra.Command, args []string) {
+		ctx := context.Background()
+		client := getAPIClient()
+		action := actions.NewConfigureAction(cliConfig, cliLogger, client)
+
+		actionConfig := actions.ConfigureConfig{
+			Global: global,
+		}
+		err := action.Run(ctx, actionConfig)
+		if err != nil {
+			cliLogger.Error("could not get tests", zap.Error(err))
+			return
+		}
+	},
+	PostRun: teardownCommand,
+}
+
+func init() {
+	configureCmd.PersistentFlags().BoolVarP(&global, "global", "g", false, "configuration will be saved in your home dir")
+	rootCmd.AddCommand(configureCmd)
+}

--- a/cli/cmd/configure_cmd_test.go
+++ b/cli/cmd/configure_cmd_test.go
@@ -1,0 +1,32 @@
+package cmd_test
+
+import (
+	"testing"
+
+	"github.com/kubeshop/tracetest/cli/cmd/e2e"
+	"github.com/kubeshop/tracetest/cli/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConfigureCmd(t *testing.T) {
+	cli := e2e.NewCLI()
+
+	configureCommand := cli.NewCommand("configure")
+
+	t.Cleanup(func() {
+		deleteFile("./config.yml")
+	})
+
+	output, err := configureCommand.Run("https://localhost:1234")
+	assert.NoError(t, err)
+	assert.NotEmpty(t, output)
+
+	tracetestConfig, err := config.LoadConfig("./config.yml")
+	require.NoError(t, err)
+
+	assert.Equal(t, "https", tracetestConfig.Scheme)
+	assert.Equal(t, "localhost:1234", tracetestConfig.Endpoint)
+	assert.Nil(t, tracetestConfig.ServerPath)
+
+}

--- a/cli/cmd/e2e/cli.go
+++ b/cli/cmd/e2e/cli.go
@@ -2,7 +2,9 @@ package e2e
 
 import (
 	"bytes"
+	"fmt"
 	"io"
+	"io/ioutil"
 	"os"
 
 	"github.com/kubeshop/tracetest/cli/cmd"
@@ -12,35 +14,77 @@ type CLI struct {
 	options []string
 }
 
+type Command struct {
+	command string
+	args    []string
+	options []string
+}
+
 func NewCLI(options ...string) CLI {
 	return CLI{options}
 }
 
-func (c CLI) RunCommand(command string, args ...string) (string, error) {
+func (c CLI) NewCommand(command string, args ...string) Command {
+	return Command{
+		command: command,
+		args:    args,
+		options: c.options,
+	}
+}
+
+func (c Command) Run(stdin ...string) (string, error) {
 	executableArgs := make([]string, 0)
 	executableArgs = append(executableArgs, "executable")
-	executableArgs = append(executableArgs, command)
+	executableArgs = append(executableArgs, c.command)
 	executableArgs = append(executableArgs, c.options...)
-	executableArgs = append(executableArgs, args...)
+	executableArgs = append(executableArgs, c.args...)
 
 	os.Args = executableArgs
 
-	old := os.Stdout
-	r, w, _ := os.Pipe()
-	os.Stdout = w
+	oldStdout := os.Stdout
+	stdoutReader, newStdout, _ := os.Pipe()
+	os.Stdout = newStdout
+
+	oldStdin := os.Stdin
+	newStdin, err := ioutil.TempFile("", "stdin")
+	if err != nil {
+		return "", err
+	}
+	os.Stdin = newStdin
+
+	err = c.WriteToStdin(stdin, newStdin)
+	if err != nil {
+		return "", fmt.Errorf("could not write to stdin: %w", err)
+	}
 
 	cmd.Execute()
 
 	outC := make(chan string)
 	go func() {
 		var buf bytes.Buffer
-		io.Copy(&buf, r)
+		io.Copy(&buf, stdoutReader)
 		outC <- buf.String()
 	}()
 
-	w.Close()
-	os.Stdout = old
+	newStdout.Close()
+	newStdin.Close()
+	os.Stdout = oldStdout
+	os.Stdin = oldStdin
 	out := <-outC
 
 	return out, nil
+}
+
+func (c Command) WriteToStdin(stdinArgs []string, stdin *os.File) error {
+	for _, input := range stdinArgs {
+		line := fmt.Sprintf("%s\n", input)
+		stdin.Write([]byte(line))
+	}
+
+	_, err := stdin.Seek(0, 0)
+	if err != nil {
+		return fmt.Errorf("could not seek beginning of file")
+	}
+
+	return nil
 }

--- a/cli/cmd/test_export_cmd_test.go
+++ b/cli/cmd/test_export_cmd_test.go
@@ -17,7 +17,8 @@ func TestTestExportCmd(t *testing.T) {
 		deleteFile(definitionFile)
 	})
 
-	output, err := cli.RunCommand("test", "export", "--config", "e2e/config.yml", "--id", "a6074714-e986-4747-a399-b87748143884", "--output", definitionFile)
+	testExportCommand := cli.NewCommand("test", "export", "--config", "e2e/config.yml", "--id", "a6074714-e986-4747-a399-b87748143884", "--output", definitionFile)
+	output, err := testExportCommand.Run()
 	assert.NoError(t, err)
 	assert.Empty(t, output)
 

--- a/cli/cmd/test_list_cmd_test.go
+++ b/cli/cmd/test_list_cmd_test.go
@@ -11,7 +11,8 @@ import (
 func TestTestListCmd(t *testing.T) {
 	cli := e2e.NewCLI()
 
-	output, err := cli.RunCommand("test", "list", "--config", "e2e/config.yml")
+	testListCommand := cli.NewCommand("test", "list", "--config", "e2e/config.yml")
+	output, err := testListCommand.Run()
 	assert.NoError(t, err)
 	assert.NotEmpty(t, output)
 	e2e.IsJsonWithFormat(t, output, []openapi.Test{})

--- a/cli/cmd/test_run_cmd_test.go
+++ b/cli/cmd/test_run_cmd_test.go
@@ -30,7 +30,8 @@ func TestRunTestCmd(t *testing.T) {
 		require.NoError(t, err)
 	})
 
-	output, err := cli.RunCommand("test", "run", "--config", "e2e/config.yml", "--definition", definitionFile)
+	testRunCommand := cli.NewCommand("test", "run", "--config", "e2e/config.yml", "--definition", definitionFile)
+	output, err := testRunCommand.Run()
 	assert.NoError(t, err)
 	assert.NotEmpty(t, output)
 
@@ -58,7 +59,8 @@ func TestRunTestCmdWhenEditingTest(t *testing.T) {
 		require.NoError(t, err)
 	})
 
-	output, err := cli.RunCommand("test", "run", "--config", "e2e/config.yml", "--definition", definitionFile)
+	testRunCommand := cli.NewCommand("test", "run", "--config", "e2e/config.yml", "--definition", definitionFile)
+	output, err := testRunCommand.Run()
 	assert.NoError(t, err)
 	assert.NotEmpty(t, output)
 
@@ -66,7 +68,7 @@ func TestRunTestCmdWhenEditingTest(t *testing.T) {
 	err = json.Unmarshal([]byte(output), &outputObject)
 	require.NoError(t, err)
 
-	updateCmdOutput, err := cli.RunCommand("test", "run", "--config", "e2e/config.yml", "--definition", definitionFile)
+	updateCmdOutput, err := testRunCommand.Run()
 	assert.NoError(t, err)
 	assert.NotEmpty(t, output)
 

--- a/cli/config.yml
+++ b/cli/config.yml
@@ -1,2 +1,0 @@
-scheme: http
-endpoint: localhost:8080

--- a/cli/config/config.go
+++ b/cli/config/config.go
@@ -1,7 +1,10 @@
 package config
 
 import (
+	"encoding/json"
 	"fmt"
+	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/spf13/viper"
@@ -13,16 +16,42 @@ type Config struct {
 	ServerPath *string `yaml:"serverPath,omitempty"`
 }
 
+func (c Config) IsEmpty() bool {
+	thisConfigJson, _ := json.Marshal(c)
+	emptyConfigJson, _ := json.Marshal(Config{})
+
+	return string(thisConfigJson) == string(emptyConfigJson)
+}
+
 func LoadConfig(configFile string) (Config, error) {
+	config, err := loadConfig(configFile)
+	if err != nil {
+		return Config{}, err
+	}
+
+	if !config.IsEmpty() {
+		return config, nil
+	}
+
+	homePath, err := os.UserHomeDir()
+	if err != nil {
+		return Config{}, fmt.Errorf("could not get user home path")
+	}
+
+	globalConfigPath := filepath.Join(homePath, ".tracetest/config.yml")
+	return loadConfig(globalConfigPath)
+}
+
+func loadConfig(configFile string) (Config, error) {
 	viper.SetConfigFile(configFile)
 	viper.SetConfigType("yaml")
 	viper.SetEnvPrefix("tracetest")
-	viper.AddConfigPath("$HOME/.tracetest/")
 	viper.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
 	viper.AutomaticEnv()
 
 	if err := viper.ReadInConfig(); err != nil {
-		return Config{}, fmt.Errorf("could not load config file: %w", err)
+		// No configuration file found, return empty config
+		return Config{}, nil
 	}
 
 	config := Config{}

--- a/cli/config/config.go
+++ b/cli/config/config.go
@@ -10,13 +10,14 @@ import (
 type Config struct {
 	Scheme     string  `yaml:"scheme"`
 	Endpoint   string  `yaml:"endpoint"`
-	ServerPath *string `yaml:"serverPath"`
+	ServerPath *string `yaml:"serverPath,omitempty"`
 }
 
 func LoadConfig(configFile string) (Config, error) {
 	viper.SetConfigFile(configFile)
 	viper.SetConfigType("yaml")
 	viper.SetEnvPrefix("tracetest")
+	viper.AddConfigPath("$HOME/.tracetest/")
 	viper.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
 	viper.AutomaticEnv()
 


### PR DESCRIPTION
This PR adds a command `tracetest configure` that allows you to define the configuration of the CLI. Now you don't have to manage the `config.yml` file manually.

Other than that, it also supports a global configuration inside `~/.tracetest/config.yml`. This is a fallback configuration that is only used if the current directory doesn't contain any config file in it. You also can write the configuration in the global config file by executing `tracetest configure --global`.

```shell
$ tracetest configure

# (current value: <value>) is only displayed if there is a config.yml file in the directory and it is 
# not empty. It shows the current value of that variable
Enter your Tracetest server URL (current value: http://localhost:8080): 
```

```shell
$ tracetest configure --global

# same thing as above, but the file ~/.tracetest/config.yml must exist for the current
# value be shown to the user
Enter your Tracetest server URL (current value: http://localhost:1234): 
```

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [x] added a test
