### PR TITLE
reduce number of db queries for getting tests

### DIFF
--- a/docker-compose.testrunner.yaml
+++ b/docker-compose.testrunner.yaml
@@ -9,6 +9,6 @@ services:
       - TARGET_URL=http://tracetest:8080
       - TRACETEST_MAIN_ENDPOINT=tracetest:8080
       - TRACETEST_TARGET_ENDPOINT=tracetest:8080
-      - DEMO_APP_URL=http://demo:8001
+      - DEMO_APP_URL=http://demo
     depends_on:
       - tracetest

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -63,26 +63,11 @@ services:
       timeout: 5s
       retries: 60
 
-  demodb:
-    container_name: demodb
-    image: postgres
-    environment:
-      POSTGRES_PASSWORD: postgres
-      POSTGRES_USER:  postgres
-      POSTGRES_DB: demodb
-    ports:
-      - 5433:5432
-    healthcheck:
-      test: pg_isready -U "$$POSTGRES_USER" -d "$$POSTGRES_DB"
-      interval: 1s
-      timeout: 5s
-      retries: 60
-
   demo:
     image: kubeshop/demo-pokemon-api:latest
     environment:
       REDIS_URL: cache
-      DATABASE_URL: postgresql://postgres:postgres@demodb:5433/pokeshop?schema=public
+      DATABASE_URL: postgresql://postgres:postgres@postgres:5432/postgres?schema=public
       RABBITMQ_HOST: queue
       POKE_API_BASE_URL: https://pokeapi.co/api/v2
       JAEGER_HOST: jaeger
@@ -90,7 +75,7 @@ services:
     ports:
       - 8001:80
     depends_on:
-      demodb:
+      postgres:
         condition: service_healthy
       cache:
         condition: service_healthy

--- a/run-tracetesting-tests.sh
+++ b/run-tracetesting-tests.sh
@@ -1,6 +1,27 @@
 #!/bin/sh
 
+STOP=yes
+
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    --no-stop)
+      STOP=no
+      shift
+      shift
+      ;;
+    -*|--*)
+      echo "Unknown option $1"
+      help_message
+      exit 1
+      ;;
+  esac
+done
+
+
 docker compose -f docker-compose.yaml up -d --build --remove-orphans
 docker compose -f docker-compose.yaml -f docker-compose.testrunner.yaml build
 docker compose -f docker-compose.yaml -f docker-compose.testrunner.yaml run testrunner
-docker compose -f docker-compose.yaml stop
+
+if [ "$STOP" == "yes" ]; then
+  docker compose -f docker-compose.yaml stop
+fi

--- a/run-tracetesting-tests.sh
+++ b/run-tracetesting-tests.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-docker compose -f docker-compose.yaml up -d --build
+docker compose -f docker-compose.yaml up -d --build --remove-orphans
 docker compose -f docker-compose.yaml -f docker-compose.testrunner.yaml build
 docker compose -f docker-compose.yaml -f docker-compose.testrunner.yaml run testrunner
 docker compose -f docker-compose.yaml stop

--- a/server/.dockerignore
+++ b/server/.dockerignore
@@ -1,0 +1,4 @@
+config.yaml
+config.yaml.sample
+coverage.out
+tracetest-server

--- a/tracetesting/.gitignore
+++ b/tracetesting/.gitignore
@@ -1,1 +1,3 @@
 results/
+config.main.yml
+config.target.yml

--- a/tracetesting/definitions/test_create_with_id_exists.yml
+++ b/tracetesting/definitions/test_create_with_id_exists.yml
@@ -1,4 +1,4 @@
-id: d85c3336-5048-4652-b564-63dfe2c83b14
+id: 7761457a-0a4b-4ada-8eab-d26c8ba48f90
 name: Test Create with existing ID
 description: ""
 trigger:

--- a/tracetesting/definitions/test_create_with_id_exists.yml
+++ b/tracetesting/definitions/test_create_with_id_exists.yml
@@ -1,5 +1,5 @@
 id: d85c3336-5048-4652-b564-63dfe2c83b14
-name: Test Create
+name: Test Create with existing ID
 description: ""
 trigger:
   type: http

--- a/tracetesting/definitions/test_create_with_id_notexists.yml
+++ b/tracetesting/definitions/test_create_with_id_notexists.yml
@@ -1,5 +1,5 @@
 id: d85c3336-5048-4652-b564-63dfe2c83b14
-name: Test Create
+name: Test Create with non-existing ID
 description: ""
 trigger:
   type: http

--- a/tracetesting/definitions/test_create_with_id_notexists.yml
+++ b/tracetesting/definitions/test_create_with_id_notexists.yml
@@ -1,4 +1,4 @@
-id: d85c3336-5048-4652-b564-63dfe2c83b14
+id: 4ab71eaa-7356-454a-b1c0-8064e2a7135d
 name: Test Create with non-existing ID
 description: ""
 trigger:

--- a/tracetesting/definitions/test_list.yml
+++ b/tracetesting/definitions/test_list.yml
@@ -14,3 +14,6 @@ testDefinition:
   assertions:
   - tracetest.response.status = 200
   - tracetest.response.body contains "${TEST_ID}"
+- selector: span[name="query"]
+  assertions:
+  - tracetest.selected_spans.count = 1

--- a/tracetesting/run.bash
+++ b/tracetesting/run.bash
@@ -23,15 +23,15 @@ echo "TRACETEST_MAIN_ENDPOINT: $TRACETEST_MAIN_ENDPOINT"
 echo "TRACETEST_TARGET_ENDPOINT: $TRACETEST_TARGET_ENDPOINT"
 echo "DEMO_APP_URL: $DEMO_APP_URL"
 
-tee config.main.yml << END
+cat << EOF > config.main.yml
 scheme: http
 endpoint: $TRACETEST_MAIN_ENDPOINT
-END
+EOF
 
-tee config.target.yml << END
+cat << EOF > config.target.yml
 scheme: http
 endpoint: $TRACETEST_TARGET_ENDPOINT
-END
+EOF
 
 
 


### PR DESCRIPTION
This PR changes the way we fetch tests from DB. instead of having two separated methods to get tests and definitions, we get the definitions as a `JOIN` when getting tests.

## Changes

- Adds tracetest for number of queries on select
- Use join to reduce number of queries.

## Fixes

-  several fixes on scripts/docker compose for running local tracetests

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [x] added a test
