### PR TITLE
Long trace attributes

### DIFF
--- a/web/src/components/AssertionForm/AssertionForm.styled.ts
+++ b/web/src/components/AssertionForm/AssertionForm.styled.ts
@@ -33,7 +33,7 @@ export const PseudoSelector = styled.div`
 
 export const Check = styled.div`
   display: grid;
-  grid-template-columns: repeat(3, 210px) 1fr;
+  grid-template-columns: repeat(3, 280px) 1fr;
   gap: 4px;
   align-items: start;
   margin-bottom: 16px;

--- a/web/src/components/AttributeRow/AttributeRow.styled.ts
+++ b/web/src/components/AttributeRow/AttributeRow.styled.ts
@@ -2,6 +2,8 @@ import {CopyOutlined, PlusOutlined} from '@ant-design/icons';
 import {Badge, Tooltip, Typography} from 'antd';
 import styled from 'styled-components';
 
+export {default as AttributeTitle} from './AttributeTitle';
+
 export const AttributeRow = styled.div`
   display: grid;
   grid-template-columns: 160px 1fr 60px;

--- a/web/src/components/AttributeRow/AttributeRow.tsx
+++ b/web/src/components/AttributeRow/AttributeRow.tsx
@@ -5,7 +5,6 @@ import {TSpanFlatAttribute} from 'types/Span.types';
 import GuidedTourService, {GuidedTours} from '../../services/GuidedTour.service';
 import AttributeValue from '../AttributeValue';
 import {Steps} from '../GuidedTour/traceStepList';
-import Highlighted from '../Highlighted';
 import AttributeCheck from './AttributeCheck';
 import * as S from './AttributeRow.styled';
 
@@ -43,11 +42,7 @@ const AttributeRow = ({
 
   return (
     <S.AttributeRow onMouseEnter={onMouseEnter} onMouseLeave={onMouseLeave}>
-      <S.TextContainer>
-        <S.Text type="secondary">
-          <Highlighted text={key} highlight={searchText} />
-        </S.Text>
-      </S.TextContainer>
+      <S.AttributeTitle title={key} searchText={searchText} />
 
       <S.AttributeValueRow>
         <AttributeValue value={value} searchText={searchText} />

--- a/web/src/components/AttributeRow/AttributeTitle.tsx
+++ b/web/src/components/AttributeRow/AttributeTitle.tsx
@@ -1,0 +1,25 @@
+import {Tooltip} from 'antd';
+import Highlighted from '../Highlighted';
+import {Text, TextContainer} from './AttributeRow.styled';
+
+interface IProps {
+  title: string;
+  searchText: string;
+}
+
+export default ({searchText, title}: IProps): JSX.Element => {
+  const textContainer = (
+    <TextContainer>
+      <Text type="secondary">
+        <Highlighted text={title} highlight={searchText} />
+      </Text>
+    </TextContainer>
+  );
+  return title.length > 26 ? (
+    <Tooltip title={title} arrowContent={null}>
+      {textContainer}
+    </Tooltip>
+  ) : (
+    textContainer
+  );
+};


### PR DESCRIPTION
This PR deals with attributes name being trucated

## Changes

- increase AttributeCheck grid column size
- Add tooltip to attribute table if key is longer than 26 characters

## Fixes

- #914 

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [x] added a test
