### PR TITLE
Add pagination in Test list

### DIFF
--- a/web/src/gateways/Test.gateway.ts
+++ b/web/src/gateways/Test.gateway.ts
@@ -5,7 +5,7 @@ const {createTest, getTestById, getTestList, runTest} = endpoints;
 
 const TestGateway = () => ({
   getList() {
-    return getTestList.initiate();
+    return getTestList.initiate({});
   },
   getById(testId: string) {
     return getTestById.initiate({testId});

--- a/web/src/gateways/__tests__/Test.gateway.test.ts
+++ b/web/src/gateways/__tests__/Test.gateway.test.ts
@@ -36,7 +36,7 @@ describe('TestGateway', () => {
     expect.assertions(1);
     await TestGateway.getList();
 
-    expect(getTestList.initiate).toBeCalledWith();
+    expect(getTestList.initiate).toBeCalledWith({});
   });
 
   it('should execute the runTest function', async () => {

--- a/web/src/pages/Home/Home.styled.tsx
+++ b/web/src/pages/Home/Home.styled.tsx
@@ -42,9 +42,7 @@ export const NoResultsIcon = styled.img.attrs({
   src: noResultsIcon,
 })``;
 
-export const NoResultsTitle = styled(Typography.Title).attrs({
-  level: 3,
-})`
+export const NoResultsTitle = styled(Typography.Title)`
   margin-top: 32px;
 `;
 

--- a/web/src/pages/Home/NoResults.tsx
+++ b/web/src/pages/Home/NoResults.tsx
@@ -6,8 +6,8 @@ const NoResults: FC = () => {
   return (
     <S.NoResultsContainer>
       <S.NoResultsIcon />
-      <S.NoResultsTitle>The are no test to show</S.NoResultsTitle>
-      <Typography.Text>Please create the new test</Typography.Text>
+      <S.NoResultsTitle>There are no test to show</S.NoResultsTitle>
+      <Typography.Text>Start by creating a new test</Typography.Text>
     </S.NoResultsContainer>
   );
 };

--- a/web/src/pages/Home/TestList.tsx
+++ b/web/src/pages/Home/TestList.tsx
@@ -1,18 +1,23 @@
 import {useCallback} from 'react';
 import {useNavigate} from 'react-router-dom';
+
+import InfiniteScroll from 'components/InfiniteScroll';
+import TestCard from 'components/TestCard';
+import useInfiniteScroll from 'hooks/useInfiniteScroll';
+import {useGetTestListQuery, useRunTestMutation} from 'redux/apis/TraceTest.api';
 import HomeAnalyticsService from 'services/Analytics/HomeAnalytics.service';
 import TestAnalyticsService from 'services/Analytics/TestAnalytics.service';
-import TestCard from '../../components/TestCard';
-import {useGetTestListQuery, useRunTestMutation} from '../../redux/apis/TraceTest.api';
+import {TTest} from 'types/Test.types';
 import * as S from './Home.styled';
+import NoResults from './NoResults';
 import {useMenuDeleteCallback} from './useMenuDeleteCallback';
 
 const {onTestClick} = HomeAnalyticsService;
 
 const TestList = () => {
   const navigate = useNavigate();
-  const {data: testList = []} = useGetTestListQuery();
   const [runTest] = useRunTestMutation();
+  const {list: resultList, hasMore, loadMore, isLoading} = useInfiniteScroll<TTest, {}>(useGetTestListQuery, {});
 
   const onClick = useCallback(
     (testId: string) => {
@@ -36,11 +41,19 @@ const TestList = () => {
   const onDelete = useMenuDeleteCallback();
 
   return (
-    <S.TestListContainer data-cy="test-list">
-      {testList?.map(test => (
-        <TestCard test={test} onClick={onClick} onDelete={onDelete} onRunTest={onRunTest} key={test.id} />
-      ))}
-    </S.TestListContainer>
+    <InfiniteScroll
+      loadMore={loadMore}
+      isLoading={isLoading}
+      hasMore={hasMore}
+      shouldTrigger={Boolean(resultList.length)}
+      emptyComponent={<NoResults />}
+    >
+      <S.TestListContainer data-cy="test-list">
+        {resultList?.map(test => (
+          <TestCard test={test} onClick={onClick} onDelete={onDelete} onRunTest={onRunTest} key={test.id} />
+        ))}
+      </S.TestListContainer>
+    </InfiniteScroll>
   );
 };
 

--- a/web/src/redux/apis/TraceTest.api.ts
+++ b/web/src/redux/apis/TraceTest.api.ts
@@ -48,8 +48,8 @@ const TraceTestAPI = createApi({
         {type: Tags.TEST, id: test?.id},
       ],
     }),
-    getTestList: build.query<TTest[], void>({
-      query: () => '/tests',
+    getTestList: build.query<TTest[], {take?: number; skip?: number}>({
+      query: ({take = 25, skip = 0}) => `/tests?take=${take}&skip=${skip}`,
       providesTags: () => [{type: Tags.TEST, id: 'LIST'}],
       transformResponse: (rawTestList: TTest[]) => rawTestList.map(rawTest => Test(rawTest)),
     }),

--- a/web/src/redux/apis/__tests__/useGetTestListQuery.test.tsx
+++ b/web/src/redux/apis/__tests__/useGetTestListQuery.test.tsx
@@ -5,7 +5,7 @@ import {useGetTestListQuery} from '../TraceTest.api';
 
 test('useGetTestListQuery', async () => {
   fetchMock.mockResponse(JSON.stringify([{testId: '24'}]));
-  const {result, waitForNextUpdate} = renderHook(() => useGetTestListQuery(), {
+  const {result, waitForNextUpdate} = renderHook(() => useGetTestListQuery({}), {
     wrapper: ReduxWrapperProvider,
   });
   expect(result.current.isLoading).toBeTruthy();


### PR DESCRIPTION
This PR adds support for infinite scroll pagination in the Test list.

## Changes

- Implement the infinite scroll hook in the Test list

## Fixes

- Fixes #991 

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
