### PR TITLE
When adding a second check in an assertion, the operator does not default to equals

### DIFF
--- a/web/src/components/AssertionForm/AssertionFormCheck.tsx
+++ b/web/src/components/AssertionForm/AssertionFormCheck.tsx
@@ -65,6 +65,7 @@ export const AssertionFormCheck = ({
         name={[name, 'comparator']}
         rules={[{required: true, message: 'Operator is required'}]}
         data-cy="assertion-check-operator"
+        initialValue={operatorList[0].value}
       >
         <S.Select style={{margin: 0}} placeholder="Assertion Type">
           {operatorList.map(({value, label}) => (


### PR DESCRIPTION
This PR adds the `equals` operator as a default value when adding a new check.

## Changes

- Assertion form

## Fixes

- Fixes #968 

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Screenshot

![Screen Shot 2022-07-25 at 09 32 08](https://user-images.githubusercontent.com/3879892/180807884-baa8cac9-4194-4be0-8456-dc88105ed424.png)