### PR TITLE
Fix timeline graph duration

### DIFF
--- a/web/src/components/Diagram/components/Timeline/Timeline.tsx
+++ b/web/src/components/Diagram/components/Timeline/Timeline.tsx
@@ -164,7 +164,7 @@ const Timeline = ({affectedSpans, spanList, selectedSpan, onSelectSpan}: IDiagra
         return scaleTime(Number(d.data.startTime || minNano) - minNano);
       })
       .attr('width', d => {
-        return scaleTime(d.data.data.duration) - 250;
+        return Number(d.data.endTime) - Number(d.data.startTime);
       })
       .attr('fill', e => {
         const span: TSpan = e.data.data;


### PR DESCRIPTION
This PR fixes the timeline graph. It was using the `duration` field which now is a string value.

## Changes

- Timeline graph

## Fixes

- N/A

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test


## Screenshot

<img width="734" alt="Screen Shot 2022-07-01 at 15 20 14" src="https://user-images.githubusercontent.com/3879892/176964218-f31130a7-5e84-402b-b538-e0cc85d263cb.png">