### PR TITLE
Update Jaeger install instructions

### DIFF
--- a/docs/installing.md
+++ b/docs/installing.md
@@ -59,7 +59,7 @@ helm repo add kubeshop https://kubeshop.github.io/helm-charts
 helm repo update
 
 helm install tracetest kubeshop/tracetest \
-  --set telemetry.dataStores.jaeger.jaeger.endpoint="jaeger-query.observability.svc.cluster.local:16685" `# update this value to point to your jaeger` install` \
+  --set telemetry.dataStores.jaeger.jaeger.endpoint="jaeger-query.observability.svc.cluster.local:16685" `# update this value to point to your jaeger install` \
   --set telemetry.exporters.collector.exporter.collector.endpoint="otel-collector.tracetest.svc.cluster.local:4317" `# update this value to point to your collector install` \
   --set server.telemetry.dataStore="jaeger"
 ```

--- a/docs/installing.md
+++ b/docs/installing.md
@@ -51,7 +51,7 @@ Tracetest currently supports two traces backend: Jaeger and Grafana Tempo.
 
 Tracetest uses [Jaeger Query Service `16685` port](https://www.jaegertracing.io/docs/1.32/deployment/#query-service--ui) to find Traces using gRPC protocol.
 
-The commands below will install Tracetest connecting to the Jaeger tracing backend on `jaeger-query:16685`.
+The commands below will install Tracetest connecting to the Jaeger tracing backend on `jaeger-query.observability.svc.cluster.local:16685`.
 
 ```sh
 # Install Kubeshop Helm repo and update it
@@ -59,8 +59,8 @@ helm repo add kubeshop https://kubeshop.github.io/helm-charts
 helm repo update
 
 helm install tracetest kubeshop/tracetest \
-  --set telemetry.dataStores.jaeger.jaeger.endpoint="jaeger-query:16685" \ # update this value to point to your jaeger install
-  --set telemetry.exporters.collector.exporter.collector.endpoint="otel-collector:4317" \ # update this value to point to your collector install
+  --set telemetry.dataStores.jaeger.jaeger.endpoint="jaeger-query.observability.svc.cluster.local:16685" `# update this value to point to your jaeger` install` \
+  --set telemetry.exporters.collector.exporter.collector.endpoint="otel-collector.tracetest.svc.cluster.local:4317" `# update this value to point to your collector install` \
   --set server.telemetry.dataStore="jaeger"
 ```
 


### PR DESCRIPTION

This PR reduces friction from trying out tracetest with Jaeger backend.

Note that I know this is a very small thing, and I just want to also say it mostly struck me because the fonts on the installation page led me to believe I needed _both_ the script _and_ helm (which I now know I don't!). If you look at `Install script` vs the bold `Using Helm` is the reason the font threw me off despite them both having the same heading level:

![image](https://user-images.githubusercontent.com/1557346/188130512-fc627805-2aa0-4c22-8364-f98a7f443a68.png)


## Changes

This change does two things:
1. Makes the inline bash comments run without error
2. Updates the endpoints to respect the multi-namespace install

## Fixes

This was debugged but viewing [#1056](https://github.com/kubeshop/tracetest/issues/1056) which also indicates a 
longer term fix in the works. However until that is in place this would
remove a lot of friction for getting started.

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [x] updated the docs
- [ ] added a test
