### PR TITLE
install dependencies to install tracetest in k8s cluster

### DIFF
--- a/cli/Makefile
+++ b/cli/Makefile
@@ -35,9 +35,6 @@ endif
 	goreleaser build --single-target --rm-dist --snapshot -f ../.goreleaser.yaml
 	cp `cat ./dist/artifacts.json | jq -rc '.[0].path'` ./dist/tracetest
 
-simple-build:
-	go build -o tracetest main.go
-
 test: mockserver
 	@go test -coverprofile=coverage.out ./...
 	@make --no-print-directory kill-mock

--- a/cli/Makefile
+++ b/cli/Makefile
@@ -35,6 +35,9 @@ endif
 	goreleaser build --single-target --rm-dist --snapshot -f ../.goreleaser.yaml
 	cp `cat ./dist/artifacts.json | jq -rc '.[0].path'` ./dist/tracetest
 
+simple-build:
+	go build -o tracetest main.go
+
 test: mockserver
 	@go test -coverprofile=coverage.out ./...
 	@make --no-print-directory kill-mock

--- a/cli/installer/docker_compose.go
+++ b/cli/installer/docker_compose.go
@@ -157,7 +157,7 @@ func filterContainers(ui UI, project *types.Project, included []string) {
 func getCollectorConfigFileContents(ui UI, config configuration) []byte {
 	contents, err := getFileContentsForVersion("local-config/collector.config.yaml", cliConfig.Version)
 	if err != nil {
-		ui.Exit(fmt.Errorf("Cannot get collector config file: %w", err).Error())
+		ui.Exit(fmt.Errorf("cannot get collector config file: %w", err).Error())
 	}
 
 	type msa = map[string]any
@@ -213,7 +213,7 @@ func getCollectorConfigFileContents(ui UI, config configuration) []byte {
 
 	updated, err := yaml.Marshal(otelConfig)
 	if err != nil {
-		ui.Exit(fmt.Errorf("Cannot get collector config file: %w", err).Error())
+		ui.Exit(fmt.Errorf("cannot get collector config file: %w", err).Error())
 	}
 
 	return updated
@@ -308,7 +308,7 @@ func getFileContentsForVersion(path, version string) ([]byte, error) {
 func getCompleteProject(ui UI) *types.Project {
 	contents, err := getFileContentsForVersion("docker-compose.yaml", cliConfig.Version)
 	if err != nil {
-		ui.Exit(fmt.Errorf("Cannot get docker-compose file: %w", err).Error())
+		ui.Exit(fmt.Errorf("cannot get docker-compose file: %w", err).Error())
 	}
 
 	workingDir, err := os.Getwd()
@@ -323,7 +323,7 @@ func getCompleteProject(ui UI) *types.Project {
 		},
 	})
 	if err != nil {
-		ui.Exit(fmt.Errorf("Cannot parse docker-compose file: %w", err).Error())
+		ui.Exit(fmt.Errorf("cannot parse docker-compose file: %w", err).Error())
 	}
 
 	return project

--- a/cli/installer/docker_compose.go
+++ b/cli/installer/docker_compose.go
@@ -340,7 +340,7 @@ func dockerChecker(ui UI) {
 		{"Install Docker Engine", installDockerEngine},
 		{"Install Docker Desktop", installDockerDesktop},
 		{"Fix manually", exitOption(
-			"Check the docker install docks on https://docs.docker.com/get-docker/",
+			"Check the docker install docs on https://docs.docker.com/get-docker/",
 		)},
 	}, 0)
 
@@ -379,7 +379,7 @@ func dockerComposeChecker(ui UI) {
 	option := ui.Select("What do you want to do?", []option{
 		{"Install Docker Compose", installDockerCompose},
 		{"Fix manually", exitOption(
-			"Check the docker compose install docks on https://docs.docker.com/compose/install/",
+			"Check the docker compose install docs on https://docs.docker.com/compose/install/",
 		)},
 	}, 0)
 
@@ -449,8 +449,8 @@ func installDockerCompose(ui UI) {
 		homebrew:           "brew install docker-compose",
 		macIntelChipManual: "TODO", // todo. see https://apple.stackexchange.com/a/73931
 		macAppleChipManual: "TODO", // todo. see https://apple.stackexchange.com/a/73931
-		windows:            "Check the install docks: https://docs.docker.com/compose/install/",
-		other:              "Check the install docks: https://docs.docker.com/compose/install/",
+		windows:            "Check the install docs: https://docs.docker.com/compose/install/",
+		other:              "Check the install docs: https://docs.docker.com/compose/install/",
 	}).exec(ui)
 }
 
@@ -472,11 +472,6 @@ func installDockerEngine(ui UI) {
 			"Architecture":  detectArchitecture(),
 		},
 		apt: `
-			DISTRO=$(lsb_release -is | tr '[:upper:]' '[:lower:]')
-
-			# cleanup. see https://docs.docker.com/engine/install/$DISTRO/#uninstall-old-versions
-			sudo apt-get -y remove docker docker-engine docker.io containerd runc
-
 			# Repo install. see https://docs.docker.com/engine/install/$DISTRO/#install-using-the-repository
 			# setup repo
 			sudo apt-get -y update
@@ -485,6 +480,12 @@ func installDockerEngine(ui UI) {
 				curl \
 				gnupg \
 				lsb-release
+
+			DISTRO=$(lsb_release -is | tr '[:upper:]' '[:lower:]')
+
+			# cleanup. see https://docs.docker.com/engine/install/$DISTRO/#uninstall-old-versions
+			sudo apt-get -y remove docker docker-engine docker.io containerd runc
+
 			sudo mkdir -p /etc/apt/keyrings
 			curl -fsSL https://download.docker.com/linux/$DISTRO/gpg | sudo gpg --batch --yes --dearmor -o /etc/apt/keyrings/docker.gpg
 
@@ -565,12 +566,6 @@ func installDockerDesktop(ui UI) {
 			"Architecture":  detectArchitecture(),
 		},
 		apt: `
-			DISTRO=$(lsb_release -is | tr '[:upper:]' '[:lower:]')
-			# cleanup old installs. See https://docs.docker.com/desktop/install/$DISTRO/#prerequisites
-			rm -rf $HOME/.docker/desktop
-			sudo rm -f /usr/local/bin/com.docker.cli
-			sudo apt-get -y purge docker-desktop
-
 			# add docker repo. See https://docs.docker.com/engine/install/$DISTRO/#set-up-the-repository
 			sudo apt-get -y update
 			sudo apt-get -y install \
@@ -578,6 +573,14 @@ func installDockerDesktop(ui UI) {
 				curl \
 				gnupg \
 				lsb-release
+
+			DISTRO=$(lsb_release -is | tr '[:upper:]' '[:lower:]')
+
+			# cleanup old installs. See https://docs.docker.com/desktop/install/$DISTRO/#prerequisites
+			rm -rf $HOME/.docker/desktop
+			sudo rm -f /usr/local/bin/com.docker.cli
+			sudo apt-get -y purge docker-desktop
+
 			sudo mkdir -p /etc/apt/keyrings
 			curl -fsSL https://download.docker.com/linux/$DISTRO/gpg | sudo gpg --yes --dearmor -o /etc/apt/keyrings/docker.gpg
 			echo \

--- a/cli/installer/installer.go
+++ b/cli/installer/installer.go
@@ -29,7 +29,7 @@ or reach us on Discord https://discord.gg/6zupCZFQbe
 
 	option := ui.Select("How do you want to run TraceTest?", []option{
 		{"Using Docker Compose", dockerCompose.Install},
-		{"Using Kubernetes cluster", kubernetes.Install},
+		{"Using Kubernetes", kubernetes.Install},
 	}, 0)
 
 	option.fn(ui)

--- a/cli/installer/installer.go
+++ b/cli/installer/installer.go
@@ -29,6 +29,7 @@ or reach us on Discord https://discord.gg/6zupCZFQbe
 
 	option := ui.Select("How do you want to run TraceTest?", []option{
 		{"Using Docker Compose", dockerCompose.Install},
+		{"Using Kubernetes cluster", kubernetes.Install},
 	}, 0)
 
 	option.fn(ui)

--- a/cli/installer/kubernetes.go
+++ b/cli/installer/kubernetes.go
@@ -208,6 +208,7 @@ func installMinikube(ui UI) {
 			sudo apt install curl -y
 			curl -LO https://storage.googleapis.com/minikube/releases/latest/minikube_latest_{{.Architecture}}.deb
 			sudo dpkg -i minikube_latest_{{.Architecture}}.deb
+			rm minikube_latest_{{.Architecture}}.deb
 		`,
 		yum: `
 			curl -LO https://storage.googleapis.com/minikube/releases/latest/minikube-latest.{{.RpmArchitecture}}.rpm

--- a/cli/installer/kubernetes.go
+++ b/cli/installer/kubernetes.go
@@ -61,6 +61,16 @@ func kubectlChecker(ui UI) {
 }
 
 func localEnvironmentChecker(ui UI) {
+
+	option := ui.Select("Are you going to run it locally or in a remote cluster?", []option{
+		{"Locally", confirmLocalK8sRunning},
+		{"Remote cluster", func(ui UI) {}},
+	}, 0)
+
+	option.fn(ui)
+}
+
+func confirmLocalK8sRunning(ui UI) {
 	localK8sRunning := ui.Confirm("Do you have a local kubernentes running?", true)
 	if !localK8sRunning {
 		option := ui.Select("We can fix that:", []option{

--- a/cli/installer/kubernetes.go
+++ b/cli/installer/kubernetes.go
@@ -1,0 +1,218 @@
+package installer
+
+var kubernetes = installer{
+	preChecks: []preChecker{
+		k8sEnvironmentChecker,
+		kubectlChecker,
+		helmChecker,
+	},
+	configs:   []configurator{},
+	installFn: kubernetesInstaller,
+}
+
+func kubernetesInstaller(config configuration, ui UI) {}
+
+func helmChecker(ui UI) {
+	if commandExists("helm") {
+		ui.Println(ui.Green("✔ helm already installed"))
+		return
+	}
+
+	ui.Warning("I didn't find helm in your system")
+	option := ui.Select("What do you want to do?", []option{
+		{"Install Helm", installHelm},
+		{"Fix it manually", exitOption(
+			"Check the helm install docs on https://helm.sh/docs/intro/install/",
+		)},
+	}, 0)
+
+	option.fn(ui)
+
+	if commandExists("helm") {
+		ui.Println(ui.Green("✔ helm was successfully installed"))
+	} else {
+		ui.Exit(ui.Red("✘ helm could not be installed. Check output for errors. " + createIssueMsg))
+	}
+}
+
+func kubectlChecker(ui UI) {
+	if commandExists("kubectl") {
+		ui.Println(ui.Green("✔ kubectl already installed"))
+		return
+	}
+
+	ui.Warning("I didn't find kubectl in your system")
+	option := ui.Select("What do you want to do?", []option{
+		{"Install Kubectl", installKubectl},
+		{"Fix it manually", exitOption(
+			"Check the kubectl install docs on https://kubernetes.io/docs/tasks/tools/#kubectl",
+		)},
+	}, 0)
+
+	option.fn(ui)
+
+	if commandExists("kubectl") {
+		ui.Println(ui.Green("✔ kubectl was successfully installed"))
+	} else {
+		ui.Exit(ui.Red("✘ kubectl could not be installed. Check output for errors. " + createIssueMsg))
+	}
+}
+
+func k8sEnvironmentChecker(ui UI) {
+	option := ui.Select("Are you going to run it locally or in a remote cluster?", []option{
+		{"Locally", minikubeChecker},
+		{"Remote cluster", nil}, // Nothing needs to be done
+	}, 0)
+
+	option.fn(ui)
+}
+
+func minikubeChecker(ui UI) {
+	// We require docker to be able to run minikube
+	dockerChecker(ui)
+
+	if commandExists("minikube") {
+		ui.Println(ui.Green("✔ minikube already installed"))
+		return
+	}
+
+	ui.Warning("I didn't find minikube in your system")
+	option := ui.Select("What do you want to do?", []option{
+		{"Install Minikube", installMinikube},
+		{"Fix it manually", exitOption(
+			"Check the helm install docs on https://minikube.sigs.k8s.io/docs/start/",
+		)},
+	}, 0)
+
+	option.fn(ui)
+
+	if commandExists("minikube") {
+		ui.Println(ui.Green("✔ minikube was successfully installed"))
+	} else {
+		ui.Exit(ui.Red("✘ minikube could not be installed. Check output for errors. " + createIssueMsg))
+	}
+}
+
+func installHelm(ui UI) {
+	(cmd{
+		sudo:          true,
+		notConfirmMsg: "No worries, you can try installing helm manually. See https://helm.sh/docs/intro/install/",
+		installDocs:   "https://helm.sh/docs/intro/install/",
+		args:          map[string]string{},
+		apt: `
+			sudo apt update -y
+			sudo apt install -y curl gpg
+
+			curl https://baltocdn.com/helm/signing.asc | gpg --dearmor | sudo tee /usr/share/keyrings/helm.gpg > /dev/null
+			sudo apt-get install apt-transport-https --yes
+			echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/helm.gpg] https://baltocdn.com/helm/stable/debian/ all main" | sudo tee /etc/apt/sources.list.d/helm-stable-debian.list
+			sudo apt-get update
+			sudo apt-get install helm
+		`,
+		yum:      "sudo yum -y install helm",
+		dnf:      "sudo dnf -y install helm",
+		homebrew: "brew install helm",
+		macIntelChipManual: `
+			curl -fsSL -o get_helm.sh https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3
+			chmod 700 get_helm.sh
+			./get_helm.sh
+		`,
+		macAppleChipManual: `
+			curl -fsSL -o get_helm.sh https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3
+			chmod 700 get_helm.sh
+			./get_helm.sh
+		`,
+		windows: "",
+		other:   "",
+	}).exec(ui)
+}
+
+func installKubectl(ui UI) {
+	(cmd{
+		sudo:          true,
+		notConfirmMsg: "No worries, you can try installing kubectl manually. See https://kubernetes.io/docs/tasks/tools/#kubectl",
+		installDocs:   "https://kubernetes.io/docs/tasks/tools/#kubectl",
+		args:          map[string]string{},
+		apt: `
+			sudo apt-get update
+			sudo apt-get install -y ca-certificates curl apt-transport-https
+
+			sudo curl -fsSLo /usr/share/keyrings/kubernetes-archive-keyring.gpg https://packages.cloud.google.com/apt/doc/apt-key.gpg
+			echo "deb [signed-by=/usr/share/keyrings/kubernetes-archive-keyring.gpg] https://apt.kubernetes.io/ kubernetes-xenial main" | sudo tee /etc/apt/sources.list.d/kubernetes.list
+
+			sudo apt-get update
+			sudo apt-get install -y kubectl
+		`,
+		yum: `
+cat <<EOF > /etc/yum.repos.d/kubernetes.repo
+[kubernetes]
+name=Kubernetes
+baseurl=https://packages.cloud.google.com/yum/repos/kubernetes-el7-\$basearch
+enabled=1
+gpgcheck=1
+gpgkey=https://packages.cloud.google.com/yum/doc/yum-key.gpg https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg
+EOF
+sudo yum -y install kubectl
+		`,
+		dnf: `
+cat <<EOF > /etc/yum.repos.d/kubernetes.repo
+[kubernetes]
+name=Kubernetes
+baseurl=https://packages.cloud.google.com/yum/repos/kubernetes-el7-\$basearch
+enabled=1
+gpgcheck=1
+gpgkey=https://packages.cloud.google.com/yum/doc/yum-key.gpg https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg
+EOF
+sudo dnf -y install kubectl
+		`,
+		homebrew: "brew install helm",
+		macIntelChipManual: `
+			curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/darwin/amd64/kubectl"
+			chmod +x ./kubectl
+			sudo mv ./kubectl /usr/local/bin/kubectl
+			sudo chown root: /usr/local/bin/kubectl
+		`,
+		macAppleChipManual: `
+			curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/darwin/arm64/kubectl"
+			chmod +x ./kubectl
+			sudo mv ./kubectl /usr/local/bin/kubectl
+			sudo chown root: /usr/local/bin/kubectl
+		`,
+		windows: "",
+		other:   "",
+	}).exec(ui)
+}
+
+func installMinikube(ui UI) {
+	(cmd{
+		sudo:          true,
+		notConfirmMsg: "No worries, you can try installing minikube manually. See https://minikube.sigs.k8s.io/docs/start/",
+		installDocs:   "https://minikube.sigs.k8s.io/docs/start/",
+		args:          map[string]string{},
+		apt: `
+			sudo apt update
+			sudo apt install curl -y
+			curl -LO https://storage.googleapis.com/minikube/releases/latest/minikube_latest_amd64.deb
+			sudo dpkg -i minikube_latest_amd64.deb
+		`,
+		yum: `
+			curl -LO https://storage.googleapis.com/minikube/releases/latest/minikube-latest.x86_64.rpm
+			sudo rpm -Uvh minikube-latest.x86_64.rpm
+		`,
+		dnf: `
+			curl -LO https://storage.googleapis.com/minikube/releases/latest/minikube-latest.x86_64.rpm
+			sudo rpm -Uvh minikube-latest.x86_64.rpm
+		`,
+		homebrew: "brew install minikube",
+		macIntelChipManual: `
+			curl -LO https://storage.googleapis.com/minikube/releases/latest/minikube-darwin-amd64
+			sudo install minikube-darwin-amd64 /usr/local/bin/minikube
+		`,
+		macAppleChipManual: `
+			curl -LO https://storage.googleapis.com/minikube/releases/latest/minikube-darwin-arm64
+			sudo install minikube-darwin-arm64 /usr/local/bin/minikube
+		`,
+		windows: "",
+		other:   "",
+	}).exec(ui)
+}

--- a/cli/installer/kubernetes.go
+++ b/cli/installer/kubernetes.go
@@ -1,5 +1,7 @@
 package installer
 
+import "strings"
+
 var kubernetes = installer{
 	preChecks: []preChecker{
 		kubectlChecker,
@@ -181,20 +183,23 @@ func installMinikube(ui UI) {
 		sudo:          true,
 		notConfirmMsg: "No worries, you can try installing minikube manually. See https://minikube.sigs.k8s.io/docs/start/",
 		installDocs:   "https://minikube.sigs.k8s.io/docs/start/",
-		args:          map[string]string{},
+		args: map[string]string{
+			"Architecture":    detectArchitecture(),
+			"RpmArchitecture": strings.Replace(detectArchitecture(), "amd64", "x86_64", 1),
+		},
 		apt: `
 			sudo apt update
 			sudo apt install curl -y
-			curl -LO https://storage.googleapis.com/minikube/releases/latest/minikube_latest_amd64.deb
-			sudo dpkg -i minikube_latest_amd64.deb
+			curl -LO https://storage.googleapis.com/minikube/releases/latest/minikube_latest_{{.Architecture}}.deb
+			sudo dpkg -i minikube_latest_{{.Architecture}}.deb
 		`,
 		yum: `
-			curl -LO https://storage.googleapis.com/minikube/releases/latest/minikube-latest.x86_64.rpm
-			sudo rpm -Uvh minikube-latest.x86_64.rpm
+			curl -LO https://storage.googleapis.com/minikube/releases/latest/minikube-latest.{{.RpmArchitecture}}.rpm
+			sudo rpm -Uvh minikube-latest.{{.RpmArchitecture}}.rpm
 		`,
 		dnf: `
-			curl -LO https://storage.googleapis.com/minikube/releases/latest/minikube-latest.x86_64.rpm
-			sudo rpm -Uvh minikube-latest.x86_64.rpm
+			curl -LO https://storage.googleapis.com/minikube/releases/latest/minikube-latest.{{.RpmArchitecture}}.rpm
+			sudo rpm -Uvh minikube-latest.{{.RpmArchitecture}}.rpm
 		`,
 		homebrew: "brew install minikube",
 		macIntelChipManual: `

--- a/cli/installer/kubernetes.go
+++ b/cli/installer/kubernetes.go
@@ -61,9 +61,6 @@ func kubectlChecker(ui UI) {
 }
 
 func minikubeChecker(ui UI) {
-	// We require docker to be able to run minikube
-	dockerChecker(ui)
-
 	if commandExists("minikube") {
 		ui.Println(ui.Green("✔ minikube already installed"))
 		return
@@ -84,6 +81,9 @@ func minikubeChecker(ui UI) {
 	} else {
 		ui.Exit(ui.Red("✘ minikube could not be installed. Check output for errors. " + createIssueMsg))
 	}
+
+	// We require docker to be able to run minikube
+	dockerChecker(ui)
 }
 
 func installHelm(ui UI) {

--- a/cli/installer/kubernetes.go
+++ b/cli/installer/kubernetes.go
@@ -213,10 +213,12 @@ func installMinikube(ui UI) {
 		yum: `
 			curl -LO https://storage.googleapis.com/minikube/releases/latest/minikube-latest.{{.RpmArchitecture}}.rpm
 			sudo rpm -Uvh minikube-latest.{{.RpmArchitecture}}.rpm
+			rm minikube-latest.{{.RpmArchitecture}}.rpm
 		`,
 		dnf: `
 			curl -LO https://storage.googleapis.com/minikube/releases/latest/minikube-latest.{{.RpmArchitecture}}.rpm
 			sudo rpm -Uvh minikube-latest.{{.RpmArchitecture}}.rpm
+			rm minikube-latest.{{.RpmArchitecture}}.rpm
 		`,
 		homebrew: "brew install minikube",
 		macIntelChipManual: `

--- a/cli/installer/kubernetes.go
+++ b/cli/installer/kubernetes.go
@@ -2,7 +2,6 @@ package installer
 
 var kubernetes = installer{
 	preChecks: []preChecker{
-		k8sEnvironmentChecker,
 		kubectlChecker,
 		helmChecker,
 	},
@@ -56,15 +55,9 @@ func kubectlChecker(ui UI) {
 	} else {
 		ui.Exit(ui.Red("✘ kubectl could not be installed. Check output for errors. " + createIssueMsg))
 	}
-}
 
-func k8sEnvironmentChecker(ui UI) {
-	option := ui.Select("Are you going to run it locally or in a remote cluster?", []option{
-		{"Locally", minikubeChecker},
-		{"Remote cluster", nil}, // Nothing needs to be done
-	}, 0)
-
-	option.fn(ui)
+	// If user doesn't have kubectl, it probably doesn't have minikube either, so suggest installig it
+	minikubeChecker(ui)
 }
 
 func minikubeChecker(ui UI) {

--- a/cli/installer/tracetest.go
+++ b/cli/installer/tracetest.go
@@ -133,7 +133,7 @@ func getTracetestConfigFileContents(ui UI, config configuration) []byte {
 
 	out, err := yaml.Marshal(sc)
 	if err != nil {
-		ui.Exit(fmt.Errorf("Cannot marshal tracetest config file: %w", err).Error())
+		ui.Exit(fmt.Errorf("cannot marshal tracetest config file: %w", err).Error())
 	}
 
 	return out


### PR DESCRIPTION
This PR installs the basic dependencies needed by the CLI to install the tracetest server to a k8s cluster.

This also fixes docker-engine installation on Ubuntu

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
