### PR TITLE
Rename "unknown" spans to "general" in backend

### DIFF
--- a/server/traces/otel_converter.go
+++ b/server/traces/otel_converter.go
@@ -94,7 +94,7 @@ func spanType(attrs Attributes) string {
 			return "exception"
 		}
 	}
-	return "unknown"
+	return "general"
 }
 
 func getAttributeValue(value *v11.AnyValue) string {


### PR DESCRIPTION
This PR changes the spans with no defined type from semantic conventions from "unknown" to "general" in the backend

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
