### PR TITLE
Dogfood tests locally with docker compose

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,2 @@
 Dockerfile
+node_modules

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,2 @@
 Dockerfile
-node_modules
+web/node_modules

--- a/cli/Makefile
+++ b/cli/Makefile
@@ -20,7 +20,7 @@ generate-client:
 
 	go fmt ./...; cd ..
 
-build: generate-client
+build:
 	go build -o tracetest main.go
 
 test: mockserver

--- a/docker-compose.testrunner.yaml
+++ b/docker-compose.testrunner.yaml
@@ -1,0 +1,14 @@
+version: "3.2"
+services:
+  testrunner:
+    container_name: testrunner
+    build:
+      context: .
+      dockerfile: testrunner.Dockerfile
+    environment:
+      - TARGET_URL=http://tracetest:8080
+      - TRACETEST_MAIN_ENDPOINT=tracetest:8080
+      - TRACETEST_TARGET_ENDPOINT=tracetest:8080
+      - DEMO_APP_URL=http://demo:8001
+    depends_on:
+      - tracetest

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -5,15 +5,18 @@ services:
     image: kubeshop/tracetest
     build: .
     environment:
-      - VERSION=1.0
+      - VERSION=dev
     volumes:
       - type: bind
         source: ./server/config.yaml
         target: /app/config.yaml
     ports:
       - 8080:8080
+      - 8081:8080
     depends_on:
       postgres:
+        condition: service_healthy
+      jaeger:
         condition: service_healthy
 
   postgres:
@@ -35,3 +38,64 @@ services:
     ports:
       - "6831:6831/udp"
       - "16686:16686"
+    healthcheck:
+      test: ["CMD", "wget", "--spider", "localhost:16686"]
+      interval: 1s
+      timeout: 3s
+      retries: 60
+
+  cache:
+    image: redis:6
+    ports:
+      - 6379:6379
+    healthcheck:
+      test: ["CMD", "redis-cli","ping"]
+      interval: 1s
+      timeout: 3s
+      retries: 60
+  queue:
+    image: rabbitmq:3.9
+    ports:
+      - 5672:5672
+      - 15672:15672
+    healthcheck:
+      test: rabbitmq-diagnostics -q check_running
+      interval: 1s
+      timeout: 5s
+      retries: 60
+
+  demodb:
+    container_name: demodb
+    image: postgres
+    environment:
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_USER:  postgres
+      POSTGRES_DB: demodb
+    ports:
+      - 5433:5432
+    healthcheck:
+      test: pg_isready -U "$$POSTGRES_USER" -d "$$POSTGRES_DB"
+      interval: 1s
+      timeout: 5s
+      retries: 60
+
+  demo:
+    image: kubeshop/demo-pokemon-api:latest
+    environment:
+      REDIS_URL: cache
+      DATABASE_URL: postgresql://postgres:postgres@demodb:5433/pokeshop?schema=public
+      RABBITMQ_HOST: queue
+      POKE_API_BASE_URL: https://pokeapi.co/api/v2
+      JAEGER_HOST: jaeger
+      JAEGER_PORT: 6832
+    ports:
+      - 8001:80
+    depends_on:
+      demodb:
+        condition: service_healthy
+      cache:
+        condition: service_healthy
+      queue:
+        condition: service_healthy
+      jaeger:
+        condition: service_healthy

--- a/run-tracetesting-tests.sh
+++ b/run-tracetesting-tests.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+docker compose -f docker-compose.yaml -f docker-compose.testrunner.yaml build
+docker compose -f docker-compose.yaml -f docker-compose.testrunner.yaml run testrunner
+docker compose -f docker-compose.yaml stop

