### PR TITLE
🦟 reverting selected assertion check on selector

### DIFF
--- a/web/src/selectors/TestDefinition.selectors.ts
+++ b/web/src/selectors/TestDefinition.selectors.ts
@@ -59,13 +59,7 @@ const TestDefinitionSelectors = () => ({
   selectDefinitionBySelector: createSelector(selectDefinitionList, selectorSelector, (definitionList, selector) =>
     definitionList.find(def => def.selector === selector)
   ),
-  selectAffectedSpans: createSelector(stateSelector, ({affectedSpans, assertionResults, selectedAssertion}) => {
-    const foundAssertion = assertionResults?.resultList.find(({selector}) => selector === selectedAssertion);
-
-    if (!foundAssertion) return [];
-
-    return affectedSpans;
-  }),
+  selectAffectedSpans: createSelector(stateSelector, ({affectedSpans}) => affectedSpans),
   selectSelectedAssertion: createSelector(stateSelector, ({selectedAssertion}) => selectedAssertion),
   selectAssertionResultsBySpan,
   selectSelectedSpan: createSelector(stateSelector, ({selectedSpan}) => selectedSpan),

--- a/web/src/selectors/TestDefinition.selectors.ts
+++ b/web/src/selectors/TestDefinition.selectors.ts
@@ -59,7 +59,13 @@ const TestDefinitionSelectors = () => ({
   selectDefinitionBySelector: createSelector(selectDefinitionList, selectorSelector, (definitionList, selector) =>
     definitionList.find(def => def.selector === selector)
   ),
-  selectAffectedSpans: createSelector(stateSelector, ({affectedSpans}) => affectedSpans),
+  selectAffectedSpans: createSelector(stateSelector, ({affectedSpans, assertionResults, selectedAssertion}) => {
+    if (!selectedAssertion) return affectedSpans;
+
+    const foundAssertion = assertionResults?.resultList.find(({selector}) => selector === selectedAssertion);
+
+    return !foundAssertion ? [] : affectedSpans;
+  }),
   selectSelectedAssertion: createSelector(stateSelector, ({selectedAssertion}) => selectedAssertion),
   selectAssertionResultsBySpan,
   selectSelectedSpan: createSelector(stateSelector, ({selectedSpan}) => selectedSpan),


### PR DESCRIPTION
This PR fixes a problem we are having when adding a new assertion. The affected spans are not showing up because of the selected assertion check we have doesn't exists in the state.

## Changes

- Validates if the selected assertion has any value

## Fixes

- 

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test


https://www.loom.com/share/bc58e5ff43484879ad3c6a285be7a889