### PR TITLE
🔍 712  implement full text search

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -36,7 +36,6 @@
         "react-dom": "17.0.2",
         "react-flow-renderer": "9.7.3",
         "react-intersection-observer": "9.1.0",
-        "react-json-pretty": "2.2.0",
         "react-json-view": "1.21.3",
         "react-redux": "7.2.6",
         "react-reflex": "4.0.9",
@@ -30830,18 +30829,6 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="
     },
-    "node_modules/react-json-pretty": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/react-json-pretty/-/react-json-pretty-2.2.0.tgz",
-      "integrity": "sha512-3UMzlAXkJ4R8S4vmkRKtvJHTewG4/rn1Q18n0zqdu/ipZbUPLVZD+QwC7uVcD/IAY3s8iNVHlgR2dMzIUS0n1A==",
-      "dependencies": {
-        "prop-types": "^15.6.2"
-      },
-      "peerDependencies": {
-        "react": ">=15.0",
-        "react-dom": ">=15.0"
-      }
-    },
     "node_modules/react-json-view": {
       "version": "1.21.3",
       "resolved": "https://registry.npmjs.org/react-json-view/-/react-json-view-1.21.3.tgz",
@@ -59955,14 +59942,6 @@
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="
-    },
-    "react-json-pretty": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/react-json-pretty/-/react-json-pretty-2.2.0.tgz",
-      "integrity": "sha512-3UMzlAXkJ4R8S4vmkRKtvJHTewG4/rn1Q18n0zqdu/ipZbUPLVZD+QwC7uVcD/IAY3s8iNVHlgR2dMzIUS0n1A==",
-      "requires": {
-        "prop-types": "^15.6.2"
-      }
     },
     "react-json-view": {
       "version": "1.21.3",

--- a/web/package.json
+++ b/web/package.json
@@ -32,7 +32,6 @@
     "react-dom": "17.0.2",
     "react-flow-renderer": "9.7.3",
     "react-intersection-observer": "9.1.0",
-    "react-json-pretty": "2.2.0",
     "react-json-view": "1.21.3",
     "react-redux": "7.2.6",
     "react-reflex": "4.0.9",

--- a/web/src/components/AttributeList/AttributeList.tsx
+++ b/web/src/components/AttributeList/AttributeList.tsx
@@ -3,6 +3,7 @@ import {useState} from 'react';
 import {TResultAssertions} from 'types/Assertion.types';
 import {TSpanFlatAttribute} from 'types/Span.types';
 import TraceAnalyticsService from 'services/Analytics/TraceAnalytics.service';
+import {useSpan} from 'providers/Span/Span.provider';
 import {useGuidedTour} from 'providers/GuidedTour/GuidedTour.provider';
 import * as S from './AttributeList.styled';
 import EmptyAttributeList from './EmptyAttributeList';
@@ -15,6 +16,7 @@ interface IProps {
 
 const AttributeList: React.FC<IProps> = ({assertions, attributeList, onCreateAssertion}) => {
   const [isCopied, setIsCopied] = useState(false);
+  const {searchText} = useSpan();
 
   const onCopy = (value: string) => {
     TraceAnalyticsService.onAttributeCopy();
@@ -32,6 +34,7 @@ const AttributeList: React.FC<IProps> = ({assertions, attributeList, onCreateAss
     <S.AttributeList data-cy="attribute-list">
       {attributeList.map((attribute, index) => (
         <AttributeRow
+          searchText={searchText}
           shouldDisplayActions={getShouldDisplayActions(index)}
           assertionsFailed={assertions?.[attribute.key]?.failed}
           assertionsPassed={assertions?.[attribute.key]?.passed}

--- a/web/src/components/AttributeRow/AttributeRow.tsx
+++ b/web/src/components/AttributeRow/AttributeRow.tsx
@@ -5,6 +5,7 @@ import {TSpanFlatAttribute} from 'types/Span.types';
 import GuidedTourService, {GuidedTours} from '../../services/GuidedTour.service';
 import AttributeValue from '../AttributeValue';
 import {Steps} from '../GuidedTour/traceStepList';
+import Highlighted from '../Highlighted';
 import AttributeCheck from './AttributeCheck';
 import * as S from './AttributeRow.styled';
 
@@ -17,6 +18,7 @@ interface IProps {
   onCreateAssertion(attribute: TSpanFlatAttribute): void;
   setIsCopied(value: boolean): void;
   shouldDisplayActions: boolean;
+  searchText: string;
 }
 
 const AttributeRow = ({
@@ -29,6 +31,7 @@ const AttributeRow = ({
   onCreateAssertion,
   setIsCopied,
   shouldDisplayActions,
+  searchText,
 }: IProps) => {
   const {isHovering, onMouseEnter, onMouseLeave} = useHover();
   const passedCount = assertionsPassed?.length ?? 0;
@@ -41,11 +44,13 @@ const AttributeRow = ({
   return (
     <S.AttributeRow onMouseEnter={onMouseEnter} onMouseLeave={onMouseLeave}>
       <S.TextContainer>
-        <S.Text type="secondary">{key}</S.Text>
+        <S.Text type="secondary">
+          <Highlighted text={key} highlight={searchText} />
+        </S.Text>
       </S.TextContainer>
 
       <S.AttributeValueRow>
-        <AttributeValue value={value} />
+        <AttributeValue value={value} searchText={searchText} />
         {passedCount > 0 && <AttributeCheck items={assertionsPassed!} type="success" />}
         {failedCount > 0 && <AttributeCheck items={assertionsFailed!} type="error" />}
       </S.AttributeValueRow>

--- a/web/src/components/AttributeValue/AttributeValue.tsx
+++ b/web/src/components/AttributeValue/AttributeValue.tsx
@@ -1,27 +1,34 @@
 import {TextProps} from 'antd/lib/typography/Text';
 import {useMemo, useState} from 'react';
-import JSONPretty from 'react-json-pretty';
 
 import {isJson} from 'utils/Common';
+import Highlighted from '../Highlighted';
 import * as S from './AttributeValue.styled';
 
 interface IProps extends TextProps {
   value: string;
+  searchText?: string;
 }
 
-const AttributeValue: React.FC<IProps> = ({value, ...props}) => {
+const AttributeValue = ({value, searchText = '', ...props}: IProps) => {
   const [isCollapsed, setIsCollapsed] = useState(false);
   const isJsonValue = useMemo(() => isJson(value), [value]);
 
   if (isJsonValue) {
     return (
       <S.ValueJson $isCollapsed={isCollapsed} onClick={() => setIsCollapsed(!isCollapsed)} {...props}>
-        <JSONPretty data={value} />
+        <pre>
+          <Highlighted highlight={searchText} text={JSON.stringify(JSON.parse(value), null, 2)} />
+        </pre>
       </S.ValueJson>
     );
   }
 
-  return <S.ValueText {...props}>{value}</S.ValueText>;
+  return (
+    <S.ValueText {...props}>
+      <Highlighted text={value} highlight={searchText} />
+    </S.ValueText>
+  );
 };
 
 export default AttributeValue;

--- a/web/src/components/Diagram/Diagram.tsx
+++ b/web/src/components/Diagram/Diagram.tsx
@@ -1,4 +1,5 @@
 import {TestState} from '../../constants/TestRun.constants';
+import {useSpan} from '../../providers/Span/Span.provider';
 import {TSpan} from '../../types/Span.types';
 import {TTestRunState} from '../../types/TestRun.types';
 import {TTrace} from '../../types/Trace.types';
@@ -12,12 +13,17 @@ export enum SupportedDiagrams {
 }
 
 export interface IDiagramProps {
-  affectedSpans: string[];
-  onSelectSpan?(spanId: string): void;
-  selectedSpan?: TSpan;
   trace: TTrace;
   type: SupportedDiagrams;
   runState: TTestRunState;
+}
+
+export interface IDiagramComponentProps {
+  spanList: TSpan[];
+  affectedSpans: string[];
+  matchedSpans: string[];
+  selectedSpan?: TSpan;
+  onSelectSpan(spanId: string): void;
 }
 
 const ComponentMap: Record<string, typeof DAGComponent | typeof TimelineChart> = {
@@ -25,13 +31,15 @@ const ComponentMap: Record<string, typeof DAGComponent | typeof TimelineChart> =
   [SupportedDiagrams.Timeline]: TimelineChart,
 };
 
-const Diagram: React.FC<IDiagramProps> = ({type, runState, ...props}) => {
+const Diagram: React.FC<IDiagramProps> = ({type, runState, trace}) => {
   const Component = ComponentMap[type || ''] || DAGComponent;
+  const {onSelectSpan, selectedSpan, affectedSpans, matchedSpans} = useSpan();
+  const spanList = trace.spans || [];
 
   return runState === TestState.FINISHED ? (
-    <Component type={type} runState={runState} {...props} />
+    <Component {...{spanList, onSelectSpan, selectedSpan, affectedSpans, matchedSpans}} />
   ) : (
-    <SkeletonDiagram onSelectSpan={props.onSelectSpan} selectedSpan={props.selectedSpan} />
+    <SkeletonDiagram onSelectSpan={onSelectSpan} selectedSpan={selectedSpan} />
   );
 };
 

--- a/web/src/components/Diagram/components/DAG/DAG.styled.tsx
+++ b/web/src/components/Diagram/components/DAG/DAG.styled.tsx
@@ -5,6 +5,10 @@ export const Container = styled.div<{$showAffected: boolean}>`
   position: relative;
   height: 100%;
 
+  .react-flow__node-TraceNode.matched > div {
+    box-shadow: 0 4px 8px #61175E;
+  }
+
   ${({$showAffected}) =>
     $showAffected &&
     css`

--- a/web/src/components/Diagram/components/DAG/DAG.tsx
+++ b/web/src/components/Diagram/components/DAG/DAG.tsx
@@ -1,24 +1,19 @@
 import {Steps} from 'components/GuidedTour/traceStepList';
 import React, {useCallback, useMemo} from 'react';
 import ReactFlow, {Background, FlowElement} from 'react-flow-renderer';
-import {TraceNodes} from 'constants/Diagram.constants';
 import {useDAGChart} from 'hooks/useDAGChart';
 import TraceDiagramAnalyticsService from 'services/Analytics/TraceDiagramAnalytics.service';
 import GuidedTourService, {GuidedTours} from 'services/GuidedTour.service';
+import SpanService from 'services/Span.service';
 import {TSpan} from 'types/Span.types';
 import TraceNode from 'components/TraceNode';
-import {IDiagramProps} from 'components/Diagram/Diagram';
+import {IDiagramComponentProps} from 'components/Diagram/Diagram';
 import * as S from './DAG.styled';
 import Controls from './Controls';
 
 const {onClickSpan} = TraceDiagramAnalyticsService;
 
-const DAG: React.FC<IDiagramProps> = ({
-  affectedSpans,
-  trace: {spans = []},
-  selectedSpan,
-  onSelectSpan,
-}): JSX.Element => {
+const DAG = ({spanList = [], affectedSpans, onSelectSpan, matchedSpans, selectedSpan}: IDiagramComponentProps) => {
   const handleElementClick = useCallback(
     (event, {id}: FlowElement) => {
       onClickSpan(id);
@@ -28,15 +23,8 @@ const DAG: React.FC<IDiagramProps> = ({
   );
 
   const nodeList = useMemo(
-    () =>
-      spans.map(span => ({
-        id: span.id,
-        parentIds: span.parentId ? [span.parentId] : [],
-        data: span,
-        type: TraceNodes.TraceNode,
-        className: affectedSpans.includes(span.id) ? 'affected' : '',
-      })),
-    [affectedSpans, spans]
+    () => SpanService.getNodeListFromSpanList(spanList, affectedSpans, matchedSpans),
+    [affectedSpans, matchedSpans, spanList]
   );
 
   const elementList = useDAGChart<TSpan>(nodeList, selectedSpan, onSelectSpan);

--- a/web/src/components/Diagram/components/TimelineChart.tsx
+++ b/web/src/components/Diagram/components/TimelineChart.tsx
@@ -1,26 +1,26 @@
 import {useCallback, useEffect, useMemo, useRef} from 'react';
 import * as d3 from 'd3';
-import TraceAnalyticsService from '../../../services/Analytics/TraceAnalytics.service';
-import {IDiagramProps} from '../Diagram';
-import {TSpan} from '../../../types/Span.types';
-import {getNotchColor} from '../../TraceNode/TraceNode.styled';
+import TraceAnalyticsService from 'services/Analytics/TraceAnalytics.service';
+import {TSpan} from 'types/Span.types';
+import {getNotchColor} from 'components/TraceNode/TraceNode.styled';
+import {IDiagramComponentProps} from '../Diagram';
 import * as S from './TimelineChart.styled';
 
 const {onTimelineSpanClick} = TraceAnalyticsService;
 
 const barHeight = 54;
 
-export const TimelineChart = ({affectedSpans, trace, selectedSpan, onSelectSpan}: IDiagramProps) => {
+export const TimelineChart = ({affectedSpans, spanList, selectedSpan, onSelectSpan}: IDiagramComponentProps) => {
   const svgRef = useRef<SVGSVGElement>(null);
   const treeFactory = d3.tree().size([200, 450]).nodeSize([0, 5]);
 
-  const spanDates = trace.spans.map(span => ({
+  const spanDates = spanList.map(span => ({
     startTime: span.startTime,
     endTime: span.endTime,
     span,
   }));
 
-  const spanMap = trace.spans.reduce(
+  const spanMap = spanList.reduce(
     (acc: {[key: string]: {id: string; parentIds: Array<string | undefined>; data: any}}, span) => {
       acc[span.id] = acc[span.id] || {
         id: span.id,
@@ -94,7 +94,7 @@ export const TimelineChart = ({affectedSpans, trace, selectedSpan, onSelectSpan}
       })
       .attr('y', 20);
     chart.append('g').attr('class', 'container').attr('transform', `translate(0, 50)`);
-  }, [trace]);
+  }, [spanList]);
 
   const drawChart = useCallback(() => {
     const nodes = treeFactory(root);

--- a/web/src/components/DiagramSwitcher/DiagramSwitcher.tsx
+++ b/web/src/components/DiagramSwitcher/DiagramSwitcher.tsx
@@ -31,7 +31,7 @@ const DiagramSwitcher: React.FC<IProps> = ({onSearch, onTypeChange, selectedType
           />
         </Tooltip>
       </S.Switch>
-      <SearchInput onSearch={onSearch} width="100%" placeholder="Search in trace (Not implemented yet)" />
+      <SearchInput onSearch={onSearch} width="100%" placeholder="Search in trace" />
     </S.DiagramSwitcher>
   );
 };

--- a/web/src/components/Highlighted/Highlighted.styled.ts
+++ b/web/src/components/Highlighted/Highlighted.styled.ts
@@ -1,0 +1,7 @@
+import styled from 'styled-components';
+
+export const Mark = styled.mark`
+  && {
+    background-color: #61175e29;
+  }
+`;

--- a/web/src/components/Highlighted/Highlighted.tsx
+++ b/web/src/components/Highlighted/Highlighted.tsx
@@ -1,0 +1,29 @@
+import * as S from './Highlighted.styled';
+
+interface IProps {
+  text: string;
+  highlight: string;
+}
+
+const Highlighted = ({text, highlight}: IProps) => {
+  if (!highlight.trim()) return <span>{text}</span>;
+
+  const regex = new RegExp(`(${highlight})`, 'gi');
+  const partList = text.split(regex);
+
+  return (
+    <span>
+      {partList.filter(String).map((part, index) =>
+        regex.test(part) ? (
+          // eslint-disable-next-line react/no-array-index-key
+          <S.Mark key={`${part}-${index}`}>{part}</S.Mark>
+        ) : (
+          // eslint-disable-next-line react/no-array-index-key
+          <span key={`${part}-${index}`}>{part}</span>
+        )
+      )}
+    </span>
+  );
+};
+
+export default Highlighted;

--- a/web/src/components/Highlighted/index.ts
+++ b/web/src/components/Highlighted/index.ts
@@ -1,0 +1,2 @@
+// eslint-disable-next-line no-restricted-exports
+export {default} from './Highlighted';

--- a/web/src/components/Run/Run.tsx
+++ b/web/src/components/Run/Run.tsx
@@ -1,12 +1,8 @@
-import {useCallback} from 'react';
-import {useStoreActions} from 'react-flow-renderer';
-
 import RunBottomPanel from 'components/RunBottomPanel';
 import {RunLayoutProvider} from 'components/RunLayout';
 import RunTopPanel from 'components/RunTopPanel';
 import {TTest} from 'types/Test.types';
 import {TTestRun} from 'types/TestRun.types';
-import {useSpan} from '../../providers/Span/Span.provider';
 
 interface IProps {
   displayError: boolean;
@@ -15,30 +11,14 @@ interface IProps {
 }
 
 const Run = ({displayError, run, test}: IProps) => {
-  const addSelected = useStoreActions(actions => actions.addSelectedElements);
-  const {selectedSpan, onSelectSpan} = useSpan();
-
-  const handleSelectSpan = useCallback(
-    (spanId: string) => {
-      const span = run?.trace?.spans.find(({id}) => id === spanId);
-      if (span) {
-        addSelected([{id: span?.id}]);
-        onSelectSpan(span);
-      }
-    },
-    [addSelected, onSelectSpan, run?.trace?.spans]
-  );
-
   if (displayError) {
     return null;
   }
 
   return (
     <RunLayoutProvider
-      bottomPanel={
-        <RunBottomPanel onSelectSpan={handleSelectSpan} run={run} selectedSpan={selectedSpan!} testId={test?.id!} />
-      }
-      topPanel={<RunTopPanel onSelectSpan={handleSelectSpan} run={run} selectedSpan={selectedSpan!} />}
+      bottomPanel={<RunBottomPanel run={run} testId={test?.id!} />}
+      topPanel={<RunTopPanel run={run} />}
     />
   );
 };

--- a/web/src/components/RunBottomPanel/RunBottomPanel.tsx
+++ b/web/src/components/RunBottomPanel/RunBottomPanel.tsx
@@ -3,21 +3,20 @@ import {useAssertionForm} from 'components/AssertionForm/AssertionFormProvider';
 import LoadingSpinner from 'components/LoadingSpinner';
 import TestResults from 'components/TestResults';
 import {useTestDefinition} from 'providers/TestDefinition/TestDefinition.provider';
-import {TSpan} from 'types/Span.types';
 import {TTestRun} from 'types/TestRun.types';
+import { useSpan } from '../../providers/Span/Span.provider';
 import Header from './Header';
 import * as S from './RunBottomPanel.styled';
 
 interface IProps {
-  onSelectSpan: (spanId: string) => void;
   run: TTestRun;
-  selectedSpan: TSpan;
   testId: string;
 }
 
-const RunBottomPanel = ({onSelectSpan, run: {id: runId}, run, selectedSpan, testId}: IProps) => {
+const RunBottomPanel = ({run: {id: runId}, run, testId}: IProps) => {
   const {isOpen: isAssertionFormOpen, formProps, onSubmit, close} = useAssertionForm();
   const {isLoading, assertionResults} = useTestDefinition();
+  const {selectedSpan, onSelectSpan} = useSpan();
 
   return (
     <>
@@ -25,7 +24,7 @@ const RunBottomPanel = ({onSelectSpan, run: {id: runId}, run, selectedSpan, test
         assertionResults={assertionResults}
         isDisabled={isAssertionFormOpen}
         run={run}
-        selectedSpan={selectedSpan}
+        selectedSpan={selectedSpan!}
       />
       <S.Container id="assertions-container">
         <S.Content>

--- a/web/src/components/RunTopPanel/RunTopPanel.tsx
+++ b/web/src/components/RunTopPanel/RunTopPanel.tsx
@@ -6,19 +6,16 @@ import DiagramSwitcher from 'components/DiagramSwitcher';
 import SpanDetail from 'components/SpanDetail';
 import TraceAnalyticsService from 'services/Analytics/TraceAnalytics.service';
 import {useSpan} from 'providers/Span/Span.provider';
-import {TSpan} from 'types/Span.types';
 import {TTestRun} from 'types/TestRun.types';
 import * as S from './RunTopPanel.styled';
 
 interface IProps {
-  onSelectSpan: (spanId: string) => void;
   run: TTestRun;
-  selectedSpan: TSpan;
 }
 
-const RunTopPanel = ({onSelectSpan, run, selectedSpan}: IProps) => {
+const RunTopPanel = ({run}: IProps) => {
   const [diagramType, setDiagramType] = useState<SupportedDiagrams>(SupportedDiagrams.DAG);
-  const {affectedSpans} = useSpan();
+  const {onSearch, selectedSpan} = useSpan();
 
   return (
     <S.Container>
@@ -28,17 +25,10 @@ const RunTopPanel = ({onSelectSpan, run, selectedSpan}: IProps) => {
             TraceAnalyticsService.onSwitchDiagramView(type);
             setDiagramType(type);
           }}
-          onSearch={() => console.log('onSearch')}
+          onSearch={onSearch}
           selectedType={diagramType}
         />
-        <Diagram
-          affectedSpans={affectedSpans}
-          onSelectSpan={onSelectSpan}
-          selectedSpan={selectedSpan}
-          trace={run.trace!}
-          runState={run.state}
-          type={diagramType}
-        />
+        <Diagram trace={run.trace!} runState={run.state} type={diagramType} />
       </S.LeftPanel>
       <S.RightPanel>
         <SpanDetail span={selectedSpan} />

--- a/web/src/components/SpanDetail/SpanDetail.styled.ts
+++ b/web/src/components/SpanDetail/SpanDetail.styled.ts
@@ -57,3 +57,12 @@ export const AddAssertionButton = styled(Button).attrs({
     font-weight: 600;
   }
 `;
+
+export const Dot = styled.div`
+  height: 10px;
+  width: 10px;
+  margin-left: 5px;
+  background-color: #61175e29;
+  border-radius: 50%;
+  display: inline-block;
+`;

--- a/web/src/components/SpanDetail/SpanDetailTabs.tsx
+++ b/web/src/components/SpanDetail/SpanDetailTabs.tsx
@@ -2,16 +2,20 @@ import {Tabs} from 'antd';
 import {capitalize} from 'lodash';
 import React, {useMemo} from 'react';
 
+import {getObjectIncludesText} from 'utils/Common';
+import {useSpan} from 'providers/Span/Span.provider';
 import AttributeList from 'components/AttributeList';
 import TraceAnalyticsService from 'services/Analytics/TraceAnalytics.service';
 import SpanAttributeService from 'services/SpanAttribute.service';
 import {ISpanDetailsComponentProps} from './SpanDetail';
+import * as S from './SpanDetail.styled';
 
 const SpanDetailTabs: React.FC<ISpanDetailsComponentProps> = ({
   span: {attributeList = [], type} = {},
   onCreateAssertion,
   assertions,
 }) => {
+  const {searchText} = useSpan();
   const sectionList = useMemo(
     () => SpanAttributeService.getSpanAttributeSectionsList(attributeList, type!),
     [attributeList, type]
@@ -20,7 +24,14 @@ const SpanDetailTabs: React.FC<ISpanDetailsComponentProps> = ({
   return (
     <Tabs data-cy="span-details-attributes" onChange={tabName => TraceAnalyticsService.onChangeTab(tabName)}>
       {sectionList.map(({section, attributeList: attrList}) => (
-        <Tabs.TabPane tab={capitalize(section)} key={section}>
+        <Tabs.TabPane
+          tab={
+            <span>
+              {capitalize(section)} {getObjectIncludesText(attrList, searchText) && <S.Dot />}
+            </span>
+          }
+          key={section}
+        >
           <AttributeList assertions={assertions} attributeList={attrList} onCreateAssertion={onCreateAssertion} />
         </Tabs.TabPane>
       ))}

--- a/web/src/components/SpanDetail/SpanHeader.tsx
+++ b/web/src/components/SpanDetail/SpanHeader.tsx
@@ -1,17 +1,25 @@
 import {Typography} from 'antd';
+import {useSpan} from '../../providers/Span/Span.provider';
 import GuidedTourService, {GuidedTours} from '../../services/GuidedTour.service';
 import {Steps} from '../GuidedTour/traceStepList';
+import Highlighted from '../Highlighted';
 import * as S from './SpanDetail.styled';
 
 interface IProps {
   title: string;
 }
 
-const SpanHeader: React.FC<IProps> = ({title}) => (
-  <S.SpanHeader data-tour={GuidedTourService.getStep(GuidedTours.Trace, Steps.Details)}>
-    <S.SpanHeaderTitle>Span Details</S.SpanHeaderTitle>
-    <Typography.Text type="secondary">{title}</Typography.Text>
-  </S.SpanHeader>
-);
+const SpanHeader: React.FC<IProps> = ({title}) => {
+  const {searchText} = useSpan();
+
+  return (
+    <S.SpanHeader data-tour={GuidedTourService.getStep(GuidedTours.Trace, Steps.Details)}>
+      <S.SpanHeaderTitle>Span Details</S.SpanHeaderTitle>
+      <Typography.Text type="secondary">
+        <Highlighted highlight={searchText} text={title} />
+      </Typography.Text>
+    </S.SpanHeader>
+  );
+};
 
 export default SpanHeader;

--- a/web/src/components/TraceNode/components/GenericTraceNode.tsx
+++ b/web/src/components/TraceNode/components/GenericTraceNode.tsx
@@ -1,13 +1,12 @@
 import Text from 'antd/lib/typography/Text';
 import {capitalize} from 'lodash';
-import React from 'react';
 import {Handle, Position} from 'react-flow-renderer';
-import {SemanticGroupNamesToText} from '../../../constants/SemanticGroupNames.constants';
+import {SemanticGroupNamesToText} from 'constants/SemanticGroupNames.constants';
+import SpanService from 'services/Span.service';
 import * as S from '../TraceNode.styled';
-import SpanService from '../../../services/Span.service';
 import {TTraceNodeProps} from '../TraceNode';
 
-const GenericTraceNode: React.FC<TTraceNodeProps> = ({id, data: {name, type}, data: span, selected}) => {
+const GenericTraceNode = ({id, data: {name, type}, data: span, selected}: TTraceNodeProps) => {
   const {heading, primary} = SpanService.getSpanNodeInfo(span);
   const spanTypeText = SemanticGroupNamesToText[type];
 

--- a/web/src/redux/apis/TraceTest.api.ts
+++ b/web/src/redux/apis/TraceTest.api.ts
@@ -125,6 +125,11 @@ const TraceTestAPI = createApi({
       query: ({testId, runId, query}) => `/tests/${testId}/run/${runId}/select?query=${encodeURIComponent(query)}`,
       providesTags: (result, error, {query}) => (result ? [{type: Tags.SPAN, id: `${query}-LIST`}] : []),
     }),
+    // TODO: add when ready
+    // searchSpans: build.query<string[], {testId: string; runId: string; query: string}>({
+    //   query: ({testId, runId, query}) => `/tests/${testId}/run/${runId}/select?query=${encodeURIComponent(query)}`,
+    //   providesTags: (result, error, {query}) => (result ? [{type: Tags.SPAN, id: `${query}-SEARCH`}] : []),
+    // }),
   }),
 });
 
@@ -143,6 +148,8 @@ export const {
   useLazyGetRunListQuery,
   useDryRunMutation,
   useDeleteRunByIdMutation,
+  // useSearchSpansQuery,
+  // useLazySearchSpansQuery,
 } = TraceTestAPI;
 export const {endpoints} = TraceTestAPI;
 

--- a/web/src/services/Span.service.ts
+++ b/web/src/services/Span.service.ts
@@ -1,7 +1,10 @@
 import {differenceBy, intersectionBy} from 'lodash';
-import {CompareOperator, PseudoSelector} from '../constants/Operator.constants';
-import {SELECTOR_DEFAULT_ATTRIBUTES, SemanticGroupNameNodeMap} from '../constants/SemanticGroupNames.constants';
-import {TSpan, TSpanFlatAttribute} from '../types/Span.types';
+import {TraceNodes} from 'constants/Diagram.constants';
+import {CompareOperator, PseudoSelector} from 'constants/Operator.constants';
+import {SELECTOR_DEFAULT_ATTRIBUTES, SemanticGroupNameNodeMap} from 'constants/SemanticGroupNames.constants';
+import {TSpan, TSpanFlatAttribute} from 'types/Span.types';
+import {getObjectIncludesText} from 'utils/Common';
+import {IDAGNode} from './DAG.service';
 import OperatorService from './Operator.service';
 
 const itemSelectorKeys = SELECTOR_DEFAULT_ATTRIBUTES.flatMap(el => el.attributes);
@@ -53,6 +56,30 @@ const SpanService = () => ({
     };
 
     return {selectorList, pseudoSelector};
+  },
+
+  searchSpanList(spanList: TSpan[], searchText: string) {
+    if (!searchText.trim()) return [];
+
+    return spanList.reduce<string[]>(
+      (matchList, span) => (getObjectIncludesText(span, searchText) ? [...matchList, span.id] : matchList),
+      []
+    );
+  },
+
+  getNodeListFromSpanList(spanList: TSpan[], affectedList: string[], matchedList: string[]): IDAGNode<TSpan>[] {
+    return spanList.map(span => {
+      const isAffected = affectedList.includes(span.id);
+      const isMatched = matchedList.includes(span.id);
+
+      return {
+        id: span.id,
+        parentIds: span.parentId ? [span.parentId] : [],
+        data: span,
+        type: TraceNodes.TraceNode,
+        className: `${isAffected ? 'affected' : ''} ${isMatched ? 'matched' : ''}`,
+      };
+    });
   },
 });
 

--- a/web/src/services/__tests__/Span.service.test.ts
+++ b/web/src/services/__tests__/Span.service.test.ts
@@ -67,4 +67,20 @@ describe('SpanService', () => {
       expect(selectorInfo.pseudoSelector).toEqual({selector: PseudoSelector.ALL});
     });
   });
+
+  describe('getNodeListFromSpanList', () => {
+    it('should return the node list from the span list', () => {
+      const span1 = SpanMock.model({id: '1'});
+      const span2 = SpanMock.model({id: '2'});
+      const spanList = [span1, span2];
+      const affectedList = [span1.id];
+      const matchedList = [span2.id];
+
+      const nodeList = SpanService.getNodeListFromSpanList(spanList, affectedList, matchedList);
+
+      expect(nodeList).toHaveLength(spanList.length);
+      expect(nodeList[0].className?.trim()).toContain('affected');
+      expect(nodeList[1].className?.trim()).toContain('matched');
+    });
+  });
 });

--- a/web/src/utils/Common.ts
+++ b/web/src/utils/Common.ts
@@ -14,3 +14,12 @@ export const isJson = (str: string) => {
 
   return Number.isNaN(Number(str)) && !isBoolean(str) && true;
 };
+
+export const getObjectIncludesText = (object: unknown, text: string): boolean => {
+  if (!text.length) return false;
+
+  const searchTextLower = text.toLowerCase();
+  const stringSpan = JSON.stringify(object).toLowerCase();
+
+  return stringSpan.includes(searchTextLower);
+};


### PR DESCRIPTION
This PR implements the full-text search from the front end side (waiting on the BE service to be ready) as well as adding new styles to display what spans and attributes match the search.

## Changes

- Trace search input works now!
- New styles for matched spans and attributes

## Fixes

- https://github.com/kubeshop/tracetest/issues/712 (Partially, still need the BE service).

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [x] added a test
