### PR TITLE
add workflow to test installer

### DIFF
--- a/.github/workflows/pull-request-installer.yaml
+++ b/.github/workflows/pull-request-installer.yaml
@@ -41,5 +41,10 @@ jobs:
               ;;
           esac
         run: |
+          echo
+          echo "ARCH"
+          uname -p
+          echo
+
           curl -L https://raw.githubusercontent.com/kubeshop/tracetest/main/install-cli.sh | sh
           tracetest

--- a/.github/workflows/pull-request-installer.yaml
+++ b/.github/workflows/pull-request-installer.yaml
@@ -1,0 +1,43 @@
+name: Installer Pull Request
+on:
+  push:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+    branches:
+      - main
+    paths:
+      - install-cli.sh
+
+jobs:
+  linux:
+    name: Linux
+    strategy:
+      matrix:
+        distro: [ubuntu_latest, fedora_latest, alpine_latest]
+        arch: [armv7, aarch64]
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+    - uses: uraimo/run-on-arch-action@v2
+      name: install on ${{ matrix.distro }} ${{ matrix.arch }}
+      with:
+        distro: ${{ matrix.distro }}
+        arch: ${{ matrix.arch }}
+        run: |
+          curl -L https://raw.githubusercontent.com/kubeshop/tracetest/main/install-cli.sh | bash
+          tracetest
+  mac:
+    name: MacOS
+    runs-on: macos-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+    - name: install
+      run: |
+        /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+        curl -L https://raw.githubusercontent.com/kubeshop/tracetest/main/install-cli.sh | bash
+        tracetest

--- a/.github/workflows/pull-request-installer.yaml
+++ b/.github/workflows/pull-request-installer.yaml
@@ -1,6 +1,5 @@
 name: Installer Pull Request
 on:
-  push:
   pull_request:
     types:
       - opened

--- a/.github/workflows/pull-request-installer.yaml
+++ b/.github/workflows/pull-request-installer.yaml
@@ -18,17 +18,28 @@ jobs:
         options: -v ${{ github.workspace }}:/app -e GITHUB_SHA
         run: |
          case "${{ matrix.distro }}" in
-            ubuntu*|jessie|stretch|buster|bullseye)
+            ubuntu)
               apt-get update -q -y
               apt-get install -q -y curl
               ;;
-            fedora*)
+            fedora)
               yum install -y curl --refresh
               ;;
-            alpine*)
+            alpine)
               apk add --update curl
               ;;
           esac
 
           curl -L https://raw.githubusercontent.com/kubeshop/tracetest/${GITHUB_SHA}/install-cli.sh | sh
           tracetest
+
+  macos:
+    name: MacOS
+    runs-on: macos-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+    - run: |
+        /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+        curl -L https://raw.githubusercontent.com/kubeshop/tracetest/${GITHUB_SHA}/install-cli.sh | sh
+        tracetest

--- a/.github/workflows/pull-request-installer.yaml
+++ b/.github/workflows/pull-request-installer.yaml
@@ -38,6 +38,20 @@ jobs:
       uses: actions/checkout@v3
     - name: install
       run: |
+        case "${{ matrix.distro }}" in
+          ubuntu*|jessie|stretch|buster|bullseye)
+            apt-get update -q -y
+            apt-get install -q -y curl
+            ;;
+          fedora*)
+            dnf -y update
+            dnf -y install curl
+            ;;
+          alpine*)
+            apk update
+            apk add curl
+            ;;
+        esac
         /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
         curl -L https://raw.githubusercontent.com/kubeshop/tracetest/main/install-cli.sh | bash
         tracetest

--- a/.github/workflows/pull-request-installer.yaml
+++ b/.github/workflows/pull-request-installer.yaml
@@ -24,7 +24,7 @@ jobs:
       uses: addnab/docker-run-action@v3
       with:
         image: ${{matrix.distro}}
-        options: -v ${{ github.workspace }}:/app -e COMMIT=$GITHUB_SHA
+        options: -v ${{ github.workspace }}:/app -e GITHUB_SHA
         run: |
           echo
           echo "ARCH"
@@ -44,6 +44,6 @@ jobs:
               ;;
           esac
 
-          echo "Commit: " ${COMMIT}
+          echo "Commit: " ${GITHUB_SHA}
           curl -L https://raw.githubusercontent.com/kubeshop/tracetest/${COMMIT}/install-cli.sh | sh
           tracetest

--- a/.github/workflows/pull-request-installer.yaml
+++ b/.github/workflows/pull-request-installer.yaml
@@ -38,6 +38,7 @@ jobs:
       uses: actions/checkout@v3
     - name: install
       run: |
+        echo "running on ${{ matrix.distro }}"
         case "${{ matrix.distro }}" in
           ubuntu*|jessie|stretch|buster|bullseye)
             apt-get update -q -y

--- a/.github/workflows/pull-request-installer.yaml
+++ b/.github/workflows/pull-request-installer.yaml
@@ -44,6 +44,6 @@ jobs:
               ;;
           esac
 
