### PR TITLE
fix: use the new cypress project id

### DIFF
--- a/web/cypress.json
+++ b/web/cypress.json
@@ -4,5 +4,5 @@
   "viewportWidth": 1440,
   "viewportHeight": 1080,
   "responseTimeout": 30000,
-  "projectId": "dhaoea"
+  "projectId": "6dm1if"
 }


### PR DESCRIPTION
This PR makes tracetest use our new cypress account

## Checklist

- [ ] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
