### PR TITLE
add example of how to connect tracetest and opensearch

### DIFF
--- a/examples/tracetest-opensearch/README.md
+++ b/examples/tracetest-opensearch/README.md
@@ -6,7 +6,7 @@ This repository objective is to show how you can configure your tracetest instan
 
 1. [Install the tracetest CLI](https://github.com/kubeshop/tracetest/blob/main/docs/installing.md#cli-installation)
 2. Run `tracetest configure` on a terminal and type: `http://localhost:8080` to make your CLI send all requests to that address
-3. Run the project by using docker-compose: `docker-compose up`
+3. Run the project by using docker-compose: `docker-compose up` (Linux) or `docker compose up` (Mac)
 4. Test if it works by running: `tracetest test run -d tests/list-tests.yaml`. This would trigger a test that will send and retrieve spans from the opensearch instance that is running on your machine.
 
 ## Project structure

--- a/examples/tracetest-opensearch/README.md
+++ b/examples/tracetest-opensearch/README.md
@@ -9,6 +9,8 @@ This repository objective is to show how you can configure your tracetest instan
 3. Run the project by using docker-compose: `docker-compose up` (Linux) or `docker compose up` (Mac)
 4. Test if it works by running: `tracetest test run -d tests/list-tests.yaml`. This would trigger a test that will send and retrieve spans from the opensearch instance that is running on your machine.
 
+> :warning: Note: The OpenSearch configuration used for this example is not meant to be used in production.
+
 ## Project structure
 
 - `opensearch` is a folder that contains all configuration files used to configure the local opensearch instance;

--- a/examples/tracetest-opensearch/README.md
+++ b/examples/tracetest-opensearch/README.md
@@ -1,0 +1,16 @@
+# Tracetest + Opensearch
+
+This repository objective is to show how you can configure your tracetest instance to connect to an opensearch instance and use it as its tracing backend.
+
+## Steps
+
+1. [Install the tracetest CLI](https://github.com/kubeshop/tracetest/blob/main/docs/installing.md#cli-installation)
+2. Run `tracetest configure` on a terminal and type: `http://localhost:8080` to make your CLI send all requests to that address
+3. Run the project by using docker-compose: `docker-compose up`
+4. Test if it works by running: `tracetest test run -d tests/list-tests.yaml`. This would trigger a test that will send and retrieve spans from the opensearch instance that is running on your machine.
+
+## Project structure
+
+- `opensearch` is a folder that contains all configuration files used to configure the local opensearch instance;
+- `collector.config.yaml` is the configuration of the opentelemetry collector that will receive traces and send them to opensearch
+- `tracetest-config.yaml` is the configuration of the tracetest instance, including how to connect to the opensearch instance

--- a/examples/tracetest-opensearch/collector.config.yaml
+++ b/examples/tracetest-opensearch/collector.config.yaml
@@ -1,0 +1,29 @@
+receivers:
+  otlp:
+    protocols:
+      grpc:
+      http:
+
+
+processors:
+  batch:
+    timeout: 100ms
+
+  # Data sources: traces
+  probabilistic_sampler:
+    hash_seed: 22
+    sampling_percentage: 100
+
+exporters:
+  otlp/2:
+    endpoint: data-prepper:21890
+    tls:
+      insecure: true
+      insecure_skip_verify: true
+
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [probabilistic_sampler, batch]
+      exporters: [otlp/2]

--- a/examples/tracetest-opensearch/docker-compose.yml
+++ b/examples/tracetest-opensearch/docker-compose.yml
@@ -2,7 +2,6 @@ version: '3'
 services:
 
     tracetest:
-        container_name: tracetest
         image: kubeshop/tracetest:v0.6.4
         volumes:
             - type: bind
@@ -17,7 +16,6 @@ services:
                 condition: service_started
 
     postgres:
-        container_name: postgres
         image: postgres:14
         environment:
             POSTGRES_PASSWORD: postgres
@@ -46,7 +44,6 @@ services:
 
     data-prepper:
         restart: unless-stopped
-        container_name: data-prepper
         image: opensearchproject/data-prepper:latest
         volumes:
             - ./opensearch/opensearch-analytics.yaml:/usr/share/data-prepper/pipelines.yaml

--- a/examples/tracetest-opensearch/docker-compose.yml
+++ b/examples/tracetest-opensearch/docker-compose.yml
@@ -15,8 +15,6 @@ services:
                 condition: service_healthy
             otel-collector:
                 condition: service_started
-        networks:
-            - local
 
     postgres:
         container_name: postgres
@@ -31,8 +29,6 @@ services:
             interval: 1s
             timeout: 5s
             retries: 60
-        networks:
-            - local
 
     otel-collector:
         image: otel/opentelemetry-collector:0.54.0
@@ -47,8 +43,6 @@ services:
             - ./collector.config.yaml:/otel-local-config.yaml
         depends_on:
             - data-prepper
-        networks:
-            - local
 
     data-prepper:
         restart: unless-stopped
@@ -62,8 +56,6 @@ services:
         depends_on:
             opensearch:
                 condition: service_healthy
-        networks:
-            - local
 
     opensearch:
         image: opensearchproject/opensearch:latest
@@ -88,8 +80,3 @@ services:
             interval: 5s
             timeout: 10s
             retries: 5
-        networks:
-            - local
-
-networks:
-    local:

--- a/examples/tracetest-opensearch/docker-compose.yml
+++ b/examples/tracetest-opensearch/docker-compose.yml
@@ -1,0 +1,95 @@
+version: '3'
+services:
+
+    tracetest:
+        container_name: tracetest
+        image: kubeshop/tracetest:v0.6.4
+        volumes:
+            - type: bind
+              source: ./tracetest-config.yaml
+              target: /app/config.yaml
+        ports:
+            - 8080:8080
+        depends_on:
+            postgres:
+                condition: service_healthy
+            otel-collector:
+                condition: service_started
+        networks:
+            - local
+
+    postgres:
+        container_name: postgres
+        image: postgres:14
+        environment:
+            POSTGRES_PASSWORD: postgres
+            POSTGRES_USER: postgres
+        ports:
+            - 5432:5432
+        healthcheck:
+            test: pg_isready -U "$$POSTGRES_USER" -d "$$POSTGRES_DB"
+            interval: 1s
+            timeout: 5s
+            retries: 60
+        networks:
+            - local
+
+    otel-collector:
+        image: otel/opentelemetry-collector:0.54.0
+        ports:
+            - "55679:55679"
+            - "4317:4317"
+            - "8888:8888"
+        command:
+            - "--config"
+            - "/otel-local-config.yaml"
+        volumes:
+            - ./collector.config.yaml:/otel-local-config.yaml
+        depends_on:
+            - data-prepper
+        networks:
+            - local
+
+    data-prepper:
+        restart: unless-stopped
+        container_name: data-prepper
+        image: opensearchproject/data-prepper:latest
+        volumes:
+            - ./opensearch/opensearch-analytics.yaml:/usr/share/data-prepper/pipelines.yaml
+            - ./opensearch/opensearch-data-prepper-config.yaml:/usr/share/data-prepper/data-prepper-config.yaml
+        ports:
+            - "21890:21890"
+        depends_on:
+            opensearch:
+                condition: service_healthy
+        networks:
+            - local
+
+    opensearch:
+        image: opensearchproject/opensearch:latest
+        environment:
+            - discovery.type=single-node
+            - bootstrap.memory_lock=true # along with the memlock settings below, disables swapping
+            - "OPENSEARCH_JAVA_OPTS=-Xms512m -Xmx512m" # minimum and maximum Java heap size, recommend setting both to 50% of system RAM
+        volumes:
+            - ./opensearch/opensearch.yaml:/usr/share/opensearch/config/opensearch.yml
+        ulimits:
+            memlock:
+                soft: -1
+                hard: -1
+            nofile:
+                soft: 65536 # maximum number of open files for the OpenSearch user, set to at least 65536 on modern systems
+                hard: 65536
+        ports:
+            - 9200:9200
+            - 9600:9600 # required for Performance Analyzer
+        healthcheck:
+            test: curl -s http://localhost:9200 >/dev/null || exit 1
+            interval: 5s
+            timeout: 10s
+            retries: 5
+        networks:
+            - local
+
+networks:
+    local:

--- a/examples/tracetest-opensearch/opensearch/opensearch-analytics.yaml
+++ b/examples/tracetest-opensearch/opensearch/opensearch-analytics.yaml
@@ -1,0 +1,22 @@
+entry-pipeline:
+  delay: "100"
+  source:
+    otel_trace_source:
+      ssl: false
+  sink:
+    - pipeline:
+        name: "raw-pipeline"
+
+raw-pipeline:
+  source:
+    pipeline:
+      name: "entry-pipeline"
+  prepper:
+    - otel_trace_raw_prepper:
+  sink:
+    - opensearch:
+        hosts:
+          - "http://opensearch:9200"
+        insecure: true
+        trace-analytics-raw: true
+        index: traces

--- a/examples/tracetest-opensearch/opensearch/opensearch-data-prepper-config.yaml
+++ b/examples/tracetest-opensearch/opensearch/opensearch-data-prepper-config.yaml
@@ -1,0 +1,1 @@
+ssl: false

--- a/examples/tracetest-opensearch/opensearch/opensearch.yaml
+++ b/examples/tracetest-opensearch/opensearch/opensearch.yaml
@@ -1,0 +1,38 @@
+---
+cluster.name: docker-cluster
+
+# Bind to all interfaces because we don't know what IP address Docker will assign to us.
+network.host: 0.0.0.0
+
+# # minimum_master_nodes need to be explicitly set when bound on a public IP
+# # set to 1 to allow single node clusters
+# discovery.zen.minimum_master_nodes: 1
+
+# Setting network.host to a non-loopback address enables the annoying bootstrap checks. "Single-node" mode disables them again.
+# discovery.type: single-node
+
+######## Start OpenSearch Security Demo Configuration ########
+# WARNING: revise all the lines below before you go into production
+# plugins.security.ssl.transport.pemcert_filepath: esnode.pem
+# plugins.security.ssl.transport.pemkey_filepath: esnode-key.pem
+# plugins.security.ssl.transport.pemtrustedcas_filepath: root-ca.pem
+# plugins.security.ssl.transport.enforce_hostname_verification: false
+# plugins.security.ssl.http.enabled: true
+# plugins.security.ssl.http.pemcert_filepath: esnode.pem
+# plugins.security.ssl.http.pemkey_filepath: esnode-key.pem
+# plugins.security.ssl.http.pemtrustedcas_filepath: root-ca.pem
+# plugins.security.allow_unsafe_democertificates: true
+# plugins.security.allow_default_init_securityindex: true
+# plugins.security.authcz.admin_dn:
+#   - CN=kirk,OU=client,O=client,L=test, C=de
+
+# plugins.security.audit.type: internal_opensearch
+# plugins.security.enable_snapshot_restore_privilege: true
+# plugins.security.check_snapshot_restore_write_privileges: true
+# plugins.security.restapi.roles_enabled: ["all_access", "security_rest_api_access"]
+# plugins.security.system_indices.enabled: true
+# plugins.security.system_indices.indices: [".plugins-ml-model", ".plugins-ml-task", ".opendistro-alerting-config", ".opendistro-alerting-alert*", ".opendistro-anomaly-results*", ".opendistro-anomaly-detector*", ".opendistro-anomaly-checkpoints", ".opendistro-anomaly-detection-state", ".opendistro-reports-*", ".opensearch-notifications-*", ".opensearch-notebooks", ".opensearch-observability", ".opendistro-asynchronous-search-response*", ".replication-metadata-store"]
+
+plugins.security.disabled: true
+node.max_local_storage_nodes: 3
+######## End OpenSearch Security Demo Configuration ########

--- a/examples/tracetest-opensearch/tests/list-tests.yaml
+++ b/examples/tracetest-opensearch/tests/list-tests.yaml
@@ -1,0 +1,15 @@
+id: e9c6cff9-974d-4263-8a23-22f1e9f975aa
+name: List all tracetest tests
+description: List all existing tests from tracetest API
+trigger:
+  type: http
+  httpRequest:
+    url: http://tracetest:8080/api/tests
+    method: GET
+    headers:
+    - key: Content-Type
+      value: application/json
+testDefinition:
+- selector: span[name = "Tracetest trigger"]
+  assertions:
+  - tracetest.selected_spans.count = 1

--- a/examples/tracetest-opensearch/tracetest-config.yaml
+++ b/examples/tracetest-opensearch/tracetest-config.yaml
@@ -1,0 +1,32 @@
+postgresConnString: "host=postgres user=postgres password=postgres port=5432 sslmode=disable"
+
+poolingConfig:
+  maxWaitTimeForTrace: 10m
+  retryDelay: 5s
+
+googleAnalytics:
+  enabled: false
+
+telemetry:
+  dataStores:
+    opensearch:
+      type: opensearch
+      opensearch:
+        addresses:
+          - http://opensearch:9200
+        index: traces
+
+  exporters:
+    collector:
+      serviceName: tracetest
+      sampling: 100 # 100%
+      exporter:
+        type: collector
+        collector:
+          endpoint: otel-collector:4317
+
+server:
+  telemetry:
+    dataStore: opensearch
+    exporter: collector
+    applicationExporter: collector

--- a/examples/tracetest-opensearch/tracetest-config.yaml
+++ b/examples/tracetest-opensearch/tracetest-config.yaml
@@ -5,7 +5,7 @@ poolingConfig:
   retryDelay: 5s
 
 googleAnalytics:
-  enabled: false
+  enabled: true
 
 telemetry:
   dataStores:


### PR DESCRIPTION
This PR adds an example of how one can setup tracetest to connect to an opensearch instance and use it as a tracing backend.

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [x] updated the docs
- [ ] added a test
