### PR TITLE
feat: GA Beacon for new server installs

### DIFF
--- a/server/analytics/analytics_test.go
+++ b/server/analytics/analytics_test.go
@@ -8,16 +8,19 @@ import (
 )
 
 func TestReadyness(t *testing.T) {
-	analytics.Init(false, "test", "1.0")
+	analytics.Init(false, "serverID", "test", "1.0")
 	assert.True(t, analytics.Ready())
 
-	analytics.Init(true, "test", "1.0")
+	analytics.Init(true, "serverID", "test", "1.0")
 	assert.True(t, analytics.Ready())
 
-	analytics.Init(true, "", "1.0")
+	analytics.Init(true, "serverID", "", "1.0")
 	assert.False(t, analytics.Ready())
 
-	analytics.Init(true, "test", "")
+	analytics.Init(true, "serverID", "test", "")
+	assert.False(t, analytics.Ready())
+
+	analytics.Init(true, "", "test", "1.0")
 	assert.False(t, analytics.Ready())
 
 }

--- a/server/app/app.go
+++ b/server/app/app.go
@@ -63,9 +63,22 @@ func spaHandler(staticPath, indexPath string, tplVars map[string]string) http.Ha
 
 func (a *App) Start() error {
 	fmt.Println("Starting tracetest", Version)
-	err := analytics.Init(a.config.GA.Enabled, "tracetest", Version)
+
+	serverID, isNewInstall, err := a.db.ServerID()
 	if err != nil {
 		return err
+	}
+
+	err = analytics.Init(a.config.GA.Enabled, serverID, "tracetest", Version)
+	if err != nil {
+		return err
+	}
+
+	if isNewInstall {
+		err = analytics.CreateAndSendEvent("install_server", "beacon")
+		if err != nil {
+			return err
+		}
 	}
 
 	ex, err := executor.New()

--- a/server/migrations/6_server_id.down.sql
+++ b/server/migrations/6_server_id.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE "server";

--- a/server/migrations/6_server_id.up.sql
+++ b/server/migrations/6_server_id.up.sql
@@ -1,0 +1,4 @@
+CREATE TABLE IF NOT EXISTS "server"  (
+	id varchar(100) NOT NULL PRIMARY KEY,
+  created_at timestamp NOT NULL DEFAULT NOW()
+);

--- a/server/model/repository.go
+++ b/server/model/repository.go
@@ -36,5 +36,6 @@ type Repository interface {
 	DefinitionRepository
 	RunRepository
 
+	ServerID() (id string, isNew bool, _ error)
 	Drop() error
 }

--- a/server/testdb/mock.go
+++ b/server/testdb/mock.go
@@ -16,6 +16,11 @@ type MockRepository struct {
 	T mock.TestingT
 }
 
+func (m *MockRepository) ServerID() (string, bool, error) {
+	args := m.Called()
+	return args.String(0), args.Bool(1), args.Error(2)
+}
+
 func (m *MockRepository) CreateTest(_ context.Context, test model.Test) (model.Test, error) {
 	args := m.Called(test)
 	return args.Get(0).(model.Test), args.Error(1)

--- a/server/testdb/postgres.go
+++ b/server/testdb/postgres.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/denisbrodbeck/machineid"
 	"github.com/golang-migrate/migrate/v4"
 	"github.com/golang-migrate/migrate/v4/database/postgres"
 	_ "github.com/golang-migrate/migrate/v4/source/file"
@@ -60,6 +61,47 @@ func (p *postgresDB) ensureLatestMigration() error {
 	}
 
 	return nil
+}
+
+func (td *postgresDB) ServerID() (id string, isNew bool, err error) {
+	isNew = false
+	id = ""
+
+	err = td.db.
+		QueryRow(`SELECT id FROM "server" LIMIT 1`).
+		Scan(&id)
+	if err != nil && err != sql.ErrNoRows {
+		err = fmt.Errorf("could not get serverID from DB: %w", err)
+		return
+	}
+
+	if id != "" {
+		return
+	}
+
+	// no id, let's creat it
+	isNew = true
+	id, err = machineid.ProtectedID("tracetest")
+	if err != nil {
+		err = fmt.Errorf("could not get machineID: %w", err)
+		return
+	}
+
+	stmt, err := td.db.Prepare(`INSERT INTO "server" (id) VALUES ($1)`)
+	if err != nil {
+		err = fmt.Errorf("could not prepare stmt: %w", err)
+		return
+	}
+	defer stmt.Close()
+
+	_, err = stmt.Exec(id)
+	if err != nil {
+		err = fmt.Errorf("could not save serverID into DB: %w", err)
+		return
+	}
+
+	return
+
 }
 
 func (td *postgresDB) Drop() error {


### PR DESCRIPTION
This PR allows for sending new install beacons to GA. It works by creating a `server` table, where we save the generated server id. This guarantees that each install will have only one ID, and we can detect when that id is being created. Thus, we can detect "new installs" and signal them.

## Changes

- Add a new server table
- Move machineID generation to repo so it can be persisted

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
