### PR TITLE
fix: map correct error type for SpanAssertionResult.CompareErr

### DIFF
--- a/server/model/json.go
+++ b/server/model/json.go
@@ -41,7 +41,13 @@ func (sar *SpanAssertionResult) UnmarshalJSON(data []byte) error {
 
 	sar.SpanID = sid
 	sar.ObservedValue = aux.ObservedValue
-	sar.CompareErr = stringToErr(aux.CompareErr)
+	if err := stringToErr(aux.CompareErr); err != nil {
+		if err.Error() == comparator.ErrNoMatch.Error() {
+			err = comparator.ErrNoMatch
+		}
+
+		sar.CompareErr = err
+	}
 
 	return nil
 }


### PR DESCRIPTION
This PR adds a check when unmarshalling `SpanAsseritonResult` so it can use the correc `comparator.ErrNoMatch` type when the original marshaled error was that.

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
