### PR TITLE
Rendering issue in assertion results unless screen is wide

### DIFF
--- a/web/src/components/AssertionItem/AssertionItem.styled.ts
+++ b/web/src/components/AssertionItem/AssertionItem.styled.ts
@@ -26,6 +26,12 @@ export const AssertionCollapse = styled(Collapse)<{$isSelected: boolean}>`
   }
 `;
 
+export const CheckContainer = styled.div`
+  span {
+    overflow-wrap: anywhere;
+  }
+`;
+
 export const Column = styled.div`
   display: flex;
   flex-direction: column;

--- a/web/src/components/AssertionItem/CheckItem.tsx
+++ b/web/src/components/AssertionItem/CheckItem.tsx
@@ -12,7 +12,7 @@ const CheckItem = ({check}: IProps) => (
   <S.GridContainer>
     <S.Row>
       {check.result.passed ? <S.IconSuccess /> : <S.IconError />}
-      <div>
+      <S.CheckContainer>
         {check.assertion.attribute}
         {` `}
         <S.SecondaryText>
@@ -20,7 +20,7 @@ const CheckItem = ({check}: IProps) => (
         </S.SecondaryText>
         {` `}
         <AttributeValue value={check.assertion.expected} />
-      </div>
+      </S.CheckContainer>
     </S.Row>
 
     <S.Row $align="end">


### PR DESCRIPTION
This PR fixes a `word break` issue in the assertion check.

## Changes

- Word break css for assertion check

## Fixes

- Fixes #969

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Screenshot

![2022-07-22 17 05 03](https://user-images.githubusercontent.com/3879892/180574688-f4e853c6-9191-4e3f-ab2b-db44c40e9afc.gif)