### PR TITLE
🐛  668 Issues with state when in draft mode

### DIFF
--- a/web/src/components/AssertionCard/AssertionCard.tsx
+++ b/web/src/components/AssertionCard/AssertionCard.tsx
@@ -58,9 +58,9 @@ const AssertionCard: React.FC<TAssertionCardProps> = ({
     e => {
       e.stopPropagation();
       AssertionAnalyticsService.onRevertAssertion();
-      revert(originalSelector);
+      revert(originalSelector, selector);
     },
-    [revert, originalSelector]
+    [revert, originalSelector, selector]
   );
 
   return (

--- a/web/src/providers/TestDefinition/TestDefinition.provider.tsx
+++ b/web/src/providers/TestDefinition/TestDefinition.provider.tsx
@@ -15,7 +15,7 @@ import {TTestDefinitionEntry} from 'types/TestDefinition.types';
 import useTestDefinitionCrud from './hooks/useTestDefinitionCrud';
 
 interface IContext {
-  revert: (originalSelector: string) => void;
+  revert: (originalSelector: string, selector: string) => void;
   add(testDefinition: TTestDefinitionEntry): void;
   update(selector: string, testDefinition: TTestDefinitionEntry): void;
   remove(selector: string): void;
@@ -62,15 +62,16 @@ const TestDefinitionProvider: React.FC<IProps> = ({children, testId, runId}) => 
   const {run} = useTestRun();
   const assertionResults = useAppSelector(state => TestDefinitionSelectors.selectAssertionResults(state));
   const definitionList = useAppSelector(state => TestDefinitionSelectors.selectDefinitionList(state));
+  const isDraftMode = useAppSelector(state => TestDefinitionSelectors.selectIsDraftMode(state));
   const isLoading = useAppSelector(state => TestDefinitionSelectors.selectIsLoading(state));
   const isInitialized = useAppSelector(state => TestDefinitionSelectors.selectIsInitialized(state));
   const {data: test} = useGetTestByIdQuery({testId});
 
-  const {add, cancel, publish, runTest, remove, dryRun, update, isDraftMode, init, reset, revert} =
-    useTestDefinitionCrud({
-      testId,
-      runId,
-    });
+  const {add, cancel, publish, runTest, remove, dryRun, update, init, reset, revert} = useTestDefinitionCrud({
+    testId,
+    runId,
+    isDraftMode,
+  });
 
   useEffect(() => {
     if (run.state === 'FINISHED') init(run.result);

--- a/web/src/providers/TestDefinition/hooks/useDraftMode.ts
+++ b/web/src/providers/TestDefinition/hooks/useDraftMode.ts
@@ -1,8 +1,6 @@
-import {useEffect, useState} from 'react';
+import {useEffect} from 'react';
 
-const useDraftMode = (isDefaultDraftMode = false) => {
-  const [isDraftMode, setIsDraftMode] = useState(isDefaultDraftMode);
-
+const useDraftMode = (isDraftMode: boolean) => {
   useEffect(() => {
     if (isDraftMode) window.onbeforeunload = () => true;
     else window.onbeforeunload = null;
@@ -13,8 +11,6 @@ const useDraftMode = (isDefaultDraftMode = false) => {
       window.onbeforeunload = null;
     };
   }, []);
-
-  return {isDraftMode, setIsDraftMode};
 };
 
 export default useDraftMode;

--- a/web/src/providers/TestDefinition/hooks/useTestDefinitionCrud.ts
+++ b/web/src/providers/TestDefinition/hooks/useTestDefinitionCrud.ts
@@ -21,16 +21,17 @@ import TestRunGateway from '../../../gateways/TestRun.gateway';
 interface IProps {
   runId: string;
   testId: string;
+  isDraftMode: boolean;
 }
 
-const useTestDefinitionCrud = ({runId, testId}: IProps) => {
-  const {isDraftMode, setIsDraftMode} = useDraftMode();
+const useTestDefinitionCrud = ({runId, testId, isDraftMode}: IProps) => {
+  useDraftMode(isDraftMode);
   const dispatch = useAppDispatch();
   const navigate = useNavigate();
 
   const revert = useCallback(
-    (originalSelector: string) => {
-      return dispatch(revertDefinition({originalSelector}));
+    (originalSelector: string, selector: string) => {
+      return dispatch(revertDefinition({originalSelector, selector}));
     },
     [dispatch]
   );
@@ -44,12 +45,11 @@ const useTestDefinitionCrud = ({runId, testId}: IProps) => {
 
   const publish = useCallback(async () => {
     const {id} = await dispatch(TestDefinitionActions.publish({testId, runId})).unwrap();
-    setIsDraftMode(false);
     dispatch(clearAffectedSpans());
     dispatch(setSelectedAssertion(''));
 
     navigate(`/test/${testId}/run/${id}`);
-  }, [dispatch, navigate, runId, setIsDraftMode, testId]);
+  }, [dispatch, navigate, runId, testId]);
 
   const runTest = useCallback(async () => {
     const {id} = await dispatch(TestRunGateway.runTest(testId)).unwrap();
@@ -59,32 +59,28 @@ const useTestDefinitionCrud = ({runId, testId}: IProps) => {
   }, [dispatch, navigate, testId]);
 
   const cancel = useCallback(() => {
-    setIsDraftMode(false);
     dispatch(resetDefinitionList());
-  }, [dispatch, setIsDraftMode]);
+  }, [dispatch]);
 
   const add = useCallback(
     async (definition: TTestDefinitionEntry) => {
       dispatch(addDefinition({definition}));
-      setIsDraftMode(true);
     },
-    [dispatch, setIsDraftMode]
+    [dispatch]
   );
 
   const update = useCallback(
     async (selector: string, definition: TTestDefinitionEntry) => {
       dispatch(updateDefinition({definition, selector}));
-      setIsDraftMode(true);
     },
-    [dispatch, setIsDraftMode]
+    [dispatch]
   );
 
   const remove = useCallback(
     async (selector: string) => {
       dispatch(removeDefinition({selector}));
-      setIsDraftMode(true);
     },
-    [dispatch, setIsDraftMode]
+    [dispatch]
   );
 
   const init = useCallback(
@@ -98,7 +94,7 @@ const useTestDefinitionCrud = ({runId, testId}: IProps) => {
     dispatch(resetAction());
   }, [dispatch]);
 
-  return {revert, init, reset, add, remove, update, publish, runTest, cancel, dryRun, isDraftMode};
+  return {revert, init, reset, add, remove, update, publish, runTest, cancel, dryRun};
 };
 
 export default useTestDefinitionCrud;

--- a/web/src/redux/slices/TestDefinition.slice.ts
+++ b/web/src/redux/slices/TestDefinition.slice.ts
@@ -1,21 +1,7 @@
-import {CaseReducer, createSlice, PayloadAction} from '@reduxjs/toolkit';
-
+import {createSlice} from '@reduxjs/toolkit';
 import {TAssertionResults} from 'types/Assertion.types';
-import {TSpan} from 'types/Span.types';
-import {TTestDefinitionEntry} from 'types/TestDefinition.types';
-import TestDefinitionActions, {TChange} from '../actions/TestDefinition.actions';
-
-interface ITestDefinitionState {
-  initialDefinitionList: TTestDefinitionEntry[];
-  definitionList: TTestDefinitionEntry[];
-  assertionResults?: TAssertionResults;
-  changeList: TChange[];
-  isLoading: boolean;
-  isInitialized: boolean;
-  affectedSpans: string[];
-  selectedAssertion: string;
-  selectedSpan?: TSpan;
-}
+import {ITestDefinitionState, TTestDefinitionEntry, TTestDefinitionSliceActions} from 'types/TestDefinition.types';
+import TestDefinitionActions from '../actions/TestDefinition.actions';
 
 export const initialState: ITestDefinitionState = {
   initialDefinitionList: [],
@@ -26,6 +12,7 @@ export const initialState: ITestDefinitionState = {
   affectedSpans: [],
   selectedAssertion: '',
   selectedSpan: undefined,
+  isDraftMode: false,
 };
 
 export const assertionResultsToDefinitionList = (assertionResults: TAssertionResults): TTestDefinitionEntry[] => {
@@ -38,27 +25,7 @@ export const assertionResultsToDefinitionList = (assertionResults: TAssertionRes
   }));
 };
 
-const testDefinitionSlice = createSlice<
-  ITestDefinitionState,
-  {
-    reset: CaseReducer<ITestDefinitionState>;
-    initDefinitionList: CaseReducer<ITestDefinitionState, PayloadAction<{assertionResults: TAssertionResults}>>;
-    addDefinition: CaseReducer<ITestDefinitionState, PayloadAction<{definition: TTestDefinitionEntry}>>;
-    updateDefinition: CaseReducer<
-      ITestDefinitionState,
-      PayloadAction<{definition: TTestDefinitionEntry; selector: string}>
-    >;
-    removeDefinition: CaseReducer<ITestDefinitionState, PayloadAction<{selector: string}>>;
-    revertDefinition: CaseReducer<ITestDefinitionState, PayloadAction<{originalSelector: string}>>;
-    resetDefinitionList: CaseReducer<ITestDefinitionState>;
-    setAssertionResults: CaseReducer<ITestDefinitionState, PayloadAction<TAssertionResults>>;
-    clearAffectedSpans: CaseReducer<ITestDefinitionState>;
-    setAffectedSpans: CaseReducer<ITestDefinitionState, PayloadAction<string[]>>;
-    setSelectedAssertion: CaseReducer<ITestDefinitionState, PayloadAction<string>>;
-    setSelectedSpan: CaseReducer<ITestDefinitionState, PayloadAction<TSpan | undefined>>;
-  },
-  'testDefinition'
->({
+const testDefinitionSlice = createSlice<ITestDefinitionState, TTestDefinitionSliceActions, 'testDefinition'>({
   name: 'testDefinition',
   initialState,
   reducers: {
@@ -71,22 +38,14 @@ const testDefinitionSlice = createSlice<
       state.initialDefinitionList = definitionList;
       state.definitionList = definitionList;
       state.isInitialized = true;
+      state.isDraftMode = false;
     },
     addDefinition(state, {payload: {definition}}) {
+      state.isDraftMode = true;
       state.definitionList = [...state.definitionList, definition];
     },
-    revertDefinition(state, {payload: {originalSelector}}) {
-      const initialDefinition = state.initialDefinitionList.find(
-        definition => definition.originalSelector === originalSelector
-      );
-
-      state.definitionList = initialDefinition
-        ? state.definitionList.map(definition =>
-            definition.originalSelector === originalSelector ? initialDefinition : definition
-          )
-        : state.definitionList.filter(definition => definition.originalSelector === originalSelector);
-    },
     updateDefinition(state, {payload: {definition, selector}}) {
+      state.isDraftMode = true;
       state.definitionList = state.definitionList.map(def => {
         if (def.selector === selector)
           return {
@@ -98,6 +57,7 @@ const testDefinitionSlice = createSlice<
       });
     },
     removeDefinition(state, {payload: {selector}}) {
+      state.isDraftMode = true;
       state.definitionList = state.definitionList.map(def => {
         if (def.selector === selector)
           return {
@@ -109,7 +69,23 @@ const testDefinitionSlice = createSlice<
         return def;
       });
     },
+    revertDefinition(state, {payload: {originalSelector, selector}}) {
+      const initialDefinition = state.initialDefinitionList.find(
+        definition => definition.originalSelector === originalSelector
+      );
+
+      state.definitionList = initialDefinition
+        ? state.definitionList.map(definition =>
+            definition.originalSelector === originalSelector ? initialDefinition : definition
+          )
+        : state.definitionList.filter(definition => definition.selector !== selector);
+
+      const pendingChanges = state.definitionList.filter(({isDraft}) => isDraft).length;
+
+      if (!pendingChanges) state.isDraftMode = false;
+    },
     resetDefinitionList(state) {
+      state.isDraftMode = false;
       state.definitionList = state.initialDefinitionList;
     },
     setAssertionResults(state, {payload}) {
@@ -135,6 +111,9 @@ const testDefinitionSlice = createSlice<
     builder
       .addCase(TestDefinitionActions.dryRun.fulfilled, (state, {payload}) => {
         state.assertionResults = payload;
+      })
+      .addCase(TestDefinitionActions.publish.pending, state => {
+        state.isDraftMode = false;
       })
       .addCase(TestDefinitionActions.publish.fulfilled, (state, {payload: {result}}) => {
         const definitionList = assertionResultsToDefinitionList(result);

--- a/web/src/redux/slices/__tests__/TestDefinition.slice.test.ts
+++ b/web/src/redux/slices/__tests__/TestDefinition.slice.test.ts
@@ -86,6 +86,7 @@ describe('TestDefinitionReducer', () => {
       expect(Reducer(state, addDefinition({definition}))).toEqual({
         ...initialState,
         definitionList: [...definitionList, definition],
+        isDraftMode: true,
       });
     });
 
@@ -98,12 +99,17 @@ describe('TestDefinitionReducer', () => {
         })
       );
 
-      expect(result.definitionList[0]).toEqual(definition);
+      expect(result.definitionList[0]).toEqual({...definition, originalSelector: undefined});
       expect(result).toEqual({
         ...initialState,
-        definitionList: [definition, ...definitionList.slice(1, definitionList.length)],
+        definitionList: [
+          {...definition, originalSelector: undefined},
+          ...definitionList.slice(1, definitionList.length),
+        ],
+        isDraftMode: true,
       });
     });
+
     it('should handle the revert definition action', () => {
       const initialSelector = 'span[http.status_code] = "204"]';
       const result = Reducer(
@@ -118,6 +124,7 @@ describe('TestDefinitionReducer', () => {
         },
         revertDefinition({
           originalSelector: definitionSelector,
+          selector: '',
         })
       );
 
@@ -138,6 +145,7 @@ describe('TestDefinitionReducer', () => {
           {...definitionList[0], isDraft: true, isDeleted: true},
           ...definitionList.slice(1, definitionList.length),
         ],
+        isDraftMode: true,
       });
     });
   });
@@ -179,5 +187,13 @@ describe('TestDefinitionReducer', () => {
       expect(result.assertionResults).toEqual(run.result);
       expect(result.initialDefinitionList).toEqual(assertionResultsToDefinitionList(run.result));
     });
+  });
+
+  it('should handle on pending publish', () => {
+    const result = Reducer(initialState, {
+      type: 'testDefinition/publish/pending',
+    });
+
+    expect(result.isDraftMode).toBeFalsy();
   });
 });

--- a/web/src/selectors/TestDefinition.selectors.ts
+++ b/web/src/selectors/TestDefinition.selectors.ts
@@ -59,10 +59,17 @@ const TestDefinitionSelectors = () => ({
   selectDefinitionBySelector: createSelector(selectDefinitionList, selectorSelector, (definitionList, selector) =>
     definitionList.find(def => def.selector === selector)
   ),
-  selectAffectedSpans: createSelector(stateSelector, ({affectedSpans}) => affectedSpans),
+  selectAffectedSpans: createSelector(stateSelector, ({affectedSpans, assertionResults, selectedAssertion}) => {
+    const foundAssertion = assertionResults?.resultList.find(({selector}) => selector === selectedAssertion);
+
+    if (!foundAssertion) return [];
+
+    return affectedSpans;
+  }),
   selectSelectedAssertion: createSelector(stateSelector, ({selectedAssertion}) => selectedAssertion),
   selectAssertionResultsBySpan,
   selectSelectedSpan: createSelector(stateSelector, ({selectedSpan}) => selectedSpan),
+  selectIsDraftMode: createSelector(stateSelector, ({isDraftMode}) => isDraftMode),
 });
 
 export default TestDefinitionSelectors();

--- a/web/src/services/__tests__/Selector.service.test.ts
+++ b/web/src/services/__tests__/Selector.service.test.ts
@@ -33,7 +33,7 @@ describe('AssertionService', () => {
           value: 'http',
         },
       ]);
-      expect(result).toStrictEqual(`span[service.name = "pokeshop" tracetest.span.type contains "http"]`);
+      expect(result).toStrictEqual(`span[service.name = "pokeshop"  tracetest.span.type contains "http"]`);
     });
   });
 

