### PR TITLE
feat: save junit file from cli

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -293,7 +293,6 @@ paths:
             application/xml:
               schema:
                 type: string
-                format: binary
 
 
   /tests/{testId}/run/{runId}:

--- a/cli/cmd/test_run_cmd.go
+++ b/cli/cmd/test_run_cmd.go
@@ -10,6 +10,7 @@ import (
 
 var runTestFileDefinition string
 var runTestWaitForResult bool
+var runTestJUnit string
 
 var testRunCmd = &cobra.Command{
 	Use:    "run",
@@ -24,6 +25,7 @@ var testRunCmd = &cobra.Command{
 		actionArgs := actions.RunTestConfig{
 			DefinitionFile: runTestFileDefinition,
 			WaitForResult:  runTestWaitForResult,
+			JUnit:          runTestJUnit,
 		}
 
 		err := runTestAction.Run(ctx, actionArgs)
@@ -38,5 +40,6 @@ var testRunCmd = &cobra.Command{
 func init() {
 	testRunCmd.PersistentFlags().StringVarP(&runTestFileDefinition, "definition", "d", "", "--definition <definition-file.yml>")
 	testRunCmd.PersistentFlags().BoolVarP(&runTestWaitForResult, "wait-for-result", "w", false, "")
+	testRunCmd.PersistentFlags().StringVarP(&runTestJUnit, "junit", "j", "", "--junit <junit-output.xml>")
 	testCmd.AddCommand(testRunCmd)
 }

--- a/cli/cmd/test_run_cmd_test.go
+++ b/cli/cmd/test_run_cmd_test.go
@@ -80,6 +80,24 @@ func TestRunTestCmdWhenEditingTest(t *testing.T) {
 	assert.Equal(t, *outputObject.Test.Id, *updateOutputObject.Test.Id)
 }
 
+func TestRunTestJUnitCmdValidation(t *testing.T) {
+	cli := e2e.NewCLI()
+
+	definitionFile := "test_run_cmd_test_definition.yml"
+	err := copyFile("../testdata/definitions/valid_http_test_definition.yml", definitionFile)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		err := deleteFile(definitionFile)
+		require.NoError(t, err)
+	})
+
+	testRunCommand := cli.NewCommand("test", "run", "--config", "e2e/config.yml", "--definition", definitionFile, "--junit", "junit_output.xml")
+	output, err := testRunCommand.Run()
+	assert.NoError(t, err)
+	assert.NotEmpty(t, output)
+	assert.Contains(t, output, "--junit option requires --wait-for-result")
+}
+
 func copyFile(source string, destination string) error {
 	input, err := os.ReadFile(source)
 	if err != nil {

--- a/cli/openapi/api_api.go
+++ b/cli/openapi/api_api.go
@@ -226,6 +226,102 @@ func (a *ApiApiService) DeleteTestExecute(r ApiDeleteTestRequest) (*http.Respons
 	return localVarHTTPResponse, nil
 }
 
+type ApiDeleteTestRunRequest struct {
+	ctx        context.Context
+	ApiService *ApiApiService
+	testId     string
+	runId      string
+}
+
+func (r ApiDeleteTestRunRequest) Execute() (*http.Response, error) {
+	return r.ApiService.DeleteTestRunExecute(r)
+}
+
+/*
+DeleteTestRun delete a test run
+
+delete a test run
+
+ @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+ @param testId
+ @param runId
+ @return ApiDeleteTestRunRequest
+*/
+func (a *ApiApiService) DeleteTestRun(ctx context.Context, testId string, runId string) ApiDeleteTestRunRequest {
+	return ApiDeleteTestRunRequest{
+		ApiService: a,
+		ctx:        ctx,
+		testId:     testId,
+		runId:      runId,
+	}
+}
+
+// Execute executes the request
+func (a *ApiApiService) DeleteTestRunExecute(r ApiDeleteTestRunRequest) (*http.Response, error) {
+	var (
+		localVarHTTPMethod = http.MethodDelete
+		localVarPostBody   interface{}
+		formFiles          []formFile
+	)
+
+	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "ApiApiService.DeleteTestRun")
+	if err != nil {
+		return nil, &GenericOpenAPIError{error: err.Error()}
+	}
+
+	localVarPath := localBasePath + "/tests/{testId}/run/{runId}"
+	localVarPath = strings.Replace(localVarPath, "{"+"testId"+"}", url.PathEscape(parameterToString(r.testId, "")), -1)
+	localVarPath = strings.Replace(localVarPath, "{"+"runId"+"}", url.PathEscape(parameterToString(r.runId, "")), -1)
+
+	localVarHeaderParams := make(map[string]string)
+	localVarQueryParams := url.Values{}
+	localVarFormParams := url.Values{}
+
+	// to determine the Content-Type header
+	localVarHTTPContentTypes := []string{}
+
+	// set Content-Type header
+	localVarHTTPContentType := selectHeaderContentType(localVarHTTPContentTypes)
+	if localVarHTTPContentType != "" {
+		localVarHeaderParams["Content-Type"] = localVarHTTPContentType
+	}
+
+	// to determine the Accept header
+	localVarHTTPHeaderAccepts := []string{}
+
+	// set Accept header
+	localVarHTTPHeaderAccept := selectHeaderAccept(localVarHTTPHeaderAccepts)
+	if localVarHTTPHeaderAccept != "" {
+		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
+	}
+	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, formFiles)
+	if err != nil {
+		return nil, err
+	}
+
+	localVarHTTPResponse, err := a.client.callAPI(req)
+	if err != nil || localVarHTTPResponse == nil {
+		return localVarHTTPResponse, err
+	}
+
+	localVarBody, err := ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarHTTPResponse.Body.Close()
+	localVarHTTPResponse.Body = ioutil.NopCloser(bytes.NewBuffer(localVarBody))
+	if err != nil {
+		return localVarHTTPResponse, err
+	}
+
+	if localVarHTTPResponse.StatusCode >= 300 {
+		newErr := &GenericOpenAPIError{
+			body:  localVarBody,
+			error: localVarHTTPResponse.Status,
+		}
+		return localVarHTTPResponse, newErr
+	}
+
+	return localVarHTTPResponse, nil
+}
+
 type ApiDryRunAssertionRequest struct {
 	ctx            context.Context
 	ApiService     *ApiApiService
@@ -304,6 +400,113 @@ func (a *ApiApiService) DryRunAssertionExecute(r ApiDryRunAssertionRequest) (*As
 	}
 	// body params
 	localVarPostBody = r.testDefinition
+	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, formFiles)
+	if err != nil {
+		return localVarReturnValue, nil, err
+	}
+
+	localVarHTTPResponse, err := a.client.callAPI(req)
+	if err != nil || localVarHTTPResponse == nil {
+		return localVarReturnValue, localVarHTTPResponse, err
+	}
+
+	localVarBody, err := ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarHTTPResponse.Body.Close()
+	localVarHTTPResponse.Body = ioutil.NopCloser(bytes.NewBuffer(localVarBody))
+	if err != nil {
+		return localVarReturnValue, localVarHTTPResponse, err
+	}
+
+	if localVarHTTPResponse.StatusCode >= 300 {
+		newErr := &GenericOpenAPIError{
+			body:  localVarBody,
+			error: localVarHTTPResponse.Status,
+		}
+		return localVarReturnValue, localVarHTTPResponse, newErr
+	}
+
+	err = a.client.decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+	if err != nil {
+		newErr := &GenericOpenAPIError{
+			body:  localVarBody,
+			error: err.Error(),
+		}
+		return localVarReturnValue, localVarHTTPResponse, newErr
+	}
+
+	return localVarReturnValue, localVarHTTPResponse, nil
+}
+
+type ApiGetRunResultJUnitRequest struct {
+	ctx        context.Context
+	ApiService *ApiApiService
+	testId     string
+	runId      string
+}
+
+func (r ApiGetRunResultJUnitRequest) Execute() (string, *http.Response, error) {
+	return r.ApiService.GetRunResultJUnitExecute(r)
+}
+
+/*
+GetRunResultJUnit get test run results in JUnit xml format
+
+get test run results in JUnit xml format
+
+ @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+ @param testId
+ @param runId
+ @return ApiGetRunResultJUnitRequest
+*/
+func (a *ApiApiService) GetRunResultJUnit(ctx context.Context, testId string, runId string) ApiGetRunResultJUnitRequest {
+	return ApiGetRunResultJUnitRequest{
+		ApiService: a,
+		ctx:        ctx,
+		testId:     testId,
+		runId:      runId,
+	}
+}
+
+// Execute executes the request
+//  @return string
+func (a *ApiApiService) GetRunResultJUnitExecute(r ApiGetRunResultJUnitRequest) (string, *http.Response, error) {
+	var (
+		localVarHTTPMethod  = http.MethodGet
+		localVarPostBody    interface{}
+		formFiles           []formFile
+		localVarReturnValue string
+	)
+
+	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "ApiApiService.GetRunResultJUnit")
+	if err != nil {
+		return localVarReturnValue, nil, &GenericOpenAPIError{error: err.Error()}
+	}
+
+	localVarPath := localBasePath + "/tests/{testId}/run/{runId}/junit.xml"
+	localVarPath = strings.Replace(localVarPath, "{"+"testId"+"}", url.PathEscape(parameterToString(r.testId, "")), -1)
+	localVarPath = strings.Replace(localVarPath, "{"+"runId"+"}", url.PathEscape(parameterToString(r.runId, "")), -1)
+
+	localVarHeaderParams := make(map[string]string)
+	localVarQueryParams := url.Values{}
+	localVarFormParams := url.Values{}
+
+	// to determine the Content-Type header
+	localVarHTTPContentTypes := []string{}
+
+	// set Content-Type header
+	localVarHTTPContentType := selectHeaderContentType(localVarHTTPContentTypes)
+	if localVarHTTPContentType != "" {
+		localVarHeaderParams["Content-Type"] = localVarHTTPContentType
+	}
+
+	// to determine the Accept header
+	localVarHTTPHeaderAccepts := []string{"application/xml"}
+
+	// set Accept header
+	localVarHTTPHeaderAccept := selectHeaderAccept(localVarHTTPHeaderAccepts)
+	if localVarHTTPHeaderAccept != "" {
+		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
+	}
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, formFiles)
 	if err != nil {
 		return localVarReturnValue, nil, err

--- a/server/junit/junit.go
+++ b/server/junit/junit.go
@@ -3,6 +3,7 @@ package junit
 import (
 	"encoding/xml"
 	"errors"
+	"fmt"
 
 	"github.com/kubeshop/tracetest/server/assertions/comparator"
 	"github.com/kubeshop/tracetest/server/model"
@@ -14,6 +15,9 @@ func FromRunResult(test model.Test, run model.Run) ([]byte, error) {
 
 	var testTotals, testFails, testErrs int
 
+	if run.Results == nil {
+		return nil, fmt.Errorf("run has no results")
+	}
 	run.Results.Results.Map(func(selector model.SpanQuery, results []model.AssertionResult) {
 		checks := []check{}
 		var total, fails, errs int


### PR DESCRIPTION
This PR adds an option in the CLI to save a test run result in JUnit format in a local file. It must be run with `--wait-for-result` so it has results to check.

## Changes

- Add new option to `test run`

## Fixes

- nil pointer error in server when run has no results (i.e. run ended with error)

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [x] added a test
