### PR TITLE
👁  Adding extra server info to all analytics events

### DIFF
--- a/web/src/components/WithAnalytics/WithAnalytics.tsx
+++ b/web/src/components/WithAnalytics/WithAnalytics.tsx
@@ -5,7 +5,7 @@ const withAnalytics = <P extends object>(Component: React.ComponentType<P>, name
   const FunctionComponent = (props: P) => {
     useEffect(() => {
       AnalyticsService.page(name);
-    }, []);
+    }, [props]);
 
     return <Component {...props} />;
   };

--- a/web/src/services/Analytics/Analytics.service.ts
+++ b/web/src/services/Analytics/Analytics.service.ts
@@ -15,13 +15,20 @@ const AnalyticsService = (): TAnalyticsService => ({
   event<A>(category: Categories, action: A, label: string) {
     if (!isEnabled) return;
     analytics.track(String(action), {
+      serverID,
+      appVersion,
+      env,
       label,
       category,
     });
   },
   page(name: string) {
     if (!isEnabled) return;
-    analytics.page(name);
+    analytics.page(name, {
+      serverID,
+      appVersion,
+      env,
+    });
   },
   identify() {
     if (!isEnabled) return;

--- a/web/src/types/Common.types.ts
+++ b/web/src/types/Common.types.ts
@@ -34,9 +34,9 @@ export type TFilter = TTestSchemas['SelectorFilter'];
 export type Model<T, R> = Modify<Required<T>, R>;
 
 export interface IAnalytics {
-  identify(traits: Record<string, string>): void;
-  track(event: string, traits: {[key: string]: any}): void;
-  page(pageName: string): void;
+  identify(traits: Record<string, any>): void;
+  track(event: string, traits: Record<string, any>): void;
+  page(pageName: string, traits: Record<string, any>): void;
 }
 
 export declare type RecursivePartial<T> = T extends object


### PR DESCRIPTION
This PR adds the server-side info to all of the analytics events (track, page, identify).

## Changes
- Adds the server info to each analytics method.

## Fixes

- Analytics

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