--- a/web/src/types/TestDefinition.types.ts
+++ b/web/src/types/TestDefinition.types.ts
@@ -1,5 +1,8 @@
-import {TAssertion} from './Assertion.types';
+import {CaseReducer, PayloadAction} from '@reduxjs/toolkit';
+import {TChange} from '../redux/actions/TestDefinition.actions';
+import {TAssertion, TAssertionResults} from './Assertion.types';
 import {Model, TTestSchemas} from './Common.types';
+import {TSpan} from './Span.types';
 
 export type TRawTestDefinition = TTestSchemas['TestDefinition'];
 
@@ -23,3 +26,34 @@ export type TTestDefinition = Model<
     definitions?: TRawTestDefinition;
   }
 >;
+
+export interface ITestDefinitionState {
+  initialDefinitionList: TTestDefinitionEntry[];
+  definitionList: TTestDefinitionEntry[];
+  assertionResults?: TAssertionResults;
+  changeList: TChange[];
+  isLoading: boolean;
+  isInitialized: boolean;
+  affectedSpans: string[];
+  selectedAssertion: string;
+  selectedSpan?: TSpan;
+  isDraftMode: boolean;
+}
+
+export type TTestDefinitionSliceActions = {
+  reset: CaseReducer<ITestDefinitionState>;
+  initDefinitionList: CaseReducer<ITestDefinitionState, PayloadAction<{assertionResults: TAssertionResults}>>;
+  addDefinition: CaseReducer<ITestDefinitionState, PayloadAction<{definition: TTestDefinitionEntry}>>;
+  updateDefinition: CaseReducer<
+    ITestDefinitionState,
+    PayloadAction<{definition: TTestDefinitionEntry; selector: string}>
+  >;
+  removeDefinition: CaseReducer<ITestDefinitionState, PayloadAction<{selector: string}>>;
+  revertDefinition: CaseReducer<ITestDefinitionState, PayloadAction<{originalSelector: string; selector: string}>>;
+  resetDefinitionList: CaseReducer<ITestDefinitionState>;
+  setAssertionResults: CaseReducer<ITestDefinitionState, PayloadAction<TAssertionResults>>;
+  clearAffectedSpans: CaseReducer<ITestDefinitionState>;
+  setAffectedSpans: CaseReducer<ITestDefinitionState, PayloadAction<string[]>>;
+  setSelectedAssertion: CaseReducer<ITestDefinitionState, PayloadAction<string>>;
+  setSelectedSpan: CaseReducer<ITestDefinitionState, PayloadAction<TSpan | undefined>>;
+};


### PR DESCRIPTION
This PR fixes the issues we had with the edit mode state. things like:
1. Deleting all of the assertions when reverting a newly created one.
2. Not resetting the edit state after there aren't any pending changes.
3. Affected spans should only be present when the assertion exists.

## Changes

- Moving the `isDraftMode` flag to the slice.
- Updating the affected spans selector to try to find the selected assertion first.
- Adding a validation for pending changes to remove the draft status.

## Fixes

- https://github.com/kubeshop/tracetest/issues/668

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [x] added a test
