### PR TITLE
example: add example using tempo as the tracing backend and fix support for tempo

### DIFF
--- a/examples/tracetest-tempo/README.md
+++ b/examples/tracetest-tempo/README.md
@@ -1,6 +1,6 @@
-# Tracetest + Opensearch
+# Tracetest + Grafana Tempo
 
-This repository objective is to show how you can configure your tracetest instance to connect to an opensearch instance and use it as its tracing backend.
+This repository objective is to show how you can configure your tracetest instance to connect to grafana tempo instance and use it as its tracing backend.
 
 ## Steps
 
@@ -9,10 +9,4 @@ This repository objective is to show how you can configure your tracetest instan
 3. Run the project by using docker-compose: `docker-compose up` (Linux) or `docker compose up` (Mac)
 4. Test if it works by running: `tracetest test run -d tests/list-tests.yaml`. This would trigger a test that will send and retrieve spans from the opensearch instance that is running on your machine.
 
-> :warning: Note: The OpenSearch configuration used for this example is not meant to be used in production.
-
-## Project structure
-
-- `opensearch` is a folder that contains all configuration files used to configure the local opensearch instance;
-- `collector.config.yaml` is the configuration of the opentelemetry collector that will receive traces and send them to opensearch
-- `tracetest-config.yaml` is the configuration of the tracetest instance, including how to connect to the opensearch instance
+> :warning: Note: The Tempo configuration used for this example is not meant to be used in production.

