### PR TITLE
Improve websockets notifications

### DIFF
--- a/docs/websocket.md
+++ b/docs/websocket.md
@@ -15,7 +15,7 @@ Once the connection is open, you can send a message with the format:
 ```json
 {
     "type": "subscribe",
-    "resource": "test/{testID}/result/{resultID}"
+    "resource": "test/{testID}/run/{runID}"
 }
 ```
 
@@ -50,7 +50,7 @@ But send this message to the websocket connection:
 ```json
 {
     "type": "unsubscribe",
-    "resource": "test/{testID}/result/{resultID}",
+    "resource": "test/{testID}/run/{runID}",
     "subscriptionId": "id returned in the subscription command"
 }
 ```

--- a/server/app/app.go
+++ b/server/app/app.go
@@ -90,7 +90,10 @@ func (a *App) Start() error {
 
 	subscriptionManager := subscription.NewManager()
 
-	execTestUpdater := executor.NewDBUpdater(a.db)
+	execTestUpdater := (executor.CompositeUpdater{}).
+		Add(executor.NewDBUpdater(a.db)).
+		Add(executor.NewSubscriptionUpdater(subscriptionManager))
+
 	assertionRunner := executor.NewAssertionRunner(execTestUpdater)
 	assertionRunner.Start(5)
 	defer assertionRunner.Stop()

--- a/server/app/app.go
+++ b/server/app/app.go
@@ -90,15 +90,16 @@ func (a *App) Start() error {
 
 	subscriptionManager := subscription.NewManager()
 
-	assertionRunner := executor.NewAssertionRunner(a.db)
+	execTestUpdater := executor.NewDBUpdater(a.db)
+	assertionRunner := executor.NewAssertionRunner(execTestUpdater)
 	assertionRunner.Start(5)
 	defer assertionRunner.Stop()
 
-	tracePoller := executor.NewTracePoller(a.traceDB, a.db, a.config.PoolingRetryDelay(), a.config.MaxWaitTimeForTraceDuration(), subscriptionManager, assertionRunner)
+	tracePoller := executor.NewTracePoller(a.traceDB, execTestUpdater, assertionRunner, a.config.PoolingRetryDelay(), a.config.MaxWaitTimeForTraceDuration())
 	tracePoller.Start(5) // worker count. should be configurable
 	defer tracePoller.Stop()
 
-	runner := executor.NewPersistentRunner(ex, a.db, tracePoller)
+	runner := executor.NewPersistentRunner(ex, a.db, execTestUpdater, tracePoller)
 	runner.Start(5) // worker count. should be configurable
 	defer runner.Stop()
 

--- a/server/executor/assertion_runner_test.go
+++ b/server/executor/assertion_runner_test.go
@@ -44,7 +44,7 @@ func TestExecutorSuccessfulExecution(t *testing.T) {
 			test, run, err := loadTestFile(testCase.Tracefile)
 			require.NoError(t, err)
 
-			assertionExecutor := executor.NewAssertionRunner(repo)
+			assertionExecutor := executor.NewAssertionRunner(executor.NewDBUpdater(repo))
 
 			test, err = repo.CreateTest(ctx, test)
 			require.NoError(t, err)

--- a/server/executor/run_updater.go
+++ b/server/executor/run_updater.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/kubeshop/tracetest/server/model"
+	"github.com/kubeshop/tracetest/server/subscription"
 )
 
 type RunUpdater interface {
@@ -44,14 +45,20 @@ func (u dbUpdater) Update(ctx context.Context, run model.Run) error {
 	return u.repo.UpdateRun(ctx, run)
 }
 
-// type webSockersUpdater struct {
-// 	repo model.RunRepository
-// }
+type subscriptionUpdater struct {
+	manager *subscription.Manager
+}
 
-// func NewWebSockerUpdater(repo model.RunRepository) RunUpdater {
-// 	return webSockersUpdater{repo}
-// }
+func NewSubscriptionUpdater(manager *subscription.Manager) RunUpdater {
+	return subscriptionUpdater{manager}
+}
 
-// func (u webSockersUpdater) Update(ctx context.Context, run model.Run) error {
-// 	return u.repo.UpdateRun(ctx, run)
-// }
+func (u subscriptionUpdater) Update(ctx context.Context, run model.Run) error {
+	u.manager.PublishUpdate(subscription.Message{
+		ResourceID: run.ResourceID(),
+		Type:       "result_update",
+		Content:    run,
+	})
+
+	return nil
+}

--- a/server/executor/run_updater.go
+++ b/server/executor/run_updater.go
@@ -1,0 +1,57 @@
+package executor
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/kubeshop/tracetest/server/model"
+)
+
+type RunUpdater interface {
+	Update(context.Context, model.Run) error
+}
+
+type CompositeUpdater struct {
+	listeners []RunUpdater
+}
+
+func (u CompositeUpdater) Add(l RunUpdater) CompositeUpdater {
+	u.listeners = append(u.listeners, l)
+	return u
+}
+
+var _ RunUpdater = CompositeUpdater{}
+
+func (u CompositeUpdater) Update(ctx context.Context, run model.Run) error {
+	for _, l := range u.listeners {
+		if err := l.Update(ctx, run); err != nil {
+			return fmt.Errorf("composite updating error: %w", err)
+		}
+	}
+
+	return nil
+}
+
+type dbUpdater struct {
+	repo model.RunRepository
+}
+
+func NewDBUpdater(repo model.RunRepository) RunUpdater {
+	return dbUpdater{repo}
+}
+
+func (u dbUpdater) Update(ctx context.Context, run model.Run) error {
+	return u.repo.UpdateRun(ctx, run)
+}
+
+// type webSockersUpdater struct {
+// 	repo model.RunRepository
+// }
+
+// func NewWebSockerUpdater(repo model.RunRepository) RunUpdater {
+// 	return webSockersUpdater{repo}
+// }
+
+// func (u webSockersUpdater) Update(ctx context.Context, run model.Run) error {
+// 	return u.repo.UpdateRun(ctx, run)
+// }

--- a/server/executor/runner_test.go
+++ b/server/executor/runner_test.go
@@ -101,7 +101,6 @@ func (f runnerFixture) expectSuccessExec(test model.Test) {
 func (f runnerFixture) expectSuccessResultPersist(test model.Test) {
 	expectCreateRun(f.mockDB, test)
 	f.mockDB.On("UpdateRun", mock.Anything).Return(noError)
-	f.mockDB.On("UpdateTestVersion", mock.Anything).Return(noError)
 	f.mockDB.On("UpdateRun", mock.Anything).Return(noError)
 	f.mockTracePoller.expectPoll(test)
 }
@@ -125,7 +124,7 @@ func runnerSetup(t *testing.T) runnerFixture {
 
 	mtp.Test(t)
 	return runnerFixture{
-		runner:          executor.NewPersistentRunner(me, db, mtp),
+		runner:          executor.NewPersistentRunner(me, db, executor.NewDBUpdater(db), mtp),
 		mockExecutor:    me,
 		mockDB:          db,
 		mockTracePoller: mtp,

--- a/server/model/run.go
+++ b/server/model/run.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/kubeshop/tracetest/server/id"
 	"github.com/kubeshop/tracetest/server/traces"
 )
 
@@ -13,7 +14,19 @@ var (
 	Now = func() time.Time {
 		return time.Now()
 	}
+
+	IDGen = id.NewRandGenerator()
 )
+
+func NewRun() Run {
+	return Run{
+		ID:        IDGen.UUID(),
+		TraceID:   IDGen.TraceID(),
+		SpanID:    IDGen.SpanID(),
+		State:     RunStateCreated,
+		CreatedAt: Now(),
+	}
+}
 
 func (r Run) ResourceID(testID string) string {
 	return fmt.Sprintf("test/%s/run/%s", testID, r.ID)

--- a/server/model/run.go
+++ b/server/model/run.go
@@ -28,8 +28,8 @@ func NewRun() Run {
 	}
 }
 
-func (r Run) ResourceID(testID string) string {
-	return fmt.Sprintf("test/%s/run/%s", testID, r.ID)
+func (r Run) ResourceID() string {
+	return fmt.Sprintf("test/%s/run/%s", r.TestID, r.ID)
 }
 
 func (r Run) Copy() Run {

--- a/server/model/tests.go
+++ b/server/model/tests.go
@@ -36,6 +36,8 @@ type (
 
 	Run struct {
 		ID                        uuid.UUID
+		TestID                    uuid.UUID
+		TestVersion               int
 		TraceID                   trace.TraceID
 		SpanID                    trace.SpanID
 		State                     RunState
@@ -49,7 +51,6 @@ type (
 		Response                  HTTPResponse
 		Trace                     *traces.Trace
 		Results                   *RunResults
-		TestVersion               int
 	}
 
 	RunResults struct {

--- a/server/subscription/manager.go
+++ b/server/subscription/manager.go
@@ -47,11 +47,11 @@ func (m *Manager) Unsubscribe(resourceID string, subscriptionID string) {
 	m.subscriptions[resourceID] = newArray
 }
 
-func (m *Manager) PublishUpdate(resourceID string, message Message) {
+func (m *Manager) PublishUpdate(message Message) {
 	m.mutex.Lock()
 	defer m.mutex.Unlock()
 
-	if subscribers, ok := m.subscriptions[resourceID]; ok {
+	if subscribers, ok := m.subscriptions[message.ResourceID]; ok {
 		for _, subscriber := range subscribers {
 			subscriber.Notify(message)
 		}

--- a/server/subscription/manager_test.go
+++ b/server/subscription/manager_test.go
@@ -25,17 +25,19 @@ func TestManagerSubscriptionDifferentResources(t *testing.T) {
 	manager.Subscribe("test:2", subscriber2)
 
 	test1Message := subscription.Message{
-		Type:    "test_update",
-		Content: "test1 update",
+		ResourceID: "test:1",
+		Type:       "test_update",
+		Content:    "test1 update",
 	}
 
 	test2Message := subscription.Message{
-		Type:    "test_update",
-		Content: "test2 update",
+		ResourceID: "test:2",
+		Type:       "test_update",
+		Content:    "test2 update",
 	}
 
-	manager.PublishUpdate("test:1", test1Message)
-	manager.PublishUpdate("test:2", test2Message)
+	manager.PublishUpdate(test1Message)
+	manager.PublishUpdate(test2Message)
 
 	assert.Equal(t, test1Message, messageReceivedBySubscriber1, "received message should be equal to the one sent")
 	assert.Equal(t, test2Message, messageReceivedBySubscriber2, "received message should be equal to the one sent")
@@ -63,7 +65,7 @@ func TestManagerSubscriptionSameResourceDifferentSubscribers(t *testing.T) {
 		Content: "test1 update",
 	}
 
-	manager.PublishUpdate("test:1", test1Message)
+	manager.PublishUpdate(test1Message)
 
 	assert.NotNil(t, messageReceivedBySubscriber1, "message received by subscriber should not be nil")
 	assert.Equal(t, messageReceivedBySubscriber1.Type, messageReceivedBySubscriber2.Type, "subscribers of the same resource should receive the same message")
@@ -80,23 +82,25 @@ func TestManagerUnsubscribe(t *testing.T) {
 	})
 
 	message1 := subscription.Message{
-		Type:    "test_update",
-		Content: "Test was updated",
+		ResourceID: "test:1",
+		Type:       "test_update",
+		Content:    "Test was updated",
 	}
 
 	message2 := subscription.Message{
-		Type:    "test_deleted",
-		Content: "Test was deleted",
+		ResourceID: "test:2",
+		Type:       "test_deleted",
+		Content:    "Test was deleted",
 	}
 
 	manager.Subscribe("test:1", subscriber)
-	manager.PublishUpdate("test:1", message1)
+	manager.PublishUpdate(message1)
 
 	assert.Equal(t, message1.Type, receivedMessage.Type)
 	assert.Equal(t, message1.Content, receivedMessage.Content)
 
 	manager.Unsubscribe("test:1", subscriber.ID())
-	manager.PublishUpdate("test:1", message2)
+	manager.PublishUpdate(message2)
 
 	assert.Equal(t, message1.Type, receivedMessage.Type, "subscriber should not be notified after unsubscribed")
 	assert.Equal(t, message1.Content, receivedMessage.Content, "subscriber should not be notified after unsubscribed")

--- a/server/testdb/runs.go
+++ b/server/testdb/runs.go
@@ -21,6 +21,7 @@ func (td *postgresDB) CreateRun(ctx context.Context, test model.Test, run model.
 	defer stmt.Close()
 
 	run.ID = IDGen.UUID()
+	run.TestID = test.ID
 	run.State = model.RunStateCreated
 	run.TestVersion = test.Version
 
@@ -72,7 +73,7 @@ func (td *postgresDB) DeleteRun(ctx context.Context, r model.Run) error {
 }
 
 func (td *postgresDB) GetRun(ctx context.Context, id uuid.UUID) (model.Run, error) {
-	stmt, err := td.db.Prepare("SELECT run, test_version FROM runs WHERE id = $1")
+	stmt, err := td.db.Prepare("SELECT run, test_id, test_version FROM runs WHERE id = $1")
 	if err != nil {
 		return model.Run{}, err
 	}
@@ -86,7 +87,7 @@ func (td *postgresDB) GetRun(ctx context.Context, id uuid.UUID) (model.Run, erro
 }
 
 func (td *postgresDB) GetTestRuns(ctx context.Context, test model.Test, take, skip int32) ([]model.Run, error) {
-	stmt, err := td.db.Prepare("SELECT run, test_version FROM runs WHERE test_id = $1 ORDER BY (run ->> 'CreatedAt')::timestamp DESC LIMIT $2 OFFSET $3")
+	stmt, err := td.db.Prepare("SELECT run, test_id, test_version FROM runs WHERE test_id = $1 ORDER BY (run ->> 'CreatedAt')::timestamp DESC LIMIT $2 OFFSET $3")
 	if err != nil {
 		return nil, err
 	}
@@ -110,7 +111,7 @@ func (td *postgresDB) GetTestRuns(ctx context.Context, test model.Test, take, sk
 }
 
 func (td *postgresDB) GetRunByTraceID(ctx context.Context, test model.Test, traceID trace.TraceID) (model.Run, error) {
-	stmt, err := td.db.Prepare("SELECT run, test_version FROM runs WHERE test_id = $1 AND run ->> 'TraceId' = $2")
+	stmt, err := td.db.Prepare("SELECT run, test_id, test_version FROM runs WHERE test_id = $1 AND run ->> 'TraceId' = $2")
 	if err != nil {
 		return model.Run{}, err
 	}
@@ -132,25 +133,33 @@ func encodeRun(r model.Run) (string, error) {
 	return string(b), nil
 }
 
-func decodeRun(b []byte, testVersion int) (model.Run, error) {
+func decodeRun(b []byte, testID string, testVersion int) (model.Run, error) {
+	tid, err := uuid.Parse(testID)
+	if err != nil {
+		return model.Run{}, fmt.Errorf("unmarshal run testID: %w", err)
+	}
 	var run model.Run
-	err := json.Unmarshal(b, &run)
+	err = json.Unmarshal(b, &run)
 	if err != nil {
 		return model.Run{}, fmt.Errorf("unmarshal run: %w", err)
 	}
 	run.TestVersion = testVersion
+	run.TestID = tid
 	return run, nil
 }
 
 func readRunRow(row scanner) (model.Run, error) {
-	var b []byte
-	var testVersion int
-	err := row.Scan(&b, &testVersion)
+	var (
+		b           []byte
+		testVersion int
+		testID      string
+	)
+	err := row.Scan(&b, &testID, &testVersion)
 	switch err {
 	case sql.ErrNoRows:
 		return model.Run{}, ErrNotFound
 	case nil:
-		return decodeRun(b, testVersion)
+		return decodeRun(b, testID, testVersion)
 	default:
 		return model.Run{}, fmt.Errorf("read run row: %w", err)
 	}


### PR DESCRIPTION
This PR ensures that all testRun updates are correctly notified to subscriptions by changing the notification approach. Instead of having each step "manually" notifying when necessary, I've implemented a composite "RunUpdater" that encapsulates all the update related processes. Now, when a testRun is updated during the testing process, it will automatically notify any subscribers.

For cleanness, this PR also made the `ResourceID` a method of the `TestRun`, which required to have the `TestID` available on the TestRun entity. It is mainly an internal field, so no mappings to openapi where made.

## Changes

-

## Fixes

-

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [x] updated the docs
- [ ] added a test
