### PR TITLE
🐛 fixing wrong empty assertion selector

### DIFF
--- a/web/src/providers/TestDefinition/TestDefinition.provider.tsx
+++ b/web/src/providers/TestDefinition/TestDefinition.provider.tsx
@@ -89,7 +89,9 @@ const TestDefinitionProvider = ({children, testId, runId}: IProps) => {
     (assertionResult?: TAssertionResultEntry) => {
       dispatch(
         RouterActions.updateSearch({
-          [RouterSearchFields.SelectedAssertion]: encryptString(assertionResult?.selector || ''),
+          [RouterSearchFields.SelectedAssertion]: assertionResult?.selector
+            ? encryptString(assertionResult?.selector)
+            : '',
         })
       );
     },


### PR DESCRIPTION
This PR fixes an issue when trying to exit the selected mode after arriving to the run view with a selected assertion

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
