### PR TITLE
fix: better variable injection

### DIFF
--- a/cli/actions/run_test_action.go
+++ b/cli/actions/run_test_action.go
@@ -86,9 +86,6 @@ func (a runTestAction) runDefinition(ctx context.Context, definitionFile string,
 			return runTestOutput{}, fmt.Errorf("could not create test from definition: %w", err)
 		}
 
-		variableInjector := variable.NewInjector()
-		variableInjector.Inject(&test)
-
 		definition.Id = *test.Id
 		err = file.SaveDefinition(definitionFile, definition)
 		if err != nil {
@@ -150,6 +147,9 @@ func (a runTestAction) saveJUnitFile(ctx context.Context, testId, testRunId, out
 }
 
 func (a runTestAction) createTestFromDefinition(ctx context.Context, definition definition.Test) (openapi.Test, error) {
+	variableInjector := variable.NewInjector()
+	variableInjector.Inject(&definition)
+
 	openapiTest, err := conversion.ConvertTestDefinitionIntoOpenAPIObject(definition)
 	if err != nil {
 		return openapi.Test{}, err
@@ -173,6 +173,9 @@ func (a runTestAction) createTestFromDefinition(ctx context.Context, definition 
 }
 
 func (a runTestAction) updateTestFromDefinition(ctx context.Context, definition definition.Test) (openapi.Test, error) {
+	variableInjector := variable.NewInjector()
+	variableInjector.Inject(&definition)
+
 	openapiTest, err := conversion.ConvertTestDefinitionIntoOpenAPIObject(definition)
 	if err != nil {
 		return openapi.Test{}, err

--- a/cli/actions/run_test_action.go
+++ b/cli/actions/run_test_action.go
@@ -13,6 +13,7 @@ import (
 	"github.com/kubeshop/tracetest/cli/definition"
 	"github.com/kubeshop/tracetest/cli/file"
 	"github.com/kubeshop/tracetest/cli/openapi"
+	"github.com/kubeshop/tracetest/cli/variable"
 	"go.uber.org/zap"
 )
 
@@ -84,6 +85,9 @@ func (a runTestAction) runDefinition(ctx context.Context, definitionFile string,
 		if err != nil {
 			return runTestOutput{}, fmt.Errorf("could not create test from definition: %w", err)
 		}
+
+		variableInjector := variable.NewInjector()
+		variableInjector.Inject(&test)
 
 		definition.Id = *test.Id
 		err = file.SaveDefinition(definitionFile, definition)

--- a/cli/file/definition.go
+++ b/cli/file/definition.go
@@ -3,8 +3,6 @@ package file
 import (
 	"fmt"
 	"os"
-	"regexp"
-	"strings"
 
 	"github.com/kubeshop/tracetest/cli/definition"
 	"gopkg.in/yaml.v2"
@@ -14,11 +12,6 @@ func LoadDefinition(file string) (definition.Test, error) {
 	fileBytes, err := os.ReadFile(file)
 	if err != nil {
 		return definition.Test{}, fmt.Errorf("could not read test definition file %s: %w", file, err)
-	}
-
-	fileBytes, err = injectEnvVariables(fileBytes)
-	if err != nil {
-		return definition.Test{}, fmt.Errorf("could not inject env variables into definition file: %w", err)
 	}
 
 	test := definition.Test{}
@@ -42,23 +35,4 @@ func SaveDefinition(file string, definition definition.Test) error {
 	}
 
 	return nil
-}
-
-func injectEnvVariables(fileBytes []byte) ([]byte, error) {
-	envVarRegex, err := regexp.Compile(`\$\{\w+\}`)
-	if err != nil {
-		return []byte{}, fmt.Errorf("could not compile env variable regex: %w", err)
-	}
-
-	fileString := string(fileBytes)
-	allEnvVariables := envVarRegex.FindAllString(fileString, -1)
-
-	for _, envVariableExpression := range allEnvVariables {
-		envVarName := envVariableExpression[2 : len(envVariableExpression)-1] // removes '${' and '}'
-		envVarValue := os.Getenv(envVarName)
-
-		fileString = strings.Replace(fileString, envVariableExpression, envVarValue, -1)
-	}
-
-	return []byte(fileString), nil
 }

--- a/cli/file/definition_test.go
+++ b/cli/file/definition_test.go
@@ -1,7 +1,6 @@
 package file_test
 
 import (
-	"os"
 	"testing"
 
 	"github.com/kubeshop/tracetest/cli/definition"
@@ -16,7 +15,6 @@ func TestLoadDefinition(t *testing.T) {
 		File               string
 		ExpectedDefinition definition.Test
 		ShouldSucceed      bool
-		EnvVariables       map[string]string
 	}{
 		{
 			Name:          "Should_parse_valid_definition_file",
@@ -134,54 +132,10 @@ func TestLoadDefinition(t *testing.T) {
 				},
 			},
 		},
-		{
-			Name:          "Should_parse_env_variables",
-			File:          "../testdata/definitions/valid_http_test_definition_with_env_variables.yml",
-			ShouldSucceed: true,
-			EnvVariables: map[string]string{
-				"POKEMON_APP_API_KEY": "my secret key",
-			},
-			ExpectedDefinition: definition.Test{
-				Name:        "POST import pokemon",
-				Description: "Import a pokemon using its ID",
-				Trigger: definition.TestTrigger{
-					Type: "http",
-					HTTPRequest: definition.HttpRequest{
-						URL:    "http://pokemon-demo.tracetest.io/pokemon/import",
-						Method: "POST",
-						Headers: []definition.HTTPHeader{
-							{Key: "Content-Type", Value: "application/json"},
-						},
-						Body: definition.HTTPBody{
-							Type: "raw",
-							Raw:  `{ "id": 52 }`,
-						},
-						Authentication: definition.HTTPAuthentication{
-							Type: "apiKey",
-							ApiKey: definition.HTTPAPIKeyAuth{
-								Key:   "X-Key",
-								Value: "my secret key",
-								In:    "header",
-							},
-						},
-					},
-				},
-			},
-		},
 	}
 
 	for _, testCase := range testCases {
 		t.Run(testCase.Name, func(t *testing.T) {
-			for key, value := range testCase.EnvVariables {
-				os.Setenv(key, value)
-			}
-
-			t.Cleanup(func() {
-				for key := range testCase.EnvVariables {
-					os.Unsetenv(key)
-				}
-			})
-
 			definition, err := file.LoadDefinition(testCase.File)
 			if testCase.ShouldSucceed {
 				require.NoError(t, err, "LoadDefinition should not fail")

--- a/cli/variable/injector.go
+++ b/cli/variable/injector.go
@@ -1,0 +1,101 @@
+package variable
+
+import (
+	"fmt"
+	"reflect"
+	"regexp"
+	"strings"
+)
+
+type Variables map[string]string
+
+type Injector struct {
+	provider VariableProvider
+}
+
+func NewInjector(options ...InjectorOption) Injector {
+	injector := Injector{
+		provider: EnvironmentVariableProvider{},
+	}
+
+	for _, option := range options {
+		option(&injector)
+	}
+
+	return injector
+}
+
+func (i Injector) Inject(target interface{}) error {
+	targetValue := reflect.ValueOf(target)
+	if targetValue.Kind() != reflect.Ptr {
+		return fmt.Errorf("could not inject value because target is not a pointer")
+	}
+
+	targetStruct := targetValue.Elem()
+
+	return i.inject(targetStruct)
+}
+
+func (i Injector) inject(target reflect.Value) error {
+	switch target.Kind() {
+	case reflect.Struct:
+		return i.injectValuesIntoStruct(target)
+	case reflect.String:
+		return i.injectValueIntoField(target)
+	case reflect.Slice:
+		for index := 0; index < target.Len(); index++ {
+			item := target.Index(index)
+			err := i.inject(item)
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+func (i Injector) injectValuesIntoStruct(target reflect.Value) error {
+	for index := 0; index < target.NumField(); index++ {
+		field := target.Field(index)
+		err := i.inject(field)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (i Injector) injectValueIntoField(field reflect.Value) error {
+	// We only support variables replacements in strings right now
+	strValue := field.String()
+	newValue, err := i.replaceVariable(strValue)
+	if err != nil {
+		return err
+	}
+
+	field.SetString(newValue)
+	return nil
+}
+
+func (i Injector) replaceVariable(value string) (string, error) {
+	envVarRegex, err := regexp.Compile(`\$\{\w+\}`)
+	if err != nil {
+		return "", fmt.Errorf("could not compile env variable regex: %w", err)
+	}
+
+	allEnvVariables := envVarRegex.FindAllString(value, -1)
+
+	for _, envVariableExpression := range allEnvVariables {
+		envVarName := envVariableExpression[2 : len(envVariableExpression)-1] // removes '${' and '}'
+		envVarValue, err := i.provider.GetVariable(envVarName)
+		if err != nil {
+			return "", err
+		}
+
+		value = strings.Replace(value, envVariableExpression, envVarValue, -1)
+	}
+
+	return value, nil
+}

--- a/cli/variable/injector_test.go
+++ b/cli/variable/injector_test.go
@@ -1,0 +1,77 @@
+package variable_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/kubeshop/tracetest/cli/definition"
+	"github.com/kubeshop/tracetest/cli/variable"
+	"github.com/stretchr/testify/assert"
+)
+
+type testingVarProvider struct {
+	variables map[string]string
+}
+
+func (p testingVarProvider) GetVariable(name string) (string, error) {
+	if _, ok := p.variables[name]; !ok {
+		return "", fmt.Errorf("could not resolve variable \"%s\"", name)
+	}
+
+	return p.variables[name], nil
+}
+
+func TestInjectorWithStruct(t *testing.T) {
+	provider := testingVarProvider{
+		variables: map[string]string{
+			"TRACETEST_URL":       "http://localhost:8080",
+			"POKEMON_API_URL":     "http://pokemon.api:8080",
+			"EXPECTED_POKEMON_ID": "521",
+		},
+	}
+	injector := variable.NewInjector(variable.WithVariableProvider(provider))
+
+	input := definition.Test{
+		Name: "Test ${TRACETEST_URL}",
+		Trigger: definition.TestTrigger{
+			Type: "http",
+			HTTPRequest: definition.HttpRequest{
+				URL:    "${POKEMON_API_URL}",
+				Method: "GET",
+			},
+		},
+		TestDefinition: []definition.TestDefinition{
+			{
+				Selector: "http.url = \"${POKEMON_API_URL}\"",
+				Assertions: []string{
+					"tracetest.span.duration < 100",
+					`tracetest.response.body contains '"id": ${EXPECTED_POKEMON_ID}'`,
+				},
+			},
+		},
+	}
+
+	expectedDefinition := definition.Test{
+		Name: "Test http://localhost:8080",
+		Trigger: definition.TestTrigger{
+			Type: "http",
+			HTTPRequest: definition.HttpRequest{
+				URL:    "http://pokemon.api:8080",
+				Method: "GET",
+			},
+		},
+		TestDefinition: []definition.TestDefinition{
+			{
+				Selector: "http.url = \"http://pokemon.api:8080\"",
+				Assertions: []string{
+					"tracetest.span.duration < 100",
+					`tracetest.response.body contains '"id": 521'`,
+				},
+			},
+		},
+	}
+	err := injector.Inject(&input)
+	assert.NoError(t, err)
+
+	assert.Equal(t, expectedDefinition, input)
+}

--- a/cli/variable/options.go
+++ b/cli/variable/options.go
@@ -1,0 +1,9 @@
+package variable
+
+type InjectorOption func(*Injector)
+
+func WithVariableProvider(provider VariableProvider) InjectorOption {
+	return func(i *Injector) {
+		i.provider = provider
+	}
+}

--- a/cli/variable/provider.go
+++ b/cli/variable/provider.go
@@ -1,0 +1,13 @@
+package variable
+
+import "os"
+
+type VariableProvider interface {
+	GetVariable(string) (string, error)
+}
+
+type EnvironmentVariableProvider struct{}
+
+func (p EnvironmentVariableProvider) GetVariable(name string) (string, error) {
+	return os.Getenv(name), nil
+}


### PR DESCRIPTION
This PR injects variables in a better way using reflection and allows the injection to happen after the definition is loaded. This was done so the test definition doesn't have its variables replaced with the values present on the executor machine.

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [x] added a test
