### PR TITLE
Fix create test spec from drawer

### DIFF
--- a/web/src/components/FailedTrace/__tests__/FailedTrace.test.tsx
+++ b/web/src/components/FailedTrace/__tests__/FailedTrace.test.tsx
@@ -1,10 +1,8 @@
 import {render} from 'test-utils';
 import FailedTrace from '../index';
-import TestMock from '../../../models/__mocks__/Test.mock';
 import TestRunMock from '../../../models/__mocks__/TestRun.mock';
 
 test('FailedTrace', () => {
-  const test = TestMock.model();
-  const {getByText} = render(<FailedTrace testId={test.id} isDisplayingError run={TestRunMock.model()} />);
+  const {getByText} = render(<FailedTrace isDisplayingError run={TestRunMock.model()} />);
   expect(getByText('Test Run Failed')).toBeTruthy();
 });

--- a/web/src/components/RunDetailTrace/RunDetailTrace.tsx
+++ b/web/src/components/RunDetailTrace/RunDetailTrace.tsx
@@ -1,4 +1,5 @@
-import {useState} from 'react';
+import {useCallback, useState} from 'react';
+import {useNavigate} from 'react-router-dom';
 
 import Drawer from 'components/Drawer';
 import SpanDetail from 'components/SpanDetail';
@@ -27,12 +28,17 @@ const RunDetailTrace = ({run, testId}: IProps) => {
   const selectedSpan = useAppSelector(TraceSelectors.selectSelectedSpan);
   const searchText = useAppSelector(TraceSelectors.selectSearchText);
   const span = useAppSelector(state => SpanSelectors.selectSpanById(state, selectedSpan, testId, run.id));
+  const navigate = useNavigate();
   const [visualizationType, setVisualizationType] = useState(VisualizationType.Dag);
+
+  const handleOnCreateSpec = useCallback(() => {
+    navigate(`/test/${testId}/run/${run.id}/test`);
+  }, [navigate, run.id, testId]);
 
   return (
     <S.Container>
       <Drawer>
-        <SpanDetail searchText={searchText} span={span} />
+        <SpanDetail onCreateTestSpec={handleOnCreateSpec} searchText={searchText} span={span} />
       </Drawer>
 
       <S.Section>

--- a/web/src/components/RunDetailTrigger/RunDetailTrigger.tsx
+++ b/web/src/components/RunDetailTrigger/RunDetailTrigger.tsx
@@ -12,7 +12,7 @@ interface IProps {
   isError: boolean;
 }
 
-const RunDetailTrigger = ({test, test: {id}, run: {triggerResult, state, executionTime}, run, isError}: IProps) => {
+const RunDetailTrigger = ({test, run: {triggerResult, state, executionTime}, run, isError}: IProps) => {
   const shouldDisplayError = isError || state === TestState.FAILED;
 
   return (

--- a/web/src/components/SpanDetail/SpanDetail.tsx
+++ b/web/src/components/SpanDetail/SpanDetail.tsx
@@ -1,3 +1,4 @@
+import {noop} from 'lodash';
 import {useCallback} from 'react';
 
 import {CompareOperator} from 'constants/Operator.constants';
@@ -14,11 +15,12 @@ import Header from './Header';
 import * as S from './SpanDetail.styled';
 
 interface IProps {
+  onCreateTestSpec?(): void;
   searchText?: string;
   span?: TSpan;
 }
 
-const SpanDetail = ({searchText, span}: IProps) => {
+const SpanDetail = ({onCreateTestSpec = noop, searchText, span}: IProps) => {
   const {open} = useTestSpecForm();
   const spansResult = useAppSelector(TestDefinitionSelectors.selectSpansResult);
   const assertions = useAppSelector(state =>
@@ -44,8 +46,10 @@ const SpanDetail = ({searchText, span}: IProps) => {
           selector,
         },
       });
+
+      onCreateTestSpec();
     },
-    [span, open]
+    [onCreateTestSpec, open, span]
   );
 
   return (


### PR DESCRIPTION
This PR fixes the creation of a test spec from the Drawer in the Trace mode.

## Changes

- Add navigate function to move to the Test mode.

## Fixes

-

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
