### PR TITLE
🐛 973 fixing minor assertions issues

### DIFF
--- a/web/src/components/AdvancedEditor/AdvancedEditor.tsx
+++ b/web/src/components/AdvancedEditor/AdvancedEditor.tsx
@@ -37,6 +37,7 @@ const AdvancedEditor = ({testId, runId, onChange = noop, value = ''}: IProps) =>
         spellCheck={false}
         autoFocus
         theme={editorTheme}
+        placeholder="Selecting All Spans"
       />
     </S.AdvancedEditor>
   );

--- a/web/src/components/AssertionForm/AssertionFormSelector.tsx
+++ b/web/src/components/AssertionForm/AssertionFormSelector.tsx
@@ -49,7 +49,6 @@ const AssertionFormSelector = ({
       <Form.Item
         name="selectorList"
         rules={[
-          {required: true, message: 'At least one selector is required'},
           {
             validator: (_, value: TSpanSelector[]) =>
               SelectorService.validateSelector(
@@ -73,7 +72,6 @@ const AssertionFormSelector = ({
     <S.AdvancedSelectorInputContainer>
       <Form.Item
         name="selector"
-        rules={[{required: true, message: 'The selector cannot be empty'}]}
         validateTrigger={[]}
         hasFeedback
         help={!isValid ? 'Invalid selector' : ''}

--- a/web/src/components/AssertionForm/AssertionFormSelectorInput.tsx
+++ b/web/src/components/AssertionForm/AssertionFormSelectorInput.tsx
@@ -133,7 +133,7 @@ const AssertionFormSelectorInput: React.FC<TItemSelectorDropdownProps> = ({
   return (
     <S.SelectorContainer data-cy="assertion-form-selector-input">
       <MultiSelectInput
-        placeholder="Filter Spans"
+        placeholder="Selecting All Spans"
         onClear={handleClear}
         entryList={entryList}
         onStepEntry={handleOnStepEntry}

--- a/web/src/components/AssertionItem/AssertionHeader.tsx
+++ b/web/src/components/AssertionItem/AssertionHeader.tsx
@@ -26,10 +26,15 @@ const AssertionHeader = ({
   <S.Column>
     {isAdvancedMode || isAdvancedSelector ? (
       <div>
-        <S.HeaderText>{title}</S.HeaderText>
+        <S.HeaderText>{title || 'All Spans'}</S.HeaderText>
       </div>
     ) : (
       <S.SelectorContainer>
+        {!selectorList.length && (
+          <S.Selector>
+            <S.HeaderText>All Spans</S.HeaderText>
+          </S.Selector>
+        )}
         {selectorList.map(({key, value, operator}) => (
           <S.Selector key={`${key} ${operator} ${value}`}>
             <S.HeaderTextSecondary>

--- a/web/src/selectors/Assertion.selectors.ts
+++ b/web/src/selectors/Assertion.selectors.ts
@@ -1,4 +1,5 @@
 import {createSelector} from '@reduxjs/toolkit';
+import {sortBy} from 'lodash';
 
 import {endpoints} from 'redux/apis/TraceTest.api';
 import {RootState} from 'redux/store';
@@ -31,7 +32,14 @@ const selectAffectedSpanList = createSelector(stateSelector, paramsSelector, (st
 const AssertionSelectors = () => {
   return {
     selectAffectedSpanList,
-    selectAttributeList: createSelector(selectAffectedSpanList, SpanSelectors.selectAffectedSpans, (spanList, affectedSpans) => spanList.flatMap(span => span.attributeList).concat(SpanAttributeService.getPseudoAttributeList(affectedSpans.length))),
+    selectAttributeList: createSelector(
+      selectAffectedSpanList,
+      SpanSelectors.selectAffectedSpans,
+      (spanList, affectedSpans) =>
+        spanList
+          .flatMap(span => span.attributeList)
+          .concat(SpanAttributeService.getPseudoAttributeList(affectedSpans.length))
+    ),
     selectAllAttributeList: createSelector(stateSelector, paramsSelector, (state, {testId, runId}) => {
       const {data: {trace} = {}} = endpoints.getRunById.select({testId, runId})(state);
 
@@ -43,9 +51,12 @@ const AssertionSelectors = () => {
       selectAffectedSpanList,
       currentSelectorListSelector,
       (spanList, currentSelectorList) =>
-        SpanAttributeService.getFilteredSelectorAttributeList(
-          spanList.flatMap(span => span.attributeList),
-          currentSelectorList
+        sortBy(
+          SpanAttributeService.getFilteredSelectorAttributeList(
+            spanList.flatMap(span => span.attributeList),
+            currentSelectorList
+          ),
+          'key'
         )
     ),
   };


### PR DESCRIPTION
This PR fixes some issues regarding the assertion form. including:
1. Attribute list for checks not being in alphabetical order.
2. Not able to select all spans

## Changes

- Removing the required rules for the selector input.
- Adding a sorting for when fetching the attribute list.

## Fixes

- https://github.com/kubeshop/tracetest/issues/974
- https://github.com/kubeshop/tracetest/issues/973

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
