### PR TITLE
Add homebrew support to cli install script

### DIFF
--- a/docs/installing.md
+++ b/docs/installing.md
@@ -96,17 +96,21 @@ helm delete tracetest
 ## CLI Installation
 Every time we release a new version of Tracetest, we generate binaries for Linux, MacOS, and Windows. Supporting both amd64, and ARM64 architectures. You can find the latest version [here](https://github.com/kubeshop/tracetest/releases/latest).
 
-### Linux
+### Linux/Mac
+
+We provide an install script that automatically uses the best available method for install. 
 
 ```sh
 curl -L https://raw.githubusercontent.com/kubeshop/tracetest/main/install-cli.sh | bash
 ```
 
-### MacOS
+You can also manually use homebrew:
 
 ```sh
 brew install kubeshop/tracetest/tracetest
 ```
+
+Or you can manually download the release packages from our [release page](https://github.com/kubeshop/tracetest/releases)
 
 ### Windows
 Download one of the files from the latest tag, extract to your machine, and then [add the tracetest binary to your PATH variable](https://stackoverflow.com/a/41895179)

--- a/install-cli.sh
+++ b/install-cli.sh
@@ -84,11 +84,15 @@ install_rpm() {
   sudo rpm -i $file_path
 }
 
+install_homebrew() {
+  brew install kubeshop/tracetest/tracetest
+}
+
 run() {
     ensure_required_dependencies_are_present
 
     os=$(get_os)
-    if [ "$os" != "linux" ]; then
+    if [ "$os" = "windows" ]; then
       echo $os 'OS not supported by this script. See https://kubeshop.github.io/tracetest/installing/#cli-installation'
       exit 1
     fi
@@ -96,13 +100,10 @@ run() {
     latest_version=`get_latest_version`
     arch=`get_arch`
 
-    if cmd_exists dpkg; then
+    if cmd_exists brew; then
+      install_homebrew
+    elif cmd_exists dpkg; then
       download_link=`get_download_link $os $arch $latest_version deb`
-      echo
-      echo
-      echo $download_link
-      echo
-      echo
       install_dpkg $download_link
     elif cmd_exists rpm; then
       download_link=`get_download_link $os $arch $latest_version rpm`


### PR DESCRIPTION
This PR adds support for homebrew in the CLI setup script. This allows to use the same script on Mac, and support linux users with Homebrew installed.

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [x] updated the docs
- [ ] added a test
