### PR TITLE
Fix grpc parent span

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -159,7 +159,7 @@ jobs:
           --set poolingConfig.maxWaitTimeForTrace="60s" \
           --set poolingConfig.retryDelay="6s" \
           --set ingress.enabled=false \
-          --wait --timeout 3m
+          --wait --timeout 10m
 
   e2e:
     needs: deploy

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -272,24 +272,24 @@ jobs:
           TARGET_URL="http://tracetest-pr-${{ github.event.pull_request.number }}.tracetest-pr-${{ github.event.pull_request.number }}:8080" \
           ./run.bash
 
-  cleanup:
-    runs-on: ubuntu-latest
-    needs: [trace-testing, e2e]
-    if: always()
-    steps:
-      - uses: google-github-actions/setup-gcloud@94337306dda8180d967a56932ceb4ddcf01edae7
-        with:
-          service_account_key: ${{ secrets.GKE_SA_KEY }}
-          project_id: ${{ secrets.GKE_PROJECT }}
+  # cleanup:
+  #   runs-on: ubuntu-latest
+  #   needs: [trace-testing, e2e]
+  #   if: always()
+  #   steps:
+  #     - uses: google-github-actions/setup-gcloud@94337306dda8180d967a56932ceb4ddcf01edae7
+  #       with:
+  #         service_account_key: ${{ secrets.GKE_SA_KEY }}
+  #         project_id: ${{ secrets.GKE_PROJECT }}
 
-      - uses: google-github-actions/get-gke-credentials@fb08709ba27618c31c09e014e1d8364b02e5042e
-        with:
-          cluster_name: ${{ secrets.GKE_CLUSTER }}
-          location: ${{ secrets.GKE_ZONE }}
-          credentials: ${{ secrets.GKE_SA_KEY }}
+  #     - uses: google-github-actions/get-gke-credentials@fb08709ba27618c31c09e014e1d8364b02e5042e
+  #       with:
+  #         cluster_name: ${{ secrets.GKE_CLUSTER }}
+  #         location: ${{ secrets.GKE_ZONE }}
+  #         credentials: ${{ secrets.GKE_SA_KEY }}
 
-      - name: Uninstall tracetest
-        run: |
-          helm delete tracetest-pr-${{ github.event.pull_request.number }} \
-          --namespace tracetest-pr-${{ github.event.pull_request.number }}
-          kubectl delete ns tracetest-pr-${{ github.event.pull_request.number }}
+  #     - name: Uninstall tracetest
+  #       run: |
+  #         helm delete tracetest-pr-${{ github.event.pull_request.number }} \
+  #         --namespace tracetest-pr-${{ github.event.pull_request.number }}
+  #         kubectl delete ns tracetest-pr-${{ github.event.pull_request.number }}

--- a/run-tracetesting-tests.sh
+++ b/run-tracetesting-tests.sh
@@ -1,12 +1,16 @@
 #!/bin/sh
 
 STOP=yes
+RESTART=yes
 
 while [[ $# -gt 0 ]]; do
   case $1 in
     --no-stop)
       STOP=no
       shift
+      ;;
+    --no-restart)
+      RESTART=no
       shift
       ;;
     -*|--*)
