### PR TITLE
Add missing slash

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -123,7 +123,7 @@ echo
 echo "--> install tracetest version $version to namespace $NAMESPACE"
 helm upgrade --install tracetest kubeshop/tracetest \
   --namespace $NAMESPACE --create-namespace \
-  --set telemetry.dataStores.${TRACE_BACKEND}.${TRACE_BACKEND}.endpoint="$TRACE_BACKEND_ENDPOINT"
+  --set telemetry.dataStores.${TRACE_BACKEND}.${TRACE_BACKEND}.endpoint="$TRACE_BACKEND_ENDPOINT" \
   --set server.telemetry.dataStore="${TRACE_BACKEND}"
 
 


### PR DESCRIPTION
Add missing backslash which fixes helm install command


## Changes

- Adds backslash to `helm upgrade --install` command

## Fixes

- Fixes installer

## Checklist

- [ ] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
