### PR TITLE
feat: convert time into the right time unit

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -155,6 +155,8 @@ jobs:
           --set tracingBackend=jaeger \
           --set jaegerConnectionConfig.endpoint="jaeger-query.tracetest.svc.cluster.local:16685" \
           --set telemetry.jaeger.host="jaeger-agent.tracetest.svc.cluster.local" \
+          --set poolingConfig.maxWaitTimeForTrace="60s" \
+          --set poolingConfig.retryDelay="5s" \
           --set ingress.enabled=false \
           --wait --timeout 3m
 

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -156,7 +156,7 @@ jobs:
           --set jaegerConnectionConfig.endpoint="jaeger-query.tracetest.svc.cluster.local:16685" \
           --set telemetry.jaeger.host="jaeger-agent.tracetest.svc.cluster.local" \
           --set poolingConfig.maxWaitTimeForTrace="60s" \
-          --set poolingConfig.retryDelay="5s" \
+          --set poolingConfig.retryDelay="1s" \
           --set ingress.enabled=false \
           --wait --timeout 3m
 

--- a/cli/conversion/parser/assertion_parser.go
+++ b/cli/conversion/parser/assertion_parser.go
@@ -17,7 +17,7 @@ type Assertion struct {
 type assertionParserObject struct {
 	Attribute string `@Attribute`
 	Operator  string `@Operator`
-	Value     string `@(Number|QuotedString|SingleQuotedString)`
+	Value     string `@(Duration|Number|QuotedString|SingleQuotedString)`
 }
 
 var languageLexer = lexer.MustStateful(lexer.Rules{
@@ -25,6 +25,7 @@ var languageLexer = lexer.MustStateful(lexer.Rules{
 		{Name: "Operator", Pattern: `!=|<=|>=|=|<|>|contains`},
 		{Name: "Attribute", Pattern: `[a-zA-Z_][a-zA-Z0-9_\.]*`},
 		{Name: "whitespace", Pattern: `\s+`, Action: nil},
+		{Name: "Duration", Pattern: `([0-9]+(\.[0-9]+)?)(ns|μs|ms|s|m|h)`},
 		{Name: "Number", Pattern: `([0-9]+(\.[0-9]+)?)`},
 		{Name: "QuotedString", Pattern: `".*`, Action: lexer.Push("QuotedString")},
 		{Name: "SingleQuotedString", Pattern: `'.*`, Action: lexer.Push("SingleQuotedString")},

--- a/cli/conversion/parser/assertion_parser.go
+++ b/cli/conversion/parser/assertion_parser.go
@@ -25,7 +25,7 @@ var languageLexer = lexer.MustStateful(lexer.Rules{
 		{Name: "Operator", Pattern: `!=|<=|>=|=|<|>|contains`},
 		{Name: "Attribute", Pattern: `[a-zA-Z_][a-zA-Z0-9_\.]*`},
 		{Name: "whitespace", Pattern: `\s+`, Action: nil},
-		{Name: "Duration", Pattern: `([0-9]+(\.[0-9]+)?)(ns|μs|ms|s|m|h)`},
+		{Name: "Duration", Pattern: `([0-9]+(\.[0-9]+)?)(ns|us|ms|s|m|h)`},
 		{Name: "Number", Pattern: `([0-9]+(\.[0-9]+)?)`},
 		{Name: "QuotedString", Pattern: `".*`, Action: lexer.Push("QuotedString")},
 		{Name: "SingleQuotedString", Pattern: `'.*`, Action: lexer.Push("SingleQuotedString")},

--- a/cli/conversion/parser/assertion_parser_test.go
+++ b/cli/conversion/parser/assertion_parser_test.go
@@ -142,11 +142,11 @@ func TestParseAssertion(t *testing.T) {
 		},
 		{
 			Name:  "should_parse_microsecond_duration",
-			Query: `tracetest.span.duration <= 100μs`,
+			Query: `tracetest.span.duration <= 100us`,
 			ExpectedOutput: parser.Assertion{
 				Attribute: "tracetest.span.duration",
 				Operator:  "<=",
-				Value:     "100μs",
+				Value:     "100us",
 			},
 		},
 		{

--- a/cli/conversion/parser/assertion_parser_test.go
+++ b/cli/conversion/parser/assertion_parser_test.go
@@ -131,6 +131,60 @@ func TestParseAssertion(t *testing.T) {
 				Value:     "199.99",
 			},
 		},
+		{
+			Name:  "should_parse_nanosecond_duration",
+			Query: `tracetest.span.duration <= 100ns`,
+			ExpectedOutput: parser.Assertion{
+				Attribute: "tracetest.span.duration",
+				Operator:  "<=",
+				Value:     "100ns",
+			},
+		},
+		{
+			Name:  "should_parse_microsecond_duration",
+			Query: `tracetest.span.duration <= 100μs`,
+			ExpectedOutput: parser.Assertion{
+				Attribute: "tracetest.span.duration",
+				Operator:  "<=",
+				Value:     "100μs",
+			},
+		},
+		{
+			Name:  "should_parse_millisecond_duration",
+			Query: `tracetest.span.duration <= 100ms`,
+			ExpectedOutput: parser.Assertion{
+				Attribute: "tracetest.span.duration",
+				Operator:  "<=",
+				Value:     "100ms",
+			},
+		},
+		{
+			Name:  "should_parse_second_duration",
+			Query: `tracetest.span.duration <= 100s`,
+			ExpectedOutput: parser.Assertion{
+				Attribute: "tracetest.span.duration",
+				Operator:  "<=",
+				Value:     "100s",
+			},
+		},
+		{
+			Name:  "should_parse_minute_duration",
+			Query: `tracetest.span.duration <= 100m`,
+			ExpectedOutput: parser.Assertion{
+				Attribute: "tracetest.span.duration",
+				Operator:  "<=",
+				Value:     "100m",
+			},
+		},
+		{
+			Name:  "should_parse_hour_duration",
+			Query: `tracetest.span.duration <= 100h`,
+			ExpectedOutput: parser.Assertion{
+				Attribute: "tracetest.span.duration",
+				Operator:  "<=",
+				Value:     "100h",
+			},
+		},
 	}
 
 	for _, testCase := range testCases {

--- a/cli/file/definition_test.go
+++ b/cli/file/definition_test.go
@@ -38,7 +38,7 @@ func TestLoadDefinition(t *testing.T) {
 					{
 						Selector: "span[name = \"POST /pokemon/import\"]",
 						Assertions: []string{
-							"tracetest.span.duration <= 100",
+							"tracetest.span.duration <= 100ms",
 							"http.status_code = 200",
 						},
 					},
@@ -64,7 +64,7 @@ func TestLoadDefinition(t *testing.T) {
 						Selector: "span[name = \"consume message from queue\"]:last span[name = \"save pokemon on database\"]",
 						Assertions: []string{
 							"db.repository.operation = \"create\"",
-							"tracetest.span.duration <= 100",
+							"tracetest.span.duration <= 100ms",
 							`tracetest.response.body contains "\"id\": 52"`,
 						},
 					},
@@ -94,7 +94,7 @@ func TestLoadDefinition(t *testing.T) {
 					{
 						Selector: "span[name = \"POST /pokemon/import\"]",
 						Assertions: []string{
-							"tracetest.span.duration <= 100",
+							"tracetest.span.duration <= 100ms",
 							"http.status_code = 200",
 						},
 					},
@@ -120,7 +120,7 @@ func TestLoadDefinition(t *testing.T) {
 						Selector: "span[name = \"consume message from queue\"]:last span[name = \"save pokemon on database\"]",
 						Assertions: []string{
 							"db.repository.operation = \"create\"",
-							"tracetest.span.duration <= 100",
+							"tracetest.span.duration <= 100ms",
 						},
 					},
 				},

--- a/cli/testdata/definitions/valid_http_test_definition.yml
+++ b/cli/testdata/definitions/valid_http_test_definition.yml
@@ -1,9 +1,10 @@
+id: ea8003c5-c93b-41a6-ac1b-63569552f4ff
 name: POST import pokemon
 description: Import a pokemon using its ID
 trigger:
   type: http
   httpRequest:
-    url: http://pokemon-demo.tracetest.io/pokemon/import
+    url: http://localhost:3001/pokemon/import
     method: POST
     headers:
     - key: Content-Type
@@ -12,7 +13,7 @@ trigger:
 testDefinition:
 - selector: span[name = "POST /pokemon/import"]
   assertions:
-  - tracetest.span.duration <= 100
+  - tracetest.span.duration <= 100ms
   - http.status_code = 200
 - selector: span[name = "send message to queue"]
   assertions:
@@ -20,13 +21,13 @@ testDefinition:
 - selector: span[name = "consume message from queue"]:last
   assertions:
   - messaging.message.payload contains 52
-- selector: span[name = "consume message from queue"]:last span[name = "import
-    pokemon from pokeapi"]
+- selector: span[name = "consume message from queue"]:last span[name = "import pokemon
+    from pokeapi"]
   assertions:
   - http.status_code = 200
-- selector: span[name = "consume message from queue"]:last span[name = "save
-    pokemon on database"]
+- selector: span[name = "consume message from queue"]:last span[name = "save pokemon
+    on database"]
   assertions:
   - db.repository.operation = "create"
-  - tracetest.span.duration <= 100
+  - tracetest.span.duration <= 100ms
   - 'tracetest.response.body contains "\"id\": 52"'

--- a/cli/testdata/definitions/valid_http_test_definition.yml
+++ b/cli/testdata/definitions/valid_http_test_definition.yml
@@ -1,10 +1,9 @@
-id: ea8003c5-c93b-41a6-ac1b-63569552f4ff
 name: POST import pokemon
 description: Import a pokemon using its ID
 trigger:
   type: http
   httpRequest:
-    url: http://localhost:3001/pokemon/import
+    url: http://pokemon-demo.tracetest.io/pokemon/import
     method: POST
     headers:
     - key: Content-Type

--- a/cli/testdata/definitions/valid_http_test_definition_with_id.yml
+++ b/cli/testdata/definitions/valid_http_test_definition_with_id.yml
@@ -13,7 +13,7 @@ trigger:
 testDefinition:
 - selector: span[name = "POST /pokemon/import"]
   assertions:
-  - tracetest.span.duration <= 100
+  - tracetest.span.duration <= 100ms
   - http.status_code = 200
 - selector: span[name = "send message to queue"]
   assertions:
@@ -27,4 +27,4 @@ testDefinition:
 - selector: span[name = "consume message from queue"]:last span[name = "save pokemon on database"]
   assertions:
   - db.repository.operation = "create"
-  - tracetest.span.duration <= 100
+  - tracetest.span.duration <= 100ms

--- a/server/app/app.go
+++ b/server/app/app.go
@@ -18,6 +18,7 @@ import (
 	"github.com/kubeshop/tracetest/server/openapi"
 	"github.com/kubeshop/tracetest/server/subscription"
 	"github.com/kubeshop/tracetest/server/tracedb"
+	"github.com/kubeshop/tracetest/server/traces"
 	"go.opentelemetry.io/otel/trace"
 )
 
@@ -101,7 +102,13 @@ func (a *App) Start() error {
 	assertionRunner.Start(5)
 	defer assertionRunner.Stop()
 
-	pollerExecutor := executor.NewPollerExecutor(a.tracer, execTestUpdater, a.traceDB, a.config.PoolingRetryDelay(), a.config.MaxWaitTimeForTraceDuration())
+	traceConversionConfig := traces.NewConversionConfig()
+	// hardcoded for now. In the future we will get those values from the database
+	traceConversionConfig.AddTimeFields(
+		"tracetest.span.duration",
+	)
+
+	pollerExecutor := executor.NewPollerExecutor(a.tracer, execTestUpdater, a.traceDB, a.config.PoolingRetryDelay(), a.config.MaxWaitTimeForTraceDuration(), traceConversionConfig)
 
 	tracePoller := executor.NewTracePoller(pollerExecutor, execTestUpdater, assertionRunner, a.config.PoolingRetryDelay(), a.config.MaxWaitTimeForTraceDuration())
 	tracePoller.Start(5) // worker count. should be configurable

--- a/server/app/app.go
+++ b/server/app/app.go
@@ -108,7 +108,7 @@ func (a *App) Start() error {
 		"tracetest.span.duration",
 	)
 
-	pollerExecutor := executor.NewPollerExecutor(a.tracer, execTestUpdater, a.traceDB, a.config.PoolingRetryDelay(), a.config.MaxWaitTimeForTraceDuration(), traceConversionConfig)
+	pollerExecutor := executor.NewPollerExecutor(a.tracer, execTestUpdater, a.traceDB, a.config.PoolingRetryDelay(), a.config.MaxWaitTimeForTraceDuration())
 
 	tracePoller := executor.NewTracePoller(pollerExecutor, execTestUpdater, assertionRunner, a.config.PoolingRetryDelay(), a.config.MaxWaitTimeForTraceDuration())
 	tracePoller.Start(5) // worker count. should be configurable
@@ -118,7 +118,7 @@ func (a *App) Start() error {
 	runner.Start(5) // worker count. should be configurable
 	defer runner.Stop()
 
-	controller := httpServer.NewController(a.db, runner, assertionRunner)
+	controller := httpServer.NewController(a.db, runner, assertionRunner, traceConversionConfig)
 	apiApiController := openapi.NewApiApiController(controller)
 	customController := httpServer.NewCustomController(controller, apiApiController, openapi.DefaultErrorHandler, a.tracer)
 	httpRouter := customController

--- a/server/executor/poller_executor.go
+++ b/server/executor/poller_executor.go
@@ -16,7 +16,6 @@ type DefaultPollerExecutor struct {
 	updater           RunUpdater
 	traceDB           tracedb.TraceDB
 	maxTracePollRetry int
-	conversionConfig  traces.ConversionConfig
 }
 
 type InstrumentedPollerExecutor struct {
@@ -44,14 +43,12 @@ func NewPollerExecutor(
 	traceDB tracedb.TraceDB,
 	retryDelay time.Duration,
 	maxWaitTimeForTrace time.Duration,
-	conversionConfig traces.ConversionConfig,
 ) PollerExecutor {
 	maxTracePollRetry := int(math.Ceil(float64(maxWaitTimeForTrace) / float64(retryDelay)))
 	pollerExecutor := &DefaultPollerExecutor{
 		updater:           updater,
 		traceDB:           traceDB,
 		maxTracePollRetry: maxTracePollRetry,
-		conversionConfig:  conversionConfig,
 	}
 
 	return &InstrumentedPollerExecutor{
@@ -67,7 +64,7 @@ func (pe DefaultPollerExecutor) ExecuteRequest(request *PollingRequest) (bool, m
 		return false, model.Run{}, err
 	}
 
-	trace := traces.FromOtel(otelTrace, pe.conversionConfig)
+	trace := traces.FromOtel(otelTrace)
 	trace.ID = run.TraceID
 
 	if !pe.donePollingTraces(request, trace) {

--- a/server/http/controller.go
+++ b/server/http/controller.go
@@ -20,6 +20,7 @@ import (
 	"github.com/kubeshop/tracetest/server/model"
 	"github.com/kubeshop/tracetest/server/openapi"
 	"github.com/kubeshop/tracetest/server/testdb"
+	"github.com/kubeshop/tracetest/server/traces"
 	"gopkg.in/yaml.v3"
 )
 
@@ -38,13 +39,14 @@ func NewController(
 	testDB model.Repository,
 	runner executor.Runner,
 	assertionRunner executor.AssertionRunner,
+	traceConversionConfig traces.ConversionConfig,
 ) openapi.ApiApiServicer {
 	return &controller{
 		testDB:          testDB,
 		runner:          runner,
 		assertionRunner: assertionRunner,
-		openapi:         OpenAPIMapper{},
-		model:           ModelMapper{Comparators: comparator.DefaultRegistry()},
+		openapi:         OpenAPIMapper{traceConversionConfig},
+		model:           ModelMapper{Comparators: comparator.DefaultRegistry(), traceConversionConfig: traceConversionConfig},
 	}
 }
 

--- a/server/http/controller_test.go
+++ b/server/http/controller_test.go
@@ -117,7 +117,7 @@ func setupController(t *testing.T) controllerFixture {
 	mdb.Test(t)
 	return controllerFixture{
 		db: mdb,
-		c:  http.NewController(mdb, nil, nil),
+		c:  http.NewController(mdb, nil, nil, traces.NewConversionConfig()),
 	}
 }
 

--- a/server/testdb/definitions_test.go
+++ b/server/testdb/definitions_test.go
@@ -20,7 +20,7 @@ func TestDefinitions(t *testing.T) {
 		{
 			Attribute:  "tracetest.span.duration",
 			Comparator: comparator.Eq,
-			Value:      "2000",
+			Value:      "2000000000",
 		},
 	})
 

--- a/server/testfixtures/import_pokemon_test_fixture.go
+++ b/server/testfixtures/import_pokemon_test_fixture.go
@@ -119,7 +119,7 @@ func createTestDefinition(testID string) error {
 					{
 						Attribute:  "tracetest.span.duration",
 						Comparator: "<",
-						Expected:   "200",
+						Expected:   "200ms",
 					},
 				},
 			},

--- a/server/testmock/data/pokeshop_import_pokemon.json
+++ b/server/testmock/data/pokeshop_import_pokemon.json
@@ -32,7 +32,7 @@
               {
                 "attribute": "tracetest.span.duration",
                 "comparator": "<",
-                "value": "100"
+                "value": "100000000"
               }
             ]
           },
@@ -42,7 +42,7 @@
               {
                 "attribute": "tracetest.span.duration",
                 "comparator": "<",
-                "value": "1000"
+                "value": "1000000000"
               }
             ]
           }
@@ -106,7 +106,7 @@
               "http.response.body":  "{\"id\":52}",
               "tracetest.response.status": "200",
               "tracetest.response.body": "{\"id\":52}",
-              "tracetest.span.duration": "2",
+              "tracetest.span.duration": "2000000",
               "tracetest.span.type": "http"
             },
             "Children": [
@@ -118,7 +118,7 @@
                 "Attributes": {
                   "service.name": "pokeshop-worker",
                   "messaging.destination": "/queue/syncronizePokemon",
-                  "tracetest.span.duration": "234",
+                  "tracetest.span.duration": "234000000",
                   "tracetest.span.type": "messaging"
                 },
                 "Children": []
@@ -132,7 +132,7 @@
                   "service.name": "pokeshop-worker",
                   "db.name": "pokeshop",
                   "db.system": "postgresql",
-                  "tracetest.span.duration": "2",
+                  "tracetest.span.duration": "2000000",
                   "tracetest.span.type": "database"
                 },
                 "Children": []

--- a/server/testmock/data/pokeshop_import_pokemon_failed_assertions.json
+++ b/server/testmock/data/pokeshop_import_pokemon_failed_assertions.json
@@ -32,7 +32,7 @@
             {
               "attribute": "tracetest.span.duration",
               "comparator": "<",
-              "value": "100"
+              "value": "100000000"
             }
           ]
         },
@@ -42,7 +42,7 @@
             {
               "attribute": "tracetest.span.duration",
               "comparator": "<",
-              "value": "1000"
+              "value": "1000000000"
             }
           ]
         }
@@ -106,7 +106,7 @@
             "http.response.body":  "{\"id\":52}",
             "tracetest.response.status": "200",
             "tracetest.response.body": "{\"id\":52}",
-            "tracetest.span.duration": "2",
+            "tracetest.span.duration": "2000000",
             "tracetest.span.type": "http"
           },
           "Children": [
@@ -118,7 +118,7 @@
               "Attributes": {
                 "service.name": "pokeshop-worker",
                 "messaging.destination": "/queue/syncronizePokemon",
-                "tracetest.span.duration": "234",
+                "tracetest.span.duration": "234000000",
                 "tracetest.span.type": "messaging"
               },
               "Children": []
@@ -132,7 +132,7 @@
                 "service.name": "pokeshop-worker",
                 "db.name": "pokeshop",
                 "db.system": "postgresql",
-                "tracetest.span.duration": "2",
+                "tracetest.span.duration": "2000000",
                 "tracetest.span.type": "database"
               },
               "Children": []

--- a/server/traces/conversion_config.go
+++ b/server/traces/conversion_config.go
@@ -1,0 +1,22 @@
+package traces
+
+type ConversionConfig struct {
+	timeFields map[string]bool
+}
+
+func NewConversionConfig() ConversionConfig {
+	return ConversionConfig{
+		timeFields: make(map[string]bool, 0),
+	}
+}
+
+func (c ConversionConfig) AddTimeFields(fields ...string) {
+	for _, field := range fields {
+		c.timeFields[field] = true
+	}
+}
+
+func (c ConversionConfig) IsTimeField(field string) bool {
+	_, ok := c.timeFields[field]
+	return ok
+}

--- a/server/traces/otel_converter.go
+++ b/server/traces/otel_converter.go
@@ -12,7 +12,28 @@ import (
 	v1 "go.opentelemetry.io/proto/otlp/trace/v1"
 )
 
-func FromOtel(input *v1.TracesData) Trace {
+type ConversionConfig struct {
+	timeFields map[string]bool
+}
+
+func NewConversionConfig() ConversionConfig {
+	return ConversionConfig{
+		timeFields: make(map[string]bool, 0),
+	}
+}
+
+func (c ConversionConfig) AddTimeFields(fields ...string) {
+	for _, field := range fields {
+		c.timeFields[field] = true
+	}
+}
+
+func (c ConversionConfig) IsTimeField(field string) bool {
+	_, ok := c.timeFields[field]
+	return ok
+}
+
+func FromOtel(input *v1.TracesData, config ConversionConfig) Trace {
 	flattenSpans := make([]*v1.Span, 0)
 	for _, resource := range input.ResourceSpans {
 		for _, librarySpans := range resource.InstrumentationLibrarySpans {
@@ -22,14 +43,14 @@ func FromOtel(input *v1.TracesData) Trace {
 
 	spansMap := map[trace.SpanID]*Span{}
 	for _, span := range flattenSpans {
-		newSpan := convertOtelSpanIntoSpan(span)
+		newSpan := convertOtelSpanIntoSpan(span, config)
 		spansMap[newSpan.ID] = newSpan
 	}
 
 	return createTrace(flattenSpans, spansMap)
 }
 
-func convertOtelSpanIntoSpan(span *v1.Span) *Span {
+func convertOtelSpanIntoSpan(span *v1.Span, config ConversionConfig) *Span {
 	attributes := make(Attributes, 0)
 	for _, attribute := range span.Attributes {
 		attributes[attribute.Key] = getAttributeValue(attribute.Value)
@@ -50,6 +71,15 @@ func convertOtelSpanIntoSpan(span *v1.Span) *Span {
 	attributes["tracetest.span.type"] = spanType(attributes)
 	attributes["tracetest.span.duration"] = spanDuration(span)
 
+	for name, value := range attributes {
+		if config.IsTimeField(name) {
+			valueAsInt, err := strconv.Atoi(value)
+			if err == nil {
+				attributes[name] = ConvertNanoSecondsIntoProperTimeUnit(valueAsInt)
+			}
+		}
+	}
+
 	spanID := createSpanID(span.SpanId)
 	return &Span{
 		ID:         spanID,
@@ -64,7 +94,7 @@ func convertOtelSpanIntoSpan(span *v1.Span) *Span {
 
 func spanDuration(span *v1.Span) string {
 	if span.GetStartTimeUnixNano() != 0 && span.GetEndTimeUnixNano() != 0 {
-		spanDuration := (span.GetEndTimeUnixNano() - span.GetStartTimeUnixNano()) / 1000 / 1000 // in milliseconds
+		spanDuration := (span.GetEndTimeUnixNano() - span.GetStartTimeUnixNano())
 		return strconv.FormatUint(spanDuration, 10)
 	}
 

--- a/server/traces/time_converter.go
+++ b/server/traces/time_converter.go
@@ -36,13 +36,13 @@ func ConvertNanoSecondsIntoProperTimeUnit(value int) string {
 	unit := timeUnits[int(scale)]
 
 	if scale == SECOND_SCALE {
-		return convertSecondsIntoPropertTimeUnit(convertedNumber)
+		return convertSecondsIntoProperTimeUnit(convertedNumber)
 	}
 
 	return fmt.Sprintf("%.0f%s", convertedNumber, unit)
 }
 
-func convertSecondsIntoPropertTimeUnit(number float64) string {
+func convertSecondsIntoProperTimeUnit(number float64) string {
 	scale := SECOND_SCALE
 	if number >= 60 {
 		number = number / 60

--- a/server/traces/time_converter.go
+++ b/server/traces/time_converter.go
@@ -1,0 +1,65 @@
+package traces
+
+import (
+	"fmt"
+	"math"
+)
+
+const (
+	NANOSECOND_SCALE  = 0
+	MICROSECOND_SCALE = 1
+	MILLISECOND_SCALE = 2
+	SECOND_SCALE      = 3
+	MINUTE_SCALE      = 4
+	HOUR_SCALE        = 5
+)
+
+var timeUnits = []string{"ns", "μs", "ms", "s", "m", "h"}
+
+func ConvertNanoSecondsIntoProperTimeUnit(value int) string {
+	// Scale is basically how many times we can divide value by 1000.
+	// To achieve that, we use Log1000(value). However, go doesn't support that,
+	// so we need to use the math transformation:
+	// Log1000(value) = Log(value) / Log(1000)
+	//
+	// As we don't care about the floating point part of the result, we use Floor to remove it
+	scale := math.Floor(math.Log(float64(value)) / math.Log(1000))
+	if scale > SECOND_SCALE {
+		scale = SECOND_SCALE
+	}
+
+	divisor := math.Pow(1000, scale)
+	convertedNumber := float64(value) / divisor
+	unit := timeUnits[int(scale)]
+
+	if scale == SECOND_SCALE {
+		return convertSecondsIntoPropertTimeUnit(convertedNumber)
+	}
+
+	return fmt.Sprintf("%.0f%s", convertedNumber, unit)
+}
+
+func convertSecondsIntoPropertTimeUnit(number float64) string {
+	scale := SECOND_SCALE
+	if number >= 60 {
+		number = number / 60
+		scale = MINUTE_SCALE
+	}
+
+	if number >= 60 {
+		number = number / 60
+		scale = HOUR_SCALE
+	}
+
+	unit := timeUnits[scale]
+
+	if isWholeNumber(number) {
+		return fmt.Sprintf("%.0f%s", number, unit)
+	}
+
+	return fmt.Sprintf("%.1f%s", number, unit)
+}
+
+func isWholeNumber(number float64) bool {
+	return math.Mod(number, 1.0) == 0
+}

--- a/server/traces/time_converter.go
+++ b/server/traces/time_converter.go
@@ -3,6 +3,8 @@ package traces
 import (
 	"fmt"
 	"math"
+	"regexp"
+	"strconv"
 )
 
 const (
@@ -62,4 +64,30 @@ func convertSecondsIntoPropertTimeUnit(number float64) string {
 
 func isWholeNumber(number float64) bool {
 	return math.Mod(number, 1.0) == 0
+}
+
+var timeFieldRegex = regexp.MustCompile(`^([0-9]+(\.[0-9]+)?)(ns|μs|ms|s|m|h)$`)
+
+func ConvertTimeFieldIntoNanoSeconds(value string) int {
+	result := timeFieldRegex.FindAllStringSubmatch(value, -1)
+	number, err := strconv.ParseFloat(result[0][1], 64)
+	if err != nil {
+		return 0
+	}
+
+	unit := result[0][3]
+	scale := scaleOfUnit(unit)
+
+	return int(math.Floor(number * scale))
+}
+
+func scaleOfUnit(unit string) float64 {
+	scaleIndex := 0
+	for index, item := range timeUnits {
+		if item == unit {
+			scaleIndex = index
+		}
+	}
+
+	return math.Pow(1000, float64(scaleIndex))
 }

--- a/server/traces/time_converter.go
+++ b/server/traces/time_converter.go
@@ -17,7 +17,7 @@ const (
 	HOUR_SCALE        = 5
 )
 
-var timeUnits = []string{"ns", "μs", "ms", "s", "m", "h"}
+var timeUnits = []string{"ns", "us", "ms", "s", "m", "h"}
 
 func ConvertNanoSecondsIntoProperTimeUnit(value int) string {
 	// Scale is basically how many times we can divide value by 1000.
@@ -67,10 +67,10 @@ func isWholeNumber(number float64) bool {
 	return math.Mod(number, 1.0) == 0
 }
 
-var timeFieldRegex = regexp.MustCompile(`^([0-9]+(\.[0-9]+)?)(ns|μs|ms|s|m|h)$`)
+var timeFieldRegex = regexp.MustCompile(`^([0-9]+(\.[0-9]+)?)(ns|us|ms|s|m|h)$`)
 var unitScale = map[string]time.Duration{
 	"ns": time.Nanosecond,
-	"μs": time.Microsecond,
+	"us": time.Microsecond,
 	"ms": time.Millisecond,
 	"s":  time.Second,
 	"m":  time.Minute,

--- a/server/traces/time_converter_test.go
+++ b/server/traces/time_converter_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestTimeConvertion(t *testing.T) {
+func TestConversionBetweenNanoSecondsToDuration(t *testing.T) {
 	testCases := []struct {
 		Name           string
 		Input          int
@@ -78,6 +78,82 @@ func TestTimeConvertion(t *testing.T) {
 	for _, testCase := range testCases {
 		t.Run(testCase.Name, func(t *testing.T) {
 			output := traces.ConvertNanoSecondsIntoProperTimeUnit(testCase.Input)
+			assert.Equal(t, testCase.ExpectedOutput, output)
+		})
+	}
+}
+
+func TestConversionBetweenDurationToNanoSeconds(t *testing.T) {
+	testCases := []struct {
+		Name           string
+		Input          string
+		ExpectedOutput int
+	}{
+		{
+			Name:           "should convert ns",
+			Input:          "120ns",
+			ExpectedOutput: 120,
+		},
+		{
+			Name:           "should floor ns with decimals",
+			Input:          "120.5ns",
+			ExpectedOutput: 120,
+		},
+		{
+			Name:           "should convert μs",
+			Input:          "35μs",
+			ExpectedOutput: 35000,
+		},
+		{
+			Name:           "should convert μs with decimal",
+			Input:          "35.8μs",
+			ExpectedOutput: 35800,
+		},
+		{
+			Name:           "should convert ms",
+			Input:          "68ms",
+			ExpectedOutput: 68000000,
+		},
+		{
+			Name:           "should convert ms with decimal",
+			Input:          "68.35ms",
+			ExpectedOutput: 68350000,
+		},
+		{
+			Name:           "should convert s",
+			Input:          "1s",
+			ExpectedOutput: 1000000000,
+		},
+		{
+			Name:           "should convert s with decimal",
+			Input:          "1.23s",
+			ExpectedOutput: 1230000000,
+		},
+		{
+			Name:           "should convert m",
+			Input:          "1m",
+			ExpectedOutput: 60000000000,
+		},
+		{
+			Name:           "should convert m with decimal",
+			Input:          "1.5m",
+			ExpectedOutput: 90000000000,
+		},
+		{
+			Name:           "should convert h",
+			Input:          "1h",
+			ExpectedOutput: 3600000000000,
+		},
+		{
+			Name:           "should convert h with decimal",
+			Input:          "2.5m",
+			ExpectedOutput: 8000000000000,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.Name, func(t *testing.T) {
+			output := traces.ConvertTimeFieldIntoNanoSeconds(testCase.Input)
 			assert.Equal(t, testCase.ExpectedOutput, output)
 		})
 	}

--- a/server/traces/time_converter_test.go
+++ b/server/traces/time_converter_test.go
@@ -146,8 +146,8 @@ func TestConversionBetweenDurationToNanoSeconds(t *testing.T) {
 		},
 		{
 			Name:           "should convert h with decimal",
-			Input:          "2.5m",
-			ExpectedOutput: 8000000000000,
+			Input:          "2.5h",
+			ExpectedOutput: 9000000000000,
 		},
 	}
 

--- a/server/traces/time_converter_test.go
+++ b/server/traces/time_converter_test.go
@@ -21,12 +21,12 @@ func TestConversionBetweenNanoSecondsToDuration(t *testing.T) {
 		{
 			Name:           "should convert microseconds",
 			Input:          93000,
-			ExpectedOutput: "93μs",
+			ExpectedOutput: "93us",
 		},
 		{
 			Name:           "should not render decimals when time is in microseconds",
 			Input:          93400,
-			ExpectedOutput: "93μs",
+			ExpectedOutput: "93us",
 		},
 		{
 			Name:           "should convert milliseconds",
@@ -100,13 +100,13 @@ func TestConversionBetweenDurationToNanoSeconds(t *testing.T) {
 			ExpectedOutput: 120,
 		},
 		{
-			Name:           "should convert μs",
-			Input:          "35μs",
+			Name:           "should convert us",
+			Input:          "35us",
 			ExpectedOutput: 35000,
 		},
 		{
-			Name:           "should convert μs with decimal",
-			Input:          "35.8μs",
+			Name:           "should convert us with decimal",
+			Input:          "35.8us",
 			ExpectedOutput: 35800,
 		},
 		{

--- a/server/traces/time_converter_test.go
+++ b/server/traces/time_converter_test.go
@@ -1,0 +1,84 @@
+package traces_test
+
+import (
+	"testing"
+
+	"github.com/kubeshop/tracetest/server/traces"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTimeConvertion(t *testing.T) {
+	testCases := []struct {
+		Name           string
+		Input          int
+		ExpectedOutput string
+	}{
+		{
+			Name:           "should convert nanoseconds",
+			Input:          38,
+			ExpectedOutput: "38ns",
+		},
+		{
+			Name:           "should convert microseconds",
+			Input:          93000,
+			ExpectedOutput: "93μs",
+		},
+		{
+			Name:           "should not render decimals when time is in microseconds",
+			Input:          93400,
+			ExpectedOutput: "93μs",
+		},
+		{
+			Name:           "should convert milliseconds",
+			Input:          29000000,
+			ExpectedOutput: "29ms",
+		},
+		{
+			Name:           "should not render decimals when time is in milliseconds",
+			Input:          27356000,
+			ExpectedOutput: "27ms",
+		},
+		{
+			Name:           "should convert seconds",
+			Input:          1000000000,
+			ExpectedOutput: "1s",
+		},
+		{
+			Name:           "should render decimals when time is in seconds",
+			Input:          1200000000,
+			ExpectedOutput: "1.2s",
+		},
+		{
+			Name:           "should convert minutes",
+			Input:          1620000000000, // 27m
+			ExpectedOutput: "27m",
+		},
+		{
+			Name:           "should render decimals when time is in minutes",
+			Input:          1650000000000, // 27m and 30 seconds
+			ExpectedOutput: "27.5m",
+		},
+		{
+			Name:           "should convert hours",
+			Input:          7200000000000, // 2 hours
+			ExpectedOutput: "2h",
+		},
+		{
+			Name:           "should convert hours",
+			Input:          9000000000000, // 2 hours and 30 minutes
+			ExpectedOutput: "2.5h",
+		},
+		{
+			Name:           "hour should be the largest unit",
+			Input:          38880000000000000, // 450 days
+			ExpectedOutput: "10800h",
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.Name, func(t *testing.T) {
+			output := traces.ConvertNanoSecondsIntoProperTimeUnit(testCase.Input)
+			assert.Equal(t, testCase.ExpectedOutput, output)
+		})
+	}
+}

--- a/web/cypress/integration/Trace/RunTest.spec.ts
+++ b/web/cypress/integration/Trace/RunTest.spec.ts
@@ -17,7 +17,7 @@ describe('Run Test', () => {
     cy.get(`[data-cy^=test-run-result-]`).first().click();
     cy.location('href').should('match', /\/run\/.*/i);
 
-    cy.get('[data-cy=run-test-button]', {timeout: 10000}).should('be.visible');
+    cy.get('[data-cy=run-test-button]', {timeout: 20000}).should('be.visible');
     cy.get(`[data-cy^=run-test-button]`).first().click();
 
     cy.wait(2000);


### PR DESCRIPTION
# Problem
Today we show time attributes (especially `tracetest.span.duration`) as a number. That number represents the number of milliseconds that the took to execute the operation. However, there is no indication that is in `ms`, and worse, sometimes some operations take less than one millisecond and the duration appears as `0`. 

> :information_source: Note: Before that, we were displaying the duration as the number of nanoseconds to execute the operation. It was precise, but the number was too big to be easily understood.

# Solution
Convert the duration from nanoseconds to a nice human-readable value and show the time unit. So instead of showing `1400000000`, Tracetest is going to show it as `1.4s` instead. It converts from nanoseconds (`ns`) to microseconds (`μs`), milliseconds(`ms`), seconds(`s`), minutes(`m`), and hours(`h`). Any value bigger than 24 hours will be displayed as hours anyway.

> Note: we are only showing decimal digits for seconds and above. So if duration is `1200000ns` it would be converted to `1ms` instead of `1.2ms`.

## Description

This PR adds code to convert the span attributes, assertion values, and result values into the right time unit. This is done in the mapping layer between the controller and the actual application code.

The values from the trace are kept untouched. So only the representation layer has changed.

It is executing the conversion during the trace fetch so we just have to convert it once.

## Screenshots of this working on the DAG page

![image](https://user-images.githubusercontent.com/2704737/176791066-eba7d9da-6890-43b0-b520-84711fbc10fa.png)

![image](https://user-images.githubusercontent.com/2704737/176791114-43cde470-795a-46c1-a983-84924d5a3ee4.png)

![image](https://user-images.githubusercontent.com/2704737/176791136-3459b96e-c415-487b-8242-c58ab02d2d8e.png)


## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [x] added a test
