### PR TITLE
Feat: poller instrumentation

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -74,7 +74,6 @@ jobs:
           npm test
 
   build-docker:
-    needs: [unit-test-frontend, unit-test-backend, unit-test-cli]
     name: "Build Image"
     runs-on: ubuntu-latest
     steps:
@@ -113,7 +112,7 @@ jobs:
         mv /tmp/.buildx-cache-new /tmp/.buildx-cache
 
   deploy:
-    needs: build-docker
+    needs:  [unit-test-frontend, unit-test-backend, unit-test-cli, build-docker]
     name: Deploy
     runs-on: ubuntu-latest
 

--- a/server/app/app.go
+++ b/server/app/app.go
@@ -99,7 +99,7 @@ func (a *App) Start() error {
 	assertionRunner.Start(5)
 	defer assertionRunner.Stop()
 
-	pollerExecutor := executor.NewPollerExecutor(execTestUpdater, a.traceDB, a.config.PoolingRetryDelay(), a.config.MaxWaitTimeForTraceDuration())
+	pollerExecutor := executor.NewPollerExecutor(a.tracer, execTestUpdater, a.traceDB, a.config.PoolingRetryDelay(), a.config.MaxWaitTimeForTraceDuration())
 
 	tracePoller := executor.NewTracePoller(pollerExecutor, execTestUpdater, assertionRunner, a.config.PoolingRetryDelay(), a.config.MaxWaitTimeForTraceDuration())
 	tracePoller.Start(5) // worker count. should be configurable

--- a/server/app/app.go
+++ b/server/app/app.go
@@ -99,7 +99,9 @@ func (a *App) Start() error {
 	assertionRunner.Start(5)
 	defer assertionRunner.Stop()
 
-	tracePoller := executor.NewTracePoller(a.traceDB, execTestUpdater, assertionRunner, a.config.PoolingRetryDelay(), a.config.MaxWaitTimeForTraceDuration())
+	pollerExecutor := executor.NewPollerExecutor(execTestUpdater, a.traceDB, a.config.PoolingRetryDelay(), a.config.MaxWaitTimeForTraceDuration())
+
+	tracePoller := executor.NewTracePoller(pollerExecutor, execTestUpdater, assertionRunner, a.config.PoolingRetryDelay(), a.config.MaxWaitTimeForTraceDuration())
 	tracePoller.Start(5) // worker count. should be configurable
 	defer tracePoller.Stop()
 

--- a/server/executor/poller_executor.go
+++ b/server/executor/poller_executor.go
@@ -73,6 +73,8 @@ func (pe DefaultPollerExecutor) ExecuteRequest(request PollingRequest) (bool, mo
 		return false, model.Run{}, nil
 	}
 
+	trace = trace.Sort()
+
 	run = run.SuccessfullyPolledTraces(augmentData(&trace, run.Response))
 
 	fmt.Printf("completed polling result %s after %d times, number of spans: %d \n", run.ID, request.count, len(run.Trace.Flat))

--- a/server/executor/poller_executor.go
+++ b/server/executor/poller_executor.go
@@ -8,6 +8,7 @@ import (
 	"github.com/kubeshop/tracetest/server/model"
 	"github.com/kubeshop/tracetest/server/tracedb"
 	"github.com/kubeshop/tracetest/server/traces"
+	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
 )
 
@@ -27,6 +28,11 @@ func (pe InstrumentedPollerExecutor) ExecuteRequest(request PollingRequest) (boo
 	defer span.End()
 
 	finished, run, err := pe.pollerExecutor.ExecuteRequest(request)
+
+	span.SetAttributes(
+		attribute.Bool("tracetest.run.trace_poller.succesful", finished),
+		attribute.String("tracetest.run.trace_poller.test_id", request.test.ID.String()),
+	)
 
 	return finished, run, err
 }

--- a/server/executor/poller_executor.go
+++ b/server/executor/poller_executor.go
@@ -1,0 +1,78 @@
+package executor
+
+import (
+	"fmt"
+	"math"
+	"time"
+
+	"github.com/kubeshop/tracetest/server/model"
+	"github.com/kubeshop/tracetest/server/tracedb"
+	"github.com/kubeshop/tracetest/server/traces"
+)
+
+type DefaultPollerExecutor struct {
+	updater           RunUpdater
+	traceDB           tracedb.TraceDB
+	maxTracePollRetry int
+}
+
+var _ PollerExecutor = &DefaultPollerExecutor{}
+
+func NewPollerExecutor(
+	updater RunUpdater,
+	traceDB tracedb.TraceDB,
+	retryDelay time.Duration,
+	maxWaitTimeForTrace time.Duration,
+) PollerExecutor {
+	maxTracePollRetry := int(math.Ceil(float64(maxWaitTimeForTrace) / float64(retryDelay)))
+	return &DefaultPollerExecutor{
+		updater:           updater,
+		traceDB:           traceDB,
+		maxTracePollRetry: maxTracePollRetry,
+	}
+}
+
+func (pe DefaultPollerExecutor) ExecuteRequest(request PollingRequest) (bool, model.Run, error) {
+	run := request.run
+	otelTrace, err := pe.traceDB.GetTraceByID(request.ctx, run.TraceID.String())
+	if err != nil {
+		return false, model.Run{}, err
+	}
+
+	trace := traces.FromOtel(otelTrace)
+	trace.ID = run.TraceID
+	run.Trace = &trace
+	request.run = run
+
+	if !pe.donePollingTraces(request, trace) {
+		return false, model.Run{}, nil
+	}
+
+	run = run.SuccessfullyPolledTraces(augmentData(&trace, run.Response))
+
+	fmt.Printf("completed polling result %s after %d times, number of spans: %d \n", run.ID, request.count, len(run.Trace.Flat))
+
+	err = pe.updater.Update(request.ctx, run)
+	if err != nil {
+		return false, model.Run{}, nil
+	}
+
+	return true, run, nil
+}
+
+func (pe DefaultPollerExecutor) donePollingTraces(job PollingRequest, trace traces.Trace) bool {
+	// we're done if we have the same amount of spans after polling or `maxTracePollRetry` times
+	if job.count == pe.maxTracePollRetry {
+		return true
+	}
+
+	if job.run.Trace == nil {
+		return false
+	}
+
+	if len(trace.Flat) > 0 && len(trace.Flat) == len(job.run.Trace.Flat) {
+		return true
+	}
+
+	return false
+}

--- a/server/executor/trace_poller.go
+++ b/server/executor/trace_poller.go
@@ -22,12 +22,16 @@ type PersistentTracePoller interface {
 	WorkerPool
 }
 
+type PollerExecutor interface {
+	ExecuteRequest(request PollingRequest) (bool, model.Run, error)
+}
+
 type TraceFetcher interface {
 	GetTraceByID(ctx context.Context, traceID string) (*v1.TracesData, error)
 }
 
 func NewTracePoller(
-	tf TraceFetcher,
+	pe PollerExecutor,
 	updater RunUpdater,
 	assertionRunner AssertionRunner,
 	retryDelay time.Duration,
@@ -36,11 +40,11 @@ func NewTracePoller(
 	maxTracePollRetry := int(math.Ceil(float64(maxWaitTimeForTrace) / float64(retryDelay)))
 	return tracePoller{
 		updater:             updater,
-		traceDB:             tf,
+		pollerExecutor:      pe,
 		maxWaitTimeForTrace: maxWaitTimeForTrace,
 		maxTracePollRetry:   maxTracePollRetry,
 		retryDelay:          retryDelay,
-		executeQueue:        make(chan tracePollReq, 5),
+		executeQueue:        make(chan PollingRequest, 5),
 		exit:                make(chan bool, 1),
 		assertionRunner:     assertionRunner,
 	}
@@ -48,18 +52,18 @@ func NewTracePoller(
 
 type tracePoller struct {
 	updater             RunUpdater
-	traceDB             TraceFetcher
+	pollerExecutor      PollerExecutor
 	maxWaitTimeForTrace time.Duration
 	assertionRunner     AssertionRunner
 
 	retryDelay        time.Duration
 	maxTracePollRetry int
 
-	executeQueue chan tracePollReq
+	executeQueue chan PollingRequest
 	exit         chan bool
 }
 
-type tracePollReq struct {
+type PollingRequest struct {
 	ctx   context.Context
 	test  model.Test
 	run   model.Run
@@ -101,42 +105,28 @@ func (tp tracePoller) Stop() {
 }
 
 func (tp tracePoller) Poll(ctx context.Context, test model.Test, run model.Run) {
-	tp.enqueueJob(tracePollReq{
+	tp.enqueueJob(PollingRequest{
 		ctx:  ctx,
 		test: test,
 		run:  run,
 	})
 }
 
-func (tp tracePoller) enqueueJob(job tracePollReq) {
+func (tp tracePoller) enqueueJob(job PollingRequest) {
 	tp.executeQueue <- job
 }
 
-func (tp tracePoller) processJob(job tracePollReq) {
-	run := job.run
-
-	otelTrace, err := tp.traceDB.GetTraceByID(job.ctx, run.TraceID.String())
+func (tp tracePoller) processJob(job PollingRequest) {
+	finished, run, err := tp.pollerExecutor.ExecuteRequest(job)
 	if err != nil {
 		tp.handleTraceDBError(job, err)
 		return
 	}
 
-	trace := traces.FromOtel(otelTrace)
-	trace.ID = run.TraceID
-	if !tp.donePollingTraces(job, trace) {
-		fmt.Println("Not done polling traces. Requeue")
-		run.Trace = &trace
-		job.run = run
-		job.count = job.count + 1
+	if !finished {
+		job.count += 1
 		tp.requeue(job)
-		return
 	}
-
-	run = run.SuccessfullyPolledTraces(augmentData(&trace, run.Response))
-
-	fmt.Printf("completed polling result %s after %d times, number of spans: %d \n", job.run.ID, job.count, len(run.Trace.Flat))
-
-	tp.handleDBError(tp.updater.Update(job.ctx, run))
 
 	err = tp.runAssertions(job.ctx, job.test, run)
 	if err != nil {
@@ -167,25 +157,7 @@ func augmentData(trace *traces.Trace, resp model.HTTPResponse) *traces.Trace {
 	return trace
 }
 
-func (tp tracePoller) donePollingTraces(job tracePollReq, trace traces.Trace) bool {
-	// we're done if we have the same amount of spans after polling or `maxTracePollRetry` times
-	if job.count == tp.maxTracePollRetry {
-		return true
-	}
-
-	if job.run.Trace == nil {
-		return false
-	}
-
-	if len(trace.Flat) > 0 && len(trace.Flat) == len(job.run.Trace.Flat) {
-		return true
-	}
-
-	return false
-
-}
-
-func (tp tracePoller) handleTraceDBError(job tracePollReq, err error) {
+func (tp tracePoller) handleTraceDBError(job PollingRequest, err error) {
 	run := job.run
 	if errors.Is(err, tracedb.ErrTraceNotFound) {
 		if time.Since(run.ServiceTriggeredAt) < tp.maxWaitTimeForTrace {
@@ -203,7 +175,7 @@ func (tp tracePoller) handleTraceDBError(job tracePollReq, err error) {
 
 }
 
-func (tp tracePoller) requeue(job tracePollReq) {
+func (tp tracePoller) requeue(job PollingRequest) {
 	go func() {
 		fmt.Printf("requeuing result %s for %d time\n", job.run.ID, job.count)
 		time.Sleep(tp.retryDelay)

--- a/server/executor/trace_poller.go
+++ b/server/executor/trace_poller.go
@@ -128,9 +128,6 @@ func (tp tracePoller) processJob(job PollingRequest) {
 		tp.requeue(job)
 	}
 
-	trace = trace.Sort()
-	run = run.SuccessfullyPolledTraces(augmentData(&trace, run.Response))
-
 	fmt.Printf("completed polling result %s after %d times, number of spans: %d \n", job.run.ID, job.count, len(run.Trace.Flat))
 
 	tp.handleDBError(tp.updater.Update(job.ctx, run))

--- a/tracetesting/definitions/test_run.yml
+++ b/tracetesting/definitions/test_run.yml
@@ -22,3 +22,7 @@ testDefinition:
 - selector: span[name = "Fetch trace"]
   assertions:
   - tracetest.selected_spans.count > 0
+- selector: span[name = "Fetch trace"]:last
+  assertions:
+  - tracetest.run.trace_poller.test_id = "${TEST_ID}"
+  - tracetest.run.trace_poller.succesful = true

--- a/tracetesting/definitions/test_run.yml
+++ b/tracetesting/definitions/test_run.yml
@@ -10,12 +10,15 @@ trigger:
     - key: Content-Type
       value: application/json
 testDefinition:
-- selector: span[name="POST /api/tests/{testId}/run" tracetest.span.type="http"]
+- selector: span[name = "POST /api/tests/{testId}/run" tracetest.span.type = "http"]
   assertions:
   - tracetest.response.status = 200
-- selector: span[name="Trigger test"]
+- selector: span[name = "Trigger test"]
   assertions:
   - tracetest.selected_spans.count = 1
   - tracetest.run.trigger.test_id = "${TEST_ID}"
   - tracetest.run.trigger.type = "http"
   - tracetest.run.trigger.http.response_code = 200
+- selector: span[name = "Fetch trace"]
+  assertions:
+  - tracetest.selected_spans.count > 0

--- a/tracetesting/definitions/test_run.yml
+++ b/tracetesting/definitions/test_run.yml
@@ -25,4 +25,4 @@ testDefinition:
 - selector: span[name = "Fetch trace"]:last
   assertions:
   - tracetest.run.trace_poller.test_id = "${TEST_ID}"
-  - tracetest.run.trace_poller.succesful = true
+  - tracetest.run.trace_poller.succesful = "true"


### PR DESCRIPTION
This PR adds instrumentation for the `trace poller` process. Every time we try to get a trace, a new span is created. This also changes the integration test to check for the new instrumentation 

## Changes

- Add instrumentation to the trace polling process

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [x] added a test
