### PR TITLE
feat: correctly expose websockets 

### DIFF
--- a/.github/workflows/deploy-beta.yml
+++ b/.github/workflows/deploy-beta.yml
@@ -90,5 +90,6 @@ jobs:
           --set jaegerConnectionConfig.endpoint="jaeger-query.tracetest.svc.cluster.local:16685" \
           --set ingress.enabled=true \
           --set 'ingress.hosts[0].host=beta.tracetest.io,ingress.hosts[0].paths[0].path=/,ingress.hosts[0].paths[0].pathType=Prefix' \
+          --set ingress.annotations."beta\.cloud\.google\.com/backend-config"=tracetest-beta \
           --set ingress.annotations."networking\.gke\.io/managed-certificates"=tracetest-beta \
           --set ingress.annotations."networking\.gke\.io/v1beta1\.FrontendConfig"="ssl-redirect"

--- a/.github/workflows/deploy-demo.yml
+++ b/.github/workflows/deploy-demo.yml
@@ -92,5 +92,6 @@ jobs:
           --set jaegerConnectionConfig.endpoint="jaeger-query.tracetest.svc.cluster.local:16685" \
           --set ingress.enabled=true \
           --set 'ingress.hosts[0].host=demo.tracetest.io,ingress.hosts[0].paths[0].path=/,ingress.hosts[0].paths[0].pathType=Prefix' \
+          --set ingress.annotations."beta\.cloud\.google\.com/backend-config"=tracetest-beta \
           --set ingress.annotations."networking\.gke\.io/managed-certificates"=tracetest-demo \
           --set ingress.annotations."networking\.gke\.io/v1beta1\.FrontendConfig"="ssl-redirect"

--- a/.github/workflows/deploy-demo.yml
+++ b/.github/workflows/deploy-demo.yml
@@ -92,6 +92,6 @@ jobs:
           --set jaegerConnectionConfig.endpoint="jaeger-query.tracetest.svc.cluster.local:16685" \
           --set ingress.enabled=true \
           --set 'ingress.hosts[0].host=demo.tracetest.io,ingress.hosts[0].paths[0].path=/,ingress.hosts[0].paths[0].pathType=Prefix' \
-          --set ingress.annotations."beta\.cloud\.google\.com/backend-config"=tracetest-beta \
+          --set ingress.annotations."beta\.cloud\.google\.com/backend-config"=tracetest-demo \
           --set ingress.annotations."networking\.gke\.io/managed-certificates"=tracetest-demo \
           --set ingress.annotations."networking\.gke\.io/v1beta1\.FrontendConfig"="ssl-redirect"

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -12,7 +12,6 @@ services:
         target: /app/config.yaml
     ports:
       - 8080:8080
-      - 8081:8081
     depends_on:
       postgres:
         condition: service_healthy

--- a/docs/websocket.md
+++ b/docs/websocket.md
@@ -4,7 +4,7 @@ Tracetest allow you to subscribe to updates of resources using websockets. There
 
 ## Endpoint
  
-You can open a websocket connection by sending a request to port `8081` using the path `/ws`. Example: `ws://localhost:8081/ws`.
+You can open a websocket connection by sending a request the path `/ws`. Example: `ws://localhost:8080/ws`.
 
 ## Messages
 

