### PR TITLE
set sampling as 10% in collector

### DIFF
--- a/k8s/collector.yml
+++ b/k8s/collector.yml
@@ -16,7 +16,7 @@ data:
       # Data sources: traces
       probabilistic_sampler:
         hash_seed: 22
-        sampling_percentage: 100
+        sampling_percentage: 10
 
     exporters:
       logging:


### PR DESCRIPTION
This PR changes our collector sampling config so we don't send too much telemetry to lightstep, and we test our ability to fetch traces even when sampling is on.


## Checklist

- [ ] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