--- a/testrunner.Dockerfile
+++ b/testrunner.Dockerfile
@@ -1,0 +1,20 @@
+FROM golang:1.18-alpine AS build-cli
+WORKDIR /go/src
+
+RUN apk add --update make
+
+COPY ./cli/go.mod ./cli/go.sum ./
+RUN go mod download
+COPY ./cli ./
+RUN make build
+
+FROM alpine
+
+RUN apk add bash jq curl
+
+WORKDIR /app
+COPY --from=build-cli /go/src/tracetest /app/cli/tracetest
+COPY ./tracetesting ./tracetesting
+
+WORKDIR /app/tracetesting
+CMD ["/bin/bash", "/app/tracetesting/run.bash"]

--- a/tracetesting/config.main.yml
+++ b/tracetesting/config.main.yml
@@ -1,2 +1,0 @@
-scheme: http
-endpoint: localhost:8080

--- a/tracetesting/config.target.yml
+++ b/tracetesting/config.target.yml
@@ -1,2 +1,0 @@
-scheme: http
-endpoint: localhost:8081

--- a/tracetesting/funcs.bash
+++ b/tracetesting/funcs.bash
@@ -1,11 +1,11 @@
 #!/bin/bash
 
 tracetest_main() {
-   $TRACETEST_CMD --config ./config.main.yml $@
+   $TRACETEST_CLI --config ./config.main.yml $@
 }
 
 tracetest_target() {
-  $TRACETEST_CMD --config ./config.target.yml $@
+  $TRACETEST_CLI --config ./config.target.yml $@
 }
 
 tracetest_target_curl() {

--- a/tracetesting/run.bash
+++ b/tracetesting/run.bash
@@ -1,6 +1,6 @@
 #/bin/bash
 
-export TRACETEST_CMD=${TRACETEST_CLI:-"../cli/tracetest"}
+export TRACETEST_CLI=${TRACETEST_CLI:-"../cli/tracetest"}
 if ! command -v "$TRACETEST_CLI" &> /dev/null; then
   echo "\$TRACETEST_CLI not set to executable. set to $TRACETEST_CLI";
   exit 2
@@ -12,13 +12,28 @@ if [  "$TARGET_URL" = "" ]; then
   exit 2
 fi
 
+
+export TRACETEST_MAIN_ENDPOINT=${TRACETEST_MAIN_ENDPOINT:-"localhost:8080"}
+export TRACETEST_TARGET_ENDPOINT=${TRACETEST_TARGET_ENDPOINT:-"localhost:8081"}
+export DEMO_APP_URL=${DEMO_APP_URL-"http://demo-pokemon-api.demo.svc.cluster.local"}
+
 echo "TRACETEST_CLI: $TRACETEST_CLI"
 echo "TARGET_URL: $TARGET_URL"
+echo "TRACETEST_MAIN_ENDPOINT: $TRACETEST_MAIN_ENDPOINT"
+echo "TRACETEST_TARGET_ENDPOINT: $TRACETEST_TARGET_ENDPOINT"
+echo "DEMO_APP_URL: $DEMO_APP_URL"
 
-export TRACETEST_MAIN_ENDPOINT="localhost:8080"
-export TRACETEST_TARGET_ENDPOINT="localhost:8081"
+tee config.main.yml << END
+scheme: http
+endpoint: $TRACETEST_MAIN_ENDPOINT
+END
 
-export DEMO_APP_URL=${DEMO_APP_URL-"http://demo-pokemon-api.demo.svc.cluster.local"}
+tee config.target.yml << END
+scheme: http
+endpoint: $TRACETEST_TARGET_ENDPOINT
+END
+
+
 
 mkdir -p results/responses
 

--- a/web/. dockerignore
+++ b/web/. dockerignore
@@ -1,3 +1,0 @@
-node_modules
-build
-Dockerfile


### PR DESCRIPTION
This PR adds a command to locally run dogfood tests with just one command. Without this, developing tests is annoying, because you need to carefully setup some port forwardings to a k8s instance.

## Changes

-

## Fixes

-

## Checklist

- [x] tested locally
- [x] added new dependencies
- [ ] updated the docs
- [ ] added a test
