### PR TITLE
fix: don't match parent span when child selector is provided

### DIFF
--- a/server/assertions/selectors/search.go
+++ b/server/assertions/selectors/search.go
@@ -11,6 +11,8 @@ func filterSpans(rootSpan traces.Span, spanSelector SpanSelector) []traces.Span 
 		if spanSelector.MatchesFilters(span) {
 			if spanSelector.ChildSelector != nil {
 				childFilteredSpans := filterSpans(span, *spanSelector.ChildSelector)
+				// filteredSpans include the parent span, so we have to remove it
+				childFilteredSpans = removeSpanFromList(childFilteredSpans, span.ID)
 				filteredSpans = append(filteredSpans, childFilteredSpans...)
 			} else {
 				filteredSpans = append(filteredSpans, span)
@@ -47,4 +49,16 @@ func filterDuplicated(spans []traces.Span) []traces.Span {
 	}
 
 	return uniqueSpans
+}
+
+func removeSpanFromList(spans []traces.Span, id trace.SpanID) []traces.Span {
+	idString := id.String()
+	list := make([]traces.Span, 0, len(spans))
+	for _, span := range spans {
+		if span.ID.String() != idString {
+			list = append(list, span)
+		}
+	}
+
+	return list
 }

--- a/server/assertions/selectors/selector_test.go
+++ b/server/assertions/selectors/selector_test.go
@@ -118,6 +118,11 @@ func TestSelector(t *testing.T) {
 			Expression:      `span[tracetest.span.type="db"]:nth_child(2)`,
 			ExpectedSpanIds: []trace.SpanID{updatePokemonDatabaseSpanID},
 		},
+		{
+			Name:            "Selector should not match parent when children are specified",
+			Expression:      `span[service.name = "Pokeshop-worker"] span[service.name = "Pokeshop-worker"]`,
+			ExpectedSpanIds: []trace.SpanID{updatePokemonDatabaseSpanID},
+		},
 	}
 
 	for _, testCase := range testCases {


### PR DESCRIPTION
This PR makes the selector doesn't match the parent span when a child span is provided.


## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [x] added a test
