### PR TITLE
🐛 Filtering metadata array for rpc requests

### DIFF
--- a/web/src/services/Triggers/Rpc.service.ts
+++ b/web/src/services/Triggers/Rpc.service.ts
@@ -35,13 +35,14 @@ const RpcTriggerService = (): IRpcTriggerService => ({
   async getRequest(values) {
     const {protoFile, message: request, metadata, method, auth, url: address} = values as IRpcValues;
     const protobufFile = await protoFile.text();
+    const parsedMetadata = metadata.filter(({key}) => key);
 
     return {
       address,
       request,
       auth,
       method,
-      metadata,
+      metadata: parsedMetadata,
       protobufFile,
     };
   },


### PR DESCRIPTION
This PR fixes the way we send the metadata array by default to the backend removing the faulty objects.

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