--- a/examples/tracetest-tempo/README.md
+++ b/examples/tracetest-tempo/README.md
@@ -1,0 +1,18 @@
+# Tracetest + Opensearch
+
+This repository objective is to show how you can configure your tracetest instance to connect to an opensearch instance and use it as its tracing backend.
+
+## Steps
+
+1. [Install the tracetest CLI](https://github.com/kubeshop/tracetest/blob/main/docs/installing.md#cli-installation)
+2. Run `tracetest configure` on a terminal and type: `http://localhost:8080` to make your CLI send all requests to that address
+3. Run the project by using docker-compose: `docker-compose up` (Linux) or `docker compose up` (Mac)
+4. Test if it works by running: `tracetest test run -d tests/list-tests.yaml`. This would trigger a test that will send and retrieve spans from the opensearch instance that is running on your machine.
+
+> :warning: Note: The OpenSearch configuration used for this example is not meant to be used in production.
+
+## Project structure
+
+- `opensearch` is a folder that contains all configuration files used to configure the local opensearch instance;
+- `collector.config.yaml` is the configuration of the opentelemetry collector that will receive traces and send them to opensearch
+- `tracetest-config.yaml` is the configuration of the tracetest instance, including how to connect to the opensearch instance

--- a/examples/tracetest-tempo/collector.config.yaml
+++ b/examples/tracetest-tempo/collector.config.yaml
@@ -1,0 +1,27 @@
+receivers:
+  otlp:
+    protocols:
+      grpc:
+      http:
+
+processors:
+  batch:
+    timeout: 100ms
+
+  # Data sources: traces
+  probabilistic_sampler:
+    hash_seed: 22
+    sampling_percentage: 100
+
+exporters:
+  otlp/2:
+    endpoint: tempo:4317
+    tls:
+      insecure: true
+
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [probabilistic_sampler, batch]
+      exporters: [otlp/2]

--- a/examples/tracetest-tempo/docker-compose.yml
+++ b/examples/tracetest-tempo/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3'
 services:
 
     tracetest:
-        image: kubeshop/tracetest:v0.6.4
+        image: kubeshop/tracetest:v0.6.6
         volumes:
             - type: bind
               source: ./tracetest-config.yaml

--- a/examples/tracetest-tempo/docker-compose.yml
+++ b/examples/tracetest-tempo/docker-compose.yml
@@ -1,0 +1,53 @@
+version: '3'
+services:
+
+    tracetest:
+        image: kubeshop/tracetest:v0.6.4
+        volumes:
+            - type: bind
+              source: ./tracetest-config.yaml
+              target: /app/config.yaml
+        ports:
+            - 8080:8080
+        depends_on:
+            postgres:
+                condition: service_healthy
+            otel-collector:
+                condition: service_started
+
+    postgres:
+        image: postgres:14
+        environment:
+            POSTGRES_PASSWORD: postgres
+            POSTGRES_USER: postgres
+        ports:
+            - 5432:5432
+        healthcheck:
+            test: pg_isready -U "$$POSTGRES_USER" -d "$$POSTGRES_DB"
+            interval: 1s
+            timeout: 5s
+            retries: 60
+
+    otel-collector:
+        image: otel/opentelemetry-collector:0.54.0
+        ports:
+            - "55679:55679"
+            - "4317:4317"
+            - "8888:8888"
+        command:
+            - "--config"
+            - "/otel-local-config.yaml"
+        volumes:
+            - ./collector.config.yaml:/otel-local-config.yaml
+        depends_on:
+            - tempo
+
+    tempo:
+        image: grafana/tempo:1.5.0
+        command: ["-config.file=/etc/tempo.yaml"]
+        ports:
+        - "3100:3100"
+        - "9095:9095"
+        - "4317"
+        volumes:
+        - ./tempo.config.yaml:/etc/tempo.yaml

--- a/examples/tracetest-tempo/tempo.config.yaml
+++ b/examples/tracetest-tempo/tempo.config.yaml
@@ -1,0 +1,46 @@
+auth_enabled: false
+
+server:
+  http_listen_port: 3100
+  grpc_listen_port: 9095
+
+distributor:
+  receivers:                           # this configuration will listen on all ports and protocols that tempo is capable of.
+    jaeger:                            # the receives all come from the OpenTelemetry collector.  more configuration information can
+      protocols:                       # be found there: https://github.com/open-telemetry/opentelemetry-collector/tree/master/receiver
+        thrift_http:                   #
+        grpc:                          # for a production deployment you should only enable the receivers you need!
+        thrift_binary:
+        thrift_compact:
+    zipkin:
+    otlp:
+      protocols:
+        http:
+        grpc:
+    opencensus:
+
+ingester:
+  trace_idle_period: 10s               # the length of time after a trace has not received spans to consider it complete and flush it
+  max_block_bytes: 1_000_000           # cut the head block when it hits this size or ...
+  #traces_per_block: 1_000_000
+  max_block_duration: 5m               #   this much time passes
+
+compactor:
+  compaction:
+    compaction_window: 1h              # blocks in this time window will be compacted together
+    max_compaction_objects: 1000000    # maximum size of compacted blocks
+    block_retention: 1h
+    compacted_block_retention: 10m
+
+storage:
+  trace:
+    backend: local                     # backend configuration to use
+    wal:
+      path: /tmp/tempo/wal            # where to store the the wal locally
+      #bloom_filter_false_positive: .05 # bloom filter false positive rate.  lower values create larger filters but fewer false positives
+      #index_downsample: 10             # number of traces per index record
+    local:
+      path: /tmp/tempo/blocks
+    pool:
+      max_workers: 100                 # the worker pool mainly drives querying, but is also used for polling the blocklist
+      queue_depth: 10000

--- a/examples/tracetest-tempo/tests/list-tests.yaml
+++ b/examples/tracetest-tempo/tests/list-tests.yaml
@@ -1,0 +1,19 @@
+id: e9c6cff9-974d-4263-8a23-22f1e9f975aa
+name: List all tracetest tests
+description: List all existing tests from tracetest API
+trigger:
+  type: http
+  httpRequest:
+    url: http://localhost:8080/api/tests
+    method: GET
+    headers:
+    - key: Content-Type
+      value: application/json
+  grpc:
+    protobufFile: ""
+    address: ""
+    method: ""
+testDefinition:
+- selector: span[name = "Tracetest trigger"]
+  assertions:
+  - tracetest.selected_spans.count = 1

--- a/examples/tracetest-tempo/tracetest-config.yaml
+++ b/examples/tracetest-tempo/tracetest-config.yaml
@@ -1,0 +1,32 @@
+postgresConnString: "host=postgres user=postgres password=postgres port=5432 sslmode=disable"
+
+poolingConfig:
+  maxWaitTimeForTrace: 10m
+  retryDelay: 5s
+
+googleAnalytics:
+  enabled: true
+
+telemetry:
+  dataStores:
+    tempo:
+      type: tempo
+      tempo:
+        endpoint: tempo:9095
+        tls:
+          insecure: true
+
+  exporters:
+    collector:
+      serviceName: tracetest
+      sampling: 100 # 100%
+      exporter:
+        type: collector
+        collector:
+          endpoint: otel-collector:4317
+
+server:
+  telemetry:
+    dataStore: tempo
+    exporter: collector
+    applicationExporter: collector

--- a/server/tracedb/tempodb.go
+++ b/server/tracedb/tempodb.go
@@ -55,7 +55,6 @@ func (ttd *tempoTraceDB) GetTraceByID(ctx context.Context, traceID string) (trac
 		return traces.Trace{}, fmt.Errorf("tempo err: %w", err)
 	}
 
-	fmt.Printf("tempo resp: %#v\n", resp.Trace.Batches)
 	if len(resp.Trace.Batches) == 0 {
 		return traces.Trace{}, ErrTraceNotFound
 	}

--- a/server/traces/otel_converter.go
+++ b/server/traces/otel_converter.go
@@ -123,6 +123,10 @@ func getAttributeValue(value *v11.AnyValue) string {
 }
 
 func createSpanID(id []byte) trace.SpanID {
+	if id == nil {
+		return trace.SpanID{}
+	}
+
 	var sid [8]byte
 	copy(sid[:], id[:8])
 


### PR DESCRIPTION
This PR fixes a panic that happens when connecting to tempo while polling traces. It also adds an example on how to connect to tempo using Tracetest.

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [x] updated the docs
- [ ] added a test
