### PR TITLE
Add zoom in and zoom out controls in test view page

### DIFF
--- a/web/src/components/Diagram/components/DAG.styled.tsx
+++ b/web/src/components/Diagram/components/DAG.styled.tsx
@@ -25,6 +25,7 @@ export const Controls = styled.div`
 
 export const ZoomButton = styled(Button)`
   color: rgba(3, 24, 73, 0.3);
+  width: 24px;
 
   &:hover,
   &:focus {

--- a/web/src/components/Diagram/components/DAG.styled.tsx
+++ b/web/src/components/Diagram/components/DAG.styled.tsx
@@ -1,3 +1,4 @@
+import {Button} from 'antd';
 import styled, {css} from 'styled-components';
 
 export const Container = styled.div<{$showAffected: boolean}>`
@@ -11,4 +12,22 @@ export const Container = styled.div<{$showAffected: boolean}>`
         opacity: 0.5;
       }
     `}
+`;
+
+export const Controls = styled.div`
+  background-color: #fbfbff;
+  border-bottom-left-radius: 8px;
+  position: absolute;
+  right: 0;
+  top: -14px;
+  z-index: 9;
+`;
+
+export const ZoomButton = styled(Button)`
+  color: rgba(3, 24, 73, 0.3);
+
+  &:hover,
+  &:focus {
+    background-color: unset;
+  }
 `;

--- a/web/src/components/Diagram/components/DAG.tsx
+++ b/web/src/components/Diagram/components/DAG.tsx
@@ -1,5 +1,14 @@
+import {ZoomInOutlined, ZoomOutOutlined} from '@ant-design/icons';
+
 import React, {useCallback, useEffect, useMemo} from 'react';
-import ReactFlow, {ArrowHeadType, Background, Elements, FlowElement, Position} from 'react-flow-renderer';
+import ReactFlow, {
+  ArrowHeadType,
+  Background,
+  Elements,
+  FlowElement,
+  Position,
+  useZoomPanHelper,
+} from 'react-flow-renderer';
 import {IDAGNode, useDAGChart} from '../../../hooks/useDAGChart';
 import TraceNode from '../../TraceNode';
 import * as S from './DAG.styled';
@@ -18,6 +27,8 @@ const Diagram: React.FC<IDiagramProps> = ({
   selectedSpan,
   onSelectSpan,
 }): JSX.Element => {
+  const {zoomIn, zoomOut} = useZoomPanHelper();
+
   const nodeList = useMemo<IDAGNode<TSpan>[]>(
     () =>
       spans.map(span => ({
@@ -82,6 +93,10 @@ const Diagram: React.FC<IDiagramProps> = ({
 
   return (
     <S.Container $showAffected={affectedSpans.length > 0} data-cy="diagram-dag">
+      <S.Controls>
+        <S.ZoomButton icon={<ZoomInOutlined />} onClick={() => zoomIn()} type="text" />
+        <S.ZoomButton icon={<ZoomOutOutlined />} onClick={() => zoomOut()} type="text" />
+      </S.Controls>
       <ReactFlow
         nodeTypes={{TraceNode}}
         defaultZoom={0.5}


### PR DESCRIPTION
This PR adds the zoom in/zoom out controls for the trace diagram in the test view page.

## Changes

- New zoom controls.

## Fixes

- #667 

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Demo

https://user-images.githubusercontent.com/3879892/172200398-07bf947c-dd32-456f-abcb-7ecc0f2c4bd6.mov