### PR TITLE
remove unused reference test run

### DIFF
--- a/api/tests.yaml
+++ b/api/tests.yaml
@@ -23,8 +23,6 @@ components:
         definition:
           $ref: "#/components/schemas/TestDefinition"
           description: Definition of assertions that are going to be made
-        referenceTestRun:
-          $ref: "#/components/schemas/TestRun"
 
     TestDefinition:
       type: object

--- a/cli/conversion/openapi_definition_conversion_test.go
+++ b/cli/conversion/openapi_definition_conversion_test.go
@@ -29,7 +29,6 @@ func TestOpenAPIToDefinitionConversion(t *testing.T) {
 				Version:          openApiInt(3),
 				ServiceUnderTest: &openapi.TestServiceUnderTest{},
 				Definition:       &openapi.TestDefinition{},
-				ReferenceTestRun: &openapi.TestRun{},
 			},
 			ExpectedOutput: definition.Test{
 				Id:             "624a8dea-f152-48d4-a742-30b210094959",
@@ -303,7 +302,6 @@ func TestOpenAPIToDefinitionConversion(t *testing.T) {
 						},
 					},
 				},
-				ReferenceTestRun: &openapi.TestRun{},
 			},
 			ExpectedOutput: definition.Test{
 				Id:          "624a8dea-f152-48d4-a742-30b210094959",

--- a/cli/openapi/model_test_.go
+++ b/cli/openapi/model_test_.go
@@ -23,7 +23,6 @@ type Test struct {
 	Version          *int32                `json:"version,omitempty"`
 	ServiceUnderTest *TestServiceUnderTest `json:"serviceUnderTest,omitempty"`
 	Definition       *TestDefinition       `json:"definition,omitempty"`
-	ReferenceTestRun *TestRun              `json:"referenceTestRun,omitempty"`
 }
 
 // NewTest instantiates a new Test object
@@ -235,38 +234,6 @@ func (o *Test) SetDefinition(v TestDefinition) {
 	o.Definition = &v
 }
 
-// GetReferenceTestRun returns the ReferenceTestRun field value if set, zero value otherwise.
-func (o *Test) GetReferenceTestRun() TestRun {
-	if o == nil || o.ReferenceTestRun == nil {
-		var ret TestRun
-		return ret
-	}
-	return *o.ReferenceTestRun
-}
-
-// GetReferenceTestRunOk returns a tuple with the ReferenceTestRun field value if set, nil otherwise
-// and a boolean to check if the value has been set.
-func (o *Test) GetReferenceTestRunOk() (*TestRun, bool) {
-	if o == nil || o.ReferenceTestRun == nil {
-		return nil, false
-	}
-	return o.ReferenceTestRun, true
-}
-
-// HasReferenceTestRun returns a boolean if a field has been set.
-func (o *Test) HasReferenceTestRun() bool {
-	if o != nil && o.ReferenceTestRun != nil {
-		return true
-	}
-
-	return false
-}
-
-// SetReferenceTestRun gets a reference to the given TestRun and assigns it to the ReferenceTestRun field.
-func (o *Test) SetReferenceTestRun(v TestRun) {
-	o.ReferenceTestRun = &v
-}
-
 func (o Test) MarshalJSON() ([]byte, error) {
 	toSerialize := map[string]interface{}{}
 	if o.Id != nil {
@@ -286,9 +253,6 @@ func (o Test) MarshalJSON() ([]byte, error) {
 	}
 	if o.Definition != nil {
 		toSerialize["definition"] = o.Definition
-	}
-	if o.ReferenceTestRun != nil {
-		toSerialize["referenceTestRun"] = o.ReferenceTestRun
 	}
 	return json.Marshal(toSerialize)
 }

--- a/server/http/mappings.go
+++ b/server/http/mappings.go
@@ -23,9 +23,8 @@ func (m OpenAPIMapper) Test(in model.Test) openapi.Test {
 		ServiceUnderTest: openapi.TestServiceUnderTest{
 			Request: m.HTTPRequest(in.ServiceUnderTest.Request),
 		},
-		Definition:       m.Definition(in.Definition),
-		ReferenceTestRun: m.Run(in.ReferenceRun),
-		Version:          int32(in.Version),
+		Definition: m.Definition(in.Definition),
+		Version:    int32(in.Version),
 	}
 }
 
@@ -253,9 +252,8 @@ func (m ModelMapper) Test(in openapi.Test) model.Test {
 		ServiceUnderTest: model.ServiceUnderTest{
 			Request: m.HTTPRequest(in.ServiceUnderTest.Request),
 		},
-		ReferenceRun: m.Run(in.ReferenceTestRun),
-		Definition:   m.Definition(in.Definition),
-		Version:      int(in.Version),
+		Definition: m.Definition(in.Definition),
+		Version:    int(in.Version),
 	}
 }
 

--- a/server/openapi/model_test_.go
+++ b/server/openapi/model_test_.go
@@ -22,8 +22,6 @@ type Test struct {
 	ServiceUnderTest TestServiceUnderTest `json:"serviceUnderTest,omitempty"`
 
 	Definition TestDefinition `json:"definition,omitempty"`
-
-	ReferenceTestRun TestRun `json:"referenceTestRun,omitempty"`
 }
 
 // AssertTestRequired checks if the required fields are not zero-ed
@@ -32,9 +30,6 @@ func AssertTestRequired(obj Test) error {
 		return err
 	}
 	if err := AssertTestDefinitionRequired(obj.Definition); err != nil {
-		return err
-	}
-	if err := AssertTestRunRequired(obj.ReferenceTestRun); err != nil {
 		return err
 	}
 	return nil

