### PR TITLE
Fix selected assertion

### DIFF
--- a/web/src/components/AssertionItem/AssertionItem.tsx
+++ b/web/src/components/AssertionItem/AssertionItem.tsx
@@ -23,7 +23,7 @@ interface IProps {
   onSelectSpan(spanId: string): void;
   onSetFocusedSpan(spanId: string): void;
   onSetSelectedAssertion(assertionResult?: TAssertionResultEntry): void;
-  selectedAssertion: string;
+  selectedAssertion?: string;
   selectedSpan?: string;
   trace?: TTrace;
   viewResultsMode: ResultViewModes;

--- a/web/src/redux/slices/TestDefinition.slice.ts
+++ b/web/src/redux/slices/TestDefinition.slice.ts
@@ -11,7 +11,7 @@ export const initialState: ITestDefinitionState = {
   changeList: [],
   isLoading: false,
   isInitialized: false,
-  selectedAssertion: '',
+  selectedAssertion: undefined,
   isDraftMode: false,
   viewResultsMode: UserPreferencesService.getUserPreference('viewResultsMode'),
 };
@@ -105,7 +105,7 @@ const testDefinitionSlice = createSlice<ITestDefinitionState, TTestDefinitionSli
     },
     setSelectedAssertion(state, {payload: assertionResult}) {
       if (assertionResult) state.selectedAssertion = assertionResult.selector;
-      else state.selectedAssertion = '';
+      else state.selectedAssertion = undefined;
     },
   },
   extraReducers: builder => {

--- a/web/src/redux/slices/__tests__/TestDefinition.slice.test.ts
+++ b/web/src/redux/slices/__tests__/TestDefinition.slice.test.ts
@@ -221,7 +221,7 @@ describe('TestDefinitionReducer', () => {
     it('should handle on setSelectedAssertion with empty value', () => {
       const result = Reducer({...initialState, selectedAssertion: '12345'}, setSelectedAssertion());
 
-      expect(result.selectedAssertion).toEqual('');
+      expect(result.selectedAssertion).toBeUndefined();
     });
   });
 });

--- a/web/src/services/Assertion.service.ts
+++ b/web/src/services/Assertion.service.ts
@@ -5,7 +5,7 @@ import {TAssertionResult, ICheckResult, TRawAssertionResult} from 'types/Asserti
 
 const AssertionService = () => ({
   getSpanIds(resultList: TRawAssertionResult[]) {
-    const spanIds = resultList.flatMap(assertion => assertion?.spanResults?.map(span => span.spanId ?? '') ?? []);
+    const spanIds = resultList.flatMap(assertion => assertion?.spanResults?.map(span => span.spanId ?? '') ?? []).filter(spanId => Boolean(spanId));
     return uniq(spanIds);
   },
 

--- a/web/src/types/TestDefinition.types.ts
+++ b/web/src/types/TestDefinition.types.ts
@@ -34,7 +34,7 @@ export interface ITestDefinitionState {
   changeList: TChange[];
   isLoading: boolean;
   isInitialized: boolean;
-  selectedAssertion: string;
+  selectedAssertion: string | undefined;
   isDraftMode: boolean;
   viewResultsMode: ResultViewModes;
 }


### PR DESCRIPTION
With the changed introduce in #974, we were having an incorrect behavior in the `select assertion` logic when you add an empty selector (to select all spans). 

The problem is caused because we use the `selector` as an identifier of the assertion, but now (having it as empty) it was collapsing with the logic for a `non-selected` assertion.

## Changes

- Change the `selectedAssertion` state to be `undefined` if no assertion is selected.

## Fixes

- #974 

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
