### PR TITLE
remove warning from console

### DIFF
--- a/web/src/components/AssertionCheckRow/AssertionCheckRow.tsx
+++ b/web/src/components/AssertionCheckRow/AssertionCheckRow.tsx
@@ -32,7 +32,9 @@ const AssertionCheckRow: React.FC<TAssertionCheckRowProps> = ({
     return (isSelected ? [<S.SelectedLabelBadge count="selected" key="selected" />] : []).concat(
       signatureSelectorList.map(({key, value}, index) => (
         <S.LabelTooltip title={key} key={key}>
-          <S.LabelBadge $spanType={!index ? span?.type : undefined} count={value} />
+          <span>
+            <S.LabelBadge $spanType={!index ? span?.type : undefined} count={value} />
+          </span>
         </S.LabelTooltip>
       ))
     );


### PR DESCRIPTION
This PR remove tooltip issue emiting a warning
Same as the one described here
https://github.com/ant-design/ant-design/issues/21133

## Changes

- add a span element between the tooltip and the badge

## Fixes

- removes warning

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
