### PR TITLE
Fix event propagation when removing selector

### DIFF
--- a/web/src/components/MultiSelectInput/MultiSelectInputTag.tsx
+++ b/web/src/components/MultiSelectInput/MultiSelectInputTag.tsx
@@ -15,10 +15,10 @@ const MultiSelectInputTag: React.FC<IProps> = ({value, entryListCount, onDeselec
     <S.SelectedTag
       {...props}
       closable={isLast}
-      onClose={event => {
-        event.stopPropagation();
-        event.preventDefault();
-
+      onMouseDown={e => {
+        if (isLast) e.stopPropagation();
+      }}
+      onClose={() => {
         onDeselect(Number(entryNumber));
       }}
       isLast={isLast}


### PR DESCRIPTION
This PR fixes an event propagation when removing a value from the `MultiSelectInput` component. 
With this change we want to handle the following use case: When you click the X to delete one filter it puts you in the `add a new filter` mode and prompts you for an attribute. We want to avoid the add a new filter mode in this situation.

## Changes

- Antd lib uses the [rc-select](https://github.com/react-component/select) component. This component has an `onMouseDown` [event that was firing the function to open the options panel](https://github.com/react-component/select/blob/master/src/Selector/MultipleSelector.tsx#L127). With this change we are stopping the event propagation when doing a mouseDown in the close icon.

## Fixes

- #552 

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Now

https://user-images.githubusercontent.com/3879892/172238887-4b654a14-d512-4692-a257-9ae049c2b30d.mov

## Before

https://user-images.githubusercontent.com/3879892/172238959-835c058c-3458-4f9e-8d6e-cda9e64b1ab6.mov