### PR TITLE
🐛 656 multiple minor fixes

### DIFF
--- a/web/src/components/AssertionCardList/AssertionCardList.styled.ts
+++ b/web/src/components/AssertionCardList/AssertionCardList.styled.ts
@@ -18,4 +18,7 @@ export const EmptyStateContainer = styled.div`
 
 export const EmptyStateIcon = styled.img.attrs({
   src: noResultsIcon,
-})``;
+})`
+  width: 90px;
+  height: auto;
+`;

--- a/web/src/components/AssertionCardList/AssertionCardList.tsx
+++ b/web/src/components/AssertionCardList/AssertionCardList.tsx
@@ -58,7 +58,7 @@ const AssertionCardList: React.FC<TAssertionCardListProps> = ({assertionResults:
       ) : (
         <S.EmptyStateContainer data-cy="empty-assertion-card-list">
           <S.EmptyStateIcon />
-          <Typography.Text disabled>No Data</Typography.Text>
+          <Typography.Text disabled>Add an Assertion to See the Result</Typography.Text>
         </S.EmptyStateContainer>
       )}
     </S.AssertionCardList>

--- a/web/src/components/FailedTrace/FailedTrace.tsx
+++ b/web/src/components/FailedTrace/FailedTrace.tsx
@@ -7,12 +7,19 @@ import * as S from './FailedTrace.styled';
 
 interface IFailedTraceProps {
   isDisplayingError: boolean;
+  run: TTestRun;
   testId: string;
   onEdit(): void;
   onRunTest(result: TTestRun): void;
 }
 
-const FailedTrace: React.FC<IFailedTraceProps> = ({onRunTest, onEdit, testId, isDisplayingError}) => {
+const FailedTrace: React.FC<IFailedTraceProps> = ({
+  onRunTest,
+  onEdit,
+  testId,
+  isDisplayingError,
+  run: {lastErrorState},
+}) => {
   const [runNewTest] = useRunTestMutation();
 
   const onReRun = useCallback(async () => {
@@ -26,7 +33,7 @@ const FailedTrace: React.FC<IFailedTraceProps> = ({onRunTest, onEdit, testId, is
         <S.FailedIcon />
         <S.TextContainer>
           <Typography.Title level={3}>Test Run Failed</Typography.Title>
-          <Typography.Text type="secondary">Information explaining the state the test failed at.</Typography.Text>
+          <Typography.Text type="secondary">{lastErrorState}</Typography.Text>
           <Typography.Text type="secondary">
             Please let us know about this issue - <a href={GITHUB_ISSUES_URL}>create an issue</a> or contact us via{' '}
             <a href={DISCORD_URL}>Discord</a>.

--- a/web/src/components/FailedTrace/__tests__/FailedTrace.test.tsx
+++ b/web/src/components/FailedTrace/__tests__/FailedTrace.test.tsx
@@ -3,13 +3,20 @@ import {MemoryRouter} from 'react-router-dom';
 import FailedTrace from '../index';
 import {ReduxWrapperProvider} from '../../../redux/ReduxWrapperProvider';
 import TestMock from '../../../models/__mocks__/Test.mock';
+import TestRunMock from '../../../models/__mocks__/TestRun.mock';
 
 test('FailedTrace', () => {
   const test = TestMock.model();
   const {getByText} = render(
     <MemoryRouter>
       <ReduxWrapperProvider>
-        <FailedTrace onRunTest={jest.fn()} testId={test.id} isDisplayingError onEdit={jest.fn()} />
+        <FailedTrace
+          onRunTest={jest.fn()}
+          testId={test.id}
+          isDisplayingError
+          onEdit={jest.fn()}
+          run={TestRunMock.model()}
+        />
       </ReduxWrapperProvider>
     </MemoryRouter>
   );

--- a/web/src/constants/Span.constants.ts
+++ b/web/src/constants/Span.constants.ts
@@ -31,6 +31,7 @@ export const SpanAttributeSections: Record<SemanticGroupNames, Record<string, TV
       Attributes.HTTP_REQUEST_CONTENT_LENGTH,
       Attributes.HTTP_REQUEST_CONTENT_LENGTH_UNCOMPRESSED,
       Attributes.HTTP_USER_AGENT,
+      Attributes.HTTP_REQUEST_HEADER,
     ],
     [SectionNames.response]: [
       Attributes.HTTP_STATUS_CODE,
@@ -38,6 +39,7 @@ export const SpanAttributeSections: Record<SemanticGroupNames, Record<string, TV
       Attributes.TRACETEST_RESPONSE_HEADERS,
       Attributes.HTTP_RESPONSE_CONTENT_LENGTH,
       Attributes.HTTP_RESPONSE_CONTENT_LENGTH_UNCOMPRESSED,
+      Attributes.HTTP_RESPONSE_HEADER,
     ],
   },
   [SemanticGroupNames.Database]: {

--- a/web/src/constants/SpanAttribute.constants.ts
+++ b/web/src/constants/SpanAttribute.constants.ts
@@ -1,18 +1,20 @@
 import {SemanticAttributes, SemanticResourceAttributes} from '@opentelemetry/semantic-conventions';
 
 export const TraceTestAttributes = {
+  NAME: 'name',
+  TRACETEST_SPAN_TYPE: 'tracetest.span.type',
+  TRACETEST_SPAN_DURATION: 'tracetest.span.duration',
+  TRACETEST_RESPONSE_STATUS: 'tracetest.response.status',
   TRACETEST_RESPONSE_BODY: 'tracetest.response.body',
   TRACETEST_RESPONSE_HEADERS: 'tracetest.response.headers',
-  TRACETEST_RESPONSE_STATUS: 'tracetest.response.status',
-  TRACETEST_SPAN_DURATION: 'tracetest.span.duration',
-  TRACETEST_SPAN_TYPE: 'tracetest.span.type',
-  NAME: 'name',
 };
 
 export const Attributes = {
   ...SemanticAttributes,
   ...SemanticResourceAttributes,
   ...TraceTestAttributes,
+  HTTP_REQUEST_HEADER: 'http.request.header.',
+  HTTP_RESPONSE_HEADER: 'http.response.header',
 };
 
 export * from '@opentelemetry/semantic-conventions';

--- a/web/src/pages/Trace/TraceContent.tsx
+++ b/web/src/pages/Trace/TraceContent.tsx
@@ -44,6 +44,7 @@ const TraceContent = () => {
       <FailedTrace
         onRunTest={onRunTest}
         testId={testId}
+        run={run}
         isDisplayingError={isDisplayingError}
         onEdit={() => console.log('onEdit')}
       />

--- a/web/src/services/SpanAttribute.service.ts
+++ b/web/src/services/SpanAttribute.service.ts
@@ -6,15 +6,16 @@ import {
   SelectorAttributesWhiteList,
   SpanAttributeSections,
 } from 'constants/Span.constants';
-import {Attributes} from 'constants/SpanAttribute.constants';
+import {Attributes, TraceTestAttributes} from 'constants/SpanAttribute.constants';
 import {TSpanFlatAttribute} from 'types/Span.types';
 import {isJson} from 'utils/Common';
 
 const flatAttributes = Object.values(Attributes);
+const flatTraceTestAttributes = Object.values(TraceTestAttributes);
 
 const filterAttributeList = (attributeList: TSpanFlatAttribute[], attrKeyList: string[]): TSpanFlatAttribute[] => {
   return attrKeyList.reduce<TSpanFlatAttribute[]>((list, key) => {
-    const foundAttrList = attributeList.filter(attr => attr.key === key);
+    const foundAttrList = attributeList.filter(attr => attr.key.indexOf(key) === 0);
 
     return foundAttrList.length ? list.concat(foundAttrList) : list;
   }, []);
@@ -22,6 +23,18 @@ const filterAttributeList = (attributeList: TSpanFlatAttribute[], attrKeyList: s
 
 const removeFromAttributeList = (attributeList: TSpanFlatAttribute[], attrKeyList: string[]): TSpanFlatAttribute[] =>
   remove(attributeList, attr => !attrKeyList.includes(attr.key));
+
+const getCustomAttributeList = (attributeList: TSpanFlatAttribute[]) => {
+  const traceTestList = filterAttributeList(attributeList, flatTraceTestAttributes);
+
+  const filetedList = attributeList.filter(attr => {
+    const foundAttr = flatAttributes.find(key => attr.key.indexOf(key) === 0);
+
+    return !foundAttr;
+  });
+
+  return traceTestList.concat(filetedList);
+};
 
 const SpanAttributeService = () => ({
   getSpanAttributeSectionsList(
@@ -32,7 +45,7 @@ const SpanAttributeService = () => ({
     const defaultSectionList = [
       {
         section: SectionNames.custom,
-        attributeList: attributeList.filter(attr => !flatAttributes.includes(attr.key)),
+        attributeList: getCustomAttributeList(attributeList),
       },
       {
         section: SectionNames.all,
@@ -56,7 +69,7 @@ const SpanAttributeService = () => ({
     const duplicatedFiltered = removeFromAttributeList(attributeList, currentSelectorList);
     const whiteListFiltered = filterAttributeList(duplicatedFiltered, SelectorAttributesWhiteList);
     const blackListFiltered = removeFromAttributeList(whiteListFiltered, SelectorAttributesBlackList);
-    const customList = attributeList.filter(attr => !flatAttributes.includes(attr.key));
+    const customList = getCustomAttributeList(attributeList);
 
     const parsedList = blackListFiltered.concat(customList).filter(attr => !isJson(attr.value) && !isEmpty(attr));
 


### PR DESCRIPTION
This PR updates the empty state styling for assertions, updates the custom attributes to display better data and adds the `lastErrorState` to the failed trace component.

## Changes

- No assertions state style update
- Last error state added to the failed trace component.
- Updating the custom attribute tab 

## Fixes

- https://github.com/kubeshop/tracetest/issues/656

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [x] added a test
