### PR TITLE
feat: return openapi objects in websocket response

### DIFF
--- a/server/http/websocket/messages.go
+++ b/server/http/websocket/messages.go
@@ -1,5 +1,12 @@
 package websocket
 
+import (
+	"fmt"
+
+	"github.com/kubeshop/tracetest/server/http"
+	"github.com/kubeshop/tracetest/server/model"
+)
+
 type Message struct {
 	Type    string      `json:"type"`
 	Message interface{} `json:"message"`
@@ -34,8 +41,19 @@ func ErrorMessage(err error) Message {
 }
 
 func ResourceUpdatedEvent(resource interface{}) Event {
+	var mapped interface{}
+	switch v := resource.(type) {
+	case model.Run:
+		mapped = (http.OpenAPIMapper{}).Run(&v)
+	case *model.Run:
+		mapped = (http.OpenAPIMapper{}).Run(v)
+	default:
+		fmt.Printf("type %T mapping not supported\n", v)
+		mapped = v
+	}
+
 	return Event{
 		Type:  "update",
-		Event: resource,
+		Event: mapped,
 	}
 }


### PR DESCRIPTION
This PR adds openapi mapping to websocket response

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