--- a/web/src/components/TestHeader/TestHeader.tsx
+++ b/web/src/components/TestHeader/TestHeader.tsx
@@ -29,7 +29,7 @@ const TestHeader = ({
   extraContent,
   onBack,
   showInfo,
-  test: {name, referenceTestRun, serviceUnderTest, version = 1, id},
+  test: {name, serviceUnderTest, version = 1, id},
   testState,
   testVersion,
   totalSpans,
@@ -58,10 +58,10 @@ const TestHeader = ({
             </S.TestName>
             {showInfo && (
               <Info
-                date={referenceTestRun?.createdAt ?? ''}
+                date={run?.createdAt ?? ''}
                 executionTime={executionTime ?? 0}
                 totalSpans={totalSpans ?? 0}
-                traceId={referenceTestRun?.traceId ?? ''}
+                traceId={run?.traceId ?? ''}
               />
             )}
           </S.Row>

--- a/web/src/models/Test.model.ts
+++ b/web/src/models/Test.model.ts
@@ -1,15 +1,7 @@
 import {TRawTest, TTest} from '../types/Test.types';
 import TestDefinition from './TestDefinition.model';
 
-const Test = ({
-  id = '',
-  name = '',
-  description = '',
-  definition,
-  version = 1,
-  serviceUnderTest,
-  referenceTestRun,
-}: TRawTest): TTest => {
+const Test = ({id = '', name = '', description = '', definition, version = 1, serviceUnderTest}: TRawTest): TTest => {
   return {
     id,
     name,
@@ -17,7 +9,6 @@ const Test = ({
     description,
     definition: TestDefinition(definition || {}),
     serviceUnderTest,
-    referenceTestRun,
   };
 };
 

--- a/web/src/types/Generated.types.ts
+++ b/web/src/types/Generated.types.ts
@@ -36,9 +36,15 @@ export interface paths {
     /** rerun a test run */
     post: operations["rerunTestRun"];
   };
+  "/tests/{testId}/run/{runId}/junit.xml": {
+    /** get test run results in JUnit xml format */
+    get: operations["getRunResultJUnit"];
+  };
   "/tests/{testId}/run/{runId}": {
     /** get a particular test Run */
     get: operations["getTestRun"];
+    /** delete a test run */
+    delete: operations["deleteTestRun"];
   };
   "/tests/{testId}/definition": {
     /** Gets definition for a test */
@@ -236,6 +242,23 @@ export interface operations {
       };
     };
   };
+  /** get test run results in JUnit xml format */
+  getRunResultJUnit: {
+    parameters: {
+      path: {
+        testId: string;
+        runId: string;
+      };
+    };
+    responses: {
+      /** JUnit formatted file */
+      200: {
+        content: {
+          "application/xml": string;
+        };
+      };
+    };
+  };
   /** get a particular test Run */
   getTestRun: {
     parameters: {
@@ -251,6 +274,19 @@ export interface operations {
           "application/json": external["tests.yaml"]["components"]["schemas"]["TestRun"];
         };
       };
+    };
+  };
+  /** delete a test run */
+  deleteTestRun: {
+    parameters: {
+      path: {
+        testId: string;
+        runId: string;
+      };
+    };
+    responses: {
+      /** OK */
+      204: never;
     };
   };
   /** Gets definition for a test */
@@ -317,7 +353,6 @@ export interface external {
             | "PROPFIND"
             | "VIEW";
           headers?: external["http.yaml"]["components"]["schemas"]["HTTPHeader"][];
-          /** Format: byte */
           body?: string;
           auth?: external["http.yaml"]["components"]["schemas"]["HTTPAuth"];
         };
@@ -325,7 +360,6 @@ export interface external {
           status?: string;
           statusCode?: number;
           headers?: external["http.yaml"]["components"]["schemas"]["HTTPHeader"][];
-          /** Format: byte */
           body?: string;
         };
         HTTPAuth: {
@@ -365,7 +399,6 @@ export interface external {
           };
           /** @description Definition of assertions that are going to be made */
           definition?: external["tests.yaml"]["components"]["schemas"]["TestDefinition"];
-          referenceTestRun?: external["tests.yaml"]["components"]["schemas"]["TestRun"];
         };
         /** @example [object Object] */
         TestDefinition: {
@@ -445,7 +478,6 @@ export interface external {
     components: {
       schemas: {
         Trace: {
-          /** Format: byte */
           traceId?: string;
           tree?: external["trace.yaml"]["components"]["schemas"]["Span"];
           /** @description falttened version, mapped as spanId -> span{} */
@@ -456,9 +488,7 @@ export interface external {
           };
         };
         Span: {
-          /** Format: byte */
           id?: string;
-          /** Format: byte */
           parentId?: string;
           name?: string;
           /** @description span start time in unix milli format */

--- a/web/src/types/Test.types.ts
+++ b/web/src/types/Test.types.ts
@@ -1,6 +1,5 @@
 import {Model, THttpSchemas, TTestSchemas} from './Common.types';
 import {TTestDefinition} from './TestDefinition.types';
-import {TRawTestRun} from './TestRun.types';
 
 export type TRawTest = TTestSchemas['Test'];
 export type TTest = Model<
@@ -10,6 +9,5 @@ export type TTest = Model<
     serviceUnderTest?: {
       request?: THttpSchemas['HTTPRequest'];
     };
-    referenceTestRun?: TRawTestRun;
   }
 >;


### PR DESCRIPTION
This PR removes the unused property `referenceTestRun`

## Changes

- Remove field from openapi
- Update server generated models
- Update cli generated models

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
