### PR TITLE
Fix fit in view function from the DAG

### DIFF
--- a/web/src/components/Diagram/components/DAG/DAG.tsx
+++ b/web/src/components/Diagram/components/DAG/DAG.tsx
@@ -28,6 +28,7 @@ const DAG = ({affectedSpans}: IDiagramComponentProps) => {
         nodes={nodes}
         deleteKeyCode={null}
         fitView
+        minZoom={0.1}
         multiSelectionKeyCode={null}
         nodesConnectable={false}
         nodeTypes={nodeTypes}


### PR DESCRIPTION
This PR sets the DAG min zoom to `0.1` to make the `fit-view` action work properly.

## Changes

- DAG min zoom.

## Fixes

- Fixes #1037 

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Screenshot

![2022-08-08 11 52 59](https://user-images.githubusercontent.com/3879892/183475836-8f0d1ea0-7f02-4d34-a7d5-8f1355b6f87d.gif)\