### PR TITLE
feat: Allow assertions at the span collection level

### DIFF
--- a/server/assertions/assertions.go
+++ b/server/assertions/assertions.go
@@ -27,7 +27,6 @@ func Assert(defs model.OrderedMap[model.SpanQuery, []model.Assertion], trace tra
 }
 
 func assert(a model.Assertion, spans []traces.Span) model.AssertionResult {
-
 	if a.Attribute.IsMeta() {
 		return assertMeta(a, spans)
 	}
@@ -36,7 +35,6 @@ func assert(a model.Assertion, spans []traces.Span) model.AssertionResult {
 }
 
 func assertMeta(a model.Assertion, spans []traces.Span) model.AssertionResult {
-
 	res := func(res model.SpanAssertionResult, err error) model.AssertionResult {
 		return model.AssertionResult{
 			Assertion: a,

--- a/server/assertions/assertions.go
+++ b/server/assertions/assertions.go
@@ -46,8 +46,9 @@ func assert(a model.Assertion, spans []traces.Span) model.AssertionResult {
 func apply(a model.Assertion, span traces.Span) model.SpanAssertionResult {
 	expected := a.Value
 	actual := span.Attributes.Get(a.Attribute)
+	sid := trace.SpanID(span.ID)
 	return model.SpanAssertionResult{
-		SpanID:        trace.SpanID(span.ID),
+		SpanID:        &sid,
 		ObservedValue: actual,
 		CompareErr:    a.Comparator.Compare(expected, actual),
 	}

--- a/server/assertions/assertions.go
+++ b/server/assertions/assertions.go
@@ -27,10 +27,43 @@ func Assert(defs model.OrderedMap[model.SpanQuery, []model.Assertion], trace tra
 }
 
 func assert(a model.Assertion, spans []traces.Span) model.AssertionResult {
+
+	if a.Attribute.IsMeta() {
+		return assertMeta(a, spans)
+	}
+
+	return assertIndividualSpans(a, spans)
+}
+
+func assertMeta(a model.Assertion, spans []traces.Span) model.AssertionResult {
+
+	res := func(res model.SpanAssertionResult, err error) model.AssertionResult {
+		return model.AssertionResult{
+			Assertion: a,
+			AllPassed: err == nil,
+			Results:   []model.SpanAssertionResult{res},
+		}
+	}
+
+	ma, err := metaAttr(a.Attribute.String())
+	if err != nil {
+		return res(model.SpanAssertionResult{}, err)
+	}
+
+	sar := apply(a, ma.Value(spans), nil)
+
+	return res(sar, sar.CompareErr)
+}
+
+func assertIndividualSpans(a model.Assertion, spans []traces.Span) model.AssertionResult {
 	res := make([]model.SpanAssertionResult, len(spans))
 	allPassed := true
 	for i, span := range spans {
-		res[i] = apply(a, span)
+		res[i] = apply(
+			a,
+			span.Attributes.Get(a.Attribute.String()),
+			&span.ID,
+		)
 		if res[i].CompareErr != nil {
 			allPassed = false
 		}
@@ -43,12 +76,10 @@ func assert(a model.Assertion, spans []traces.Span) model.AssertionResult {
 	}
 }
 
-func apply(a model.Assertion, span traces.Span) model.SpanAssertionResult {
+func apply(a model.Assertion, actual string, spanID *trace.SpanID) model.SpanAssertionResult {
 	expected := a.Value
-	actual := span.Attributes.Get(a.Attribute.String())
-	sid := trace.SpanID(span.ID)
 	return model.SpanAssertionResult{
-		SpanID:        &sid,
+		SpanID:        spanID,
 		ObservedValue: actual,
 		CompareErr:    a.Comparator.Compare(expected, actual),
 	}

--- a/server/assertions/assertions.go
+++ b/server/assertions/assertions.go
@@ -45,7 +45,7 @@ func assert(a model.Assertion, spans []traces.Span) model.AssertionResult {
 
 func apply(a model.Assertion, span traces.Span) model.SpanAssertionResult {
 	expected := a.Value
-	actual := span.Attributes.Get(a.Attribute)
+	actual := span.Attributes.Get(a.Attribute.String())
 	sid := trace.SpanID(span.ID)
 	return model.SpanAssertionResult{
 		SpanID:        &sid,

--- a/server/assertions/assetions_test.go
+++ b/server/assertions/assetions_test.go
@@ -50,7 +50,7 @@ func TestAssertion(t *testing.T) {
 					},
 					Results: []model.SpanAssertionResult{
 						{
-							SpanID:        spanID,
+							SpanID:        &spanID,
 							ObservedValue: "2000",
 							CompareErr:    nil,
 						},
@@ -93,7 +93,7 @@ func TestAssertion(t *testing.T) {
 					},
 					Results: []model.SpanAssertionResult{
 						{
-							SpanID:        spanID,
+							SpanID:        &spanID,
 							ObservedValue: `{"id":52}`,
 							CompareErr:    nil,
 						},
@@ -107,7 +107,7 @@ func TestAssertion(t *testing.T) {
 					},
 					Results: []model.SpanAssertionResult{
 						{
-							SpanID:        spanID,
+							SpanID:        &spanID,
 							ObservedValue: "2000",
 							CompareErr:    nil,
 						},

--- a/server/assertions/assetions_test.go
+++ b/server/assertions/assetions_test.go
@@ -62,13 +62,13 @@ func TestAssertion(t *testing.T) {
 			name: "CanAssertOnSpanMatchCount",
 			testDef: (model.OrderedMap[model.SpanQuery, []model.Assertion]{}).MustAdd(`span[service.name="Pokeshop"]`, []model.Assertion{
 				{
-					Attribute:  ":count",
+					Attribute:  "spans_collection.count",
 					Comparator: comparator.Eq,
 					Value:      "1",
 				},
 			}).MustAdd(`span[service.name="NotExists"]`, []model.Assertion{
 				{
-					Attribute:  ":count",
+					Attribute:  "spans_collection.count",
 					Comparator: comparator.Eq,
 					Value:      "0",
 				},
@@ -86,7 +86,7 @@ func TestAssertion(t *testing.T) {
 			expectedResult: (model.OrderedMap[model.SpanQuery, []model.AssertionResult]{}).MustAdd(`span[service.name="Pokeshop"]`, []model.AssertionResult{
 				{
 					Assertion: model.Assertion{
-						Attribute:  ":count",
+						Attribute:  "spans_collection.count",
 						Comparator: comparator.Eq,
 						Value:      "1",
 					},
@@ -101,7 +101,7 @@ func TestAssertion(t *testing.T) {
 			}).MustAdd(`span[service.name="NotExists"]`, []model.AssertionResult{
 				{
 					Assertion: model.Assertion{
-						Attribute:  ":count",
+						Attribute:  "spans_collection.count",
 						Comparator: comparator.Eq,
 						Value:      "0",
 					},

--- a/server/assertions/assetions_test.go
+++ b/server/assertions/assetions_test.go
@@ -62,13 +62,13 @@ func TestAssertion(t *testing.T) {
 			name: "CanAssertOnSpanMatchCount",
 			testDef: (model.OrderedMap[model.SpanQuery, []model.Assertion]{}).MustAdd(`span[service.name="Pokeshop"]`, []model.Assertion{
 				{
-					Attribute:  "spans_collection.count",
+					Attribute:  "tracetest.selected_spans.count",
 					Comparator: comparator.Eq,
 					Value:      "1",
 				},
 			}).MustAdd(`span[service.name="NotExists"]`, []model.Assertion{
 				{
-					Attribute:  "spans_collection.count",
+					Attribute:  "tracetest.selected_spans.count",
 					Comparator: comparator.Eq,
 					Value:      "0",
 				},
@@ -86,7 +86,7 @@ func TestAssertion(t *testing.T) {
 			expectedResult: (model.OrderedMap[model.SpanQuery, []model.AssertionResult]{}).MustAdd(`span[service.name="Pokeshop"]`, []model.AssertionResult{
 				{
 					Assertion: model.Assertion{
-						Attribute:  "spans_collection.count",
+						Attribute:  "tracetest.selected_spans.count",
 						Comparator: comparator.Eq,
 						Value:      "1",
 					},
@@ -101,7 +101,7 @@ func TestAssertion(t *testing.T) {
 			}).MustAdd(`span[service.name="NotExists"]`, []model.AssertionResult{
 				{
 					Assertion: model.Assertion{
-						Attribute:  "spans_collection.count",
+						Attribute:  "tracetest.selected_spans.count",
 						Comparator: comparator.Eq,
 						Value:      "0",
 					},

--- a/server/assertions/assetions_test.go
+++ b/server/assertions/assetions_test.go
@@ -58,6 +58,63 @@ func TestAssertion(t *testing.T) {
 				},
 			}),
 		},
+		{
+			name: "CanAssertOnSpanMatchCount",
+			testDef: (model.OrderedMap[model.SpanQuery, []model.Assertion]{}).MustAdd(`span[service.name="Pokeshop"]`, []model.Assertion{
+				{
+					Attribute:  ":count",
+					Comparator: comparator.Eq,
+					Value:      "1",
+				},
+			}).MustAdd(`span[service.name="NotExists"]`, []model.Assertion{
+				{
+					Attribute:  ":count",
+					Comparator: comparator.Eq,
+					Value:      "0",
+				},
+			}),
+			trace: traces.Trace{
+				RootSpan: traces.Span{
+					ID: spanID,
+					Attributes: traces.Attributes{
+						"service.name":            "Pokeshop",
+						"tracetest.span.duration": "2000",
+					},
+				},
+			},
+			expectedAllPassed: true,
+			expectedResult: (model.OrderedMap[model.SpanQuery, []model.AssertionResult]{}).MustAdd(`span[service.name="Pokeshop"]`, []model.AssertionResult{
+				{
+					Assertion: model.Assertion{
+						Attribute:  ":count",
+						Comparator: comparator.Eq,
+						Value:      "1",
+					},
+					Results: []model.SpanAssertionResult{
+						{
+							SpanID:        &spanID,
+							ObservedValue: "1",
+							CompareErr:    nil,
+						},
+					},
+				},
+			}).MustAdd(`span[service.name="NotExists"]`, []model.AssertionResult{
+				{
+					Assertion: model.Assertion{
+						Attribute:  ":count",
+						Comparator: comparator.Eq,
+						Value:      "0",
+					},
+					Results: []model.SpanAssertionResult{
+						{
+							SpanID:        nil,
+							ObservedValue: "0",
+							CompareErr:    nil,
+						},
+					},
+				},
+			}),
+		},
 		// https://github.com/kubeshop/tracetest/issues/617
 		{
 			name: "ContainsWithJSON",

--- a/server/assertions/meta_attrs.go
+++ b/server/assertions/meta_attrs.go
@@ -10,7 +10,7 @@ import (
 var (
 	errMetaAttrNotDefined = errors.New("meta attribute not defined")
 	metaAttrsRegistry     = map[string]MetaAttribute{
-		"spans_collection.count": count{},
+		"tracetest.selected_spans.count": count{},
 	}
 )
 

--- a/server/assertions/meta_attrs.go
+++ b/server/assertions/meta_attrs.go
@@ -10,7 +10,7 @@ import (
 var (
 	errMetaAttrNotDefined = errors.New("meta attribute not defined")
 	metaAttrsRegistry     = map[string]MetaAttribute{
-		":count": count{},
+		"spans_collection.count": count{},
 	}
 )
 

--- a/server/assertions/meta_attrs.go
+++ b/server/assertions/meta_attrs.go
@@ -1,0 +1,36 @@
+package assertions
+
+import (
+	"errors"
+	"strconv"
+
+	"github.com/kubeshop/tracetest/server/traces"
+)
+
+var (
+	errMetaAttrNotDefined = errors.New("meta attribute not defined")
+	metaAttrsRegistry     = map[string]MetaAttribute{
+		":count": count{},
+	}
+)
+
+func metaAttr(name string) (MetaAttribute, error) {
+	a, ok := metaAttrsRegistry[name]
+	if !ok {
+		return nil, errMetaAttrNotDefined
+	}
+
+	return a, nil
+}
+
+type MetaAttribute interface {
+	Value(spans []traces.Span) string
+}
+
+var _ MetaAttribute = count{}
+
+type count struct{}
+
+func (c count) Value(spans []traces.Span) string {
+	return strconv.Itoa(len(spans))
+}

--- a/server/http/mappings.go
+++ b/server/http/mappings.go
@@ -386,7 +386,7 @@ func (m ModelMapper) Result(in openapi.AssertionResults) *model.RunResults {
 			for j, sar := range r.SpanResults {
 				sid, _ := trace.SpanIDFromHex(sar.SpanId)
 				sars[j] = model.SpanAssertionResult{
-					SpanID:        sid,
+					SpanID:        &sid,
 					ObservedValue: sar.ObservedValue,
 					CompareErr:    fmt.Errorf(sar.Error),
 				}

--- a/server/http/mappings.go
+++ b/server/http/mappings.go
@@ -207,7 +207,7 @@ func (m OpenAPIMapper) Result(in *model.RunResults) openapi.AssertionResults {
 }
 func (m OpenAPIMapper) Assertion(in model.Assertion) openapi.Assertion {
 	return openapi.Assertion{
-		Attribute:  in.Attribute,
+		Attribute:  in.Attribute.String(),
 		Comparator: in.Comparator.String(),
 		Expected:   in.Value,
 	}
@@ -410,7 +410,7 @@ func (m ModelMapper) Result(in openapi.AssertionResults) *model.RunResults {
 func (m ModelMapper) Assertion(in openapi.Assertion) model.Assertion {
 	comp, _ := m.Comparators.Get(in.Comparator)
 	return model.Assertion{
-		Attribute:  in.Attribute,
+		Attribute:  model.Attribute(in.Attribute),
 		Comparator: comp,
 		Value:      in.Expected,
 	}

--- a/server/http/mappings.go
+++ b/server/http/mappings.go
@@ -180,8 +180,12 @@ func (m OpenAPIMapper) Result(in *model.RunResults) openapi.AssertionResults {
 		for j, r := range inRes {
 			sres := make([]openapi.AssertionSpanResult, len(r.Results))
 			for k, asr := range r.Results {
+				sid := ""
+				if asr.SpanID != nil {
+					sid = asr.SpanID.String()
+				}
 				sres[k] = openapi.AssertionSpanResult{
-					SpanId:        asr.SpanID.String(),
+					SpanId:        sid,
 					ObservedValue: asr.ObservedValue,
 					Passed:        asr.CompareErr == nil,
 					Error:         errToString(asr.CompareErr),
@@ -384,9 +388,13 @@ func (m ModelMapper) Result(in openapi.AssertionResults) *model.RunResults {
 		for i, r := range res.Results {
 			sars := make([]model.SpanAssertionResult, len(r.SpanResults))
 			for j, sar := range r.SpanResults {
-				sid, _ := trace.SpanIDFromHex(sar.SpanId)
+				var sid *trace.SpanID
+				if sar.SpanId != "" {
+					s, _ := trace.SpanIDFromHex(sar.SpanId)
+					sid = &s
+				}
 				sars[j] = model.SpanAssertionResult{
-					SpanID:        &sid,
+					SpanID:        sid,
 					ObservedValue: sar.ObservedValue,
 					CompareErr:    fmt.Errorf(sar.Error),
 				}

--- a/server/junit/junit.go
+++ b/server/junit/junit.go
@@ -31,7 +31,7 @@ func FromRunResult(test model.Test, run model.Run) ([]byte, error) {
 					if errors.Is(sar.CompareErr, comparator.ErrNoMatch) {
 						fails++
 						c.Failure = &failure{
-							Attribute:   res.Assertion.Attribute,
+							Attribute:   res.Assertion.Attribute.String(),
 							ActualValue: sar.ObservedValue,
 						}
 					} else {

--- a/server/model/json.go
+++ b/server/model/json.go
@@ -58,7 +58,7 @@ func (a Assertion) MarshalJSON() ([]byte, error) {
 		Comparator string
 		Value      string
 	}{
-		Attribute:  a.Attribute,
+		Attribute:  a.Attribute.String(),
 		Comparator: a.Comparator.String(),
 		Value:      a.Value,
 	})
@@ -79,7 +79,7 @@ func (a *Assertion) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	a.Attribute = aux.Attribute
+	a.Attribute = Attribute(aux.Attribute)
 	a.Value = aux.Value
 	a.Comparator = c
 

--- a/server/model/json.go
+++ b/server/model/json.go
@@ -39,7 +39,7 @@ func (sar *SpanAssertionResult) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	sar.SpanID = sid
+	sar.SpanID = &sid
 	sar.ObservedValue = aux.ObservedValue
 	if err := stringToErr(aux.CompareErr); err != nil {
 		if err.Error() == comparator.ErrNoMatch.Error() {

--- a/server/model/tests.go
+++ b/server/model/tests.go
@@ -73,8 +73,13 @@ type (
 	}
 )
 
+const (
+	metaPrefix    = "tracetest.selected_spans."
+	metaPrefixLen = len("tracetest.selected_spans.")
+)
+
 func (a Attribute) IsMeta() bool {
-	return len(a) >= 18 && a[0:17] == "spans_collection."
+	return len(a) > metaPrefixLen && a[0:metaPrefixLen] == metaPrefix
 }
 
 func (a Attribute) String() string {

--- a/server/model/tests.go
+++ b/server/model/tests.go
@@ -74,7 +74,7 @@ type (
 )
 
 func (a Attribute) IsMeta() bool {
-	return a[0] == ':'
+	return len(a) >= 18 && a[0:17] == "spans_collection."
 }
 
 func (a Attribute) String() string {

--- a/server/model/tests.go
+++ b/server/model/tests.go
@@ -65,7 +65,7 @@ type (
 	}
 
 	SpanAssertionResult struct {
-		SpanID        trace.SpanID
+		SpanID        *trace.SpanID
 		ObservedValue string
 		CompareErr    error
 	}

--- a/server/model/tests.go
+++ b/server/model/tests.go
@@ -29,10 +29,12 @@ type (
 	SpanQuery string
 
 	Assertion struct {
-		Attribute  string
+		Attribute  Attribute
 		Comparator comparator.Comparator
 		Value      string
 	}
+
+	Attribute string
 
 	Run struct {
 		ID                        uuid.UUID
@@ -70,6 +72,14 @@ type (
 		CompareErr    error
 	}
 )
+
+func (a Attribute) IsMeta() bool {
+	return a[0] == ':'
+}
+
+func (a Attribute) String() string {
+	return string(a)
+}
 
 func (a Assertion) String() string {
 	return fmt.Sprintf(`"%s" %s "%s"`, a.Attribute, a.Comparator, a.Value)

--- a/server/model/tests_test.go
+++ b/server/model/tests_test.go
@@ -10,6 +10,12 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestAttributeIsMeta(t *testing.T) {
+	assert.True(t, model.Attribute("tracetest.selected_spans.something").IsMeta())
+	assert.False(t, model.Attribute("tracetest.selected_spans.").IsMeta())
+	assert.False(t, model.Attribute("db.system").IsMeta())
+}
+
 func TestDefinition(t *testing.T) {
 	t.Run("Add", func(t *testing.T) {
 		def := (model.Test{}).Definition

--- a/server/testdb/runs_test.go
+++ b/server/testdb/runs_test.go
@@ -71,7 +71,7 @@ func TestUpdateRun(t *testing.T) {
 				},
 				Results: []model.SpanAssertionResult{
 					{
-						SpanID:        run.Trace.RootSpan.ID,
+						SpanID:        &run.Trace.RootSpan.ID,
 						ObservedValue: "2000",
 						CompareErr:    nil,
 					},


### PR DESCRIPTION
This PR adds the ability to assert on the collection level. For now it only adds support for a `spans_collection.count` attribute, which maps to the amount of spans selected by the selector query.

## Changes

-

## Fixes

-

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [x] added a test
