### PR TITLE
fix: context propagation in http tracing controller

### DIFF
--- a/server/http/custom_routes.go
+++ b/server/http/custom_routes.go
@@ -7,7 +7,9 @@ import (
 
 	"github.com/gorilla/mux"
 	"github.com/kubeshop/tracetest/server/openapi"
+	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/propagation"
 	semconv "go.opentelemetry.io/otel/semconv/v1.10.0"
 	"go.opentelemetry.io/otel/trace"
 )
@@ -42,7 +44,8 @@ func (c *customController) Routes() openapi.Routes {
 
 func (c *customController) instrumentRoute(name string, route string, f http.HandlerFunc) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		ctx, span := c.tracer.Start(r.Context(), name)
+		ctx := otel.GetTextMapPropagator().Extract(r.Context(), propagation.HeaderCarrier(r.Header))
+		ctx, span := c.tracer.Start(ctx, name)
 		defer span.End()
 
 		params := make(map[string]interface{}, 0)

--- a/server/tracing/tracer.go
+++ b/server/tracing/tracer.go
@@ -9,6 +9,7 @@ import (
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/exporters/jaeger"
 	"go.opentelemetry.io/otel/exporters/stdout/stdouttrace"
+	"go.opentelemetry.io/otel/propagation"
 	"go.opentelemetry.io/otel/sdk/resource"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	semconv "go.opentelemetry.io/otel/semconv/v1.10.0"
@@ -26,6 +27,9 @@ func ShutdownTracer(ctx context.Context) error {
 }
 
 func NewTracer(ctx context.Context, config config.Config) (trace.Tracer, error) {
+	propagator := propagation.NewCompositeTextMapPropagator(propagation.Baggage{}, propagation.TraceContext{})
+	otel.SetTextMapPropagator(propagator)
+
 	r, err := resource.Merge(
 		resource.Default(),
 		resource.NewWithAttributes(


### PR DESCRIPTION
This PR enables context propagation in our HTTP endpoints

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
