### PR TITLE
fix:start end dates

### DIFF
--- a/api/trace.yaml
+++ b/api/trace.yaml
@@ -27,10 +27,12 @@ components:
           type: integer
           format: int64
           description: span start time in unix milli format
+          example: 1656701595277
         endTime:
           type: integer
           format: int64
           description: span end time in unix milli format
+          example: 1656701595800
         attributes:
           type: object
           description: Key-Value of span attributes

--- a/api/trace.yaml
+++ b/api/trace.yaml
@@ -25,9 +25,11 @@ components:
           type: string
         startTime:
           type: integer
+          format: int64
           description: span start time in unix milli format
         endTime:
           type: integer
+          format: int64
           description: span end time in unix milli format
         attributes:
           type: object

--- a/cli/openapi/model_span.go
+++ b/cli/openapi/model_span.go
@@ -20,9 +20,9 @@ type Span struct {
 	ParentId *string `json:"parentId,omitempty"`
 	Name     *string `json:"name,omitempty"`
 	// span start time in unix milli format
-	StartTime *int32 `json:"startTime,omitempty"`
+	StartTime *int64 `json:"startTime,omitempty"`
 	// span end time in unix milli format
-	EndTime *int32 `json:"endTime,omitempty"`
+	EndTime *int64 `json:"endTime,omitempty"`
 	// Key-Value of span attributes
 	Attributes *map[string]string `json:"attributes,omitempty"`
 	Children   []Span             `json:"children,omitempty"`
@@ -142,9 +142,9 @@ func (o *Span) SetName(v string) {
 }
 
 // GetStartTime returns the StartTime field value if set, zero value otherwise.
-func (o *Span) GetStartTime() int32 {
+func (o *Span) GetStartTime() int64 {
 	if o == nil || o.StartTime == nil {
-		var ret int32
+		var ret int64
 		return ret
 	}
 	return *o.StartTime
@@ -152,7 +152,7 @@ func (o *Span) GetStartTime() int32 {
 
 // GetStartTimeOk returns a tuple with the StartTime field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *Span) GetStartTimeOk() (*int32, bool) {
+func (o *Span) GetStartTimeOk() (*int64, bool) {
 	if o == nil || o.StartTime == nil {
 		return nil, false
 	}
@@ -168,15 +168,15 @@ func (o *Span) HasStartTime() bool {
 	return false
 }
 
-// SetStartTime gets a reference to the given int32 and assigns it to the StartTime field.
-func (o *Span) SetStartTime(v int32) {
+// SetStartTime gets a reference to the given int64 and assigns it to the StartTime field.
+func (o *Span) SetStartTime(v int64) {
 	o.StartTime = &v
 }
 
 // GetEndTime returns the EndTime field value if set, zero value otherwise.
-func (o *Span) GetEndTime() int32 {
+func (o *Span) GetEndTime() int64 {
 	if o == nil || o.EndTime == nil {
-		var ret int32
+		var ret int64
 		return ret
 	}
 	return *o.EndTime
@@ -184,7 +184,7 @@ func (o *Span) GetEndTime() int32 {
 
 // GetEndTimeOk returns a tuple with the EndTime field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *Span) GetEndTimeOk() (*int32, bool) {
+func (o *Span) GetEndTimeOk() (*int64, bool) {
 	if o == nil || o.EndTime == nil {
 		return nil, false
 	}
@@ -200,8 +200,8 @@ func (o *Span) HasEndTime() bool {
 	return false
 }
 
-// SetEndTime gets a reference to the given int32 and assigns it to the EndTime field.
-func (o *Span) SetEndTime(v int32) {
+// SetEndTime gets a reference to the given int64 and assigns it to the EndTime field.
+func (o *Span) SetEndTime(v int64) {
 	o.EndTime = &v
 }
 

--- a/server/http/mappings.go
+++ b/server/http/mappings.go
@@ -212,8 +212,8 @@ func (m OpenAPIMapper) Span(in traces.Span) openapi.Span {
 	return openapi.Span{
 		Id:         in.ID.String(),
 		ParentId:   parentID,
-		StartTime:  int32(in.StartTime.UnixMilli()),
-		EndTime:    int32(in.EndTime.UnixMilli()),
+		StartTime:  in.StartTime.UnixMilli(),
+		EndTime:    in.EndTime.UnixMilli(),
 		Attributes: attributes,
 		Children:   m.Spans(in.Children),
 	}

--- a/server/openapi/model_span.go
+++ b/server/openapi/model_span.go
@@ -17,10 +17,10 @@ type Span struct {
 	Name string `json:"name,omitempty"`
 
 	// span start time in unix milli format
-	StartTime int32 `json:"startTime,omitempty"`
+	StartTime int64 `json:"startTime,omitempty"`
 
 	// span end time in unix milli format
-	EndTime int32 `json:"endTime,omitempty"`
+	EndTime int64 `json:"endTime,omitempty"`
 
 	// Key-Value of span attributes
 	Attributes map[string]string `json:"attributes,omitempty"`

--- a/server/testdb/runs_test.go
+++ b/server/testdb/runs_test.go
@@ -86,6 +86,17 @@ func TestUpdateRun(t *testing.T) {
 	actual, err := db.GetRun(context.TODO(), run.ID)
 	require.NoError(t, err)
 
+	updatedList, err := db.GetTestRuns(context.TODO(), test, 20, 0)
+	require.NoError(t, err)
+
+	// Ignore time fields in this test
+	actual.Trace.RootSpan.StartTime = time.Time{}
+	actual.Trace.RootSpan.EndTime = time.Time{}
+
+	runFromList := updatedList[0]
+	runFromList.Trace.RootSpan.StartTime = time.Time{}
+	runFromList.Trace.RootSpan.EndTime = time.Time{}
+
 	assert.Equal(t, run.SpanID.String(), actual.SpanID.String())
 	assert.Equal(t, run.CreatedAt.Unix(), actual.CreatedAt.Unix())
 	assert.Equal(t, run.Request, actual.Request)
@@ -93,7 +104,5 @@ func TestUpdateRun(t *testing.T) {
 	assert.Equal(t, run.Trace, actual.Trace)
 	assert.Equal(t, run.Results, actual.Results)
 
-	updatedList, err := db.GetTestRuns(context.TODO(), test, 20, 0)
-	require.NoError(t, err)
-	assert.Equal(t, actual, updatedList[0])
+	assert.Equal(t, actual, runFromList)
 }

--- a/server/traces/traces.go
+++ b/server/traces/traces.go
@@ -127,8 +127,8 @@ func encodeSpan(s Span) encodedSpan {
 	return encodedSpan{
 		ID:         s.ID.String(),
 		Name:       s.Name,
-		StartTime:  fmt.Sprintf("%d", s.StartTime.UnixNano()),
-		EndTime:    fmt.Sprintf("%d", s.EndTime.UnixNano()),
+		StartTime:  fmt.Sprintf("%d", s.StartTime.UnixMilli()),
+		EndTime:    fmt.Sprintf("%d", s.EndTime.UnixMilli()),
 		Attributes: s.Attributes,
 		Children:   encodeChildren(s.Children),
 	}

--- a/server/traces/traces.go
+++ b/server/traces/traces.go
@@ -174,8 +174,8 @@ func (s *Span) decodeSpan(aux encodedSpan) error {
 
 	s.ID = sid
 	s.Name = aux.Name
-	s.StartTime = startTime
-	s.EndTime = endTime
+	s.StartTime = startTime.UTC()
+	s.EndTime = endTime.UTC()
 	s.Attributes = aux.Attributes
 	s.Children = children
 
@@ -183,7 +183,7 @@ func (s *Span) decodeSpan(aux encodedSpan) error {
 }
 
 func getTimeFromString(value string) (time.Time, error) {
-	nanoSeconds, err := strconv.Atoi(value)
+	milliseconds, err := strconv.Atoi(value)
 	if err != nil {
 		// Maybe it is in RFC3339 format. Convert it for compatibility sake
 		output, err := time.Parse(time.RFC3339, value)
@@ -194,7 +194,7 @@ func getTimeFromString(value string) (time.Time, error) {
 		return output, nil
 	}
 
-	return time.Unix(0, int64(nanoSeconds)), nil
+	return time.UnixMilli(int64(milliseconds)), nil
 }
 
 func decodeChildren(parent *Span, children []encodedSpan) ([]*Span, error) {

--- a/server/traces/traces_test.go
+++ b/server/traces/traces_test.go
@@ -44,8 +44,8 @@ func TestJSONEncoding(t *testing.T) {
 		"RootSpan": {
 			"ID": "%s",
 			"Name":"root",
-			"StartTime":"%s",
-			"EndTime":"%s",
+			"StartTime":"%d",
+			"EndTime":"%d",
 			"Attributes": {
 				"service.name": "root"
 			},
@@ -53,16 +53,16 @@ func TestJSONEncoding(t *testing.T) {
 				{
 					"ID": "%s",
 					"Name":"subSpan1",
-					"StartTime":"%s",
-					"EndTime":"%s",
+					"StartTime":"%d",
+					"EndTime":"%d",
 					"Attributes": {
 						"service.name": "subSpan1"
 					},
 					"Children": [
 						{
 							"ID": "%s",
-							"StartTime":"%s",
-							"EndTime":"%s",
+							"StartTime":"%d",
+							"EndTime":"%d",
 							"Name":"subSubSpan1",
 							"Attributes": {
 								"service.name": "subSubSpan1"
@@ -74,8 +74,8 @@ func TestJSONEncoding(t *testing.T) {
 				{
 					"ID": "%s",
 					"Name":"subSpan2",
-					"StartTime":"%s",
-					"EndTime":"%s",
+					"StartTime":"%d",
+					"EndTime":"%d",
 					"Attributes": {
 						"service.name": "subSpan2"
 					},
@@ -87,20 +87,20 @@ func TestJSONEncoding(t *testing.T) {
 		tid.String(),
 
 		rootSpan.ID.String(),
-		rootSpan.StartTime.Format(time.RFC3339),
-		rootSpan.EndTime.Format(time.RFC3339),
+		rootSpan.StartTime.UnixMilli(),
+		rootSpan.EndTime.UnixMilli(),
 
 		subSpan1.ID.String(),
-		subSpan1.StartTime.Format(time.RFC3339),
-		subSpan1.EndTime.Format(time.RFC3339),
+		subSpan1.StartTime.UnixMilli(),
+		subSpan1.EndTime.UnixMilli(),
 
 		subSubSpan1.ID.String(),
-		subSubSpan1.StartTime.Format(time.RFC3339),
-		subSubSpan1.EndTime.Format(time.RFC3339),
+		subSubSpan1.StartTime.UnixMilli(),
+		subSubSpan1.EndTime.UnixMilli(),
 
 		subSpan2.ID.String(),
-		subSpan2.StartTime.Format(time.RFC3339),
-		subSpan2.EndTime.Format(time.RFC3339),
+		subSpan2.StartTime.UnixMilli(),
+		subSpan2.EndTime.UnixMilli(),
 	)
 
 	t.Run("encode", func(t *testing.T) {


### PR DESCRIPTION
This PR stores the start and end date as numbers instead of date formats in the database, so we don't lose precision. 

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
