### PR TITLE
fix: assertion query quoting

### DIFF
--- a/cli/conversion/parser/assertion_parser.go
+++ b/cli/conversion/parser/assertion_parser.go
@@ -2,7 +2,6 @@ package parser
 
 import (
 	"fmt"
-	"strconv"
 
 	"github.com/alecthomas/participle/v2"
 	"github.com/alecthomas/participle/v2/lexer"
@@ -17,14 +16,15 @@ type Assertion struct {
 type assertionParserObject struct {
 	Attribute string `@Attribute`
 	Operator  string `@Operator`
-	Value     string `@Value`
+	Value     string `@(Number|QuotedString)`
 }
 
 var languageLexer = lexer.MustSimple([]lexer.SimpleRule{
 	{Name: "Operator", Pattern: `!=|<=|>=|=|<|>|contains`},
-	{Name: "Attribute", Pattern: `[a-zA-Z_][a-zA-Z0-9_\.]*`},  // anything that starts with a letter
-	{Name: "Value", Pattern: `([0-9]+(\.[0-9]+)?)|("[^"]*")`}, // number or quoted string
-	{Name: "whitespace", Pattern: `[ |\t]+`},                  // spaces and tabs
+	{Name: "Attribute", Pattern: `[a-zA-Z_][a-zA-Z0-9_\.]*`}, // anything that starts with a letter
+	{Name: "whitespace", Pattern: `[ |\t]+`},                 // spaces and tabs
+	{Name: "Number", Pattern: `([0-9]+(\.[0-9]+)?)`},
+	{Name: "QuotedString", Pattern: `("[^"]*")|('[^']*')`},
 })
 
 var defaultParser *participle.Parser
@@ -56,13 +56,7 @@ func ParseAssertion(assertionQuery string) (Assertion, error) {
 		return Assertion{}, fmt.Errorf("could not parse assertion (%s): %w", assertionQuery, err)
 	}
 
-	value := assertionParserObject.Value
-	if value[0:1] == `"` {
-		value, err = strconv.Unquote(value)
-		if err != nil {
-			return Assertion{}, fmt.Errorf("could not unquote value: %w", err)
-		}
-	}
+	value := unquote(assertionParserObject.Value)
 
 	assertion := Assertion{
 		Attribute: assertionParserObject.Attribute,
@@ -71,4 +65,13 @@ func ParseAssertion(assertionQuery string) (Assertion, error) {
 	}
 
 	return assertion, nil
+}
+
+func unquote(input string) string {
+	isQuoted := input[0:1] == `"` || input[0:1] == `'`
+	if !isQuoted {
+		return input
+	}
+
+	return input[1 : len(input)-1]
 }

--- a/cli/conversion/parser/assertion_parser_test.go
+++ b/cli/conversion/parser/assertion_parser_test.go
@@ -78,6 +78,15 @@ func TestParseAssertion(t *testing.T) {
 			},
 		},
 		{
+			Name:  "should_parse_escaped_quoted_string",
+			Query: `tracetest.response.body contains '"id":"${TEST_ID}"'`,
+			ExpectedOutput: parser.Assertion{
+				Attribute: "tracetest.response.body",
+				Operator:  "contains",
+				Value:     `"id":"${TEST_ID}"`,
+			},
+		},
+		{
 			Name:  "should_parse_string_values",
 			Query: `db.statement = "create"`,
 			ExpectedOutput: parser.Assertion{

--- a/cli/conversion/parser/assertion_parser_test.go
+++ b/cli/conversion/parser/assertion_parser_test.go
@@ -78,7 +78,7 @@ func TestParseAssertion(t *testing.T) {
 			},
 		},
 		{
-			Name:  "should_parse_escaped_quoted_string",
+			Name:  "should_parse_quoted_string_wrapped_on_single_quotes",
 			Query: `tracetest.response.body contains '"id":"${TEST_ID}"'`,
 			ExpectedOutput: parser.Assertion{
 				Attribute: "tracetest.response.body",
@@ -88,11 +88,29 @@ func TestParseAssertion(t *testing.T) {
 		},
 		{
 			Name:  "should_parse_escaped_quoted_string",
+			Query: `tracetest.response.body contains "\"id\":\"${TEST_ID}\""`,
+			ExpectedOutput: parser.Assertion{
+				Attribute: "tracetest.response.body",
+				Operator:  "contains",
+				Value:     `"id":"${TEST_ID}"`,
+			},
+		},
+		{
+			Name:  "should_parse_single_quoted_string_wrapped_on_double_quotes",
 			Query: `tracetest.response.body contains "'single quoted value'"`,
 			ExpectedOutput: parser.Assertion{
 				Attribute: "tracetest.response.body",
 				Operator:  "contains",
 				Value:     `'single quoted value'`,
+			},
+		},
+		{
+			Name:  "should_parse_escaped_single_quoted_string",
+			Query: `tracetest.response.body contains '\'id\':\'${TEST_ID}\''`,
+			ExpectedOutput: parser.Assertion{
+				Attribute: "tracetest.response.body",
+				Operator:  "contains",
+				Value:     `'id':'${TEST_ID}'`,
 			},
 		},
 		{

--- a/cli/conversion/parser/assertion_parser_test.go
+++ b/cli/conversion/parser/assertion_parser_test.go
@@ -87,6 +87,15 @@ func TestParseAssertion(t *testing.T) {
 			},
 		},
 		{
+			Name:  "should_parse_escaped_quoted_string",
+			Query: `tracetest.response.body contains "'single quoted value'"`,
+			ExpectedOutput: parser.Assertion{
+				Attribute: "tracetest.response.body",
+				Operator:  "contains",
+				Value:     `'single quoted value'`,
+			},
+		},
+		{
 			Name:  "should_parse_string_values",
 			Query: `db.statement = "create"`,
 			ExpectedOutput: parser.Assertion{

--- a/cli/file/definition_test.go
+++ b/cli/file/definition_test.go
@@ -70,6 +70,7 @@ func TestLoadDefinition(t *testing.T) {
 						Assertions: []string{
 							"db.repository.operation = \"create\"",
 							"tracetest.span.duration <= 100",
+							`tracetest.response.body contains "\"id\": 52"`,
 						},
 					},
 				},

--- a/cli/testdata/definitions/valid_http_test_definition.yml
+++ b/cli/testdata/definitions/valid_http_test_definition.yml
@@ -31,3 +31,4 @@ testDefinition:
   assertions:
   - db.repository.operation = "create"
   - tracetest.span.duration <= 100
+  - 'tracetest.response.body contains "\"id\": 52"'


### PR DESCRIPTION
This PR enables the usage of single quotes to escape double quotes in queries.

## Examples
#### "Escaping" double quotes by wrapping them in single quotes
```yaml
assertions:
    - tracetest.response.body contains '"some value that must be quoted"'
```

#### "Escaping" single quotes by wrapping them in double quotes
```yaml
assertions:
    - tracetest.response.body contains "'some value that must be singled quoted'"
```

#### Escaping quotes
```yaml
assertions:
    # Because we are adding JSON syntax to this string, and it contains a colon (:), 
    # if we don't wrap that string in single quotes, YAML will parse this string 
    # as a key-value instead of a string, breaking the YAML parser.
    - 'tracetest.response.body contains "\"id\": 52"'
```

## Fixes

- #735 

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [x] added a test
