### PR TITLE
Wizard toggle not working on an assertion that can be represented by a key value mode

### DIFF
--- a/web/src/components/AssertionItem/AssertionHeader.tsx
+++ b/web/src/components/AssertionItem/AssertionHeader.tsx
@@ -1,17 +1,53 @@
+import OperatorService from 'services/Operator.service';
+import {TPseudoSelector, TSpanSelector} from 'types/Assertion.types';
 import * as S from './AssertionItem.styled';
 
 interface IProps {
   affectedSpans: number;
   failedChecks: number;
+  isAdvancedMode: boolean;
+  isAdvancedSelector: boolean;
   passedChecks: number;
+  pseudoSelector?: TPseudoSelector;
+  selectorList: TSpanSelector[];
   title: string;
 }
 
-const AssertionHeader = ({affectedSpans, failedChecks, passedChecks, title}: IProps) => (
+const AssertionHeader = ({
+  affectedSpans,
+  failedChecks,
+  isAdvancedMode,
+  isAdvancedSelector,
+  passedChecks,
+  pseudoSelector,
+  selectorList,
+  title,
+}: IProps) => (
   <S.Column>
-    <div>
-      <S.HeaderTitle level={3}>{title}</S.HeaderTitle>
-    </div>
+    {isAdvancedMode || isAdvancedSelector ? (
+      <div>
+        <S.HeaderText>{title}</S.HeaderText>
+      </div>
+    ) : (
+      <S.SelectorContainer>
+        {selectorList.map(({key, value, operator}) => (
+          <S.Selector key={`${key} ${operator} ${value}`}>
+            <S.HeaderTextSecondary>
+              {key} • {OperatorService.getNameFromSymbol(operator)}
+            </S.HeaderTextSecondary>
+            <S.HeaderText>{value}</S.HeaderText>
+          </S.Selector>
+        ))}
+        {pseudoSelector && (
+          <S.Selector key="pseudo-selector">
+            <S.HeaderTextSecondary>pseudo selector</S.HeaderTextSecondary>
+            <S.HeaderText>
+              {pseudoSelector.selector} {pseudoSelector.number ? `(${pseudoSelector.number})` : ''}
+            </S.HeaderText>
+          </S.Selector>
+        )}
+      </S.SelectorContainer>
+    )}
     <div>
       {Boolean(passedChecks) && (
         <S.HeaderDetail>

--- a/web/src/components/AssertionItem/AssertionItem.styled.ts
+++ b/web/src/components/AssertionItem/AssertionItem.styled.ts
@@ -71,6 +71,15 @@ export const HeaderSpansIcon = styled(ApartmentOutlined)`
   margin-right: 4px;
 `;
 
+export const HeaderText = styled(Typography.Text)``;
+
+export const HeaderTextSecondary = styled(Typography.Text).attrs({
+  type: 'secondary',
+})`
+  font-size: ${({theme}) => theme.size.xs};
+  margin-bottom: -3px;
+`;
+
 export const HeaderTitle = styled(Typography.Title)`
   && {
     margin-bottom: 0;
@@ -94,6 +103,16 @@ export const Row = styled.div<{$align?: string}>`
 export const SecondaryText = styled(Typography.Text)`
   color: ${({theme}) => theme.color.textSecondary};
   font-size: ${({theme}) => theme.size.sm};
+`;
+
+export const Selector = styled.div`
+  display: flex;
+  flex-direction: column;
+`;
+
+export const SelectorContainer = styled.div`
+  display: flex;
+  gap: 12px;
 `;
 
 export const SpanCard = styled(Card)<{$isSelected: boolean; $type: SemanticGroupNames}>`

--- a/web/src/components/AssertionItem/AssertionItem.tsx
+++ b/web/src/components/AssertionItem/AssertionItem.tsx
@@ -1,6 +1,7 @@
 import {useMemo} from 'react';
 
 import {SemanticGroupNames} from 'constants/SemanticGroupNames.constants';
+import {ResultViewModes} from 'constants/Test.constants';
 import {useAppSelector} from 'redux/hooks';
 import TestDefinitionSelectors from 'selectors/TestDefinition.selectors';
 import AssertionAnalyticsService from 'services/Analytics/AssertionAnalytics.service';
@@ -25,10 +26,11 @@ interface IProps {
   selectedAssertion: string;
   selectedSpan?: string;
   trace?: TTrace;
+  viewResultsMode: ResultViewModes;
 }
 
 const AssertionItem = ({
-  assertionResult: {resultList, selector, spanIds},
+  assertionResult: {isAdvancedSelector, pseudoSelector, resultList, selector, selectorList, spanIds},
   assertionResult,
   onDelete,
   onEdit,
@@ -39,6 +41,7 @@ const AssertionItem = ({
   selectedAssertion,
   selectedSpan,
   trace,
+  viewResultsMode,
 }: IProps) => {
   const {
     isDeleted = false,
@@ -82,7 +85,11 @@ const AssertionItem = ({
             <AssertionHeader
               affectedSpans={spanIds.length}
               failedChecks={totalPassedChecks?.false ?? 0}
+              isAdvancedMode={viewResultsMode === ResultViewModes.Advanced}
+              isAdvancedSelector={isAdvancedSelector}
               passedChecks={totalPassedChecks?.true ?? 0}
+              pseudoSelector={pseudoSelector}
+              selectorList={selectorList}
               title={selector}
             />
           }

--- a/web/src/components/AssertionList/AssertionList.tsx
+++ b/web/src/components/AssertionList/AssertionList.tsx
@@ -74,6 +74,7 @@ const AssertionList = ({assertionResults: {resultList}, onSelectSpan}: IProps) =
               selectedAssertion={selectedAssertion}
               selectedSpan={selectedSpan?.id}
               trace={trace}
+              viewResultsMode={viewResultsMode}
             />
           ) : null
         )


### PR DESCRIPTION
This PR adds support for the `wizard` mode in the assertion header component.

## Changes

- Assertion header.

## Fixes

- Fixes #942 

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Screenshot

![2022-07-21 15 44 59](https://user-images.githubusercontent.com/3879892/180312382-29437219-6de4-4949-93ab-ac1fb575f588.gif)