-          echo "Commit: " ${GITHUB_SHA}
-          curl -L https://raw.githubusercontent.com/kubeshop/tracetest/${COMMIT}/install-cli.sh | sh
+          echo https://raw.githubusercontent.com/kubeshop/tracetest/${GITHUB_SHA}/install-cli.sh
+          curl -L https://raw.githubusercontent.com/kubeshop/tracetest/${GITHUB_SHA}/install-cli.sh | sh
           tracetest

--- a/.github/workflows/pull-request-installer.yaml
+++ b/.github/workflows/pull-request-installer.yaml
@@ -32,14 +32,3 @@ jobs:
 
           curl -L https://raw.githubusercontent.com/kubeshop/tracetest/${GITHUB_SHA}/install-cli.sh | sh
           tracetest
-
-  macos:
-    name: MacOS
-    runs-on: macos-latest
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v3
-    - run: |
-        /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
-        curl -L https://raw.githubusercontent.com/kubeshop/tracetest/${GITHUB_SHA}/install-cli.sh | sh
-        tracetest

--- a/.github/workflows/pull-request-installer.yaml
+++ b/.github/workflows/pull-request-installer.yaml
@@ -41,5 +41,5 @@ jobs:
               ;;
           esac
         run: |
-          curl -L https://raw.githubusercontent.com/kubeshop/tracetest/main/install-cli.sh | bash
+          curl -L https://raw.githubusercontent.com/kubeshop/tracetest/main/install-cli.sh | sh
           tracetest

--- a/.github/workflows/pull-request-installer.yaml
+++ b/.github/workflows/pull-request-installer.yaml
@@ -15,7 +15,7 @@ jobs:
     name: Linux
     strategy:
       matrix:
-        distro: [ubuntu, fedora, alpine]
+        distro: [ubuntu]
     runs-on: ubuntu-latest
     steps:
     - name: Checkout

--- a/.github/workflows/pull-request-installer.yaml
+++ b/.github/workflows/pull-request-installer.yaml
@@ -1,14 +1,5 @@
 name: Installer Pull Request
-on:
-  pull_request:
-    types:
-      - opened
-      - reopened
-      - synchronize
-    branches:
-      - main
-    paths:
-      - install-cli.sh
+on: [push]
 
 jobs:
   linux:

--- a/.github/workflows/pull-request-installer.yaml
+++ b/.github/workflows/pull-request-installer.yaml
@@ -16,17 +16,16 @@ jobs:
     name: Linux
     strategy:
       matrix:
-        distro: [ubuntu_latest, fedora_latest, alpine_latest]
-        arch: [armv7, aarch64]
+        distro: [ubuntu, fedora, alpine]
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
       uses: actions/checkout@v3
-    - uses: uraimo/run-on-arch-action@v2
-      name: install on ${{ matrix.distro }} ${{ matrix.arch }}
+    - name: ${{ matrix.distro }}
+      uses: addnab/docker-run-action@v3
       with:
-        distro: ${{ matrix.distro }}
-        arch: ${{ matrix.arch }}
+        image: ${{matrix.distro}}
+        options: -v ${{ github.workspace }}:/app -e COMMIT=$GITHUB_SHA
         run: |
           echo
           echo "ARCH"
@@ -46,5 +45,5 @@ jobs:
               ;;
           esac
 
-          curl -L https://raw.githubusercontent.com/kubeshop/tracetest/main/install-cli.sh | sh
+          curl -L https://raw.githubusercontent.com/kubeshop/tracetest/${COMMIT}/install-cli.sh | sh
           tracetest

--- a/.github/workflows/pull-request-installer.yaml
+++ b/.github/workflows/pull-request-installer.yaml
@@ -27,7 +27,12 @@ jobs:
       with:
         distro: ${{ matrix.distro }}
         arch: ${{ matrix.arch }}
-        install: |
+        run: |
+          echo
+          echo "ARCH"
+          uname -p
+          echo
+
           case "${{ matrix.distro }}" in
             ubuntu*|jessie|stretch|buster|bullseye)
               apt-get update -q -y
@@ -40,11 +45,6 @@ jobs:
               apk add --update curl
               ;;
           esac
-        run: |
-          echo
-          echo "ARCH"
-          uname -p
-          echo
 
           curl -L https://raw.githubusercontent.com/kubeshop/tracetest/main/install-cli.sh | sh
           tracetest

--- a/.github/workflows/pull-request-installer.yaml
+++ b/.github/workflows/pull-request-installer.yaml
@@ -26,12 +26,7 @@ jobs:
         image: ${{matrix.distro}}
         options: -v ${{ github.workspace }}:/app -e GITHUB_SHA
         run: |
-          echo
-          echo "ARCH"
-          uname -p
-          echo
-
-          case "${{ matrix.distro }}" in
+         case "${{ matrix.distro }}" in
             ubuntu*|jessie|stretch|buster|bullseye)
               apt-get update -q -y
               apt-get install -q -y curl

--- a/.github/workflows/pull-request-installer.yaml
+++ b/.github/workflows/pull-request-installer.yaml
@@ -15,7 +15,7 @@ jobs:
     name: Linux
     strategy:
       matrix:
