### PR TITLE
make single word hostname a valid url

### DIFF
--- a/web/src/components/CreateTestPlugins/Rest/steps/RequestDetails/RequestDetailsUrlInput.tsx
+++ b/web/src/components/CreateTestPlugins/Rest/steps/RequestDetails/RequestDetailsUrlInput.tsx
@@ -1,5 +1,6 @@
 import {Form, Input, Select} from 'antd';
 import {HTTP_METHOD} from 'constants/Common.constants';
+import Validator from "utils/Validator";
 import * as S from './RequestDetails.styled';
 
 interface IProps {
@@ -35,8 +36,21 @@ const RequestDetailsUrlInput = ({showMethodSelector = true, shouldValidateUrl = 
         <Form.Item
           name="url"
           rules={[
-            {required: true, message: 'Please enter a request url'},
-            shouldValidateUrl ? {type: 'url', message: 'Request url is not valid'} : {},
+            {
+              validator: async (_, value: string) => {
+                if (!shouldValidateUrl) {
+                  return Promise.resolve(true);
+                }
+                if (value === '') {
+                  return Promise.reject(new Error('Please enter a request url'));
+                }
+                const isValid = Validator.url(value);
+                if (isValid) {
+                  return Promise.resolve(isValid);
+                }
+                return Promise.reject(new Error('Request url is not valid'));
+              },
+            },
           ]}
           style={{flex: 1}}
           label={!showMethodSelector ? 'URL' : ''}

--- a/web/src/utils/Validator.ts
+++ b/web/src/utils/Validator.ts
@@ -2,17 +2,22 @@ import isEmpty from 'lodash/isEmpty';
 
 type Value = any;
 
-const pattern = {
-  // http://emailregex.com/
-  url: /^(?!mailto:)(?:(?:http|https|ftp):\/\/|\/\/)(?:\S+(?::\S*)?@)?(?:(?:(?:[1-9]\d?|1\d\d|2[01]\d|22[0-3])(?:\.(?:1?\d{1,2}|2[0-4]\d|25[0-5])){2}(?:\.(?:[0-9]\d?|1\d\d|2[0-4]\d|25[0-4]))|(?:(?:[a-z\u00a1-\uffff0-9]+-*)*[a-z\u00a1-\uffff0-9]+)(?:\.(?:[a-z\u00a1-\uffff0-9]+-*)*[a-z\u00a1-\uffff0-9]+)*(?:\.(?:[a-z\u00a1-\uffff]{2,})))|localhost)(?::\d{2,5})?(?:(\/|\?|#)[^\s]*)?$/i,
-};
-
 const Validator = {
   required(value: Value) {
     return !isEmpty(value);
   },
   url(value: Value) {
-    return typeof value === 'string' && value.length <= 2048 && Boolean(value.match(pattern.url));
+    try {
+      if (typeof value === 'string') {
+        if (value.length <= 2048) {
+          const innerUrl = new URL(value);
+          return innerUrl.protocol === 'http:' || innerUrl.protocol === 'https:';
+        }
+      }
+      return false;
+    } catch {
+      return false;
+    }
   },
 };
 

--- a/web/src/utils/__tests__/Validator.test.ts
+++ b/web/src/utils/__tests__/Validator.test.ts
@@ -19,9 +19,16 @@ describe('Validator', () => {
       expect(Validator.url(value)).toBeFalsy();
     });
 
-    it('should handle valid value', () => {
-      const value = 'https://tracetest.io/';
-      expect(Validator.required(value)).toBeTruthy();
+    it('should be invalid', () => {
+      expect(Validator.url('http://demo.@')).toBe(false);
+      expect(Validator.url('htt://demo')).toBe(false);
+    });
+
+    it('should be valid', () => {
+      expect(Validator.required('https://tracetest.io/')).toBeTruthy();
+      expect(Validator.url('http://demo')).toBe(true);
+      expect(Validator.url('http://demo.com')).toBe(true);
+      expect(Validator.url('https://www.demo.com')).toBe(true);
     });
   });
 });


### PR DESCRIPTION
This PR implements a custom validator for the url field because antd internal validation invalidates single word hostnames

## Changes

- removes Form.Item rules
- adds a single new rule with custom validtor

## Fixes

- fix issue #920 

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [x] added a test
