### PR TITLE
Upgrade ansi-regex to 4.1.1

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -46798,9 +46798,9 @@
           }
         },
         "ansi-regex": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg=="
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.1.tgz",
+          "integrity": "sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g=="
         },
         "diff-sequences": {
           "version": "24.9.0",


### PR DESCRIPTION
Signed-off-by: Israel Blancas <iblancasa@gmail.com>

## Changes

- Upgrade `ansi-regex` dependency from `4.1.0` to `4.1.1`.

## Fixes

- [CVE-2021-3807](https://nvd.nist.gov/vuln/detail/CVE-2021-3807)

## Checklist

- [x] tested locally

# Description
The project is using ansi-regex 4.1.0. It seems to be a transitive dependency. That dependency has a vulnerability ([CVE-2021-3807](https://nvd.nist.gov/vuln/detail/CVE-2021-3807)). Upgrading it to 4.1.1, solves the problem