### PR TITLE
Add HTTP auth options to Test creation

### DIFF
--- a/web/cypress/integration/Home/CreateTestWithAuthentication.spec.ts
+++ b/web/cypress/integration/Home/CreateTestWithAuthentication.spec.ts
@@ -1,0 +1,24 @@
+import {openCreateTestModal} from '../utils/Common';
+import {createTestWithAuth} from './createTestWithAuth';
+
+describe('Create test with authentication', () => {
+  beforeEach(() => {
+    cy.visit('http://localhost:3000/');
+  });
+
+  it('should create a basic GET test with api key authentication method', () => {
+    const $form = openCreateTestModal();
+    createTestWithAuth($form, 'apiKey', ['key', 'value'], () => {
+      $form.get('[data-cy=auth-apiKey-select]').click();
+      $form.get(`[data-cy=auth-apiKey-select-option-header]`).click();
+    });
+  });
+  it('should create a basic GET test with basic authentication method', () => {
+    const $form = openCreateTestModal();
+    createTestWithAuth($form, 'basic', ['username', 'password']);
+  });
+  it('should create a basic GET test with bearer authentication method', () => {
+    const $form = openCreateTestModal();
+    createTestWithAuth($form, 'bearer', ['token']);
+  });
+});

--- a/web/cypress/integration/Home/createTestWithAuth.ts
+++ b/web/cypress/integration/Home/createTestWithAuth.ts
@@ -1,0 +1,31 @@
+import {deleteTest} from '../utils/Common';
+
+export function createTestWithAuth(
+  $form: Cypress.Chainable<JQuery<HTMLElement>>,
+  method: string,
+  keys: string[],
+  callback?: () => void
+) {
+  $form.get('[data-cy=method-select]').click();
+  $form.get('[data-cy=method-select-option-GET]').click();
+  const name = `Test - Pokemon - #${String(Date.now()).slice(-4)}`;
+
+  $form.get('[data-cy=url]').type('http://demo-pokemon-api.demo.svc.cluster.local/pokemon');
+  $form.get('[data-cy=name').type(name);
+
+  $form.get('[data-cy=auth-type-select]').click();
+  $form.get(`[data-cy=auth-type-select-option-${method}]`).click();
+
+  keys.forEach(key => {
+    $form.get(`[data-cy=${method}-${key}]`).type(key);
+  });
+
+  if (callback) callback();
+
+  $form.get('[data-cy=create-test-submit]').click();
+
+  cy.location('pathname').should('match', /\/test\/.*/i);
+  cy.get('[data-cy=test-details-name]').should('have.text', `${name} (v1)`);
+  deleteTest();
+  return name;
+}

--- a/web/src/components/CreateTestModal/CreateTestForm.tsx
+++ b/web/src/components/CreateTestModal/CreateTestForm.tsx
@@ -1,21 +1,22 @@
-import {DeleteOutlined, DownOutlined, PlusOutlined} from '@ant-design/icons';
-import {Button, Dropdown, Form, FormInstance, Input, Menu, Select, Typography} from 'antd';
+import {Form, FormInstance, Input} from 'antd';
 
 import {Steps} from 'components/GuidedTour/homeStepList';
 import {HTTP_METHOD} from 'constants/Common.constants';
-import {DEFAULT_HEADERS, DemoTestExampleList} from 'constants/Test.constants';
-import {camelCase} from 'lodash';
 import React from 'react';
 import GuidedTourService, {GuidedTours} from 'services/GuidedTour.service';
-import Validator from 'utils/Validator';
-import {TooltipQuestion} from '../TooltipQuestion/TooltipQuestion';
+import {RequestAuth} from '../../types/Common.types';
+import {CreateTestFormAuthInput} from './CreateTestFormAuthInput/CreateTestFormAuthInput';
+import {CreateTestFormDemoHelper} from './CreateTestFormDemoHelper';
+import {CreateTestFormHeadersInput} from './CreateTestFormHeadersInput';
+import {CreateTestFormUrlInput} from './CreateTestFormUrlInput';
 import * as S from './CreateTestModal.styled';
