### PR TITLE
fix: make spaces around operators optional in selector parsing regex

### DIFF
--- a/web/src/services/Selector.service.ts
+++ b/web/src/services/Selector.service.ts
@@ -18,7 +18,7 @@ const getValue = (value: string): string => {
 
 const selectorRegex = /span\[(.*)\]/i;
 const nthChildNumberRegex = /\((.*)\)/i;
-const operationRegex = / ([=]+|contains) /;
+const operationRegex = /\s?([=<]+|contains)\s?/;
 
 const getFilters = (selectors: TSpanSelector[]) =>
   selectors.map(({key, operator, value}) => `${key} ${operator} ${getValue(value)}`);


### PR DESCRIPTION
This PR fixes the selector parsing regex to make spaces around operators optional.
Examples:

- `selector: "span[tracetest.span.duration<=500]"` is valid
- `selector: "span[tracetest.span.type = http]"` is valid

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
