### PR TITLE
use last dragged height when reopening the drawer

### DIFF
--- a/web/src/components/ResizableDrawer/useReferenceMemo.tsx
+++ b/web/src/components/ResizableDrawer/useReferenceMemo.tsx
@@ -5,6 +5,8 @@ export function useReferenceMemo(visiblePortion: number) {
   return useMemo<Record<DrawerState, number>>(() => {
     return {
       CLOSE: visiblePortion,
+      // value not used
+      RESIZING: 0,
       // used when the page initially loads
       INITIAL: window.outerHeight * 0.2,
       // used when user open the assertion block form


### PR DESCRIPTION
This PR makes the drawer open using  to the previous dragged height

## Changes

- adds another state to DrawerState called RESIZING
- keeps tracks of the lastClosedHeight
- when lastClosedHeight exists we use it instead of the default OPEN height

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