-import CreateTestAnalyticsService from '../../services/Analytics/CreateTestAnalytics.service';
+import {useCreateTestFormHandleChangeCallback} from './useCreateTestFormHandleChangeCallback';
 
 export const FORM_ID = 'create-test';
 
 export interface ICreateTestValues {
   body: string;
+  auth: RequestAuth;
   headers: {
     key: string;
     value: string;
@@ -34,40 +35,9 @@ interface IProps {
 }
 
 const CreateTestForm = ({form, onSelectDemo, onSubmit, onValidation, selectedDemo}: IProps) => {
-  const handleOnDemoClick = ({key}: {key: string}) => {
-    CreateTestAnalyticsService.onDemoTestClick();
-    onSelectDemo(key);
-    const {body, description, method, name, url} = DemoTestExampleList.find(demo => demo.name === key) || {};
-
-    form.setFieldsValue({
-      body,
-      method,
-      name: `${name} - ${description}`,
-      url,
-    });
-
-    onValidation(true);
-  };
-
-  const handleOnValuesChange = (changedValues: any, allValues: ICreateTestValues) => {
-    const isValid =
-      Validator.required(allValues.name) && Validator.required(allValues.url) && Validator.url(allValues.url);
-    onValidation(isValid);
-  };
-
-  const menuLayout = (
-    <Menu
-      items={DemoTestExampleList.map(({name}) => ({
-        key: name,
-        label: <span data-cy={`demo-example-${camelCase(name)}`}>{name}</span>,
-      }))}
-      onClick={handleOnDemoClick}
-      style={{width: '190px'}}
-    />
-  );
-
+  const handleOnValuesChange = useCreateTestFormHandleChangeCallback(onValidation);
   return (
-    <Form
+    <Form<any>
       autoComplete="off"
       data-cy="create-test-modal"
       form={form}
@@ -77,57 +47,13 @@ const CreateTestForm = ({form, onSelectDemo, onSubmit, onValidation, selectedDem
       onValuesChange={handleOnValuesChange}
     >
       <S.GlobalStyle />
-
-      <S.DemoContainer>
-        <Typography.Text>Try these examples in our demo env: </Typography.Text>
-        <Dropdown overlay={menuLayout} placement="bottomLeft" trigger={['click']}>
-          <Typography.Link data-cy="example-button" onClick={e => e.preventDefault()} strong>
-            {selectedDemo || 'Choose Example'} <DownOutlined />
-          </Typography.Link>
-        </Dropdown>
-        <TooltipQuestion
-          margin={8}
-          title="We have a microservice based on the Pokemon API installed - pick an example to autofill this form"
-        />
-      </S.DemoContainer>
-
-      <S.Row>
-        <div>
-          <Form.Item name="method" initialValue={HTTP_METHOD.GET} valuePropName="value" noStyle>
-            <Select
-              className="select-method"
-              data-cy="method-select"
-              data-tour={GuidedTourService.getStep(GuidedTours.Home, Steps.Method)}
-              dropdownClassName="select-dropdown-method"
-              style={{minWidth: 120}}
-            >
-              {Object.keys(HTTP_METHOD).map(method => {
-                return (
-                  <Select.Option data-cy={`method-select-option-${method}`} key={method} value={method}>
-                    {method}
-                  </Select.Option>
-                );
-              })}
-            </Select>
-          </Form.Item>
-        </div>
-
-        <Form.Item
-          name="url"
-          rules={[
-            {required: true, message: 'Please enter a request url'},
-            {type: 'url', message: 'Request url is not valid'},
-          ]}
-          style={{flex: 1}}
-        >
-          <Input
-            data-cy="url"
-            data-tour={GuidedTourService.getStep(GuidedTours.Home, Steps.Url)}
-            placeholder="Enter request url"
-          />
-        </Form.Item>
-      </S.Row>
-
+      <CreateTestFormDemoHelper
+        selectedDemo={selectedDemo}
+        form={form}
+        onSelectDemo={onSelectDemo}
+        onValidation={onValidation}
+      />
+      <CreateTestFormUrlInput />
       <Form.Item
         className="input-name"
         data-cy="name"
@@ -138,50 +64,7 @@ const CreateTestForm = ({form, onSelectDemo, onSubmit, onValidation, selectedDem
       >
         <Input placeholder="Enter test name" />
       </Form.Item>
-
-      <Form.Item
-        className="input-headers"
-        data-tour={GuidedTourService.getStep(GuidedTours.Home, Steps.Headers)}
-        label="Headers list"
-      >
-        <Form.List name="headers" initialValue={DEFAULT_HEADERS}>
-          {(fields, {add, remove}) => (
-            <>
-              {fields.map((field, index) => (
-                <S.HeaderContainer key={field.name}>
-                  <Form.Item name={[field.name, 'key']} noStyle>
-                    <Input placeholder={`Header ${index + 1}`} />
-                  </Form.Item>
-
-                  <Form.Item name={[field.name, 'value']} noStyle>
-                    <Input placeholder={`Value ${index + 1}`} />
-                  </Form.Item>
-
-                  <Form.Item noStyle>
-                    <Button
-                      icon={<DeleteOutlined style={{fontSize: 12, color: 'rgba(3, 24, 73, 0.5)'}} />}
-                      onClick={() => remove(field.name)}
-                      style={{marginLeft: 12}}
-                      type="link"
-                    />
-                  </Form.Item>
-                </S.HeaderContainer>
-              ))}
-
-              <Button
-                data-cy="add-header"
-                icon={<PlusOutlined />}
-                onClick={() => add()}
-                style={{fontWeight: 600, height: 'auto', padding: 0}}
-                type="link"
-              >
-                Add Header
-              </Button>
-            </>
-          )}
-        </Form.List>
-      </Form.Item>
-
+      <CreateTestFormHeadersInput />
       <Form.Item
         className="input-body"
         data-cy="body"
@@ -192,6 +75,7 @@ const CreateTestForm = ({form, onSelectDemo, onSubmit, onValidation, selectedDem
       >
         <Input.TextArea placeholder="Enter request body text" />
       </Form.Item>
+      <CreateTestFormAuthInput form={form} />
     </Form>
   );
 };

--- a/web/src/components/CreateTestModal/CreateTestFormAuthInput/CreateTestFormAuthInput.styled.ts
+++ b/web/src/components/CreateTestModal/CreateTestFormAuthInput/CreateTestFormAuthInput.styled.ts
@@ -1,0 +1,8 @@
+import styled from 'styled-components';
+
+export const FlexContainer = styled.div`
+  align-items: center;
+  display: flex;
+  margin-bottom: 8px;
+  min-width: 100%;
+`;

--- a/web/src/components/CreateTestModal/CreateTestFormAuthInput/CreateTestFormAuthInput.tsx
+++ b/web/src/components/CreateTestModal/CreateTestFormAuthInput/CreateTestFormAuthInput.tsx
@@ -1,0 +1,31 @@
+import {Divider, Form, FormInstance} from 'antd';
+import React from 'react';
+import {ICreateTestValues} from '../CreateTestForm';
+import {apiKeyFields} from './apiKeyFields';
+import {basicFields} from './basicFields';
+import {bearerFields} from './bearerFields';
+import {CreateTestFormAuthTypeInput} from './CreateTestFormAuthTypeInput';
+
+export const CreateTestFormAuthInput: React.FC<{form: FormInstance<ICreateTestValues>}> = ({form}) => {
+  return (
+    <>
+      <Divider />
+      <CreateTestFormAuthTypeInput form={form} />
+      <Form.Item noStyle style={{width: '100%'}} shouldUpdate>
+        {({getFieldValue}) => {
+          const method = getFieldValue('auth')?.type;
+          switch (method) {
+            case 'bearer':
+              return bearerFields;
+            case 'basic':
+              return basicFields;
+            case 'apiKey':
+              return apiKeyFields;
+            default:
+              return null;
+          }
+        }}
+      </Form.Item>
+    </>
+  );
+};

--- a/web/src/components/CreateTestModal/CreateTestFormAuthInput/CreateTestFormAuthTypeInput.tsx
+++ b/web/src/components/CreateTestModal/CreateTestFormAuthInput/CreateTestFormAuthTypeInput.tsx
@@ -1,0 +1,50 @@
+import {Form, FormInstance, Select} from 'antd';
+import GuidedTourService, {GuidedTours} from '../../../services/GuidedTour.service';
+import {Steps} from '../../GuidedTour/homeStepList';
+import {ICreateTestValues} from '../CreateTestForm';
+import * as S from '../CreateTestModal.styled';
+
+function methodNaming(method: string | null) {
+  switch (method) {
+    case 'apiKey':
+      return 'API Key';
+    case 'bearer':
+      return 'Bearer Token';
+    case 'basic':
+      return 'Basic Auth';
+    default:
+      return 'No Auth';
+  }
+}
+
+export const CreateTestFormAuthTypeInput: React.FC<{form: FormInstance<ICreateTestValues>}> = ({form}) => (
+  <S.Row>
+    <Form.Item
+      style={{minWidth: '100%'}}
+      initialValue={null}
+      label="Authorization Type"
+      name={['auth', 'type']}
+      valuePropName="type"
+    >
+      <Select
+        className="select-auth-method"
+        data-cy="auth-type-select"
+        data-tour={GuidedTourService.getStep(GuidedTours.Home, Steps.Method)}
+        dropdownClassName="select-dropdown-auth-type"
+        placeholder="No Auth"
+        allowClear
+        onClear={() => form.resetFields(['auth'])}
+        onChange={e => {
+          form.resetFields(['auth']);
+          form.setFieldsValue({auth: {type: e as any}});
+        }}
+      >
+        {[null, 'apiKey', 'basic', 'bearer'].map(method => (
+          <Select.Option data-cy={`auth-type-select-option-${method}`} key={method} value={method}>
+            {methodNaming(method)}
+          </Select.Option>
+        ))}
+      </Select>
+    </Form.Item>
+  </S.Row>
+);

--- a/web/src/components/CreateTestModal/CreateTestFormAuthInput/apiKeyFields.tsx
+++ b/web/src/components/CreateTestModal/CreateTestFormAuthInput/apiKeyFields.tsx
@@ -1,0 +1,43 @@
+import {Form, Input, Select} from 'antd';
+import * as S from '../CreateTestModal.styled';
+import * as R from './CreateTestFormAuthInput.styled';
+
+export const apiKeyFields: React.ReactElement = (
+  <>
+    <S.Row>
+      <R.FlexContainer>
+        <Form.Item
+          data-cy="apiKey-key"
+          style={{flexBasis: '50%'}}
+          name={['auth', 'apiKey', 'key']}
+          label="Key"
+          rules={[{required: true}]}
+        >
+          <Input placeholder="Enter key" />
+        </Form.Item>
+        <Form.Item
+          data-cy="apiKey-value"
+          style={{flexBasis: '50%'}}
+          name={['auth', 'apiKey', 'value']}
+          label="Value"
+          rules={[{required: true}]}
+        >
+          <Input placeholder="Enter value" />
+        </Form.Item>
+      </R.FlexContainer>
+    </S.Row>
+    <Form.Item style={{minWidth: '100%'}} initialValue="query" label="Add To" name={['auth', 'apiKey', 'in']}>
+      <Select
+        className="select-auth-method"
+        data-cy="auth-apiKey-select"
+        dropdownClassName="select-dropdown-auth-method"
+      >
+        {['query', 'header'].map(m => (
+          <Select.Option data-cy={`auth-apiKey-select-option-${m}`} key={m} value={m}>
+            {m === 'query' ? 'Query Params' : 'Header'}
+          </Select.Option>
+        ))}
+      </Select>
+    </Form.Item>
+  </>
+);

--- a/web/src/components/CreateTestModal/CreateTestFormAuthInput/basicFields.tsx
+++ b/web/src/components/CreateTestModal/CreateTestFormAuthInput/basicFields.tsx
@@ -1,0 +1,29 @@
+import {Form, Input} from 'antd';
+import React from 'react';
+import * as S from '../CreateTestModal.styled';
+import * as R from './CreateTestFormAuthInput.styled';
+
+export const basicFields: React.ReactElement = (
+  <S.Row>
+    <R.FlexContainer>
+      <Form.Item
+        style={{flexBasis: '50%'}}
+        name={['auth', 'basic', 'username']}
+        data-cy="basic-username"
+        label="Username"
+        rules={[{required: true}]}
+      >
+        <Input />
+      </Form.Item>
+      <Form.Item
+        style={{flexBasis: '50%'}}
+        name={['auth', 'basic', 'password']}
+        label="Password"
+        data-cy="basic-password"
+        rules={[{required: true}]}
+      >
+        <Input />
+      </Form.Item>
+    </R.FlexContainer>
+  </S.Row>
+);

--- a/web/src/components/CreateTestModal/CreateTestFormAuthInput/bearerFields.tsx
+++ b/web/src/components/CreateTestModal/CreateTestFormAuthInput/bearerFields.tsx
@@ -1,0 +1,10 @@
+import {Form, Input} from 'antd';
+import * as S from '../CreateTestModal.styled';
+
+export const bearerFields: React.ReactElement = (
+  <S.Row style={{width: '100%'}}>
+    <Form.Item data-cy="bearer-token" name={['auth', 'bearer', 'token']} label="Token" rules={[{required: true}]}>
+      <Input />
+    </Form.Item>
+  </S.Row>
+);

--- a/web/src/components/CreateTestModal/CreateTestFormDemoHelper.tsx
+++ b/web/src/components/CreateTestModal/CreateTestFormDemoHelper.tsx
@@ -1,0 +1,60 @@
+import {DownOutlined} from '@ant-design/icons';
+import {Dropdown, FormInstance, Menu, Typography} from 'antd';
+import {camelCase} from 'lodash';
+import React from 'react';
+import {DemoTestExampleList} from '../../constants/Test.constants';
+import CreateTestAnalyticsService from '../../services/Analytics/CreateTestAnalytics.service';
+import {TooltipQuestion} from '../TooltipQuestion/TooltipQuestion';
+import {ICreateTestValues} from './CreateTestForm';
+import * as S from './CreateTestModal.styled';
+
+interface IProps {
+  form: FormInstance<ICreateTestValues>;
+  onSelectDemo(value: string): void;
+  onValidation(isValid: boolean): void;
+  selectedDemo: string;
+}
+
+export const CreateTestFormDemoHelper: React.FC<IProps> = ({selectedDemo, onSelectDemo, onValidation, form}) => {
+  const handleOnDemoClick = ({key}: {key: string}) => {
+    CreateTestAnalyticsService.onDemoTestClick();
+    onSelectDemo(key);
+    const {body, description, method, name, url} = DemoTestExampleList.find(demo => demo.name === key) || {};
+
+    form.setFieldsValue({
+      body,
+      method,
+      name: `${name} - ${description}`,
+      url,
+    });
+
+    onValidation(true);
+  };
+  return (
+    <S.DemoContainer>
+      <Typography.Text>Try these examples in our demo env: </Typography.Text>
+      <Dropdown
+        overlay={() => (
+          <Menu
+            items={DemoTestExampleList.map(({name}) => ({
+              key: name,
+              label: <span data-cy={`demo-example-${camelCase(name)}`}>{name}</span>,
+            }))}
+            onClick={handleOnDemoClick}
+            style={{width: '190px'}}
+          />
+        )}
+        placement="bottomLeft"
+        trigger={['click']}
+      >
+        <Typography.Link data-cy="example-button" onClick={e => e.preventDefault()} strong>
+          {selectedDemo || 'Choose Example'} <DownOutlined />
+        </Typography.Link>
+      </Dropdown>
+      <TooltipQuestion
+        margin={8}
+        title="We have a microservice based on the Pokemon API installed - pick an example to autofill this form"
+      />
+    </S.DemoContainer>
+  );
+};

--- a/web/src/components/CreateTestModal/CreateTestFormHeadersInput.tsx
+++ b/web/src/components/CreateTestModal/CreateTestFormHeadersInput.tsx
@@ -1,0 +1,52 @@
+import {DeleteOutlined, PlusOutlined} from '@ant-design/icons';
+import {Button, Form, Input} from 'antd';
+import React from 'react';
+import {DEFAULT_HEADERS} from '../../constants/Test.constants';
+import GuidedTourService, {GuidedTours} from '../../services/GuidedTour.service';
+import {Steps} from '../GuidedTour/homeStepList';
+import * as S from './CreateTestModal.styled';
+
+export const CreateTestFormHeadersInput: React.FC = () => (
+  <Form.Item
+    className="input-headers"
+    data-tour={GuidedTourService.getStep(GuidedTours.Home, Steps.Headers)}
+    label="Headers list"
+  >
+    <Form.List name="headers" initialValue={DEFAULT_HEADERS}>
+      {(fields, {add, remove}) => (
+        <>
+          {fields.map((field, index) => (
+            <S.HeaderContainer key={field.name}>
+              <Form.Item name={[field.name, 'key']} noStyle>
+                <Input placeholder={`Header ${index + 1}`} />
+              </Form.Item>
+
+              <Form.Item name={[field.name, 'value']} noStyle>
+                <Input placeholder={`Value ${index + 1}`} />
+              </Form.Item>
+
+              <Form.Item noStyle>
+                <Button
+                  icon={<DeleteOutlined style={{fontSize: 12, color: 'rgba(3, 24, 73, 0.5)'}} />}
+                  onClick={() => remove(field.name)}
+                  style={{marginLeft: 12}}
+                  type="link"
+                />
+              </Form.Item>
+            </S.HeaderContainer>
+          ))}
+
+          <Button
+            data-cy="add-header"
+            icon={<PlusOutlined />}
+            onClick={() => add()}
+            style={{fontWeight: 600, height: 'auto', padding: 0}}
+            type="link"
+          >
+            Add Header
+          </Button>
+        </>
+      )}
+    </Form.List>
+  </Form.Item>
+);

--- a/web/src/components/CreateTestModal/CreateTestFormUrlInput.tsx
+++ b/web/src/components/CreateTestModal/CreateTestFormUrlInput.tsx
@@ -1,0 +1,47 @@
+import {Form, Input, Select} from 'antd';
+import React from 'react';
+import {HTTP_METHOD} from '../../constants/Common.constants';
+import GuidedTourService, {GuidedTours} from '../../services/GuidedTour.service';
+import {Steps} from '../GuidedTour/homeStepList';
+import * as S from './CreateTestModal.styled';
+
+export const CreateTestFormUrlInput: React.FC = () => {
+  return (
+    <S.Row>
+      <div>
+        <Form.Item name="method" initialValue={HTTP_METHOD.GET} valuePropName="value" noStyle>
+          <Select
+            className="select-method"
+            data-cy="method-select"
+            data-tour={GuidedTourService.getStep(GuidedTours.Home, Steps.Method)}
+            dropdownClassName="select-dropdown-method"
+            style={{minWidth: 120}}
+          >
+            {Object.keys(HTTP_METHOD).map(method => {
+              return (
+                <Select.Option data-cy={`method-select-option-${method}`} key={method} value={method}>
+                  {method}
+                </Select.Option>
+              );
+            })}
+          </Select>
+        </Form.Item>
+      </div>
+
+      <Form.Item
+        name="url"
+        rules={[
+          {required: true, message: 'Please enter a request url'},
+          {type: 'url', message: 'Request url is not valid'},
+        ]}
+        style={{flex: 1}}
+      >
+        <Input
+          data-cy="url"
+          data-tour={GuidedTourService.getStep(GuidedTours.Home, Steps.Url)}
+          placeholder="Enter request url"
+        />
+      </Form.Item>
+    </S.Row>
+  );
+};

--- a/web/src/components/CreateTestModal/CreateTestModal.tsx
+++ b/web/src/components/CreateTestModal/CreateTestModal.tsx
@@ -1,13 +1,14 @@
 import {useTour} from '@reactour/tour';
 import {Button, Form, Modal, Typography} from 'antd';
-import {useState} from 'react';
-import {useNavigate} from 'react-router-dom';
 
 import {Steps} from 'components/GuidedTour/homeStepList';
+import {useState} from 'react';
+import {useNavigate} from 'react-router-dom';
 import {useCreateTestMutation, useRunTestMutation} from 'redux/apis/TraceTest.api';
-import GuidedTourService, {GuidedTours} from 'services/GuidedTour.service';
 import CreateTestAnalyticsService from 'services/Analytics/CreateTestAnalytics.service';
-import CreateTestForm, {ICreateTestValues, FORM_ID} from './CreateTestForm';
+import GuidedTourService, {GuidedTours} from 'services/GuidedTour.service';
+import {Request} from '../../types/Common.types';
+import CreateTestForm, {FORM_ID, ICreateTestValues} from './CreateTestForm';
 
 interface IProps {
   visible: boolean;
@@ -26,10 +27,19 @@ const CreateTestModal = ({onClose, visible}: IProps) => {
   const [form] = Form.useForm<ICreateTestValues>();
 
   const handleOnSubmit = async (values: ICreateTestValues) => {
+    let request: Request = {
+      url: values.url,
+      method: values.method,
+      body: values.body,
+      headers: values.headers,
+    };
+    if (values.auth?.type !== null) {
+      request = {...request, auth: values.auth};
+    }
     const test = await createTest({
       name: values.name,
       serviceUnderTest: {
-        request: {url: values.url, method: values.method, body: values.body, headers: values.headers},
+        request,
       },
     }).unwrap();
     const run = await runTest({testId: test.id}).unwrap();

--- a/web/src/components/CreateTestModal/__tests__/CreateTestModal.test.tsx
+++ b/web/src/components/CreateTestModal/__tests__/CreateTestModal.test.tsx
@@ -1,4 +1,8 @@
+import {renderHook} from '@testing-library/react-hooks';
+import {Button, Form} from 'antd';
 import {render} from 'test-utils';
+import {clickButton, selectInput, typeInputValue} from 'utils/Tests';
+import CreateTestForm, {ICreateTestValues} from '../CreateTestForm';
 
 import CreateTestModal from '../CreateTestModal';
 
@@ -11,5 +15,39 @@ describe('CreateTestModal', () => {
     expect(getByPlaceholderText('Enter request body text')).toBeInTheDocument();
     expect(getByText(/cancel/i)).toBeInTheDocument();
     expect(getAllByText(/create/i).length).toBe(2);
+  });
+
+  it('should call onSubmit', async () => {
+    const onSubmit = jest.fn();
+    const {
+      result: {
+        current: [form],
+      },
+    } = renderHook(() => Form.useForm<ICreateTestValues>());
+    render(
+      <>
+        <CreateTestForm
+          form={form}
+          onSelectDemo={jest.fn()}
+          onSubmit={onSubmit}
+          onValidation={jest.fn()}
+          selectedDemo=""
+        />
+        <Button data-cy="create-test-submit" onClick={() => form.submit()}>
+          Create
+        </Button>
+      </>
+    );
+    await typeInputValue('name', 'My cool test', 'input');
+    await selectInput('method-select', 'method-select-option-GET');
+    await typeInputValue('url', 'https://google.com');
+    await typeInputValue('body', '{id: 3}', 'textarea');
+    await selectInput('auth-type-select', 'auth-type-select-option-apiKey');
+    await typeInputValue('url', 'https://google.com');
+    await typeInputValue('apiKey-key', 'key', 'input');
+    await typeInputValue('apiKey-value', 'value', 'input');
+    await selectInput('auth-apiKey-select', 'auth-apiKey-select-option-header');
+    await clickButton('create-test-submit');
+    expect(onSubmit).toBeCalled();
   });
 });

--- a/web/src/components/CreateTestModal/useCreateTestFormHandleChangeCallback.tsx
+++ b/web/src/components/CreateTestModal/useCreateTestFormHandleChangeCallback.tsx
@@ -1,0 +1,33 @@
+import {useCallback} from 'react';
+import Validator from '../../utils/Validator';
+import {ICreateTestValues} from './CreateTestForm';
+
+export const useCreateTestFormHandleChangeCallback = (
+  onValidation: (isValid: boolean) => void
+): ((changedValues: any, allValues: ICreateTestValues) => void) => {
+  const authValidation = (testValues: ICreateTestValues): boolean => {
+    switch (testValues.auth?.type) {
+      case 'apiKey':
+        return Validator.required(testValues.auth?.apiKey?.key) && Validator.required(testValues.auth?.apiKey?.value);
+      case 'basic':
+        return (
+          Validator.required(testValues.auth?.basic?.username) && Validator.required(testValues.auth?.basic?.password)
+        );
+      case 'bearer':
+        return Validator.required(testValues.auth?.bearer?.token);
+      default:
+        return true;
+    }
+  };
+  return useCallback(
+    (changedValues: any, allValues: ICreateTestValues) => {
+      const isValid =
+        Validator.required(allValues.name) &&
+        Validator.required(allValues.url) &&
+        Validator.url(allValues.url) &&
+        authValidation(allValues);
+      onValidation(isValid);
+    },
+    [onValidation]
+  );
+};

--- a/web/src/types/Common.types.ts
+++ b/web/src/types/Common.types.ts
@@ -22,4 +22,7 @@ export type THttpSchemas = external['http.yaml']['components']['schemas'];
 export type TTraceSchemas = external['trace.yaml']['components']['schemas'];
 export type TTestSchemas = external['tests.yaml']['components']['schemas'];
 
+export type Request = THttpSchemas['HTTPRequest'];
+export type RequestAuth = THttpSchemas['HTTPRequest']['auth'];
+
 export type Model<T, R> = Modify<Required<T>, R>;

--- a/web/src/utils/Tests.tsx
+++ b/web/src/utils/Tests.tsx
@@ -1,0 +1,29 @@
+import {act, fireEvent, screen} from '@testing-library/react';
+
+export async function typeInputValue(key: string, value: string, input?: 'input' | 'textarea') {
+  const byTestId = screen.getByTestId(key);
+  const querySelector = input ? byTestId.querySelector(input) : byTestId;
+  await act(async () => {
+    fireEvent.change(querySelector as Element, {target: {value}});
+  });
+  expect(querySelector).toHaveValue(value);
+}
+
+export async function selectInput(selectorTestId: string, optionTestId: string) {
+  const byTestId = screen.getByTestId(selectorTestId).querySelector('input');
+  await act(async () => {
+    fireEvent.click(byTestId as Element);
+    fireEvent.mouseDown(byTestId as Element);
+  });
+  const selection = screen.getByTestId(optionTestId);
+  await act(async () => {
+    fireEvent.click(selection as Element);
+  });
+}
+
+export async function clickButton(testId: string) {
+  const byTestId = screen.getByTestId(testId);
+  await act(async () => {
+    fireEvent.click(byTestId as Element);
+  });
+}


### PR DESCRIPTION
This PR add authentication options to the test creation form with integration & unit tests

<img width="484" alt="Screen Shot 2022-06-14 at 18 10 13" src="https://user-images.githubusercontent.com/6259987/173689517-8f7ba385-f621-499c-96c1-ef0cf07a4ce9.png">


## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [x] added a test
