### PR TITLE
fix: replace id in test file instead of rewriting whole file

### DIFF
--- a/cli/actions/run_test_action.go
+++ b/cli/actions/run_test_action.go
@@ -96,7 +96,7 @@ func (a runTestAction) runDefinition(ctx context.Context, definitionFile string,
 	}
 
 	definition.Id = *test.Id
-	err = file.SaveDefinition(definitionFile, definition)
+	err = file.SetTestID(definitionFile, *test.Id)
 	if err != nil {
 		return runTestOutput{}, fmt.Errorf("could not save test definition: %w", err)
 	}

--- a/cli/file/definition.go
+++ b/cli/file/definition.go
@@ -3,6 +3,8 @@ package file
 import (
 	"fmt"
 	"os"
+	"regexp"
+	"strings"
 
 	"github.com/kubeshop/tracetest/cli/definition"
 	"gopkg.in/yaml.v2"
@@ -30,6 +32,29 @@ func SaveDefinition(file string, definition definition.Test) error {
 	}
 
 	err = os.WriteFile(file, yamlContent, 0644)
+	if err != nil {
+		return fmt.Errorf("could not write file: %w", err)
+	}
+
+	return nil
+}
+
+func SetTestID(file string, id string) error {
+	idStatementRegex := regexp.MustCompile("^id: [0-9a-zA-Z\\-]+\n")
+	fileBytes, err := os.ReadFile(file)
+	if err != nil {
+		return fmt.Errorf("could not read test definition file %s: %w", file, err)
+	}
+
+	fileContent := string(fileBytes)
+	idStatement := idStatementRegex.FindString(fileContent)
+	if idStatement != "" {
+		fileContent = strings.Replace(fileContent, idStatement, fmt.Sprintf("id: %s\n", id), 1)
+	} else {
+		fileContent = fmt.Sprintf("id: %s\n%s", id, fileContent)
+	}
+
+	err = os.WriteFile(file, []byte(fileContent), 0644)
 	if err != nil {
 		return fmt.Errorf("could not write file: %w", err)
 	}


### PR DESCRIPTION
This PR fixes the problems related to empty fields being added to the test file after running a test. It only adds the id property to the file if it doesn't exist and replaces it if it exists.

Related to issue #976 

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