-        distro: [ubuntu, fedora]
+        distro: [ubuntu, fedora, alpine]
     runs-on: ubuntu-latest
     steps:
     - name: Checkout

--- a/.github/workflows/pull-request-installer.yaml
+++ b/.github/workflows/pull-request-installer.yaml
@@ -30,29 +30,3 @@ jobs:
         run: |
           curl -L https://raw.githubusercontent.com/kubeshop/tracetest/main/install-cli.sh | bash
           tracetest
-  mac:
-    name: MacOS
-    runs-on: macos-latest
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v3
-    - name: install
-      run: |
-        echo "running on ${{ matrix.distro }}"
-        case "${{ matrix.distro }}" in
-          ubuntu*|jessie|stretch|buster|bullseye)
-            apt-get update -q -y
-            apt-get install -q -y curl
-            ;;
-          fedora*)
-            dnf -y update
-            dnf -y install curl
-            ;;
-          alpine*)
-            apk update
-            apk add curl
-            ;;
-        esac
-        /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
-        curl -L https://raw.githubusercontent.com/kubeshop/tracetest/main/install-cli.sh | bash
-        tracetest

--- a/.github/workflows/pull-request-installer.yaml
+++ b/.github/workflows/pull-request-installer.yaml
@@ -44,5 +44,6 @@ jobs:
               ;;
           esac
 
+          echo "Commit: " ${COMMIT}
           curl -L https://raw.githubusercontent.com/kubeshop/tracetest/${COMMIT}/install-cli.sh | sh
           tracetest

--- a/.github/workflows/pull-request-installer.yaml
+++ b/.github/workflows/pull-request-installer.yaml
@@ -15,7 +15,7 @@ jobs:
     name: Linux
     strategy:
       matrix:
-        distro: [ubuntu]
+        distro: [ubuntu, fedora]
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
@@ -44,6 +44,5 @@ jobs:
               ;;
           esac
 
-          echo https://raw.githubusercontent.com/kubeshop/tracetest/${GITHUB_SHA}/install-cli.sh
           curl -L https://raw.githubusercontent.com/kubeshop/tracetest/${GITHUB_SHA}/install-cli.sh | sh
           tracetest

--- a/.github/workflows/pull-request-installer.yaml
+++ b/.github/workflows/pull-request-installer.yaml
@@ -27,6 +27,19 @@ jobs:
       with:
         distro: ${{ matrix.distro }}
         arch: ${{ matrix.arch }}
+        install: |
+          case "${{ matrix.distro }}" in
+            ubuntu*|jessie|stretch|buster|bullseye)
+              apt-get update -q -y
+              apt-get install -q -y curl
+              ;;
+            fedora*)
+              yum install -y curl --refresh
+              ;;
+            alpine*)
+              apk add --update curl
+              ;;
+          esac
         run: |
           curl -L https://raw.githubusercontent.com/kubeshop/tracetest/main/install-cli.sh | bash
           tracetest

--- a/docs/installing.md
+++ b/docs/installing.md
@@ -101,7 +101,7 @@ You can find the latest version [here](https://github.com/kubeshop/tracetest/rel
 
 Tracetest CLI can be installed automatically using the following script:
 ```sh
-curl -L https://raw.githubusercontent.com/kubeshop/tracetest/main/install-cli.sh | bash
+curl -L https://raw.githubusercontent.com/kubeshop/tracetest/main/install-cli.sh | sh
 ```
 
 It works for systems with Hombrew, `apt-get`, `dpkg`, `yum`, `rpm` installed, and if no package manager is available, it will try to download the build and install it manually.

--- a/install-cli.sh
+++ b/install-cli.sh
@@ -141,5 +141,9 @@ if [ `id -un` != "root" ]; then
   ensure_dependency_exist "sudo"
   SUDO="sudo"
 fi
+echo
+echo "ARCH"
+uname -p
+echo
 
 run

--- a/install-cli.sh
+++ b/install-cli.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 cmd_exists() {
   command -v $1 &> /dev/null

--- a/install-cli.sh
+++ b/install-cli.sh
@@ -141,9 +141,5 @@ if [ `id -un` != "root" ]; then
   ensure_dependency_exist "sudo"
   SUDO="sudo"
 fi
-echo
-echo "ARCH"
-uname -p
-echo
 
 run

--- a/install-cli.sh
+++ b/install-cli.sh
@@ -27,7 +27,10 @@ get_os() {
 
 get_arch() {
   arch=$(uname -p)
-    case "$arch" in
+  if [ "$arch" = "unknown" ]; then
+    arch=$(uname -m)
+  fi
+  case "$arch" in
     "x86_64")
       echo "amd64"
       ;;

--- a/install-cli.sh
+++ b/install-cli.sh
@@ -37,7 +37,7 @@ get_arch() {
       ;;
 
     *)
-      echo ""
+      echo $arch
       ;;
   esac
 }


### PR DESCRIPTION
This PR adds a GH actions workflow to ensure basic functionality of the CLI installer. Right now it only tests linux on amd64, since that's the only arch we have runners configured, but can be extended to other OSs/architectures by creating self-hosted runners

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [x] added a test
