### PR TITLE
reduce otel batching timeout

### DIFF
--- a/.github/workflows/deploy-main.yml
+++ b/.github/workflows/deploy-main.yml
@@ -136,8 +136,8 @@ jobs:
           --namespace tracetest-integration \
           --set analytics.enabled=false \
           --set image.tag=sha-$(git rev-parse --short $GITHUB_SHA) \
-          --set poolingConfig.maxWaitTimeForTrace=60s \
-          --set poolingConfig.retryDelay=6s \
+          --set poolingConfig.maxWaitTimeForTrace=30s \
+          --set poolingConfig.retryDelay=500ms \
           --set telemetry.dataStores.jaeger.jaeger.endpoint="jaeger-query.tracetest.svc.cluster.local:16685" \
           --set telemetry.exporters.collector.exporter.collector.endpoint="otel-collector.tracetest.svc.cluster.local:4317" \
           --set server.telemetry.dataStore="jaeger" \

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -156,8 +156,8 @@ jobs:
           --set telemetry.dataStores.jaeger.jaeger.endpoint="jaeger-query.tracetest.svc.cluster.local:16685" \
           --set telemetry.exporters.collector.exporter.collector.endpoint="otel-collector.tracetest.svc.cluster.local:4317" \
           --set server.telemetry.dataStore="jaeger" \
-          --set poolingConfig.maxWaitTimeForTrace="60s" \
-          --set poolingConfig.retryDelay="6s" \
+          --set poolingConfig.maxWaitTimeForTrace="30s" \
+          --set poolingConfig.retryDelay="500ms" \
           --set ingress.enabled=false \
           --wait --timeout 10m
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -19,6 +19,10 @@ services:
         condition: service_healthy
       jaeger:
         condition: service_healthy
+      demo-api:
+        condition: service_healthy
+      demo-rpc:
+        condition: service_healthy
 
   postgres:
     container_name: postgres
@@ -98,6 +102,11 @@ services:
       NPM_RUN_COMMAND: api
     ports:
       - "8081:8081"
+    healthcheck:
+      test: ["CMD", "wget", "--spider", "localhost:8081"]
+      interval: 1s
+      timeout: 3s
+      retries: 60
     depends_on:
       postgres:
         condition: service_healthy
@@ -121,6 +130,11 @@ services:
       NPM_RUN_COMMAND: rpc
     ports:
       - 8082:8082
+    healthcheck:
+      test: ["CMD","lsof", "-i", "8082"]
+      interval: 1s
+      timeout: 3s
+      retries: 60
     depends_on:
       postgres:
         condition: service_healthy

--- a/k8s/collector.yml
+++ b/k8s/collector.yml
@@ -16,7 +16,8 @@ data:
         hash_seed: 22
         sampling_percentage: 100
 
-      batch: {}
+      batch:
+        timeout: 100ms
 
     exporters:
       logging:

--- a/local-config/collector.config.yaml
+++ b/local-config/collector.config.yaml
@@ -7,6 +7,7 @@ receivers:
 
 processors:
   batch:
+    timeout: 100ms
 
   # Data sources: traces
   probabilistic_sampler:
@@ -30,5 +31,5 @@ service:
   pipelines:
     traces:
       receivers: [otlp]
-      processors: [batch, probabilistic_sampler]
-      exporters: [jaeger, otlphttp]
+      processors: [probabilistic_sampler, batch]
+      exporters: [logging, jaeger]

--- a/local-config/config.tests.yaml
+++ b/local-config/config.tests.yaml
@@ -1,8 +1,8 @@
 postgresConnString: "host=postgres user=postgres password=postgres port=5432 sslmode=disable"
 
 poolingConfig:
-  maxWaitTimeForTrace: 60s
-  retryDelay: 6s
+  maxWaitTimeForTrace: 30s
+  retryDelay: 200ms
 
 googleAnalytics:
   enabled: false

--- a/local-config/config.tests.yaml
+++ b/local-config/config.tests.yaml
@@ -2,7 +2,7 @@ postgresConnString: "host=postgres user=postgres password=postgres port=5432 ssl
 
 poolingConfig:
   maxWaitTimeForTrace: 30s
-  retryDelay: 200ms
+  retryDelay: 500ms
 
 googleAnalytics:
   enabled: false

--- a/server/tracing/tracer.go
+++ b/server/tracing/tracer.go
@@ -71,7 +71,7 @@ func getTracerProvider(ctx context.Context, config config.Config) (*sdktrace.Tra
 		return nil, fmt.Errorf("could not create exporter: %w", err)
 	}
 
-	processor := sdktrace.NewBatchSpanProcessor(exporter)
+	processor := sdktrace.NewBatchSpanProcessor(exporter, sdktrace.WithBatchTimeout(100*time.Millisecond))
 	sampleRate := exporterConfig.Sampling / 100.0
 
 	return sdktrace.NewTracerProvider(


### PR DESCRIPTION
This PR lowers the batching time out for the otel collector and server exporter to 100ms, so traces are almost instantly available to tracetest. This should result in more stable test results.

## Checklist

- [ ] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
