### PR TITLE
fix: graphs rendering on documentation page

### DIFF
--- a/.github/workflows/mkdocs.yml
+++ b/.github/workflows/mkdocs.yml
@@ -22,5 +22,4 @@ jobs:
           python-version: 3.x
       - run: pip install mkdocs-material
       - run: pip install mkdocs-render-swagger-plugin
-      - run: pip install mkdocs-mermaid2-plugin
       - run: mkdocs gh-deploy --force

--- a/.github/workflows/mkdocs.yml
+++ b/.github/workflows/mkdocs.yml
@@ -1,6 +1,9 @@
 name: mkdocs
 
 on:
+  pull_request:
+    branches:
+      - main
   push:
     branches:
       - main

--- a/.github/workflows/mkdocs.yml
+++ b/.github/workflows/mkdocs.yml
@@ -1,9 +1,6 @@
 name: mkdocs
 
 on:
-  pull_request:
-    branches:
-      - main
   push:
     branches:
       - main

--- a/docs/advanced-selectors.md
+++ b/docs/advanced-selectors.md
@@ -260,15 +260,15 @@ flowchart TD
     I -->|9| J
     J -->|10| K
 
+    classDef selectedSpan fill:#439846, color:#ffffff
+    classDef candidateSpan fill:#FF6905, color:#ffffff
+
     class A selectedSpan
     class B selectedSpan
     class D selectedSpan
     class F selectedSpan
     class G selectedSpan
     class I selectedSpan
-
-    classDef selectedSpan fill:#439846, color:#ffffff
-    classDef candidateSpan fill:#FF6905, color:#ffffff
 ```
 
 ### AND condition
@@ -381,11 +381,11 @@ flowchart TD
     I -->|9| J
     J -->|10| K
 
-    class A selectedSpan
-    class F selectedSpan
-
     classDef selectedSpan fill:#439846, color:#ffffff
     classDef candidateSpan fill:#FF6905, color:#ffffff
+
+    class A selectedSpan
+    class F selectedSpan
 ```
 
 ### OR condition
@@ -498,6 +498,9 @@ flowchart TD
     I -->|9| J
     J -->|10| K
 
+    classDef selectedSpan fill:#439846, color:#ffffff
+    classDef candidateSpan fill:#FF6905, color:#ffffff
+
     class A selectedSpan
     class B selectedSpan
     class C selectedSpan
@@ -508,9 +511,6 @@ flowchart TD
     class H selectedSpan
     class I selectedSpan
     class J selectedSpan
-
-    classDef selectedSpan fill:#439846, color:#ffffff
-    classDef candidateSpan fill:#FF6905, color:#ffffff
 ```
 
 Each span selector will be executed individually and the results will be merged together, creating a list of all spans that match any of the provided span selectors.
@@ -625,6 +625,9 @@ flowchart TD
     I -->|9| J
     J -->|10| K
 
+    classDef selectedSpan fill:#439846, color:#ffffff
+    classDef candidateSpan fill:#FF6905, color:#ffffff
+
     class A selectedSpan
     class B selectedSpan
     class C selectedSpan
@@ -635,9 +638,6 @@ flowchart TD
     class H selectedSpan
     class I selectedSpan
     class J selectedSpan
-
-    classDef selectedSpan fill:#439846, color:#ffffff
-    classDef candidateSpan fill:#FF6905, color:#ffffff
 ```
 ## pseudo-classes support
 
@@ -756,15 +756,15 @@ flowchart TD
     I -->|9| J
     J -->|10| K
 
+    classDef selectedSpan fill:#439846, color:#ffffff
+    classDef candidateSpan fill:#FF6905, color:#ffffff
+
     class A selectedSpan
     class B selectedSpan
     class D selectedSpan
     class F selectedSpan
     class G selectedSpan
     class I selectedSpan
-
-    classDef selectedSpan fill:#439846, color:#ffffff
-    classDef candidateSpan fill:#FF6905, color:#ffffff
 ```
 
 ### :first
@@ -875,15 +875,15 @@ flowchart TD
     I -->|9| J
     J -->|10| K
 
+    classDef selectedSpan fill:#439846, color:#ffffff
+    classDef candidateSpan fill:#FF6905, color:#ffffff
+
     class A selectedSpan
     class B candidateSpan
     class D candidateSpan
     class F candidateSpan
     class G candidateSpan
     class I candidateSpan
-
-    classDef selectedSpan fill:#439846, color:#ffffff
-    classDef candidateSpan fill:#FF6905, color:#ffffff
 ```
 
 ### :last
@@ -994,15 +994,15 @@ flowchart TD
     I -->|9| J
     J -->|10| K
 
