### PR TITLE
add secondary filter options by tags to assertion-check-attribute

### DIFF
--- a/web/cypress/integration/Trace/CreateAssertion.spec.ts
+++ b/web/cypress/integration/Trace/CreateAssertion.spec.ts
@@ -30,10 +30,10 @@ describe('Create Assertion', () => {
 
     cy.get('[data-cy=add-assertion-form-add-check]').click();
 
-    cy.get('[data-cy=assertion-check-attribute]').last().type('duration');
-    cy.get(`${getAttributeListId(2)} + div .ant-select-item`)
-      .first()
-      .click();
+      cy.get('[data-cy=assertion-check-attribute]').last().type('time');
+      cy.get(`${getAttributeListId(2)} + div .ant-select-item`)
+        .first()
+        .click();
 
     cy.selectOperator(2);
 

--- a/web/cypress/support/commands.ts
+++ b/web/cypress/support/commands.ts
@@ -152,7 +152,7 @@ Cypress.Commands.add('editTestByTestId', (testId: string) => {
 });
 
 Cypress.Commands.add('selectOperator', (index: number, text?: string) => {
-  cy.get('[data-cy=assertion-check-operator]').last().click();
+  cy.get('[data-cy=assertion-check-operator]').last().click({force: true});
   cy.get(`${getComparatorListId(index)} + div .ant-select-item`)
     .last()
     .click();

--- a/web/src/components/AssertionForm/AssertionForm.tsx
+++ b/web/src/components/AssertionForm/AssertionForm.tsx
@@ -1,19 +1,19 @@
 import {Button, Form, Typography} from 'antd';
+import {ADVANCE_SELECTORS_DOCUMENTATION_URL} from 'constants/Common.constants';
 import {CompareOperator} from 'constants/Operator.constants';
 import React, {useState} from 'react';
 import {useAppSelector} from 'redux/hooks';
 import AssertionSelectors from 'selectors/Assertion.selectors';
+import SpanSelectors from 'selectors/Span.selectors';
 import OperatorService from 'services/Operator.service';
 import {TAssertion} from 'types/Assertion.types';
-import SpanSelectors from 'selectors/Span.selectors';
-import {ADVANCE_SELECTORS_DOCUMENTATION_URL} from 'constants/Common.constants';
 import AffectedSpanControls from '../Diagram/components/DAG/AffectedSpanControls';
 import {TooltipQuestion} from '../TooltipQuestion/TooltipQuestion';
 import * as S from './AssertionForm.styled';
 import AssertionFormCheckList from './AssertionFormCheckList';
 import AssertionFormSelector from './AssertionFormSelector';
-import useOnFieldsChange from './hooks/useOnFieldsChange';
 import useAssertionFormValues from './hooks/useAssertionFormValues';
+import useOnFieldsChange from './hooks/useOnFieldsChange';
 
 export interface IValues {
   assertionList?: TAssertion[];
@@ -57,7 +57,6 @@ const AssertionForm: React.FC<TAssertionFormProps> = ({
     form,
     attributeList,
   });
-
   return (
     <S.AssertionForm>
       <S.AssertionFormHeader>

--- a/web/src/components/AssertionForm/AssertionFormCheckList.tsx
+++ b/web/src/components/AssertionForm/AssertionFormCheckList.tsx
@@ -2,15 +2,11 @@ import {FormInstance, Select} from 'antd';
 import {FormListFieldData} from 'antd/lib/form/FormList';
 import {uniqBy} from 'lodash';
 import {useMemo} from 'react';
-import AttributesTags from '../../constants/AttributesTags.json';
 import {TAssertion} from '../../types/Assertion.types';
 import {TSpanFlatAttribute} from '../../types/Span.types';
 import {IValues} from './AssertionForm';
 import {AssertionFormCheck} from './AssertionFormCheck';
-import {
-  OtelReference,
-  useGetOTELSemanticConvertionAttributesInfo,
-} from './hooks/useGetOTELSemanticConvertionAttributesInfo';
+import {useGetOTELSemanticConvertionAttributesInfo} from './hooks/useGetOTELSemanticConvertionAttributesInfo';
 
 interface IProps {
   form: FormInstance<IValues>;
@@ -29,16 +25,10 @@ const AssertionFormCheckList: React.FC<IProps> = ({form, fields, add, remove, at
   const attributeOptionList = useMemo(() => {
     return uniqBy(attributeList, 'key').map(({key}) => (
       <Select.Option key={key} value={key}>
-        {`${key} ${
-          reference[key] || (AttributesTags as OtelReference)[key]
-            ? reference[key]
-              ? ` - ${reference[key].description}`
-              : ` - ${(AttributesTags as OtelReference)[key].description}`
-            : ''
-        }`}
+        {key}
       </Select.Option>
     ));
-  }, [attributeList, reference]);
+  }, [attributeList]);
 
   return (
     <>

--- a/web/src/components/AssertionForm/AssertionFormCheckList.tsx
+++ b/web/src/components/AssertionForm/AssertionFormCheckList.tsx
@@ -2,10 +2,15 @@ import {FormInstance, Select} from 'antd';
 import {FormListFieldData} from 'antd/lib/form/FormList';
 import {uniqBy} from 'lodash';
 import {useMemo} from 'react';
+import AttributesTags from '../../constants/AttributesTags.json';
 import {TAssertion} from '../../types/Assertion.types';
 import {TSpanFlatAttribute} from '../../types/Span.types';
 import {IValues} from './AssertionForm';
 import {AssertionFormCheck} from './AssertionFormCheck';
+import {
+  OtelReference,
+  useGetOTELSemanticConvertionAttributesInfo,
+} from './hooks/useGetOTELSemanticConvertionAttributesInfo';
 
 interface IProps {
   form: FormInstance<IValues>;
@@ -20,15 +25,20 @@ interface IProps {
 }
 
 const AssertionFormCheckList: React.FC<IProps> = ({form, fields, add, remove, attributeList, assertionList}) => {
-  const attributeOptionList = useMemo(
-    () =>
-      uniqBy(attributeList, 'key').map(({key}) => (
-        <Select.Option key={key} value={key}>
-          {key}
-        </Select.Option>
-      )),
-    [attributeList]
-  );
+  const reference = useGetOTELSemanticConvertionAttributesInfo();
+  const attributeOptionList = useMemo(() => {
+    return uniqBy(attributeList, 'key').map(({key}) => (
+      <Select.Option key={key} value={key}>
+        {`${key} ${
+          reference[key] || (AttributesTags as OtelReference)[key]
+            ? reference[key]
+              ? ` - ${reference[key].description}`
+              : ` - ${(AttributesTags as OtelReference)[key].description}`
+            : ''
+        }`}
+      </Select.Option>
+    ));
+  }, [attributeList, reference]);
 
   return (
     <>
@@ -36,6 +46,7 @@ const AssertionFormCheckList: React.FC<IProps> = ({form, fields, add, remove, at
         return (
           <AssertionFormCheck
             key={key}
+            reference={reference}
             form={form}
             add={add}
             remove={remove}

--- a/web/src/components/AssertionForm/hooks/useGetOTELSemanticConvertionAttributesInfo.tsx
+++ b/web/src/components/AssertionForm/hooks/useGetOTELSemanticConvertionAttributesInfo.tsx
@@ -1,0 +1,22 @@
+import {useGetConventionsQuery} from 'redux/apis/OtelRepo.api';
+
+export type OtelReference = Record<string, OtelReferenceModel>;
+
+export interface OtelReferenceModel {
+  description: string;
+  tags: string[];
+}
+
+export const useGetOTELSemanticConvertionAttributesInfo = (): OtelReference => {
+  return {
+    ...useGetConventionsQuery({kind: 'http'})?.data,
+    ...useGetConventionsQuery({kind: 'database'})?.data,
+    ...useGetConventionsQuery({kind: 'cloudevents'})?.data,
+    ...useGetConventionsQuery({kind: 'compatibility'})?.data,
+    ...useGetConventionsQuery({kind: 'exception'})?.data,
+    ...useGetConventionsQuery({kind: 'faas'})?.data,
+    ...useGetConventionsQuery({kind: 'general'})?.data,
+    ...useGetConventionsQuery({kind: 'messaging'})?.data,
+    ...useGetConventionsQuery({kind: 'rpc'})?.data,
+  };
+};

--- a/web/src/constants/AttributesTags.json
+++ b/web/src/constants/AttributesTags.json
@@ -1,0 +1,9 @@
+{
+  "tracetest.span.duration": {
+    "description": "",
+    "tags": [
+      "ms",
+      "time"
+    ]
+  }
+}

--- a/web/src/constants/SpanAttribute.constants.ts
+++ b/web/src/constants/SpanAttribute.constants.ts
@@ -8,10 +8,10 @@ export const TraceTestAttributes = {
   TRACETEST_RESPONSE_STATUS: 'tracetest.response.status',
   TRACETEST_RESPONSE_BODY: 'tracetest.response.body',
   TRACETEST_RESPONSE_HEADERS: 'tracetest.response.headers',
-  TRACETEST_SELECTED_SPANS_COUNT: 'tracetest.selected_spans.count'
+  TRACETEST_SELECTED_SPANS_COUNT: 'tracetest.selected_spans.count',
 };
 
-export const Attributes = {
+export const Attributes: Record<string, string> = {
   ...SemanticAttributes,
   ...SemanticResourceAttributes,
   ...TraceTestAttributes,

--- a/web/src/react-app-env.d.ts
+++ b/web/src/react-app-env.d.ts
@@ -1,1 +1,2 @@
 /// <reference types="react-scripts" />
+declare module 'js-yaml';

--- a/web/src/redux/apis/OTELYaml.d.ts
+++ b/web/src/redux/apis/OTELYaml.d.ts
@@ -1,0 +1,54 @@
+export interface OTELYaml {
+  groups: Group[];
+}
+
+export interface Group {
+  id: string;
+  prefix: string;
+  type: string;
+  brief: string;
+  note?: string;
+  attributes: Attribute[];
+  constraints?: Constraint[];
+  extends?: string;
+  span_kind?: string;
+}
+
+export interface Attribute {
+  id?: string;
+  type?: TypeClass | TypeEnum;
+  requirement_level?: RequirementLevelClass | string;
+  brief?: string;
+  sampling_relevant?: boolean;
+  examples?: Array<number | string> | number | string;
+  note?: string;
+  ref?: string;
+}
+export interface CompleteAttribute extends Attribute {
+  group: string;
+}
+
+export interface RequirementLevelClass {
+  conditionally_required?: string;
+  recommended?: string;
+}
+
+export interface TypeClass {
+  allow_custom_values: boolean;
+  members: Member[];
+}
+
+export interface Member {
+  id: string;
+  value: string;
+  brief: string;
+}
+
+export enum TypeEnum {
+  Int = 'int',
+  String = 'string',
+}
+
+export interface Constraint {
+  include: string;
+}

--- a/web/src/redux/apis/OtelRepo.api.ts
+++ b/web/src/redux/apis/OtelRepo.api.ts
@@ -1,0 +1,59 @@
+import {createApi, fetchBaseQuery} from '@reduxjs/toolkit/query/react';
+import * as jsyaml from 'js-yaml';
+import {OtelReference} from '../../components/AssertionForm/hooks/useGetOTELSemanticConvertionAttributesInfo';
+import {CompleteAttribute, OTELYaml} from './OTELYaml';
+
+const PATH = `https://raw.githubusercontent.com/open-telemetry/opentelemetry-specification/main/`;
+
+enum Tags {
+  TAGS = 'tags',
+}
+
+function normalizeThis(examples?: Array<string | number> | number | string): string[] {
+  switch (typeof examples) {
+    case 'object':
+      return examples.map(d => d.toString());
+    case 'number':
+      return [examples.toString()];
+    case 'string':
+      return [examples];
+    default:
+      return [];
+  }
+}
+
+const OtelRepoAPI = createApi({
+  reducerPath: 'otel',
+  baseQuery: fetchBaseQuery({
+    baseUrl: PATH,
+  }),
+  tagTypes: Object.values(Tags),
+  endpoints: build => ({
+    getConventions: build.query<OtelReference, {kind?: string; folder?: string}>({
+      query: ({folder = 'trace', kind: file = 'http'}) => {
+        return {
+          url: `semantic_conventions/${folder}/${file}.yaml`,
+          responseHandler: 'text',
+        };
+      },
+      providesTags: (result, error, {kind}) => [{type: Tags.TAGS, id: kind}],
+      transformResponse: (rawSpanList: string) => {
+        const message: OTELYaml = jsyaml.load(rawSpanList);
+        return (
+          (message?.groups || [])
+            .flatMap<CompleteAttribute>(s => (s.attributes || []).map(d => ({...d, group: s.id})))
+            .reduce((acc: OtelReference, d: CompleteAttribute) => {
+              let id = `${d.group}.${d?.ref || d?.id || ''}`;
+              acc[id] = {description: d?.brief || '', tags: normalizeThis(d?.examples)};
+              return acc;
+            }, {}) || {}
+        );
+      },
+    }),
+  }),
+});
+
+export const {useGetConventionsQuery} = OtelRepoAPI;
+export const {endpoints} = OtelRepoAPI;
+
+export default OtelRepoAPI;

--- a/web/src/redux/apis/TraceTest.api.ts
+++ b/web/src/redux/apis/TraceTest.api.ts
@@ -1,13 +1,13 @@
 import {createApi, fetchBaseQuery} from '@reduxjs/toolkit/query/react';
-import {uniq} from 'lodash';
-import WebSocketService, {IListenerFunction} from 'services/WebSocket.service';
-import {TRawTest, TTest} from 'types/Test.types';
 import {HTTP_METHOD} from 'constants/Common.constants';
+import {uniq} from 'lodash';
 import AssertionResults from 'models/AssertionResults.model';
 import Test from 'models/Test.model';
 import TestDefinition from 'models/TestDefinition.model';
 import TestRun from 'models/TestRun.model';
+import WebSocketService, {IListenerFunction} from 'services/WebSocket.service';
 import {TAssertion, TAssertionResults, TRawAssertionResults} from 'types/Assertion.types';
+import {TRawTest, TTest} from 'types/Test.types';
 import {TRawTestDefinition, TTestDefinition} from 'types/TestDefinition.types';
 import {TRawTestRun, TTestRun} from 'types/TestRun.types';
 
@@ -155,7 +155,6 @@ const TraceTestAPI = createApi({
         {type: Tags.TEST_RUN, id: `${testId}-${version}-definition`},
       ],
     }),
-
     // Spans
     getSelectedSpans: build.query<string[], {testId: string; runId: string; query: string}>({
       query: ({testId, runId, query}) => `/tests/${testId}/run/${runId}/select?query=${encodeURIComponent(query)}`,

--- a/web/src/redux/store.tsx
+++ b/web/src/redux/store.tsx
@@ -4,16 +4,18 @@ import TestDefinition from 'redux/slices/TestDefinition.slice';
 import Spans from 'redux/slices/Span.slice';
 import CreateTest from 'redux/slices/CreateTest.slice';
 import DAG from 'redux/slices/DAG.slice';
+import OtelRepoApi from './apis/OtelRepo.api';
 
 export const store = configureStore({
   reducer: {
     [TestAPI.reducerPath]: TestAPI.reducer,
+    [OtelRepoApi.reducerPath]: OtelRepoApi.reducer,
     spans: Spans,
     dag: DAG,
     testDefinition: TestDefinition,
     createTest: CreateTest,
   },
-  middleware: getDefaultMiddleware => getDefaultMiddleware().concat(TestAPI.middleware),
+  middleware: getDefaultMiddleware => getDefaultMiddleware().concat(TestAPI.middleware).concat(OtelRepoApi.middleware),
 });
 
 export type AppDispatch = typeof store.dispatch;

--- a/web/tsconfig.json
+++ b/web/tsconfig.json
@@ -4,7 +4,8 @@
     "lib": [
       "dom",
       "dom.iterable",
-      "esnext"
+      "esnext",
+      "es2019"
     ],
     "allowJs": true,
     "skipLibCheck": true,


### PR DESCRIPTION
This PR adds secondary filter options by tags to assertion-check-attribute

## Changes

- implements #1053 

## Fixes
Fixes #1053 

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [x] added a test
