### PR TITLE
Fix setup script

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -142,7 +142,7 @@ if [ "$SKIP_COLLECTOR" != "YES" ]; then
     echo
     echo
 
-    ./k8s/deploy-collector.sh
+    kubectl apply -f https://raw.githubusercontent.com/kubeshop/tracetest/main/k8s/collector.yml
 fi
 
 if [ "$SKIP_BACKEND" != "YES" ]; then


### PR DESCRIPTION
This PR fixes the setup script when calling it remotely by removing the dependency on the local `k8s/deploy-collector.sh` script.

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