+    classDef selectedSpan fill:#439846, color:#ffffff
+    classDef candidateSpan fill:#FF6905, color:#ffffff
+
     class A candidateSpan
     class B candidateSpan
     class D candidateSpan
     class F candidateSpan
     class G candidateSpan
     class I selectedSpan
-
-    classDef selectedSpan fill:#439846, color:#ffffff
-    classDef candidateSpan fill:#FF6905, color:#ffffff
 ```
 
 ### :nth_child
@@ -1113,15 +1113,15 @@ flowchart TD
     I -->|9| J
     J -->|10| K
 
+    classDef selectedSpan fill:#439846, color:#ffffff
+    classDef candidateSpan fill:#FF6905, color:#ffffff
+
     class A candidateSpan
     class B candidateSpan
     class D selectedSpan
     class F candidateSpan
     class G candidateSpan
     class I candidateSpan
-
-    classDef selectedSpan fill:#439846, color:#ffffff
-    classDef candidateSpan fill:#FF6905, color:#ffffff
 ```
 
 
@@ -1242,11 +1242,11 @@ flowchart TD
     I -->|9| J
     J -->|10| K
 
-    class D selectedSpan
-    class G selectedSpan
-
     classDef selectedSpan fill:#439846, color:#ffffff
     classDef candidateSpan fill:#FF6905, color:#ffffff
+
+    class D selectedSpan
+    class G selectedSpan
 ```
 
 This is a problem, because if we apply the same assertion to both spans, one of them will fail. We could try to use `nth_child` but that could break if a http request failed and the retry policy kicked in. Thus, the only way of filtering that is based on the context when it was generated. For example: using its parent span to do so.
@@ -1360,9 +1360,9 @@ flowchart TD
     I -->|9| J
     J -->|10| K
 
-    class F parentSpan
-    class G selectedSpan
-
     classDef selectedSpan fill:#439846, color:#ffffff
     classDef parentSpan fill:#3792cb, color:#ffffff
+
+    class F parentSpan
+    class G selectedSpan
 ```

--- a/docs/advanced-selectors.md
+++ b/docs/advanced-selectors.md
@@ -260,12 +260,12 @@ flowchart TD
     I -->|9| J
     J -->|10| K
 
-    A:::selectedSpan
-    B:::selectedSpan
-    D:::selectedSpan
-    F:::selectedSpan
-    G:::selectedSpan
-    I:::selectedSpan
+    class A selectedSpan
+    class B selectedSpan
+    class D selectedSpan
+    class F selectedSpan
+    class G selectedSpan
+    class I selectedSpan
 
     classDef selectedSpan fill:#439846, color:#ffffff
     classDef candidateSpan fill:#FF6905, color:#ffffff
@@ -381,8 +381,8 @@ flowchart TD
     I -->|9| J
     J -->|10| K
 
-    A:::selectedSpan
-    F:::selectedSpan
+    class A selectedSpan
+    class F selectedSpan
 
     classDef selectedSpan fill:#439846, color:#ffffff
     classDef candidateSpan fill:#FF6905, color:#ffffff
@@ -498,16 +498,16 @@ flowchart TD
     I -->|9| J
     J -->|10| K
 
-    A:::selectedSpan
-    B:::selectedSpan
-    C:::selectedSpan
-    D:::selectedSpan
-    E:::selectedSpan
-    F:::selectedSpan
-    G:::selectedSpan
-    H:::selectedSpan
-    I:::selectedSpan
-    J:::selectedSpan
+    class A selectedSpan
+    class B selectedSpan
+    class C selectedSpan
+    class D selectedSpan
+    class E selectedSpan
+    class F selectedSpan
+    class G selectedSpan
+    class H selectedSpan
+    class I selectedSpan
+    class J selectedSpan
 
     classDef selectedSpan fill:#439846, color:#ffffff
     classDef candidateSpan fill:#FF6905, color:#ffffff
@@ -625,16 +625,16 @@ flowchart TD
     I -->|9| J
     J -->|10| K
 
-    A:::selectedSpan
-    B:::selectedSpan
-    C:::selectedSpan
-    D:::selectedSpan
-    E:::selectedSpan
-    F:::selectedSpan
-    G:::selectedSpan
-    H:::selectedSpan
-    I:::selectedSpan
-    J:::selectedSpan
+    class A selectedSpan
+    class B selectedSpan
+    class C selectedSpan
+    class D selectedSpan
+    class E selectedSpan
+    class F selectedSpan
+    class G selectedSpan
+    class H selectedSpan
+    class I selectedSpan
+    class J selectedSpan
 
     classDef selectedSpan fill:#439846, color:#ffffff
     classDef candidateSpan fill:#FF6905, color:#ffffff
