### PR TITLE
🦟 922 fixing failed trace rerun

### DIFF
--- a/web/src/components/FailedTrace/FailedTrace.tsx
+++ b/web/src/components/FailedTrace/FailedTrace.tsx
@@ -1,7 +1,8 @@
 import {Button, Typography} from 'antd';
 import {useCallback} from 'react';
+import {Link, useNavigate} from 'react-router-dom';
 import {DISCORD_URL, GITHUB_ISSUES_URL} from '../../constants/Common.constants';
-import {useRunTestMutation} from '../../redux/apis/TraceTest.api';
+import {useReRunMutation} from '../../redux/apis/TraceTest.api';
 import {TTestRun} from '../../types/TestRun.types';
 import * as S from './FailedTrace.styled';
 
@@ -9,16 +10,17 @@ interface IFailedTraceProps {
   isDisplayingError: boolean;
   run: TTestRun;
   testId: string;
-  onRunTest(result: TTestRun): void;
 }
 
-const FailedTrace: React.FC<IFailedTraceProps> = ({onRunTest, testId, isDisplayingError, run: {lastErrorState}}) => {
-  const [runNewTest] = useRunTestMutation();
+const FailedTrace: React.FC<IFailedTraceProps> = ({testId, isDisplayingError, run: {lastErrorState, id}}) => {
+  const [reRunTest] = useReRunMutation();
+  const navigate = useNavigate();
 
   const onReRun = useCallback(async () => {
-    const result = await runNewTest({testId}).unwrap();
-    onRunTest(result);
-  }, [onRunTest, runNewTest, testId]);
+    const result = await reRunTest({testId, runId: id}).unwrap();
+
+    navigate(`/test/${testId}/run/${result.id}`);
+  }, [id, navigate, reRunTest, testId]);
 
   return isDisplayingError ? (
     <S.FailedTrace>
@@ -34,9 +36,11 @@ const FailedTrace: React.FC<IFailedTraceProps> = ({onRunTest, testId, isDisplayi
           <Typography.Text type="secondary">We will check it out and respond to you.</Typography.Text>
         </S.TextContainer>
         <S.ButtonContainer>
-          <Button type="primary" ghost href={`test/${testId}/edit`}>
-            Edit Test
-          </Button>
+          <Link to={`test/${testId}/edit`}>
+            <Button type="primary" ghost>
+              Edit Test
+            </Button>
+          </Link>
           <Button type="primary" ghost onClick={onReRun}>
             Rerun Test
           </Button>

--- a/web/src/pages/Trace/TraceContent.tsx
+++ b/web/src/pages/Trace/TraceContent.tsx
@@ -12,7 +12,7 @@ import * as S from './Trace.styled';
 const TraceContent = () => {
   const {testId = ''} = useParams();
   const navigate = useNavigate();
-  const {isDraftMode, test, runTest} = useTestDefinition();
+  const {isDraftMode, test} = useTestDefinition();
 
   const {isError, run} = useTestRun();
   const isDisplayingError = isError || run.state === TestState.FAILED;
@@ -29,7 +29,7 @@ const TraceContent = () => {
         testVersion={run.testVersion}
         totalSpans={run?.trace?.spans?.length}
       />
-      <FailedTrace onRunTest={runTest} testId={testId} run={run} isDisplayingError={isDisplayingError} />
+      <FailedTrace testId={testId} run={run} isDisplayingError={isDisplayingError} />
       <Run displayError={isDisplayingError} run={run} test={test} />
     </S.Wrapper>
   ) : null;


### PR DESCRIPTION
This PR fixes the double request triggered to the backend when trying to rerun a failed trace.
It also changes the endpoint to use the `/rerun` one instead `/run`

## Fixes

- https://github.com/kubeshop/tracetest/issues/922

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
