### PR TITLE
🐛 1035 minor fixes

### DIFF
--- a/web/src/components/AdvancedEditor/AdvancedEditor.styled.ts
+++ b/web/src/components/AdvancedEditor/AdvancedEditor.styled.ts
@@ -7,9 +7,6 @@ export const AdvancedEditor = styled.div`
     .cm-editor {
       border-radius: 2px;
       font-size: ${({theme}) => theme.size.md};
-    }
-
-    .cm-focused {
       outline: 1px solid ${({theme}) => theme.color.primary};
     }
 

--- a/web/src/components/Diagram/components/DAG/DAG.tsx
+++ b/web/src/components/Diagram/components/DAG/DAG.tsx
@@ -2,12 +2,12 @@ import ReactFlow, {MiniMap} from 'react-flow-renderer';
 
 import {IDiagramComponentProps} from 'components/Diagram/Diagram';
 import {Steps} from 'components/GuidedTour/traceStepList';
+import {useAssertionForm} from 'components/AssertionForm/AssertionForm.provider';
 import {useDAG} from 'providers/DAG';
 import GuidedTourService, {GuidedTours} from 'services/GuidedTour.service';
 import Controls from './Controls';
 import * as S from './DAG.styled';
 import SpanNode from './SpanNode';
-import { useAssertionForm } from 'components/AssertionForm/AssertionForm.provider';
 
 /** Important to define the nodeTypes outside of the component to prevent re-renderings */
 const nodeTypes = {span: SpanNode};

--- a/web/src/components/Diagram/components/DAG/DAG.tsx
+++ b/web/src/components/Diagram/components/DAG/DAG.tsx
@@ -7,17 +7,19 @@ import GuidedTourService, {GuidedTours} from 'services/GuidedTour.service';
 import Controls from './Controls';
 import * as S from './DAG.styled';
 import SpanNode from './SpanNode';
+import { useAssertionForm } from '../../../AssertionForm/AssertionForm.provider';
 
 /** Important to define the nodeTypes outside of the component to prevent re-renderings */
 const nodeTypes = {span: SpanNode};
 
 const DAG = ({affectedSpans}: IDiagramComponentProps) => {
   const {edges, isMiniMapActive, nodes, onMiniMapToggle, onNodesChange, onNodeClick} = useDAG();
+  const {isOpen} = useAssertionForm();
 
   return (
     <S.Container
       data-tour={GuidedTourService.getStep(GuidedTours.Trace, Steps.Graph)}
-      $showAffected={affectedSpans.length > 0}
+      $showAffected={affectedSpans.length > 0 || isOpen}
       data-cy="diagram-dag"
     >
       <Controls isMiniMapActive={isMiniMapActive} onMiniMapToggle={onMiniMapToggle} />

--- a/web/src/components/Diagram/components/DAG/DAG.tsx
+++ b/web/src/components/Diagram/components/DAG/DAG.tsx
@@ -7,7 +7,7 @@ import GuidedTourService, {GuidedTours} from 'services/GuidedTour.service';
 import Controls from './Controls';
 import * as S from './DAG.styled';
 import SpanNode from './SpanNode';
-import { useAssertionForm } from '../../../AssertionForm/AssertionForm.provider';
+import { useAssertionForm } from 'components/AssertionForm/AssertionForm.provider';
 
 /** Important to define the nodeTypes outside of the component to prevent re-renderings */
 const nodeTypes = {span: SpanNode};


### PR DESCRIPTION
This PR fixes the issue where the advanced editor looked like read-only when not focusing it and the issue regarding the selector not matching any spans looked like the spans were active.

## Changes

- Advanced editor outline is always visible.
- Adding OR condition for create assertion form status.

## Fixes

- https://github.com/kubeshop/tracetest/issues/1035
- https://github.com/kubeshop/tracetest/issues/1036

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
