### PR TITLE
fix: demo and beta settings for websocket timeout

### DIFF
--- a/.github/workflows/deploy-beta.yml
+++ b/.github/workflows/deploy-beta.yml
@@ -100,8 +100,8 @@ jobs:
           --set tracingBackend=jaeger \
           --set jaegerConnectionConfig.endpoint="jaeger-query.tracetest.svc.cluster.local:16685" \
           --set telemetry.jaeger.host="jaeger-agent.tracetest.svc.cluster.local" \
+          --set service.annotations."cloud\.google\.com/backend-config"='\{\"default\":\"tracetest-beta\"\}' \
           --set ingress.enabled=true \
           --set 'ingress.hosts[0].host=beta.tracetest.io,ingress.hosts[0].paths[0].path=/,ingress.hosts[0].paths[0].pathType=Prefix' \
-          --set ingress.annotations."beta\.cloud\.google\.com/backend-config"=tracetest-beta \
           --set ingress.annotations."networking\.gke\.io/managed-certificates"=tracetest-beta \
           --set ingress.annotations."networking\.gke\.io/v1beta1\.FrontendConfig"="ssl-redirect"

--- a/.github/workflows/release-server.yml
+++ b/.github/workflows/release-server.yml
@@ -213,9 +213,10 @@ jobs:
           --set tracingBackend=jaeger \
           --set jaegerConnectionConfig.endpoint="jaeger-query.tracetest.svc.cluster.local:16685" \
           --set telemetry.jaeger.host="jaeger-agent.tracetest.svc.cluster.local" \
+          --set service.annotations."cloud\.google\.com/backend-config"='\{\"default\":\"tracetest-beta\"\}' \
           --set ingress.enabled=true \
           --set 'ingress.hosts[0].host=demo.tracetest.io,ingress.hosts[0].paths[0].path=/,ingress.hosts[0].paths[0].pathType=Prefix' \
-          --set ingress.annotations."beta\.cloud\.google\.com/backend-config"=tracetest-demo \
+          --set service.annotations."cloud\.google\.com/backend-config"='\{\"default\":\"tracetest-demo\"\}' \
           --set ingress.annotations."networking\.gke\.io/managed-certificates"=tracetest-demo \
           --set ingress.annotations."networking\.gke\.io/v1beta1\.FrontendConfig"="ssl-redirect"
 


### PR DESCRIPTION
This PR sets the correct annotations on the services deployed in demo and beta env so we can configure the correct timeout.

Depends on https://github.com/kubeshop/helm-charts/pull/191

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
