### PR TITLE
🗺 822 Implement Advanced Query Support (Form/AssertionCard) 

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -155,6 +155,8 @@ jobs:
           --set tracingBackend=jaeger \
           --set jaegerConnectionConfig.endpoint="jaeger-query.tracetest.svc.cluster.local:16685" \
           --set telemetry.jaeger.host="jaeger-agent.tracetest.svc.cluster.local" \
+          --set poolingConfig.maxWaitTimeForTrace="60s" \
+          --set poolingConfig.retryDelay="1s" \
           --set ingress.enabled=false \
           --wait --timeout 3m
 

--- a/web/cypress/integration/Trace/CreateAssertion.spec.ts
+++ b/web/cypress/integration/Trace/CreateAssertion.spec.ts
@@ -82,6 +82,32 @@ describe('Create Assertion', () => {
     cy.get('[data-cy=assertion-card]').should('have.lengthOf', 2);
   });
 
+  it('should create a basic assertion using the advanced mode', () => {
+    cy.get(`[data-cy=trace-node-db]`).last().click();
+    cy.get('[data-cy=add-assertion-button]').click();
+    cy.get('[data-cy=assertion-form]', {timeout: 10000}).should('be.visible');
+
+    cy.get('[data-cy=mode-selector-switch]').click();
+    cy.get('[data-cy=advanced-selector]').clear().type('span[tracetest.span.type = "http"] span[tracetest.span.type = "database"]:first');
+
+    cy.get('[data-cy=assertion-check-attribute]').type('db');
+    cy.wait(500);
+    cy.get(`${getAttributeListId(0)} + div .ant-select-item`)
+      .first()
+      .click();
+
+    cy.get('[data-cy=assertion-check-operator]').click();
+    cy.get(`${getComparatorListId(0)} + div .ant-select-item`)
+      .last()
+      .click();
+    cy.get('[data-cy=assertion-check-operator] .ant-select-selection-item').should('have.text', 'Contains');
+
+    cy.get('[data-cy=assertion-form-submit-button]').click();
+
+    cy.get('[data-cy=assertion-card-list]').should('be.visible');
+    cy.get('[data-cy=assertion-card]').should('have.lengthOf', 3);
+  });
+
   it('should update an assertion', () => {
     cy.get('[data-cy=edit-assertion-button]').first().click();
     cy.get('[data-cy=assertion-form]').should('be.visible');
@@ -108,12 +134,43 @@ describe('Create Assertion', () => {
     cy.get('[data-cy=assertion-form-submit-button]').click();
 
     cy.get('[data-cy=assertion-card-list]').should('be.visible');
-    cy.get('[data-cy=assertion-card]').should('have.lengthOf', 2);
+    cy.get('[data-cy=assertion-card]').should('have.lengthOf', 3);
+  });
+
+  it('should update an assertion with advanced mode', () => {
+    cy.get('[data-cy=edit-assertion-button]').last().click();
+    cy.get('[data-cy=assertion-form]').should('be.visible');
+
+    cy.get('[data-cy=advanced-selector]').clear().type('span[tracetest.span.type = "database"]:last');
+
+    cy.get('[data-cy=assertion-check-operator]').first().click();
+    cy.get(`${getComparatorListId(0)} + div .ant-select-item`)
+      .first()
+      .click();
+    cy.get('[data-cy=assertion-check-operator] .ant-select-selection-item').first().should('have.text', 'Equals');
+
+    cy.get('[data-cy=add-assertion-form-add-check]').click();
+
+    cy.get('[data-cy=assertion-check-attribute]').last().type('service');
+    cy.wait(500);
+    cy.get(`${getAttributeListId(1)} + div .ant-select-item`)
+      .first()
+      .click();
+
+    cy.get('[data-cy=assertion-check-operator]').last().click();
+    cy.get(`${getComparatorListId(1)} + div .ant-select-item`)
+      .last()
+      .click();
+    cy.get('[data-cy=assertion-check-operator] .ant-select-selection-item').last().should('have.text', 'Contains');
+    cy.get('[data-cy=assertion-form-submit-button]').click();
+
+    cy.get('[data-cy=assertion-card-list]').should('be.visible');
+    cy.get('[data-cy=assertion-card]').should('have.lengthOf', 3);
   });
 
   it('should publish the changes', () => {
     cy.get('[data-cy=trace-actions-publish').click();
-    cy.get('[data-cy=assertion-card]', {timeout: 10000}).should('have.lengthOf', 2);
+    cy.get('[data-cy=assertion-card]', {timeout: 10000}).should('have.lengthOf', 3);
   });
 
   it('should create an assertion and revert all changes', () => {
@@ -136,9 +193,9 @@ describe('Create Assertion', () => {
     cy.get('[data-cy=assertion-form-submit-button]').click();
 
     cy.get('[data-cy=assertion-card-list]').should('exist');
-    cy.get('[data-cy=assertion-card]').should('have.lengthOf', 3);
+    cy.get('[data-cy=assertion-card]').should('have.lengthOf', 4);
 
     cy.get('[data-cy=trace-actions-revert-all').click();
-    cy.get('[data-cy=assertion-card]').should('have.lengthOf', 2);
+    cy.get('[data-cy=assertion-card]').should('have.lengthOf', 3);
   });
 });

--- a/web/cypress/integration/Trace/CreateAssertion.spec.ts
+++ b/web/cypress/integration/Trace/CreateAssertion.spec.ts
@@ -83,7 +83,7 @@ describe('Create Assertion', () => {
   });
 
   it('should create a basic assertion using the advanced mode', () => {
-    cy.get(`[data-cy=trace-node-db]`).last().click();
+    cy.get(`[data-cy=trace-node-database]`).last().click();
     cy.get('[data-cy=add-assertion-button]').click();
     cy.get('[data-cy=assertion-form]', {timeout: 10000}).should('be.visible');
 

--- a/web/cypress/integration/Trace/ShowTrace.spec.ts
+++ b/web/cypress/integration/Trace/ShowTrace.spec.ts
@@ -18,8 +18,7 @@ describe('Show Trace', () => {
     cy.get(`[data-cy^=test-run-result-]`).first().click();
     cy.location('href').should('match', /\/run\/.*/i);
 
-    cy.get('[data-cy=diagram-dag]', {timeout: 10000}).should('be.visible');
-    cy.get('[data-cy^=trace-node-]', {timeout: 10000}).should('be.visible');
+    cy.get('[data-cy^=trace-node-]', {timeout: 30000}).should('be.visible');
     cy.get('[data-cy=span-details-attributes]').should('be.visible');
     cy.get('[data-cy=empty-assertion-card-list]').should('exist');
 

--- a/web/src/components/AssertionCard/AssertionCard.styled.ts
+++ b/web/src/components/AssertionCard/AssertionCard.styled.ts
@@ -22,6 +22,7 @@ export const Body = styled.div`
   display: flex;
   flex-direction: column;
   gap: 9px;
+  background-color: #fff;
 `;
 
 export const SpanCountText = styled(Typography.Text)`

--- a/web/src/components/AssertionCard/AssertionCard.tsx
+++ b/web/src/components/AssertionCard/AssertionCard.tsx
@@ -18,13 +18,13 @@ interface IProps {
 }
 
 const AssertionCard = ({
-  assertionResult: {selector, resultList, selectorList, pseudoSelector, spanIds},
+  assertionResult: {selector, resultList, selectorList, pseudoSelector, spanIds, isAdvancedSelector},
   assertionResult,
   onSelectSpan,
   onDelete,
   onEdit,
 }: IProps) => {
-  const {setSelectedAssertion, revert} = useTestDefinition();
+  const {setSelectedAssertion, revert, viewResultsMode} = useTestDefinition();
   const {onSetFocusedSpan, selectedSpan} = useSpan();
   const selectedAssertion = useAppSelector(TestDefinitionSelectors.selectSelectedAssertion);
   const {
@@ -63,7 +63,13 @@ const AssertionCard = ({
     >
       <S.Header onClick={handleOnClick}>
         <div>
-          <AssertionCardSelectorList selectorList={selectorList} pseudoSelector={pseudoSelector} />
+          <AssertionCardSelectorList
+            viewResultsMode={viewResultsMode}
+            isAdvancedSelector={isAdvancedSelector}
+            selector={selector}
+            selectorList={selectorList}
+            pseudoSelector={pseudoSelector}
+          />
         </div>
         <S.ActionsContainer>
           {isDraft && <S.StatusTag>draft</S.StatusTag>}

--- a/web/src/components/AssertionCard/AssertionCardSelectorList.tsx
+++ b/web/src/components/AssertionCard/AssertionCardSelectorList.tsx
@@ -1,6 +1,6 @@
-import OperatorService from '../../services/Operator.service';
-import {TPseudoSelector, TSpanSelector} from '../../types/Assertion.types';
-import {TViewResultsMode} from '../../types/TestDefinition.types';
+import {ResultViewModes} from 'constants/Test.constants';
+import OperatorService from 'services/Operator.service';
+import {TPseudoSelector, TSpanSelector} from 'types/Assertion.types';
 import * as S from './AssertionCard.styled';
 
 interface IProps {
@@ -8,7 +8,7 @@ interface IProps {
   pseudoSelector?: TPseudoSelector;
   isAdvancedSelector: boolean;
   selector: string;
-  viewResultsMode: TViewResultsMode;
+  viewResultsMode: ResultViewModes;
 }
 
 const AssertionCardSelectorList = ({
@@ -18,7 +18,7 @@ const AssertionCardSelectorList = ({
   selector,
   viewResultsMode,
 }: IProps) => {
-  return isAdvancedSelector || viewResultsMode === 'advanced' ? (
+  return isAdvancedSelector || viewResultsMode === ResultViewModes.Advanced ? (
     <S.Selector>
       <S.SelectorAttributeText>selector</S.SelectorAttributeText>
       <S.SelectorValueText>{selector}</S.SelectorValueText>

--- a/web/src/components/AssertionCard/AssertionCardSelectorList.tsx
+++ b/web/src/components/AssertionCard/AssertionCardSelectorList.tsx
@@ -1,14 +1,29 @@
 import OperatorService from '../../services/Operator.service';
 import {TPseudoSelector, TSpanSelector} from '../../types/Assertion.types';
+import {TViewResultsMode} from '../../types/TestDefinition.types';
 import * as S from './AssertionCard.styled';
 
 interface IProps {
   selectorList: TSpanSelector[];
   pseudoSelector?: TPseudoSelector;
+  isAdvancedSelector: boolean;
+  selector: string;
+  viewResultsMode: TViewResultsMode;
 }
 
-const AssertionCardSelectorList: React.FC<IProps> = ({selectorList, pseudoSelector}) => {
-  return (
+const AssertionCardSelectorList = ({
+  selectorList,
+  pseudoSelector,
+  isAdvancedSelector,
+  selector,
+  viewResultsMode,
+}: IProps) => {
+  return isAdvancedSelector || viewResultsMode === 'advanced' ? (
+    <S.Selector>
+      <S.SelectorAttributeText>selector</S.SelectorAttributeText>
+      <S.SelectorValueText>{selector}</S.SelectorValueText>
+    </S.Selector>
+  ) : (
     <S.SelectorList>
       {selectorList.map(({key, value, operator}) => (
         <S.Selector key={`${key} ${operator} ${value}`}>

--- a/web/src/components/AssertionCardList/AssertionCardList.tsx
+++ b/web/src/components/AssertionCardList/AssertionCardList.tsx
@@ -4,7 +4,7 @@ import {useTestDefinition} from '../../providers/TestDefinition/TestDefinition.p
 import AssertionAnalyticsService from '../../services/Analytics/AssertionAnalytics.service';
 import {TAssertionResultEntry, TAssertionResults} from '../../types/Assertion.types';
 import AssertionCard from '../AssertionCard/AssertionCard';
-import {useAssertionForm} from '../AssertionForm/AssertionFormProvider';
+import {useAssertionForm} from '../AssertionForm/AssertionForm.provider';
 import {OPEN_BOTTOM_PANEL_STATE, useRunLayout} from '../RunLayout';
 import * as S from './AssertionCardList.styled';
 
@@ -16,24 +16,27 @@ interface TAssertionCardListProps {
 
 const AssertionCardList: React.FC<TAssertionCardListProps> = ({assertionResults: {resultList}, onSelectSpan}) => {
   const {open} = useAssertionForm();
-  const {remove} = useTestDefinition();
+  const {remove, viewResultsMode} = useTestDefinition();
   const {openBottomPanel} = useRunLayout();
 
   const handleEdit = useCallback(
-    ({selector, resultList: list, selectorList, pseudoSelector}: TAssertionResultEntry) => {
+    ({selector, resultList: list, selectorList, pseudoSelector, isAdvancedSelector}: TAssertionResultEntry) => {
       AssertionAnalyticsService.onAssertionEdit();
       openBottomPanel(OPEN_BOTTOM_PANEL_STATE.FORM);
+
       open({
         isEditing: true,
         selector,
         defaultValues: {
           assertionList: list.map(({assertion}) => assertion),
           selectorList,
+          selector,
           pseudoSelector,
+          isAdvancedSelector: viewResultsMode === 'advanced' || isAdvancedSelector,
         },
       });
     },
-    [open, openBottomPanel]
+    [open, openBottomPanel, viewResultsMode]
   );
 
   const handleDelete = useCallback(

--- a/web/src/components/AssertionCardList/AssertionCardList.tsx
+++ b/web/src/components/AssertionCardList/AssertionCardList.tsx
@@ -1,8 +1,9 @@
 import {Typography} from 'antd';
 import {useCallback} from 'react';
-import {useTestDefinition} from '../../providers/TestDefinition/TestDefinition.provider';
-import AssertionAnalyticsService from '../../services/Analytics/AssertionAnalytics.service';
-import {TAssertionResultEntry, TAssertionResults} from '../../types/Assertion.types';
+import { ResultViewModes } from 'constants/Test.constants';
+import {useTestDefinition} from 'providers/TestDefinition/TestDefinition.provider';
+import AssertionAnalyticsService from 'services/Analytics/AssertionAnalytics.service';
+import {TAssertionResultEntry, TAssertionResults} from 'types/Assertion.types';
 import AssertionCard from '../AssertionCard/AssertionCard';
 import {useAssertionForm} from '../AssertionForm/AssertionForm.provider';
 import {OPEN_BOTTOM_PANEL_STATE, useRunLayout} from '../RunLayout';
@@ -32,7 +33,7 @@ const AssertionCardList: React.FC<TAssertionCardListProps> = ({assertionResults:
           selectorList,
           selector,
           pseudoSelector,
-          isAdvancedSelector: viewResultsMode === 'advanced' || isAdvancedSelector,
+          isAdvancedSelector: viewResultsMode === ResultViewModes.Advanced || isAdvancedSelector,
         },
       });
     },

--- a/web/src/components/AssertionForm/AssertionForm.provider.tsx
+++ b/web/src/components/AssertionForm/AssertionForm.provider.tsx
@@ -53,7 +53,16 @@ const AssertionFormProvider: React.FC<{testId: string}> = ({children}) => {
 
   const open = useCallback(
     (props: IFormProps = {}) => {
-      const {isEditing, defaultValues: {selectorList = [], pseudoSelector, assertionList = []} = {}} = props;
+      const {
+        isEditing,
+        defaultValues: {
+          selectorList = [],
+          pseudoSelector,
+          assertionList = [],
+          isAdvancedSelector,
+          selector: defaultSelector,
+        } = {},
+      } = props;
       const selectorString = SelectorService.getSelectorString(selectorList, pseudoSelector);
       const definition = definitionList.find(({selector}) => selectorString === selector);
 
@@ -63,9 +72,11 @@ const AssertionFormProvider: React.FC<{testId: string}> = ({children}) => {
           isEditing: true,
           selector: selectorString,
           defaultValues: {
+            selector: defaultSelector,
             pseudoSelector,
             assertionList: isEditing ? assertionList : [...definition.assertionList, ...assertionList],
             selectorList,
+            isAdvancedSelector,
           },
         });
       else setFormProps(props);
@@ -97,15 +108,22 @@ const AssertionFormProvider: React.FC<{testId: string}> = ({children}) => {
   }, []);
 
   const onSubmit = useCallback(
-    async ({selectorList, assertionList = [], pseudoSelector}: IValues) => {
+    async ({
+      selectorList = [],
+      assertionList = [],
+      pseudoSelector,
+      isAdvancedSelector = false,
+      selector: newSelectorString = '',
+    }: IValues) => {
       const {isEditing, selector = ''} = formProps;
       const newSelector = SelectorService.getSelectorString(selectorList, pseudoSelector);
 
       const definition: TTestDefinitionEntry = {
-        selector: newSelector,
+        selector: isAdvancedSelector ? newSelectorString : newSelector,
         assertionList,
         originalSelector: newSelector,
         isDraft: true,
+        isAdvancedSelector,
       };
 
       if (isEditing) {

--- a/web/src/components/AssertionForm/AssertionForm.styled.ts
+++ b/web/src/components/AssertionForm/AssertionForm.styled.ts
@@ -16,7 +16,7 @@ export const SelectorContainer = styled.div`
 
 export const SelectorInputContainer = styled.div`
   display: grid;
-  align-items: center;
+  align-items: start;
   grid-template-columns: 850px 170px;
   gap: 14px;
 `;
@@ -53,6 +53,7 @@ export const AssertionForm = styled.div`
   width: 100%;
   padding: 16px;
   border: 1px solid rgba(3, 24, 73, 0.1);
+  background-color: #fff;
 `;
 
 export const AssertionFormTitle = styled(Typography.Text).attrs({
@@ -81,4 +82,17 @@ export const CheckActions = styled.div`
   gap: 14px;
   margin-left: 14px;
   height: 100%;
+`;
+
+export const AdvancedSelectorContainer = styled.div`
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  margin-bottom: 8px;
+`;
+
+export const AffectedSpansContainer = styled.div`
+  display: flex;
+  gap: 4px;
+  align-items: center;
 `;

--- a/web/src/components/AssertionForm/AssertionFormSelector.tsx
+++ b/web/src/components/AssertionForm/AssertionFormSelector.tsx
@@ -1,0 +1,135 @@
+import {Form, FormInstance, Input} from 'antd';
+import {useEffect, useMemo} from 'react';
+import {debounce} from 'lodash';
+import {useSpan} from 'providers/Span/Span.provider';
+import {useLazyGetSelectedSpansQuery} from 'redux/apis/TraceTest.api';
+import SelectorService from 'services/Selector.service';
+import {useAppSelector} from 'redux/hooks';
+import AssertionSelectors from 'selectors/Assertion.selectors';
+import TestDefinitionSelectors from 'selectors/TestDefinition.selectors';
+import {TPseudoSelector, TSpanSelector} from 'types/Assertion.types';
+import {IValues} from './AssertionForm';
+import * as S from './AssertionForm.styled';
+import AssertionFormSelectorInput from './AssertionFormSelectorInput';
+import AssertionFormPseudoSelectorInput from './AssertionFormPseudoSelectorInput';
+import useAssertionFormValues from './hooks/useAssertionFormValues';
+
+interface IProps {
+  form: FormInstance<IValues>;
+  testId: string;
+  runId: string;
+  isEditing: boolean;
+  selectorList: TSpanSelector[];
+  pseudoSelector?: TPseudoSelector;
+  onValidSelector(isValid: boolean): void;
+}
+
+const AssertionFormSelector = ({
+  form,
+  testId,
+  runId,
+  isEditing,
+  selectorList,
+  pseudoSelector,
+  onValidSelector,
+}: IProps) => {
+  const {onSetAffectedSpans, onClearAffectedSpans} = useSpan();
+  const [onTriggerSelectedSpans, {data: spanIdList = [], isError: isInvalidSelector}] = useLazyGetSelectedSpansQuery();
+
+  const {currentIsAdvancedSelector, currentPseudoSelector, currentSelector, currentSelectorList} =
+    useAssertionFormValues(form);
+
+  const query = useMemo(
+    () =>
+      currentIsAdvancedSelector
+        ? currentSelector
+        : SelectorService.getSelectorString(currentSelectorList || [], currentPseudoSelector),
+    [currentIsAdvancedSelector, currentPseudoSelector, currentSelector, currentSelectorList]
+  );
+
+  const handleSelector = useMemo(
+    () =>
+      debounce(async ({q, tId, rId}: {q: string; rId: string; tId: string}) => {
+        const idList = await onTriggerSelectedSpans({
+          query: q,
+          testId: tId,
+          runId: rId,
+        }).unwrap();
+
+        onSetAffectedSpans(idList);
+      }, 500),
+    [onSetAffectedSpans, onTriggerSelectedSpans]
+  );
+
+  useEffect(() => {
+    handleSelector({q: query, tId: testId, rId: runId});
+  }, [handleSelector, query, runId, testId]);
+
+  useEffect(() => {
+    form.setFields([
+      {
+        name: 'selector',
+        errors: isInvalidSelector ? ['Invalid selector'] : [],
+      },
+    ]);
+    onValidSelector(!isInvalidSelector);
+  }, [form, isInvalidSelector, onValidSelector]);
+
+  useEffect(() => {
+    return () => {
+      onClearAffectedSpans();
+    };
+  }, []);
+
+  const selectorAttributeList = useAppSelector(state =>
+    AssertionSelectors.selectSelectorAttributeList(state, testId, runId, spanIdList, currentSelectorList)
+  );
+  const definitionSelectorList = useAppSelector(state => TestDefinitionSelectors.selectDefinitionSelectorList(state));
+
+  return !currentIsAdvancedSelector ? (
+    <S.SelectorInputContainer>
+      <Form.Item
+        name="selectorList"
+        rules={[
+          {required: true, message: 'At least one selector is required'},
+          {
+            validator: (_, value: TSpanSelector[]) =>
+              SelectorService.validateSelector(
+                definitionSelectorList,
+                isEditing,
+                selectorList,
+                value,
+                currentPseudoSelector,
+                pseudoSelector
+              ),
+          },
+        ]}
+      >
+        <AssertionFormSelectorInput attributeList={selectorAttributeList} />
+      </Form.Item>
+      <Form.Item name="pseudoSelector">
+        <AssertionFormPseudoSelectorInput />
+      </Form.Item>
+    </S.SelectorInputContainer>
+  ) : (
+    <Form.Item
+      name="selector"
+      rules={[{required: true, message: 'The selector cannot be empty'}]}
+      validateTrigger={[]}
+      hasFeedback
+      help={isInvalidSelector ? 'Invalid selector' : ''}
+      validateStatus={isInvalidSelector ? 'error' : ''}
+      style={{maxWidth: '60%'}}
+    >
+      <Input.TextArea
+        data-cy="advanced-selector"
+        spellCheck={false}
+        placeholder="Enter the selector query"
+        autoSize
+        allowClear
+      />
+    </Form.Item>
+  );
+};
+
+export default AssertionFormSelector;

--- a/web/src/components/AssertionForm/__tests__/AssertionForm.test.tsx
+++ b/web/src/components/AssertionForm/__tests__/AssertionForm.test.tsx
@@ -1,6 +1,7 @@
 import {render} from '@testing-library/react';
+import {ReactFlowProvider} from 'react-flow-renderer';
+import {ReduxWrapperProvider} from 'redux/ReduxWrapperProvider';
 import AssertionForm from '../AssertionForm';
-import {ReduxWrapperProvider} from '../../../redux/ReduxWrapperProvider';
 
 const defaultProps = {
   onSubmit: jest.fn(),
@@ -12,7 +13,12 @@ const defaultProps = {
 describe('AssertionForm', () => {
   it('should render correctly', () => {
     fetchMock.mockResponse(JSON.stringify(['spanId']));
-    const {container} = render(<AssertionForm {...defaultProps} />, {wrapper: ReduxWrapperProvider}); 
+    const {container} = render(
+      <ReactFlowProvider>
+        <AssertionForm {...defaultProps} />
+      </ReactFlowProvider>,
+      {wrapper: ReduxWrapperProvider}
+    );
 
     expect(container.querySelector('form')).toBeInTheDocument();
   });

--- a/web/src/components/AssertionForm/hooks/useAssertionFormValues.ts
+++ b/web/src/components/AssertionForm/hooks/useAssertionFormValues.ts
@@ -1,0 +1,22 @@
+import {Form, FormInstance} from 'antd';
+import {useMemo} from 'react';
+import {IValues} from '../AssertionForm';
+
+const useAssertionFormValues = (form: FormInstance<IValues>) => {
+  const currentSelectorList = Form.useWatch('selectorList', form);
+  const currentPseudoSelector = Form.useWatch('pseudoSelector', form);
+  const currentIsAdvancedSelector = Form.useWatch('isAdvancedSelector', form);
+  const currentSelector = Form.useWatch('selector', form);
+
+  return useMemo(
+    () => ({
+      currentSelectorList: currentSelectorList || [],
+      currentPseudoSelector: currentPseudoSelector || undefined,
+      currentIsAdvancedSelector: currentIsAdvancedSelector || false,
+      currentSelector: currentSelector || '',
+    }),
+    [currentIsAdvancedSelector, currentPseudoSelector, currentSelector, currentSelectorList]
+  );
+};
+
+export default useAssertionFormValues;

--- a/web/src/components/AssertionForm/hooks/useOnFieldsChange.ts
+++ b/web/src/components/AssertionForm/hooks/useOnFieldsChange.ts
@@ -1,0 +1,65 @@
+import {Form, FormInstance} from 'antd';
+import {FieldData} from 'antd/node_modules/rc-field-form/es/interface';
+import {isEmpty} from 'lodash';
+import {useCallback} from 'react';
+import SelectorService from 'services/Selector.service';
+import CreateAssertionModalAnalyticsService from 'services/Analytics/CreateAssertionModalAnalytics.service';
+import {TAssertion} from 'types/Assertion.types';
+import {IValues} from '../AssertionForm';
+import {TSpanFlatAttribute} from '../../../types/Span.types';
+
+const {onChecksChange, onSelectorChange} = CreateAssertionModalAnalyticsService;
+
+interface IProps {
+  form: FormInstance<IValues>;
+  attributeList: TSpanFlatAttribute[];
+}
+
+const useOnFieldsChange = ({form, attributeList}: IProps) => {
+  const currentPseudoSelector = Form.useWatch('pseudoSelector', form) || undefined;
+  const currentSelectorList = Form.useWatch('selectorList', form) || [];
+  const currentIsAdvancedSelector = Form.useWatch('isAdvancedSelector', form) || false;
+  const currentSelector = Form.useWatch('selector', form) || '';
+  const query = currentIsAdvancedSelector
+    ? currentSelector
+    : SelectorService.getSelectorString(currentSelectorList, currentPseudoSelector);
+
+  const onFieldsChange = useCallback(
+    (changedFields: FieldData[]) => {
+      const [field] = changedFields;
+
+      const [fieldName = '', entry = 0, keyName = ''] = field.name as Array<string | number>;
+
+      if (fieldName === 'isAdvancedSelector' && field.value) {
+        form.setFieldsValue({
+          selector: query,
+        });
+      }
+
+      if (fieldName === 'selectorList') onSelectorChange();
+      if (fieldName === 'assertionList') onChecksChange();
+
+      if (fieldName === 'assertionList' && keyName === 'attribute' && field.value) {
+        const list: TAssertion[] = form.getFieldValue('assertionList') || [];
+
+        form.setFieldsValue({
+          assertionList: list.map((assertionEntry, index) => {
+            if (index === entry) {
+              const {value = ''} = attributeList?.find((el: any) => el.key === list[index].attribute) || {};
+              const isValid = typeof value === 'number' || !isEmpty(value);
+
+              return {...assertionEntry, expected: isValid ? String(value) : ''};
+            }
+
+            return assertionEntry;
+          }),
+        });
+      }
+    },
+    [attributeList, form, query]
+  );
+
+  return onFieldsChange;
+};
+
+export default useOnFieldsChange;

--- a/web/src/components/Diagram/components/DAG/AffectedSpanControls.tsx
+++ b/web/src/components/Diagram/components/DAG/AffectedSpanControls.tsx
@@ -1,0 +1,21 @@
+import {LeftOutlined, RightOutlined} from '@ant-design/icons';
+import {useSpan} from 'providers/Span/Span.provider';
+import * as S from './DAG.styled';
+import useControls from './hooks/useControls';
+
+const AffectedSpanControls = () => {
+  const {affectedSpans, onSelectSpan} = useSpan();
+  const {handleNextSpan, handlePrevSpan, indexOfFocused} = useControls({onSelectSpan});
+
+  return affectedSpans.length ? (
+    <div>
+      <S.ToggleButton onClick={handlePrevSpan} icon={<LeftOutlined />} type="text" />
+      <S.ToggleButton onClick={handleNextSpan} icon={<RightOutlined />} type="text" />
+      <S.FocusedText>
+        {indexOfFocused} of {affectedSpans.length} total
+      </S.FocusedText>
+    </div>
+  ) : null;
+};
+
+export default AffectedSpanControls;

--- a/web/src/components/Diagram/components/DAG/Controls.tsx
+++ b/web/src/components/Diagram/components/DAG/Controls.tsx
@@ -1,29 +1,16 @@
-import {LeftOutlined, RightOutlined, ZoomInOutlined, ZoomOutOutlined} from '@ant-design/icons';
+import {ZoomInOutlined, ZoomOutOutlined} from '@ant-design/icons';
 import {useReactFlow} from 'react-flow-renderer';
-import {useSpan} from 'providers/Span/Span.provider';
 import * as S from './DAG.styled';
-import useControls from './hooks/useControls';
+import AffectedSpanControls from './AffectedSpanControls';
 
-interface IProps {
-  onSelectSpan(spanId: string): void;
-}
-
-const Controls = ({onSelectSpan}: IProps) => {
+const Controls = () => {
   const {zoomIn, zoomOut} = useReactFlow();
-  const {affectedSpans} = useSpan();
-  const {handleNextSpan, handlePrevSpan, indexOfFocused} = useControls({onSelectSpan});
 
   return (
     <>
-      {Boolean(affectedSpans.length) && (
-        <S.SelectorControls>
-          <S.ToggleButton onClick={handlePrevSpan} icon={<LeftOutlined />} type="text" />
-          <S.ToggleButton onClick={handleNextSpan} icon={<RightOutlined />} type="text" />
-          <S.FocusedText>
-            {indexOfFocused} of {affectedSpans.length}
-          </S.FocusedText>
-        </S.SelectorControls>
-      )}
+      <S.SelectorControls>
+        <AffectedSpanControls />
+      </S.SelectorControls>
       <S.Controls>
         <S.ZoomButton icon={<ZoomInOutlined />} onClick={() => zoomIn()} type="text" />
         <S.ZoomButton icon={<ZoomOutOutlined />} onClick={() => zoomOut()} type="text" />

--- a/web/src/components/Diagram/components/DAG/DAG.styled.tsx
+++ b/web/src/components/Diagram/components/DAG/DAG.styled.tsx
@@ -45,9 +45,16 @@ export const ZoomButton = styled(Button)`
   }
 `;
 
-export const ToggleButton = styled(ZoomButton)``;
+export const ToggleButton = styled(ZoomButton)`
+  color: #61175e;
+
+  &:hover,
+  &:focus {
+    color: #61175e;
+  }
+`;
 
 export const FocusedText = styled(Typography.Text)`
-  color: rgba(3, 24, 73, 0.3);
+  color: #61175e;
   margin-left: 8px;
 `;

--- a/web/src/components/Diagram/components/DAG/DAG.tsx
+++ b/web/src/components/Diagram/components/DAG/DAG.tsx
@@ -12,7 +12,7 @@ import SpanNode from './SpanNode';
 /** Important to define the nodeTypes outside of the component to prevent re-renderings */
 const nodeTypes = {span: SpanNode};
 
-const DAG = ({affectedSpans, onSelectSpan}: IDiagramComponentProps) => {
+const DAG = ({affectedSpans}: IDiagramComponentProps) => {
   const {edges, nodes, onNodesChange, onNodeClick} = useDAG();
 
   return (
@@ -21,7 +21,7 @@ const DAG = ({affectedSpans, onSelectSpan}: IDiagramComponentProps) => {
       $showAffected={affectedSpans.length > 0}
       data-cy="diagram-dag"
     >
-      <Controls onSelectSpan={onSelectSpan!} />
+      <Controls />
       <ReactFlow
         edges={edges}
         nodes={nodes}

--- a/web/src/components/RunBottomPanel/Header.tsx
+++ b/web/src/components/RunBottomPanel/Header.tsx
@@ -12,6 +12,7 @@ import {TAssertionResults} from 'types/Assertion.types';
 import {TSpan} from 'types/Span.types';
 import {TTestRun} from 'types/TestRun.types';
 import {useTestDefinition} from 'providers/TestDefinition/TestDefinition.provider';
+import {ResultViewModes} from 'constants/Test.constants';
 import Date from 'utils/Date';
 import SelectorService from 'services/Selector.service';
 import * as S from './RunBottomPanel.styled';
@@ -48,7 +49,7 @@ const Header: React.FC<IProps> = ({run: {createdAt}, assertionResults, isDisable
           pseudoSelector,
           selectorList,
           selector,
-          isAdvancedSelector: viewResultsMode === 'advanced',
+          isAdvancedSelector: viewResultsMode === ResultViewModes.Advanced,
         },
       });
     },
@@ -79,11 +80,11 @@ const Header: React.FC<IProps> = ({run: {createdAt}, assertionResults, isDisable
             disabled={isDisabled}
             checkedChildren="Advanced"
             unCheckedChildren="Wizard"
-            checked={viewResultsMode === 'advanced'}
+            checked={viewResultsMode === ResultViewModes.Advanced}
             onChange={(isChecked, event) => {
               event.preventDefault();
               event.stopPropagation();
-              changeViewResultsMode(isChecked ? 'advanced' : 'wizard');
+              changeViewResultsMode(isChecked ? ResultViewModes.Advanced : ResultViewModes.Wizard);
             }}
           />
         </Tooltip>

--- a/web/src/components/RunBottomPanel/RunBottomPanel.styled.ts
+++ b/web/src/components/RunBottomPanel/RunBottomPanel.styled.ts
@@ -42,6 +42,7 @@ export const AddAssertionButton = styled(Button).attrs({
 })`
   && {
     font-weight: 600;
+    margin-left: 14px;
   }
 `;
 
@@ -61,4 +62,10 @@ export const Chevron = styled.img.attrs({
 
 export const ChevronContainer = styled.span`
   margin-left: 16px;
+`;
+
+export const Row = styled.div`
+  display: flex;
+  gap: 8px;
+  align-items: center;
 `;

--- a/web/src/components/RunBottomPanel/RunBottomPanel.tsx
+++ b/web/src/components/RunBottomPanel/RunBottomPanel.tsx
@@ -1,5 +1,5 @@
 import AssertionForm from 'components/AssertionForm';
-import {useAssertionForm} from 'components/AssertionForm/AssertionFormProvider';
+import {useAssertionForm} from 'components/AssertionForm/AssertionForm.provider';
 import LoadingSpinner from 'components/LoadingSpinner';
 import TestResults from 'components/TestResults';
 import {useTestDefinition} from 'providers/TestDefinition/TestDefinition.provider';

--- a/web/src/components/SpanDetail/SpanDetail.tsx
+++ b/web/src/components/SpanDetail/SpanDetail.tsx
@@ -8,13 +8,15 @@ import OperatorService from 'services/Operator.service';
 import {useAppSelector} from 'redux/hooks';
 import TestDefinitionSelectors from 'selectors/TestDefinition.selectors';
 import {TResultAssertions} from 'types/Assertion.types';
-import {useAssertionForm} from 'components/AssertionForm/AssertionFormProvider';
+import {useAssertionForm} from 'components/AssertionForm/AssertionForm.provider';
 
 import SpanDetailTabs from './SpanDetailTabs';
 import SpanHeader from './SpanHeader';
 import * as S from './SpanDetail.styled';
 import TraceAnalyticsService from '../../services/Analytics/TraceAnalytics.service';
 import {OPEN_BOTTOM_PANEL_STATE, useRunLayout} from '../RunLayout';
+import {useTestDefinition} from '../../providers/TestDefinition/TestDefinition.provider';
+import SelectorService from '../../services/Selector.service';
 
 export interface ISpanDetailsComponentProps {
   assertions?: TResultAssertions;
@@ -36,6 +38,7 @@ const getSpanTitle = (span: TSpan) => {
 const SpanDetail: React.FC<IProps> = ({span}) => {
   const {openBottomPanel} = useRunLayout();
   const {open} = useAssertionForm();
+  const {viewResultsMode} = useTestDefinition();
   const assertions = useAppSelector(state =>
     TestDefinitionSelectors.selectAssertionResultsBySpan(state, span?.id || '')
   );
@@ -46,9 +49,13 @@ const SpanDetail: React.FC<IProps> = ({span}) => {
       openBottomPanel(OPEN_BOTTOM_PANEL_STATE.FORM);
       TraceAnalyticsService.onAddAssertionButtonClick();
       const {selectorList, pseudoSelector} = SpanService.getSelectorInformation(span!);
+      const selector = SelectorService.getSelectorString(selectorList, pseudoSelector);
+
+      console.log('opening with selector', selector);
 
       open({
         isEditing: false,
+        selector,
         defaultValues: {
           pseudoSelector,
           assertionList: [
@@ -59,10 +66,12 @@ const SpanDetail: React.FC<IProps> = ({span}) => {
             },
           ],
           selectorList,
+          selector,
+          isAdvancedSelector: viewResultsMode === 'advanced',
         },
       });
     },
-    [open, span, openBottomPanel]
+    [openBottomPanel, span, open, viewResultsMode]
   );
 
   return (

--- a/web/src/components/SpanDetail/SpanDetail.tsx
+++ b/web/src/components/SpanDetail/SpanDetail.tsx
@@ -9,14 +9,15 @@ import {useAppSelector} from 'redux/hooks';
 import TestDefinitionSelectors from 'selectors/TestDefinition.selectors';
 import {TResultAssertions} from 'types/Assertion.types';
 import {useAssertionForm} from 'components/AssertionForm/AssertionForm.provider';
+import TraceAnalyticsService from 'services/Analytics/TraceAnalytics.service';
+import {useTestDefinition} from 'providers/TestDefinition/TestDefinition.provider';
+import SelectorService from 'services/Selector.service';
+import { ResultViewModes } from 'constants/Test.constants';
 
 import SpanDetailTabs from './SpanDetailTabs';
 import SpanHeader from './SpanHeader';
 import * as S from './SpanDetail.styled';
-import TraceAnalyticsService from '../../services/Analytics/TraceAnalytics.service';
 import {OPEN_BOTTOM_PANEL_STATE, useRunLayout} from '../RunLayout';
-import {useTestDefinition} from '../../providers/TestDefinition/TestDefinition.provider';
-import SelectorService from '../../services/Selector.service';
 
 export interface ISpanDetailsComponentProps {
   assertions?: TResultAssertions;
@@ -51,8 +52,6 @@ const SpanDetail: React.FC<IProps> = ({span}) => {
       const {selectorList, pseudoSelector} = SpanService.getSelectorInformation(span!);
       const selector = SelectorService.getSelectorString(selectorList, pseudoSelector);
 
-      console.log('opening with selector', selector);
-
       open({
         isEditing: false,
         selector,
@@ -67,7 +66,7 @@ const SpanDetail: React.FC<IProps> = ({span}) => {
           ],
           selectorList,
           selector,
-          isAdvancedSelector: viewResultsMode === 'advanced',
+          isAdvancedSelector: viewResultsMode === ResultViewModes.Advanced,
         },
       });
     },

--- a/web/src/constants/Span.constants.ts
+++ b/web/src/constants/Span.constants.ts
@@ -58,8 +58,9 @@ export const SpanAttributeSections: Record<SemanticGroupNames, Record<string, TV
       Attributes.DB_CASSANDRA_SPECULATIVE_EXECUTION_COUNT,
       Attributes.DB_CASSANDRA_COORDINATOR_ID,
       Attributes.DB_CASSANDRA_COORDINATOR_DC,
+      Attributes.DB_OPERATION,
+      Attributes.DB_STATEMENT,
     ],
-    [SectionNames.operation]: [Attributes.DB_OPERATION, Attributes.DB_STATEMENT],
   },
   [SemanticGroupNames.Messaging]: {
     [SectionNames.metadata]: [
@@ -70,16 +71,12 @@ export const SpanAttributeSections: Record<SemanticGroupNames, Record<string, TV
       Attributes.MESSAGING_KAFKA_CLIENT_ID,
       Attributes.MESSAGING_KAFKA_PARTITION,
       Attributes.MESSAGING_KAFKA_TOMBSTONE,
-    ],
-    [SectionNames.producer]: [
       Attributes.MESSAGING_DESTINATION,
       Attributes.MESSAGING_DESTINATION_KIND,
       Attributes.MESSAGING_TEMP_DESTINATION,
       Attributes.MESSAGING_CONVERSATION_ID,
       Attributes.MESSAGING_RABBITMQ_ROUTING_KEY,
       Attributes.MESSAGING_KAFKA_MESSAGE_KEY,
-    ],
-    [SectionNames.consumer]: [
       Attributes.MESSAGING_OPERATION,
       Attributes.MESSAGING_CONSUMER_ID,
       Attributes.MESSAGING_KAFKA_CONSUMER_GROUP,

--- a/web/src/constants/Test.constants.ts
+++ b/web/src/constants/Test.constants.ts
@@ -33,3 +33,8 @@ export const DemoTestExampleList: IDemoTestExample[] = [
 ];
 
 export const DEFAULT_HEADERS = [{key: 'Content-Type', value: 'application/json'}];
+
+export enum ResultViewModes {
+  Advanced = 'advanced',
+  Wizard = 'wizard',
+}

--- a/web/src/gateways/LocalStorage.gateway.ts
+++ b/web/src/gateways/LocalStorage.gateway.ts
@@ -1,4 +1,4 @@
-const LocalStorageService = <T>(defaultKey = '') => {
+const LocalStorageGateway = <T>(defaultKey = '') => {
   const localstorage = window.localStorage;
 
   return {
@@ -15,4 +15,4 @@ const LocalStorageService = <T>(defaultKey = '') => {
   };
 };
 
-export default LocalStorageService;
+export default LocalStorageGateway;

--- a/web/src/models/AssertionResults.model.ts
+++ b/web/src/models/AssertionResults.model.ts
@@ -10,6 +10,7 @@ const AssertionResults = ({allPassed = false, results = []}: TRawAssertionResult
     resultList: results.map(({selector: {query: selector = '', structure = []} = {}, results: resultList = []}) => ({
       id: uniqueId(),
       selector,
+      isAdvancedSelector: SelectorService.getIsAdvancedSelector(selector),
       spanIds: AssertionService.getSpanIds(resultList),
       originalSelector: selector,
       pseudoSelector: SelectorService.getPseudoSelectorFromStructure(structure),

--- a/web/src/models/TestDefinition.model.ts
+++ b/web/src/models/TestDefinition.model.ts
@@ -1,3 +1,4 @@
+import SelectorService from '../services/Selector.service';
 import {TRawTestDefinition, TTestDefinition} from '../types/TestDefinition.types';
 import Assertion from './Assertion.model';
 
@@ -6,6 +7,7 @@ const TestDefinition = ({definitions = []}: TRawTestDefinition): TTestDefinition
     definitionList: definitions.map(({selector: {query = ''} = {}, assertions = []}) => ({
       isDraft: false,
       isDeleted: false,
+      isAdvancedSelector: SelectorService.getIsAdvancedSelector(query),
       selector: query,
       assertionList: assertions.map(rawAssertion => Assertion(rawAssertion)),
     })),

--- a/web/src/pages/Trace/Trace.tsx
+++ b/web/src/pages/Trace/Trace.tsx
@@ -2,7 +2,7 @@ import {withTracker} from 'ga-4-react';
 import {useParams} from 'react-router-dom';
 import {ReactFlowProvider} from 'react-flow-renderer';
 import Layout from 'components/Layout';
-import AssertionFormProvider from 'components/AssertionForm/AssertionFormProvider';
+import AssertionFormProvider from 'components/AssertionForm/AssertionForm.provider';
 import EditTestModalProvider from 'components/EditTestModal/EditTestModal.provider';
 import TestRunProvider from 'providers/TestRun';
 import TestDefinitionProvider from 'providers/TestDefinition';

--- a/web/src/providers/TestDefinition/TestDefinition.provider.tsx
+++ b/web/src/providers/TestDefinition/TestDefinition.provider.tsx
@@ -11,7 +11,8 @@ import {
 import TestDefinitionSelectors from 'selectors/TestDefinition.selectors';
 import {TAssertionResultEntry, TAssertionResults} from 'types/Assertion.types';
 import {TTest} from 'types/Test.types';
-import {TTestDefinitionEntry, TViewResultsMode} from 'types/TestDefinition.types';
+import {TTestDefinitionEntry} from 'types/TestDefinition.types';
+import {ResultViewModes} from 'constants/Test.constants';
 import useTestDefinitionCrud from './hooks/useTestDefinitionCrud';
 
 interface IContext {
@@ -29,9 +30,9 @@ interface IContext {
   isError: boolean;
   isDraftMode: boolean;
   test?: TTest;
-  viewResultsMode: TViewResultsMode;
+  viewResultsMode: ResultViewModes;
   setSelectedAssertion(assertionResult?: TAssertionResultEntry): void;
-  changeViewResultsMode(viewResultsMode: TViewResultsMode): void;
+  changeViewResultsMode(viewResultsMode: ResultViewModes): void;
 }
 
 export const Context = createContext<IContext>({
@@ -48,7 +49,7 @@ export const Context = createContext<IContext>({
   isError: false,
   isDraftMode: false,
   definitionList: [],
-  viewResultsMode: 'wizard',
+  viewResultsMode: ResultViewModes.Wizard,
   setSelectedAssertion: noop,
 });
 
@@ -99,7 +100,7 @@ const TestDefinitionProvider = ({children, testId, runId}: IProps) => {
   );
 
   const changeViewResultsMode = useCallback(
-    (mode: TViewResultsMode) => {
+    (mode: ResultViewModes) => {
       dispatch(setViewResultsMode(mode));
     },
     [dispatch]

--- a/web/src/providers/TestDefinition/TestDefinition.provider.tsx
+++ b/web/src/providers/TestDefinition/TestDefinition.provider.tsx
@@ -4,11 +4,14 @@ import {useTestRun} from 'providers/TestRun/TestRun.provider';
 import {createContext, useCallback, useContext, useEffect, useMemo} from 'react';
 import {useGetTestByIdQuery} from 'redux/apis/TraceTest.api';
 import {useAppDispatch, useAppSelector} from 'redux/hooks';
-import {setSelectedAssertion as setSelectedAssertionAction} from 'redux/slices/TestDefinition.slice';
+import {
+  setSelectedAssertion as setSelectedAssertionAction,
+  setViewResultsMode,
+} from 'redux/slices/TestDefinition.slice';
 import TestDefinitionSelectors from 'selectors/TestDefinition.selectors';
 import {TAssertionResultEntry, TAssertionResults} from 'types/Assertion.types';
 import {TTest} from 'types/Test.types';
-import {TTestDefinitionEntry} from 'types/TestDefinition.types';
+import {TTestDefinitionEntry, TViewResultsMode} from 'types/TestDefinition.types';
 import useTestDefinitionCrud from './hooks/useTestDefinitionCrud';
 
 interface IContext {
@@ -26,7 +29,9 @@ interface IContext {
   isError: boolean;
   isDraftMode: boolean;
   test?: TTest;
+  viewResultsMode: TViewResultsMode;
   setSelectedAssertion(assertionResult?: TAssertionResultEntry): void;
+  changeViewResultsMode(viewResultsMode: TViewResultsMode): void;
 }
 
 export const Context = createContext<IContext>({
@@ -38,10 +43,12 @@ export const Context = createContext<IContext>({
   runTest: noop,
   dryRun: noop,
   cancel: noop,
+  changeViewResultsMode: noop,
   isLoading: false,
   isError: false,
   isDraftMode: false,
   definitionList: [],
+  viewResultsMode: 'wizard',
   setSelectedAssertion: noop,
 });
 
@@ -61,6 +68,7 @@ const TestDefinitionProvider = ({children, testId, runId}: IProps) => {
   const isDraftMode = useAppSelector(state => TestDefinitionSelectors.selectIsDraftMode(state));
   const isLoading = useAppSelector(state => TestDefinitionSelectors.selectIsLoading(state));
   const isInitialized = useAppSelector(state => TestDefinitionSelectors.selectIsInitialized(state));
+  const viewResultsMode = useAppSelector(state => TestDefinitionSelectors.selectViewResultsMode(state));
   const {data: test} = useGetTestByIdQuery({testId});
 
   const {add, cancel, publish, runTest, remove, dryRun, update, init, reset, revert} = useTestDefinitionCrud({
@@ -90,6 +98,13 @@ const TestDefinitionProvider = ({children, testId, runId}: IProps) => {
     [dispatch]
   );
 
+  const changeViewResultsMode = useCallback(
+    (mode: TViewResultsMode) => {
+      dispatch(setViewResultsMode(mode));
+    },
+    [dispatch]
+  );
+
   const value = useMemo<IContext>(
     () => ({
       add,
@@ -103,10 +118,12 @@ const TestDefinitionProvider = ({children, testId, runId}: IProps) => {
       dryRun,
       assertionResults,
       definitionList,
+      viewResultsMode,
       cancel,
       test,
       setSelectedAssertion,
       revert,
+      changeViewResultsMode,
     }),
     [
       add,
@@ -119,10 +136,12 @@ const TestDefinitionProvider = ({children, testId, runId}: IProps) => {
       dryRun,
       assertionResults,
       definitionList,
+      viewResultsMode,
       cancel,
       test,
       setSelectedAssertion,
       revert,
+      changeViewResultsMode,
     ]
   );
 

--- a/web/src/redux/apis/TraceTest.api.ts
+++ b/web/src/redux/apis/TraceTest.api.ts
@@ -176,6 +176,7 @@ export const {
   useGetRunByIdQuery,
   useGetRunListQuery,
   useGetSelectedSpansQuery,
+  useLazyGetSelectedSpansQuery,
   useReRunMutation,
   useLazyGetRunListQuery,
   useDryRunMutation,

--- a/web/src/redux/slices/TestDefinition.slice.ts
+++ b/web/src/redux/slices/TestDefinition.slice.ts
@@ -1,12 +1,8 @@
 import {createAction, createSlice} from '@reduxjs/toolkit';
 import {TAssertionResults} from 'types/Assertion.types';
-import {
-  ITestDefinitionState,
-  TTestDefinitionEntry,
-  TTestDefinitionSliceActions,
-  TViewResultsMode,
-} from 'types/TestDefinition.types';
-import UserPreferencesService from '../../services/UserPreferences.service';
+import {ITestDefinitionState, TTestDefinitionEntry, TTestDefinitionSliceActions} from 'types/TestDefinition.types';
+import {ResultViewModes} from 'constants/Test.constants';
+import UserPreferencesService from 'services/UserPreferences.service';
 import TestDefinitionActions from '../actions/TestDefinition.actions';
 
 export const initialState: ITestDefinitionState = {
@@ -31,7 +27,7 @@ export const assertionResultsToDefinitionList = (assertionResults: TAssertionRes
   }));
 };
 
-export const setViewResultsMode = createAction('testDefinition/setViewResultsMode', (mode: TViewResultsMode) => {
+export const setViewResultsMode = createAction('testDefinition/setViewResultsMode', (mode: ResultViewModes) => {
   UserPreferencesService.setPreference('viewResultsMode', mode);
 
   return {

--- a/web/src/redux/slices/TestDefinition.slice.ts
+++ b/web/src/redux/slices/TestDefinition.slice.ts
@@ -1,6 +1,12 @@
-import {createSlice} from '@reduxjs/toolkit';
+import {createAction, createSlice} from '@reduxjs/toolkit';
 import {TAssertionResults} from 'types/Assertion.types';
-import {ITestDefinitionState, TTestDefinitionEntry, TTestDefinitionSliceActions} from 'types/TestDefinition.types';
+import {
+  ITestDefinitionState,
+  TTestDefinitionEntry,
+  TTestDefinitionSliceActions,
+  TViewResultsMode,
+} from 'types/TestDefinition.types';
+import UserPreferencesService from '../../services/UserPreferences.service';
 import TestDefinitionActions from '../actions/TestDefinition.actions';
 
 export const initialState: ITestDefinitionState = {
@@ -11,17 +17,29 @@ export const initialState: ITestDefinitionState = {
   isInitialized: false,
   selectedAssertion: '',
   isDraftMode: false,
+  viewResultsMode: UserPreferencesService.getUserPreference('viewResultsMode'),
 };
 
 export const assertionResultsToDefinitionList = (assertionResults: TAssertionResults): TTestDefinitionEntry[] => {
-  return assertionResults.resultList.map(({selector, resultList}) => ({
+  return assertionResults.resultList.map(({selector, resultList, isAdvancedSelector}) => ({
     isDraft: false,
     isDeleted: false,
     selector,
     originalSelector: selector,
     assertionList: resultList.flatMap(({assertion}) => [assertion]),
+    isAdvancedSelector,
   }));
 };
+
+export const setViewResultsMode = createAction('testDefinition/setViewResultsMode', (mode: TViewResultsMode) => {
+  UserPreferencesService.setPreference('viewResultsMode', mode);
+
+  return {
+    payload: {
+      mode,
+    },
+  };
+});
 
 const testDefinitionSlice = createSlice<ITestDefinitionState, TTestDefinitionSliceActions, 'testDefinition'>({
   name: 'testDefinition',
@@ -96,6 +114,9 @@ const testDefinitionSlice = createSlice<ITestDefinitionState, TTestDefinitionSli
   },
   extraReducers: builder => {
     builder
+      .addCase(setViewResultsMode, (state, {payload: {mode}}) => {
+        state.viewResultsMode = mode;
+      })
       .addCase(TestDefinitionActions.dryRun.fulfilled, (state, {payload}) => {
         state.assertionResults = payload;
       })

--- a/web/src/selectors/TestDefinition.selectors.ts
+++ b/web/src/selectors/TestDefinition.selectors.ts
@@ -65,6 +65,7 @@ const TestDefinitionSelectors = () => ({
   selectSelectedAssertion: createSelector(stateSelector, ({selectedAssertion}) => selectedAssertion),
   selectAssertionResultsBySpan,
   selectIsDraftMode: createSelector(stateSelector, ({isDraftMode}) => isDraftMode),
+  selectViewResultsMode: createSelector(stateSelector, ({viewResultsMode}) => viewResultsMode),
 });
 
 export default TestDefinitionSelectors();

--- a/web/src/services/Selector.service.ts
+++ b/web/src/services/Selector.service.ts
@@ -126,6 +126,13 @@ const SelectorService = () => ({
       return Promise.resolve(true);
     return Promise.reject(new Error('Selector already exists'));
   },
+
+  getIsAdvancedSelector(selector: string): boolean {
+    const matches = (selector.match(/span\[/g) || []).length;
+    const hasOrOperator = selector.includes('],');
+
+    return matches > 1 || hasOrOperator;
+  },
 });
 
 export default SelectorService();

--- a/web/src/services/UserPreferences.service.ts
+++ b/web/src/services/UserPreferences.service.ts
@@ -1,0 +1,41 @@
+import LocalStorageGateway from '../gateways/LocalStorage.gateway';
+import {TViewResultsMode} from '../types/TestDefinition.types';
+
+const storageKey = 'user_preferences';
+
+interface IUserPreferences {
+  viewResultsMode: TViewResultsMode;
+}
+
+const localStorageGateway = LocalStorageGateway<IUserPreferences>(storageKey);
+
+const initialUserPreferences: IUserPreferences = {
+  viewResultsMode: 'wizard',
+};
+
+const UserPreferencesService = () => ({
+  getUserPreferences(): IUserPreferences {
+    const userPreferences = localStorageGateway.get() || initialUserPreferences;
+
+    return userPreferences;
+  },
+  getUserPreference<K extends keyof IUserPreferences>(key: K): IUserPreferences[K] {
+    const preferences = this.getUserPreferences();
+
+    return preferences[key];
+  },
+  setPreference<K extends keyof IUserPreferences>(key: K, value: IUserPreferences[K]) {
+    const preferences = this.getUserPreferences();
+
+    const updatedUserPreferences = {
+      ...preferences,
+      [key]: value,
+    };
+
+    localStorageGateway.set(updatedUserPreferences);
+
+    return updatedUserPreferences;
+  },
+});
+
+export default UserPreferencesService();

--- a/web/src/services/UserPreferences.service.ts
+++ b/web/src/services/UserPreferences.service.ts
@@ -1,16 +1,16 @@
-import LocalStorageGateway from '../gateways/LocalStorage.gateway';
-import {TViewResultsMode} from '../types/TestDefinition.types';
+import {ResultViewModes} from 'constants/Test.constants';
+import LocalStorageGateway from 'gateways/LocalStorage.gateway';
 
 const storageKey = 'user_preferences';
 
 interface IUserPreferences {
-  viewResultsMode: TViewResultsMode;
+  viewResultsMode: ResultViewModes;
 }
 
 const localStorageGateway = LocalStorageGateway<IUserPreferences>(storageKey);
 
 const initialUserPreferences: IUserPreferences = {
-  viewResultsMode: 'wizard',
+  viewResultsMode: ResultViewModes.Wizard,
 };
 
 const UserPreferencesService = () => ({

--- a/web/src/services/__tests__/SpanAttribute.service.test.ts
+++ b/web/src/services/__tests__/SpanAttribute.service.test.ts
@@ -39,10 +39,6 @@ describe('SpanAttributeService', () => {
           attributeList: [attribute],
         },
         {
-          section: SectionNames.operation,
-          attributeList: [],
-        },
-        {
           section: SectionNames.custom,
           attributeList: [],
         },
@@ -70,14 +66,6 @@ describe('SpanAttributeService', () => {
         {
           section: SectionNames.metadata,
           attributeList: [attribute],
-        },
-        {
-          section: SectionNames.producer,
-          attributeList: [],
-        },
-        {
-          section: SectionNames.consumer,
-          attributeList: [],
         },
         {
           section: SectionNames.custom,

--- a/web/src/types/Assertion.types.ts
+++ b/web/src/types/Assertion.types.ts
@@ -24,6 +24,7 @@ export type TRawAssertionResults = TTestSchemas['AssertionResults'];
 export type TAssertionResultEntry = {
   id: string;
   selector: string;
+  isAdvancedSelector: boolean;
   originalSelector: string;
   spanIds: string[];
   pseudoSelector?: TPseudoSelector;

--- a/web/src/types/TestDefinition.types.ts
+++ b/web/src/types/TestDefinition.types.ts
@@ -1,4 +1,5 @@
 import {CaseReducer, PayloadAction} from '@reduxjs/toolkit';
+import { ResultViewModes } from '../constants/Test.constants';
 import {TChange} from '../redux/actions/TestDefinition.actions';
 import {TAssertion, TAssertionResultEntry, TAssertionResults} from './Assertion.types';
 import {Model, TTestSchemas} from './Common.types';
@@ -26,8 +27,6 @@ export type TTestDefinition = Model<
     definitions?: TRawTestDefinition;
   }
 >;
-
-export type TViewResultsMode = 'wizard' | 'advanced';
 export interface ITestDefinitionState {
   initialDefinitionList: TTestDefinitionEntry[];
   definitionList: TTestDefinitionEntry[];
@@ -37,7 +36,7 @@ export interface ITestDefinitionState {
   isInitialized: boolean;
   selectedAssertion: string;
   isDraftMode: boolean;
-  viewResultsMode: TViewResultsMode;
+  viewResultsMode: ResultViewModes;
 }
 
 export type TTestDefinitionSliceActions = {

--- a/web/src/types/TestDefinition.types.ts
+++ b/web/src/types/TestDefinition.types.ts
@@ -11,6 +11,7 @@ export type TTestDefinitionEntry = {
   assertionList: TAssertion[];
   isDraft: boolean;
   isDeleted?: boolean;
+  isAdvancedSelector: boolean;
 };
 
 export type TRawTestDefinitionEntry = {
@@ -26,6 +27,7 @@ export type TTestDefinition = Model<
   }
 >;
 
+export type TViewResultsMode = 'wizard' | 'advanced';
 export interface ITestDefinitionState {
   initialDefinitionList: TTestDefinitionEntry[];
   definitionList: TTestDefinitionEntry[];
@@ -35,6 +37,7 @@ export interface ITestDefinitionState {
   isInitialized: boolean;
   selectedAssertion: string;
   isDraftMode: boolean;
+  viewResultsMode: TViewResultsMode;
 }
 
 export type TTestDefinitionSliceActions = {


### PR DESCRIPTION
This PR adds the advanced query language support for the FE to have parity with the Backend features.

## Changes

- Adds the switch for advanced vs wizard
- Adds advanced selector input.
- Introduces the user prefecences.

## Fixes

- https://github.com/kubeshop/tracetest/issues/822

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [x] added a test

https://www.loom.com/share/c0afdf06e2bf496489cdc67a04ccdb24