--- a/server/app/app.go
+++ b/server/app/app.go
@@ -106,6 +106,12 @@ func (a *App) Start() error {
 
 	router := openapi.NewRouter(customController)
 
+	wsRouter := websocket.NewRouter()
+	wsRouter.Add("subscribe", websocket.NewSubscribeCommandExecutor(subscriptionManager))
+	wsRouter.Add("unsubscribe", websocket.NewUnsubscribeCommandExecutor(subscriptionManager))
+
+	router.Handle("/ws", wsRouter.Handler())
+
 	router.PathPrefix("/").Handler(
 		spaHandler(
 			"./html",
@@ -121,14 +127,6 @@ func (a *App) Start() error {
 	if err != nil {
 		return err
 	}
-
-	go func() {
-		wsRouter := websocket.NewRouter()
-		wsRouter.Add("subscribe", websocket.NewSubscribeCommandExecutor(subscriptionManager))
-		wsRouter.Add("unsubscribe", websocket.NewUnsubscribeCommandExecutor(subscriptionManager))
-		log.Printf("WS Server started")
-		wsRouter.ListenAndServe(":8081")
-	}()
 
 	log.Printf("HTTP Server started")
 	log.Fatal(http.ListenAndServe(":8080", router))

--- a/server/http/websocket/subscribe.go
+++ b/server/http/websocket/subscribe.go
@@ -12,19 +12,17 @@ type subscriptionMessage struct {
 	Resource string `json:"resource"`
 }
 
-type SubscribeCommandExecutor struct {
+type subscribeCommandExecutor struct {
 	subscriptionManager *subscription.Manager
 }
 
-func NewSubscribeCommandExecutor(manager *subscription.Manager) SubscribeCommandExecutor {
-	return SubscribeCommandExecutor{
+func NewSubscribeCommandExecutor(manager *subscription.Manager) MessageExecutor {
+	return subscribeCommandExecutor{
 		subscriptionManager: manager,
 	}
 }
 
-var _ MessageExecutor = &SubscribeCommandExecutor{}
-
-func (e SubscribeCommandExecutor) Execute(conn *websocket.Conn, message []byte) {
+func (e subscribeCommandExecutor) Execute(conn *websocket.Conn, message []byte) {
 	msg := subscriptionMessage{}
 	err := json.Unmarshal(message, &msg)
 	if err != nil {
@@ -33,7 +31,7 @@ func (e SubscribeCommandExecutor) Execute(conn *websocket.Conn, message []byte) 
 	}
 
 	if msg.Resource == "" {
-		conn.WriteJSON(ErrorMessage(fmt.Errorf("Resource cannot be empty")))
+		conn.WriteJSON(ErrorMessage(fmt.Errorf("resource cannot be empty")))
 		return
 	}
 

--- a/server/http/websocket/unsubscribe.go
+++ b/server/http/websocket/unsubscribe.go
@@ -13,19 +13,17 @@ type unsubscribeMessage struct {
 	SubscriptionId string `json:"subscriptionId"`
 }
 
-type UnsubscribeCommandExecutor struct {
+type unsubscribeCommandExecutor struct {
 	subscriptionManager *subscription.Manager
 }
 
-func NewUnsubscribeCommandExecutor(manager *subscription.Manager) UnsubscribeCommandExecutor {
-	return UnsubscribeCommandExecutor{
+func NewUnsubscribeCommandExecutor(manager *subscription.Manager) MessageExecutor {
+	return unsubscribeCommandExecutor{
 		subscriptionManager: manager,
 	}
 }
 
-var _ MessageExecutor = &UnsubscribeCommandExecutor{}
-
-func (e UnsubscribeCommandExecutor) Execute(conn *websocket.Conn, message []byte) {
+func (e unsubscribeCommandExecutor) Execute(conn *websocket.Conn, message []byte) {
 	msg := unsubscribeMessage{}
 	err := json.Unmarshal(message, &msg)
 	if err != nil {
@@ -34,7 +32,7 @@ func (e UnsubscribeCommandExecutor) Execute(conn *websocket.Conn, message []byte
 	}
 
 	if msg.Resource == "" {
-		conn.WriteJSON(ErrorMessage(fmt.Errorf("Resource cannot be empty")))
+		conn.WriteJSON(ErrorMessage(fmt.Errorf("resource cannot be empty")))
 		return
 	}
 


### PR DESCRIPTION
This PR makes the websocket available when deployed behind a k8s ingress. Example with (temporary) deploy to beta:
![Screen Shot 2022-06-14 at 12 45 46](https://user-images.githubusercontent.com/314548/173620162-76d044a8-a772-4707-8ad0-3494b8367033.png)

## Changes

- make the WS listen on the same port as regular http requests
- fix the deploy gh actions to set new settings for ingress

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [x] updated the docs
- [ ] added a test
