### PR TITLE
add labels to issues opened by users

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -2,7 +2,7 @@
 name: Bug report
 about: Create a report to help us improve
 title: ''
-labels: ''
+labels: 'bug, triage'
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/enhancement.md
+++ b/.github/ISSUE_TEMPLATE/enhancement.md
@@ -2,7 +2,7 @@
 name: Enhancement
 about: Suggest an enhancement to existing functionality
 title: ''
-labels: ''
+labels: 'enhancement, triage'
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -2,7 +2,7 @@
 name: Feature request
 about: Suggest an idea for this project
 title: ''
-labels: ''
+labels: 'feature request, triage'
 assignees: ''
 
 ---


### PR DESCRIPTION
This PR adds labels to issues opened via templates. This adds a new label `triage` that will help us to detect issues opened by our users.

## Checklist

- [ ] tested locally
- [ ] added new dependencies
- [x] updated the docs
- [ ] added a test
