### PR TITLE
feat: http server with custom prefix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,4 +29,5 @@ COPY --from=build-go /go/src/tracetest-server ./
 COPY --from=build-go /go/src/migrations/ ./migrations/
 COPY --from=build-js /app/build /app/html
 EXPOSE 8080/tcp
+EXPOSE 8081/tcp
 ENTRYPOINT ["/app/tracetest-server"]

--- a/server/app/app.go
+++ b/server/app/app.go
@@ -41,7 +41,7 @@ func New(config config.Config, db model.Repository, tracedb tracedb.TraceDB, tra
 }
 
 func spaHandler(staticPath, indexPath string, tplVars map[string]string) http.HandlerFunc {
-	var fileMatcher = regexp.MustCompile(`\.[a-zA-Z]*$`)
+	fileMatcher := regexp.MustCompile(`\.[a-zA-Z]*$`)
 	return func(w http.ResponseWriter, r *http.Request) {
 		if !fileMatcher.MatchString(r.URL.Path) {
 			tpl, err := template.ParseFiles(filepath.Join(staticPath, indexPath))
@@ -106,7 +106,7 @@ func (a *App) Start() error {
 
 	router := openapi.NewRouter(customController)
 
-	router.PathPrefix("/").Handler(
+	router.PathPrefix(fmt.Sprintf("/%s", a.config.Http.Prefix)).Handler(
 		spaHandler(
 			"./html",
 			"index.html",
@@ -130,8 +130,13 @@ func (a *App) Start() error {
 		wsRouter.ListenAndServe(":8081")
 	}()
 
-	log.Printf("HTTP Server started")
-	log.Fatal(http.ListenAndServe(":8080", router))
+	hostPort := ":8080"
+	if a.config.Http.Port > 0 {
+		hostPort = fmt.Sprintf("%s:%d", a.config.Http.Host, a.config.Http.Port)
+	}
+
+	log.Printf("HTTP Server started on %s", hostPort)
+	log.Fatal(http.ListenAndServe(hostPort, router))
 
 	return nil
 }

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -19,6 +19,7 @@ type (
 		GA                      GoogleAnalytics                `mapstructure:"googleAnalytics"`
 		PoolingRetryDelayString string                         `mapstructure:"poolingRetryDelay"`
 		Telemetry               TelemetryConfig                `mapstructure:"telemetry"`
+		Http                    HttpServerConfig               `mapstructure:"http"`
 	}
 
 	GoogleAnalytics struct {
@@ -40,6 +41,12 @@ type (
 	JaegerTelemetryConfig struct {
 		Host string `mapstructure:"host"`
 		Port int    `mapstructure:"port"`
+	}
+
+	HttpServerConfig struct {
+		Host   string `mapstructure:"host"`
+		Port   int    `mapstructure:"port"`
+		Prefix string `mapstructure:"prefix"`
 	}
 )
 


### PR DESCRIPTION
This PR... is a work in progress. Any help is much appreciated.

TODO:

- [ ] Figure out how to inject `<base href="/">` into the page, and rewrite the JS path to be relative to that

## Changes

- Allows to configure the HTTP server, host, port, and prefix

## Fixes

- Expose `tracetest` on a particular prefix, the routing will be done by Traefik.

## Checklist

- [ ] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