@@ -18,7 +22,9 @@ while [[ $# -gt 0 ]]; do
 done
 
 
-docker compose -f docker-compose.yaml down
+if [ "$RESTART" == "yes" ]; then
+  docker compose -f docker-compose.yaml down
+fi
 docker compose -f docker-compose.yaml up -d --build --remove-orphans
 docker compose -f docker-compose.yaml -f local-config/docker-compose.testrunner.yaml build
 docker compose -f docker-compose.yaml -f local-config/docker-compose.testrunner.yaml run testrunner

--- a/run-tracetesting-tests.sh
+++ b/run-tracetesting-tests.sh
@@ -18,6 +18,7 @@ while [[ $# -gt 0 ]]; do
 done
 
 
+docker compose -f docker-compose.yaml down
 docker compose -f docker-compose.yaml up -d --build --remove-orphans
 docker compose -f docker-compose.yaml -f local-config/docker-compose.testrunner.yaml build
 docker compose -f docker-compose.yaml -f local-config/docker-compose.testrunner.yaml run testrunner

--- a/server/executor/trigger/instrument.go
+++ b/server/executor/trigger/instrument.go
@@ -2,9 +2,19 @@ package trigger
 
 import (
 	"context"
+	"io"
 
 	"github.com/kubeshop/tracetest/server/model"
+	"go.opentelemetry.io/contrib/propagators/aws/xray"
+	"go.opentelemetry.io/contrib/propagators/b3"
+	"go.opentelemetry.io/contrib/propagators/jaeger"
+	"go.opentelemetry.io/contrib/propagators/ot"
 	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/exporters/stdout/stdouttrace"
+	"go.opentelemetry.io/otel/propagation"
+	"go.opentelemetry.io/otel/sdk/resource"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	semconv "go.opentelemetry.io/otel/semconv/v1.4.0"
 	"go.opentelemetry.io/otel/trace"
 )
 
@@ -49,4 +59,30 @@ func (t *instrumentedTriggerer) Trigger(ctx context.Context, test model.Test, ti
 	span.SetAttributes(attrs...)
 
 	return resp, err
+}
+
+func propagators() propagation.TextMapPropagator {
+	return propagation.NewCompositeTextMapPropagator(propagation.Baggage{},
+		b3.New(),
+		jaeger.Jaeger{},
+		ot.OT{},
+		xray.Propagator{},
+		propagation.TraceContext{})
+}
+
+func traceProvider() *sdktrace.TracerProvider {
+	// Set standard attributes per semantic conventions
+	res := resource.NewWithAttributes(
+		semconv.SchemaURL,
+		semconv.ServiceNameKey.String("tracetest"),
+	)
+
+	// this is in fact a noop exporter, so we can ignore errors
+	spanExporter, _ := stdouttrace.New(stdouttrace.WithWriter(io.Discard))
+
+	return sdktrace.NewTracerProvider(
+		sdktrace.WithSyncer(spanExporter),
+		sdktrace.WithResource(res),
+		sdktrace.WithSampler(sdktrace.ParentBased(sdktrace.AlwaysSample())),
+	)
 }

--- a/server/go.mod
+++ b/server/go.mod
@@ -21,8 +21,10 @@ require (
 	github.com/mitchellh/mapstructure v1.4.3
 	github.com/orlangure/gnomock v0.20.0
 	github.com/prometheus/prometheus v1.8.2-0.20211217191541-41f1a8125e66
+	github.com/segmentio/analytics-go/v3 v3.2.1
 	github.com/stretchr/testify v1.7.1
 	go.opentelemetry.io/collector v0.44.0
+	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.28.0
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.28.0
 	go.opentelemetry.io/contrib/propagators/aws v1.5.0
 	go.opentelemetry.io/contrib/propagators/b3 v1.5.0
@@ -65,14 +67,12 @@ require (
 	github.com/opencontainers/image-spec v1.0.3-0.20211202183452-c5a74bcca799 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/segmentio/analytics-go/v3 v3.2.1 // indirect
 	github.com/segmentio/backo-go v1.0.0 // indirect
 	github.com/sirupsen/logrus v1.8.1 // indirect
 	github.com/spf13/cast v1.4.1 // indirect
 	github.com/streadway/amqp v1.0.0 // indirect
 	github.com/stretchr/objx v0.2.0 // indirect
 	go.opentelemetry.io/collector/model v0.44.0 // indirect
-	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.28.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/internal/retry v1.7.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.6.0 // indirect
 	go.opentelemetry.io/otel/internal/metric v0.26.0 // indirect

--- a/server/go.sum
+++ b/server/go.sum
@@ -240,6 +240,7 @@ github.com/bkaradzic/go-lz4 v1.0.0/go.mod h1:0YdlkowM3VswSROI7qDxhRvJ3sLhlFrRRwj
 github.com/bketelsen/crypt v0.0.3-0.20200106085610-5cbc8cc4026c/go.mod h1:MKsuJmJgSg28kpZDP6UIiPt0e0Oz0kqKNGyRaWEPv84=
 github.com/blang/semver v3.1.0+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
 github.com/blang/semver v3.5.1+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
+github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869 h1:DDGfHa7BWjL4YnC6+E63dPcxHo2sUxDIu8g3QgEJdRY=
 github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869/go.mod h1:Ekp36dRnpXw/yCqJaO+ZrUyxD+3VXMFFr56k5XYrpB4=
 github.com/bmizerany/pat v0.0.0-20170815010413-6226ea591a40/go.mod h1:8rLXio+WjiTceGBHIoTvn60HIbs7Hm7bcHjyrSqYB9c=
 github.com/boltdb/bolt v1.3.1/go.mod h1:clJnj/oiGkjum5o1McbSZDSLxVThjynRyGBgiAx27Ps=

--- a/server/model/grpc.go
+++ b/server/model/grpc.go
@@ -16,6 +16,16 @@ type GRPCRequest struct {
 	Request      string
 }
 
+func (a GRPCRequest) Headers() []string {
+	h := []string{}
+
+	for _, md := range a.Metadata {
+		h = append(h, md.Key+": "+md.Value)
+	}
+
+	return h
+}
+
 func (a GRPCRequest) Authenticate() {
 	if a.Auth == nil {
 		return

--- a/tracetesting/definitions/grpc_test_create.yml
+++ b/tracetesting/definitions/grpc_test_create.yml
@@ -22,6 +22,22 @@ trigger:
               "request": "{\"id\": 52}"
             }
           }
+        },
+        "definition": {
+          "definitions": [
+            {
+              "selector": {
+                "query": "span[name = \"queue.synchronizePokemon send\"]"
+              },
+              "assertions": [
+                {
+                  "attribute": "kind",
+                  "comparator": "=",
+                  "expected": "SPAN_KIND_PRODUCER"
+                }
+              ]
+            }
+          ]
         }
       }
 testDefinition:

--- a/tracetesting/definitions/grpc_test_create.yml
+++ b/tracetesting/definitions/grpc_test_create.yml
@@ -31,9 +31,9 @@ trigger:
               },
               "assertions": [
                 {
-                  "attribute": "kind",
-                  "comparator": "=",
-                  "expected": "SPAN_KIND_PRODUCER"
+                  "attribute": "tracetest.selected_spans.count",
+                  "comparator": ">",
+                  "expected": "0"
                 }
               ]
             }

--- a/tracetesting/definitions/test_create.yml
+++ b/tracetesting/definitions/test_create.yml
@@ -26,6 +26,22 @@ trigger:
               ]
             }
           }
+        },
+        "definition": {
+          "definitions": [
+            {
+              "selector": {
+                "query": "span[name = \"pg.query:SELECT\"]"
+              },
+              "assertions": [
+                {
+                  "attribute": "tracetest.selected_spans.count",
+                  "comparator": ">",
+                  "expected": "0"
+                }
+              ]
+            }
+          ]
         }
       }
 testDefinition:


### PR DESCRIPTION
This PR fixes the instrumentation for gRPC triggers, so that the parent Span ID is correctly set on the service under test.

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [x] added a test
