### PR TITLE
fix: setup script otel collector config

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -142,7 +142,7 @@ if [ "$SKIP_COLLECTOR" != "YES" ]; then
     echo
     echo
 
-    kubectl apply -f https://raw.githubusercontent.com/kubeshop/tracetest/main/k8s/collector.yml
+    kubectl apply --namespace $NAMESPACE -f https://raw.githubusercontent.com/kubeshop/tracetest/main/k8s/collector.yml
 fi
 
 if [ "$SKIP_BACKEND" != "YES" ]; then


### PR DESCRIPTION
This PR is a quick fix for the setup script. The script installs otel collector to the `default` namespace, but tracetest config expects it to be on the same namespace as tracetest, so the startup fails.

This quick fix moves the otel collector to the same ns as tracetest

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