@@ -756,12 +756,12 @@ flowchart TD
     I -->|9| J
     J -->|10| K
 
-    A:::selectedSpan
-    B:::selectedSpan
-    D:::selectedSpan
-    F:::selectedSpan
-    G:::selectedSpan
-    I:::selectedSpan
+    class A selectedSpan
+    class B selectedSpan
+    class D selectedSpan
+    class F selectedSpan
+    class G selectedSpan
+    class I selectedSpan
 
     classDef selectedSpan fill:#439846, color:#ffffff
     classDef candidateSpan fill:#FF6905, color:#ffffff
@@ -875,12 +875,12 @@ flowchart TD
     I -->|9| J
     J -->|10| K
 
-    A:::selectedSpan
-    B:::candidateSpan
-    D:::candidateSpan
-    F:::candidateSpan
-    G:::candidateSpan
-    I:::candidateSpan
+    class A selectedSpan
+    class B candidateSpan
+    class D candidateSpan
+    class F candidateSpan
+    class G candidateSpan
+    class I candidateSpan
 
     classDef selectedSpan fill:#439846, color:#ffffff
     classDef candidateSpan fill:#FF6905, color:#ffffff
@@ -994,12 +994,12 @@ flowchart TD
     I -->|9| J
     J -->|10| K
 
-    A:::candidateSpan
-    B:::candidateSpan
-    D:::candidateSpan
-    F:::candidateSpan
-    G:::candidateSpan
-    I:::selectedSpan
+    class A candidateSpan
+    class B candidateSpan
+    class D candidateSpan
+    class F candidateSpan
+    class G candidateSpan
+    class I selectedSpan
 
     classDef selectedSpan fill:#439846, color:#ffffff
     classDef candidateSpan fill:#FF6905, color:#ffffff
@@ -1113,12 +1113,12 @@ flowchart TD
     I -->|9| J
     J -->|10| K
 
-    A:::candidateSpan
-    B:::candidateSpan
-    D:::selectedSpan
-    F:::candidateSpan
-    G:::candidateSpan
-    I:::candidateSpan
+    class A candidateSpan
+    class B candidateSpan
+    class D selectedSpan
+    class F candidateSpan
+    class G candidateSpan
+    class I candidateSpan
 
     classDef selectedSpan fill:#439846, color:#ffffff
     classDef candidateSpan fill:#FF6905, color:#ffffff
@@ -1242,8 +1242,8 @@ flowchart TD
     I -->|9| J
     J -->|10| K
 
-    D:::selectedSpan
-    G:::selectedSpan
+    class D selectedSpan
+    class G selectedSpan
 
     classDef selectedSpan fill:#439846, color:#ffffff
     classDef candidateSpan fill:#FF6905, color:#ffffff
@@ -1360,8 +1360,8 @@ flowchart TD
     I -->|9| J
     J -->|10| K
 
-    F:::parentSpan
-    G:::selectedSpan
+    class F parentSpan
+    class G selectedSpan
 
     classDef selectedSpan fill:#439846, color:#ffffff
     classDef parentSpan fill:#3792cb, color:#ffffff

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -51,7 +51,6 @@ extra:
 plugins:
   - render_swagger
   - search
-  - mermaid2
 
 # Extensions
 markdown_extensions:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -57,11 +57,21 @@ plugins:
 markdown_extensions:
   - pymdownx.highlight
   - pymdownx.inlinehilite
+  # - pymdownx.superfences:
+  #     # make exceptions to highlighting of code:
+  #     custom_fences:
+  #       - name: mermaid
+  #         class: mermaid
+  #         format: !!python/name:mermaid2.fence_mermaid
   - pymdownx.superfences:
-      # make exceptions to highlighting of code:
       custom_fences:
         - name: mermaid
           class: mermaid
-          format: !!python/name:mermaid2.fence_mermaid
+          format: !!python/name:pymdownx.superfences.fence_div_format
+
+extra_css:
+  - https://unpkg.com/mermaid@9.1.3/dist/mermaid.css
+extra_javascript:
+  - https://unpkg.com/mermaid@9.1.3/dist/mermaid.min.js
 
 copyright: Copyright &copy; 2022 <a href="https://kubeshop.io">Kubeshop</a>


### PR DESCRIPTION
Our selector graph was rendered without the colors. This PR fixes it.

Before:
![image](https://user-images.githubusercontent.com/2704737/176543082-10789eca-f259-4759-bb68-ee1b7971c53e.png)


After:
![image](https://user-images.githubusercontent.com/2704737/176543119-0d5b3d82-137a-41ba-9824-5b943f1f9212.png)


## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
