### PR TITLE
fix: reduce flatten trace size

### DIFF
--- a/server/traces/traces.go
+++ b/server/traces/traces.go
@@ -85,6 +85,9 @@ func flattenSpans(res map[trace.SpanID]*Span, root *Span) {
 			flattenSpans(res, child)
 		}
 	}
+
+	// Remove children because they are now part of the flatten structure
+	root.Children = []*Span{}
 }
 
 type Attributes map[string]string

--- a/server/traces/traces.go
+++ b/server/traces/traces.go
@@ -24,7 +24,7 @@ func (t *Trace) Sort() Trace {
 		Flat:     make(map[trace.SpanID]*Span, 0),
 	}
 
-	flattenSpans(trace.Flat, &sortedRoot)
+	flattenSpans(trace.Flat, sortedRoot)
 
 	return trace
 }
@@ -63,7 +63,7 @@ func (t *Trace) UnmarshalJSON(data []byte) error {
 
 	t.ID = tid
 	t.Flat = map[trace.SpanID]*Span{}
-	flattenSpans(t.Flat, &t.RootSpan)
+	flattenSpans(t.Flat, t.RootSpan)
 	return nil
 }
 
@@ -77,17 +77,18 @@ func (t Trace) MarshalJSON() ([]byte, error) {
 	})
 }
 
-func flattenSpans(res map[trace.SpanID]*Span, root *Span) {
-	res[root.ID] = root
+func flattenSpans(res map[trace.SpanID]*Span, root Span) {
+	rootPtr := &root
+
+	// We don't need the parent in the flat structure
+	rootPtr.Parent = nil
+	res[root.ID] = rootPtr
 	for _, child := range root.Children {
-		res[child.ID] = child
-		if len(child.Children) > 0 {
-			flattenSpans(res, child)
-		}
+		flattenSpans(res, *child)
 	}
 
-	// Remove children because they are now part of the flatten structure
-	root.Children = []*Span{}
+	// Remove children and parent because they are now part of the flatten structure
+	rootPtr.Children = nil
 }
 
 type Attributes map[string]string

--- a/server/traces/traces_test.go
+++ b/server/traces/traces_test.go
@@ -20,6 +20,15 @@ func TestJSONEncoding(t *testing.T) {
 	subSubSpan1 := createSpan("subSubSpan1")
 	subSpan2 := createSpan("subSpan2")
 
+	flat := map[trace.SpanID]*traces.Span{
+		// We copy those spans so they don't have children and parents injected into them
+		// the flat structure shouldn't have children nor parent.
+		rootSpan.ID:    copySpan(rootSpan),
+		subSpan1.ID:    copySpan(subSpan1),
+		subSubSpan1.ID: copySpan(subSubSpan1),
+		subSpan2.ID:    copySpan(subSpan2),
+	}
+
 	rootSpan.Children = []*traces.Span{subSpan1, subSpan2}
 	subSpan1.Parent = rootSpan
 	subSpan2.Parent = rootSpan
@@ -31,12 +40,7 @@ func TestJSONEncoding(t *testing.T) {
 	trace := traces.Trace{
 		ID:       tid,
 		RootSpan: *rootSpan,
-		Flat: map[trace.SpanID]*traces.Span{
-			rootSpan.ID:    rootSpan,
-			subSpan1.ID:    subSpan1,
-			subSubSpan1.ID: subSubSpan1,
-			subSpan2.ID:    subSpan2,
-		},
+		Flat:     flat,
 	}
 
 	jsonEncoded := fmt.Sprintf(`{
@@ -115,10 +119,20 @@ func TestJSONEncoding(t *testing.T) {
 		err := json.Unmarshal([]byte(jsonEncoded), &actual)
 		require.NoError(t, err)
 
-		fmt.Printf("%+v\n", actual.RootSpan.Children[0].Children[0])
+		// I've added more specific validations to be easier to find where the problem is
+		require.Equal(t, trace.ID, actual.ID)
+		require.Equal(t, trace.RootSpan, actual.RootSpan)
+		require.Equal(t, trace.Flat, actual.Flat)
 
+		// I left this as a guarantee we won't forget to change this test in case we add
+		// another attribute to our traces.
 		assert.Equal(t, trace, actual)
 	})
+}
+
+func copySpan(span *traces.Span) *traces.Span {
+	newSpan := *span
+	return &newSpan
 }
 
 func createSpan(name string) *traces.Span {
@@ -130,6 +144,7 @@ func createSpan(name string) *traces.Span {
 		Attributes: traces.Attributes{
 			"service.name": name,
 		},
+		Children: nil,
 	}
 }
 


### PR DESCRIPTION
This PR reduces the size of our responses by removing children and parents from each span in the flattened structure.

It leaves us one step closer to #741 

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
