### PR TITLE
Query language reference link in the app should point to docs version

### DIFF
--- a/web/src/constants/Common.constants.ts
+++ b/web/src/constants/Common.constants.ts
@@ -15,8 +15,7 @@ export const RESOURCE_SEMANTIC_CONVENTIONS_URL =
 export const TRACE_DOCUMENTATION_URL =
   'https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/api.md';
 
-export const ADVANCE_SELECTORS_DOCUMENTATION_URL =
-  'https://github.com/kubeshop/tracetest/blob/main/docs/advanced-selectors.md';
+export const ADVANCE_SELECTORS_DOCUMENTATION_URL = 'https://kubeshop.github.io/tracetest/advanced-selectors/';
 
 export enum HTTP_METHOD {
   GET = 'GET',


### PR DESCRIPTION
This PR fixes the advanced selectors link in the app.

## Changes

- Advanced selectors link

## Fixes

- Fixes #971 

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
