### PR TITLE
Fix gRPC panic with invalid headers

### DIFF
--- a/local-config/config.tests.yaml
+++ b/local-config/config.tests.yaml
@@ -1,11 +1,4 @@
 postgresConnString: "host=postgres user=postgres password=postgres port=5432 sslmode=disable"
-tracingBackend:
-  dataStore:
-    type: jaeger
-    jaeger:
-      endpoint: jaeger:16685
-      tls:
-        insecure: true
 
 poolingConfig:
   maxWaitTimeForTrace: 60s
@@ -15,7 +8,24 @@ googleAnalytics:
   enabled: false
 
 telemetry:
-  enabled: true
-  serviceName: tracetest
-  sampling: 100 # 100%
-  otelCollectorEndpoint: otel-collector:4317
+  dataStores:
+    jaeger:
+      type: jaeger
+      jaeger:
+        endpoint: jaeger:16685
+        tls:
+          insecure: true
+
+  exporters:
+    collector:
+      serviceName: tracetest
+      sampling: 100 # 100%
+      exporter:
+        type: collector
+        collector:
+          endpoint: otel-collector:4317
+
+server:
+  telemetry:
+    exporter: collector
+    dataStore: jaeger

--- a/server/executor/trigger/grpc.go
+++ b/server/executor/trigger/grpc.go
@@ -181,7 +181,6 @@ type eventHandler struct {
 func (h *eventHandler) OnResolveMethod(md *desc.MethodDescriptor) {}
 
 func (h *eventHandler) OnSendHeaders(md metadata.MD) {
-	fmt.Printf("******** headers %v\n", md)
 }
 
 func (h *eventHandler) OnReceiveHeaders(md metadata.MD) {

--- a/server/model/grpc.go
+++ b/server/model/grpc.go
@@ -20,6 +20,11 @@ func (a GRPCRequest) Headers() []string {
 	h := []string{}
 
 	for _, md := range a.Metadata {
+		// ignore invalid values
+		if md.Key == "" {
+			continue
+		}
+
 		h = append(h, md.Key+": "+md.Value)
 	}
 

--- a/tracetesting/definitions/grpc_test_create_invalid_metadata.yml
+++ b/tracetesting/definitions/grpc_test_create_invalid_metadata.yml
@@ -1,0 +1,57 @@
+id: 8540b712-8ad6-48f0-a261-457c7da68921
+name: gRPC Test Create
+description: ""
+trigger:
+  type: http
+  httpRequest:
+    url: ${TARGET_URL}/api/tests
+    method: POST
+    headers:
+    - key: Content-Type
+      value: application/json
+    body: |
+      {
+        "name": "gRPC pokemon list",
+        "serviceUnderTest": {
+          "triggerType": "grpc",
+          "triggerSettings": {
+            "grpc": {
+              "protobufFile": "syntax = \"proto3\";\r\n\r\noption java_multiple_files = true;\r\noption java_outer_classname = \"PokeshopProto\";\r\noption objc_class_prefix = \"PKS\";\r\n\r\npackage pokeshop;\r\n\r\nservice Pokeshop {\r\n  rpc getPokemonList (GetPokemonRequest) returns (GetPokemonListResponse) {}\r\n  rpc createPokemon (Pokemon) returns (Pokemon) {}\r\n  rpc importPokemon (ImportPokemonRequest) returns (ImportPokemonRequest) {}\r\n}\r\n\r\nmessage ImportPokemonRequest {\r\n  int32 id = 1;\r\n}\r\n\r\nmessage GetPokemonRequest {\r\n  optional int32 skip = 1;\r\n  optional int32 take = 2;\r\n}\r\n\r\nmessage GetPokemonListResponse {\r\n  repeated Pokemon items = 1;\r\n  int32 totalCount = 2;\r\n}\r\n\r\nmessage Pokemon {\r\n  optional int32 id = 1;\r\n  string name = 2;\r\n  string type = 3;\r\n  bool isFeatured = 4;\r\n  optional string imageUrl = 5;\r\n}",
+              "address": "${DEMO_APP_GRPC_URL}",
+              "method": "pokeshop.Pokeshop.importPokemon",
+              "request": "{\"id\": 52}",
+              "metadata": [{}]
+            }
+          }
+        },
+        "definition": {
+          "definitions": [
+            {
+              "selector": {
+                "query": "span[name = \"queue.synchronizePokemon send\"]"
+              },
+              "assertions": [
+                {
+                  "attribute": "tracetest.selected_spans.count",
+                  "comparator": ">",
+                  "expected": "0"
+                }
+              ]
+            }
+          ]
+        }
+      }
+testDefinition:
+- selector: span[name="POST /api/tests" tracetest.span.type="http"]
+  assertions:
+  - tracetest.selected_spans.count = 1
+  - tracetest.response.status = 200
+- selector: span[name = "exec INSERT"]
+  assertions:
+  - tracetest.selected_spans.count = 2
+- selector: span[name = "exec INSERT"]:first
+  assertions:
+  - sql.query contains "INSERT INTO tests"
+- selector: span[name = "exec INSERT"]:last
+  assertions:
+  - sql.query contains "INSERT INTO definitions"

--- a/tracetesting/definitions/grpc_test_run_invalid_metadata.yml
+++ b/tracetesting/definitions/grpc_test_run_invalid_metadata.yml
@@ -1,0 +1,33 @@
+id: 9638ee3a-0952-492f-8380-7f85a7379c93
+name: gRPC Test Run
+description: ""
+trigger:
+  type: http
+  httpRequest:
+    url: ${TARGET_URL}/api/tests/${TEST_ID}/run
+    method: POST
+    headers:
+    - key: Content-Type
+      value: application/json
+testDefinition:
+- selector: span[name = "POST /api/tests/{testId}/run" tracetest.span.type = "http"]
+  assertions:
+  - tracetest.response.status = 200
+- selector: span[name = "Trigger test"]
+  assertions:
+  - tracetest.selected_spans.count = 1
+  - tracetest.run.trigger.test_id = "${TEST_ID}"
+  - tracetest.run.trigger.type = "grpc"
+  - tracetest.run.trigger.grpc.response_status_code = 0
+  - tracetest.run.trigger.grpc.response_status = "OK"
+- selector: span[name = "Fetch trace"]
+  assertions:
+  - tracetest.selected_spans.count > 0
+  - tracetest.run.trace_poller.test_id = "${TEST_ID}"
+- selector: span[name = "Fetch trace"]:last
+  assertions:
+  - tracetest.run.trace_poller.succesful = "true"
+- selector: span[name = "Execute assertions"]
+  assertions:
+  - tracetest.selected_spans.count = 1
+  - tracetest.run.assertion_runner.all_assertions_passed = "true"

--- a/tracetesting/grpc.bash
+++ b/tracetesting/grpc.bash
@@ -4,11 +4,16 @@ source ./funcs.bash
 
 EXIT_STATUS=0
 
-test "grpc_test_create" ./definitions/grpc_test_create.yml || EXIT_STATUS=$?
 
+test "grpc_test_create" ./definitions/grpc_test_create.yml || EXIT_STATUS=$?
 export TEST_ID=$(tracetest_target test list | jq -rc '.[0].id')
 require_not_empty $TEST_ID "requires TEST_ID, got $TEST_ID " || exit $?
-
 test "grpc_test_run" ./definitions/grpc_test_run.yml || EXIT_STATUS=$?
+
+
+test "grpc_test_create_invalid_metadata" ./definitions/grpc_test_create_invalid_metadata.yml || EXIT_STATUS=$?
+export TEST_ID=$(tracetest_target test list | jq -rc '.[0].id')
+require_not_empty $TEST_ID "requires TEST_ID, got $TEST_ID " || exit $?
+test "grpc_test_run_invalid_metadata" ./definitions/grpc_test_run_invalid_metadata.yml || EXIT_STATUS=$?
 
 exit $EXIT_STATUS

--- a/tracetesting/tests.bash
+++ b/tracetesting/tests.bash
@@ -5,7 +5,7 @@ source ./funcs.bash
 EXIT_STATUS=0
 
 # ensure test not exists
-tracetest_target_curl "/api/tests/383d3dce-7b60-4a61-bdea-87f47263af5d" -X DELETE
+tracetest_target_curl "/api/tests/383d3dce-7b60-4a61-bdea-87f47263af5d" -X DELETE > /dev/null 2>&1
 test "test_create_with_id_notexists" ./definitions/test_create_with_id_notexists.yml || EXIT_STATUS=$?
 test "test_create_with_id_exists" ./definitions/test_create_with_id_exists.yml || EXIT_STATUS=$?
 tracetest_target_curl "/api/tests/383d3dce-7b60-4a61-bdea-87f47263af5d" -X DELETE


### PR DESCRIPTION
This PR fixes a panic caused by invalid Metadata set for a gRPC trigger

## Changes

-

## Fixes

-

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [x] added a test
