### PR TITLE
Add support for expressions in assertion

### DIFF
--- a/server/encoding/yaml/conversion/definition_openapi_conversion.go
+++ b/server/encoding/yaml/conversion/definition_openapi_conversion.go
@@ -132,7 +132,6 @@ func convertTestSpecIntoOpenAPIObject(testSpec []definition.TestSpec) (openapi.T
 }
 
 func convertStringIntoAssertion(assertion string) (openapi.Assertion, error) {
-	// TODO: convert string into assertion (using a parser?)
 	parsedAssertion, err := parser.ParseAssertion(assertion)
 	if err != nil {
 		return openapi.Assertion{}, err

--- a/server/http/mappings/tests.go
+++ b/server/http/mappings/tests.go
@@ -378,34 +378,13 @@ func (m Model) Result(in openapi.AssertionResults) *model.RunResults {
 }
 
 func (m Model) Assertion(in openapi.Assertion) model.Assertion {
-	expression, err := parser.ParseAssertionExpression(in.Expected)
-	if err != nil {
-		// Maybe it's a string without quotes, try quoting it and see if it works
-		expression = parseQuotedAssertionValue(in)
-	}
-
-	// this totally breaks the purpose of having expressions
-	// but expressions will not work unless we receive the assertion as a string
-	// instead of an object.
-	// So we have to remove this after we start receiving the assertion as a string
-	// TODO: remove this after assertions are sent as strings
-	if expression.LiteralValue.Type() == "attribute" {
-		expression = parseQuotedAssertionValue(in)
-	}
-
+	expression, _ := parser.ParseAssertionExpression(in.Expected)
 	comp, _ := m.comparators.Get(in.Comparator)
 	return model.Assertion{
 		Attribute:  model.Attribute(in.Attribute),
 		Comparator: comp,
 		Value:      m.AssertionExpression(expression),
 	}
-}
-
-func parseQuotedAssertionValue(in openapi.Assertion) *parser.Expression {
-	quotedValue := fmt.Sprintf(`"%s"`, in.Expected)
-	expression, _ := parser.ParseAssertionExpression(quotedValue)
-
-	return expression
 }
 
 func (m Model) AssertionExpression(in *parser.Expression) *model.AssertionExpression {

--- a/web/.npmrc
+++ b/web/.npmrc
@@ -1,1 +1,2 @@
 save-exact=true
+legacy-peer-deps=true

--- a/web/cypress/e2e/TestRunDetail/CreateAssertion.spec.ts
+++ b/web/cypress/e2e/TestRunDetail/CreateAssertion.spec.ts
@@ -6,7 +6,7 @@ describe('Create Assertion', () => {
 
   it('should create a basic assertion', () => cy.createAssertion());
 
-  it('should create an assertion with multiple checks', () => {
+  it.only('should create an assertion with multiple checks', () => {
     cy.selectRunDetailMode(3);
 
     cy.get(`[data-cy=trace-node-http]`, {timeout: 20000}).first().click();
@@ -38,10 +38,6 @@ describe('Create Assertion', () => {
       .click();
 
     cy.selectOperator(2);
-
-    cy.get('[data-cy=assertion-check-value]').last().type('s');
-    cy.get('[data-cy=duration]').click();
-    cy.get(`[data-cy=duration-unit-μs]`).click();
 
     cy.get('[data-cy=assertion-form-submit-button]').click();
 

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -16787,13 +16787,19 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001306",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001306.tgz",
-      "integrity": "sha512-Wd1OuggRzg1rbnM5hv1wXs2VkxJH/AA+LuudlIqvZiCvivF+wJJe2mgBZC8gPMgI7D76PP5CTx8Luvaqc1V6OQ==",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/browserslist"
-      }
+      "version": "1.0.30001397",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001397.tgz",
+      "integrity": "sha512-SW9N2TbCdLf0eiNDRrrQXx2sOkaakNZbCjgNpPyMJJbiOrU5QzMIrXOVMRM1myBXTD5iTkdrtU/EguCrBocHlA==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        }
+      ]
     },
     "node_modules/capture-exit": {
       "version": "2.0.0",
@@ -50059,9 +50065,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001306",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001306.tgz",
-      "integrity": "sha512-Wd1OuggRzg1rbnM5hv1wXs2VkxJH/AA+LuudlIqvZiCvivF+wJJe2mgBZC8gPMgI7D76PP5CTx8Luvaqc1V6OQ=="
+      "version": "1.0.30001397",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001397.tgz",
+      "integrity": "sha512-SW9N2TbCdLf0eiNDRrrQXx2sOkaakNZbCjgNpPyMJJbiOrU5QzMIrXOVMRM1myBXTD5iTkdrtU/EguCrBocHlA=="
     },
     "capture-exit": {
       "version": "2.0.0",

--- a/web/src/components/TestSpecForm/AssertionCheckList.tsx
+++ b/web/src/components/TestSpecForm/AssertionCheckList.tsx
@@ -23,23 +23,21 @@ const AssertionCheckList = ({form, fields, add, remove, attributeList, assertion
 
   return (
     <S.AssertionsContainer>
-      <S.CheckContainer>
-        {fields.map(({key, name, ...field}, index) => {
-          return (
-            <AssertionCheck
-              key={key}
-              form={form}
-              remove={remove}
-              field={field}
-              attributeList={attributeList}
-              name={name}
-              index={index}
-              assertions={assertions}
-              reference={reference}
-            />
-          );
-        })}
-      </S.CheckContainer>
+      {fields.map(({key, name, ...field}, index) => {
+        return (
+          <AssertionCheck
+            key={key}
+            form={form}
+            remove={remove}
+            field={field}
+            attributeList={attributeList}
+            name={name}
+            index={index}
+            assertions={assertions}
+            reference={reference}
+          />
+        );
+      })}
       <S.AddCheckButton
         icon={<PlusOutlined />}
         onClick={() => {

--- a/web/src/components/TestSpecForm/ExpectedInputContainer.ts
+++ b/web/src/components/TestSpecForm/ExpectedInputContainer.ts
@@ -1,0 +1,32 @@
+import styled from 'styled-components';
+
+export const ExpectedInputContainer = styled.div`
+  width: 0;
+  flex-basis: 50%;
+  padding-left: 8px;
+
+  && {
+    .cm-editor {
+      overflow: hidden;
+      display: flex;
+      border-radius: 2px;
+      font-size: ${({theme}) => theme.size.md};
+      outline: 1px solid grey;
+      height: 32px;
+      font-family: SFPro, serif;
+    }
+    .cm-content {
+      display: flex;
+      align-items: center;
+    }
+    .cm-scroller {
+      overflow: hidden;
+    }
+    .cm-line {
+      padding: 0;
+      span {
+        font-family: SFPro, serif;
+      }
+    }
+  }
+`;

--- a/web/src/components/TestSpecForm/Fields/AttributeField.tsx
+++ b/web/src/components/TestSpecForm/Fields/AttributeField.tsx
@@ -24,6 +24,7 @@ export const AttributeField = ({field, name, reference, attributeList}: IProps):
       rules={[{required: true, message: 'Attribute is required'}]}
       data-cy="assertion-check-attribute"
       id="assertion-check-attribute"
+      style={{flexBasis: '30%', width: 0}}
     >
       <S.Select
         placeholder="Attribute"

--- a/web/src/components/TestSpecForm/TestSpecForm.styled.ts
+++ b/web/src/components/TestSpecForm/TestSpecForm.styled.ts
@@ -4,6 +4,7 @@ import styled from 'styled-components';
 
 export const Select = styled(AntSelect)`
   min-width: 88px;
+
   > .ant-select-selector {
     min-height: 100%;
   }
@@ -15,15 +16,27 @@ export const Check = styled.div`
   gap: 8px 12px;
 `;
 
-export const CheckContainer = styled.div`
-  display: grid;
-  gap: 8px 12px;
-  grid-template-columns: repeat(3, 1fr) 14px;
-  margin-bottom: 8px;
-`;
-
 export const AssertionsContainer = styled.div`
   margin-bottom: 24px;
+`;
+
+export const Container = styled.div`
+  display: flex;
+  justify-content: space-between;
+  padding-bottom: 8px;
+`;
+
+export const FieldsContainer = styled.div`
+  display: flex;
+  justify-content: space-between;
+  flex-basis: 95%;
+`;
+
+export const ActionContainer = styled.div`
+  display: flex;
+  justify-content: center;
+  align-self: center;
+  flex-basis: 5%;
 `;
 
 export const AddCheckButton = styled(Button).attrs({

--- a/web/src/components/TestSpecForm/useExpectedInputLanguage.tsx
+++ b/web/src/components/TestSpecForm/useExpectedInputLanguage.tsx
@@ -19,6 +19,9 @@ export function useExpectedInputLanguage() {
               {label: `${message?.text.toString()}ms`, value: `${message?.text.toString()}ms`},
               {label: `${message?.text.toString()}s`, value: `${message?.text.toString()}s`},
             ];
+            console.log(context.state.doc);
+            console.log(message);
+            console.log(message?.text);
             const isN = isNumber(message?.text);
             if (message?.from === 0) {
               return {from: 0, options: isN ? durationOtions : attributeOptions};
@@ -28,9 +31,7 @@ export function useExpectedInputLanguage() {
               options: isN
                 ? durationOtions
                 : [
-                    {label: 'minus', value: '-', apply: '- '},
                     {label: '+', value: '-', apply: '- '},
-                    {label: 'plus', value: '+', apply: '+ '},
                     {label: '-', value: '+', apply: '+ '},
                   ],
             };

--- a/web/src/components/TestSpecForm/useExpectedInputLanguage.tsx
+++ b/web/src/components/TestSpecForm/useExpectedInputLanguage.tsx
@@ -1,0 +1,42 @@
+import {autocompletion} from '@codemirror/autocomplete';
+import {useMemo} from 'react';
+import {Attributes} from '../../constants/SpanAttribute.constants';
+import {tracetest} from '../../utils/grammar';
+
+function isNumber(text?: string) {
+  return text?.toString().match(/^\d*(\.\d+)?$/);
+}
+
+export function useExpectedInputLanguage() {
+  return useMemo(
+    () => [
+      autocompletion({
+        override: [
+          context => {
+            const message = context.matchBefore(/\w*/);
+            const attributeOptions = Object.values(Attributes).map(s => ({label: s, value: s, apply: `${s} `}));
+            const durationOtions = [
+              {label: `${message?.text.toString()}ms`, value: `${message?.text.toString()}ms`},
+              {label: `${message?.text.toString()}s`, value: `${message?.text.toString()}s`},
+            ];
+            const isN = isNumber(message?.text);
+            if (message?.from === 0) {
+              return {from: 0, options: isN ? durationOtions : attributeOptions};
+            }
+            return {
+              from: context.pos - 1,
+              options: isN
+                ? durationOtions
+                : [
+                    {label: 'minus', value: '-', apply: '- '},
+                    {label: 'plus', value: '+', apply: '+ '},
+                  ],
+            };
+          },
+        ],
+      }),
+      tracetest(),
+    ],
+    []
+  );
+}

--- a/web/src/components/TestSpecForm/useExpectedInputLanguage.tsx
+++ b/web/src/components/TestSpecForm/useExpectedInputLanguage.tsx
@@ -29,7 +29,9 @@ export function useExpectedInputLanguage() {
                 ? durationOtions
                 : [
                     {label: 'minus', value: '-', apply: '- '},
+                    {label: '+', value: '-', apply: '- '},
                     {label: 'plus', value: '+', apply: '+ '},
+                    {label: '-', value: '+', apply: '+ '},
                   ],
             };
           },

--- a/web/src/components/TestSpecForm/useExpectedInputLanguage.tsx
+++ b/web/src/components/TestSpecForm/useExpectedInputLanguage.tsx
@@ -19,9 +19,6 @@ export function useExpectedInputLanguage() {
               {label: `${message?.text.toString()}ms`, value: `${message?.text.toString()}ms`},
               {label: `${message?.text.toString()}s`, value: `${message?.text.toString()}s`},
             ];
-            console.log(context.state.doc);
-            console.log(message);
-            console.log(message?.text);
             const isN = isNumber(message?.text);
             if (message?.from === 0) {
               return {from: 0, options: isN ? durationOtions : attributeOptions};

--- a/web/src/constants/Plugins.constants.ts
+++ b/web/src/constants/Plugins.constants.ts
@@ -41,7 +41,7 @@ const Default: IPlugin = {
   ],
 };
 
-export const pokeApi = window?.ENV?.pokeApi || 'http://demo-pokemon-api.demo.svc.cluster.local';
+export const pokeApi = window?.ENV?.pokeApi || 'http://demo-api:8081';
 
 const Rest: IPlugin = {
   name: SupportedPlugins.REST,

--- a/web/src/services/__tests__/Assertion.service.test.ts
+++ b/web/src/services/__tests__/Assertion.service.test.ts
@@ -1,11 +1,28 @@
 import faker from '@faker-js/faker';
-import AssertionService from '../Assertion.service';
 import AssertionResultMock from '../../models/__mocks__/AssertionResult.mock';
 import AssertionSpanResultMock from '../../models/__mocks__/AssertionSpanResult.mock';
+import AssertionService from '../Assertion.service';
 
 describe('AssertionService', () => {
+  describe('extractExpectedString', () => {
+    it('should return quoted string', () => {
+      expect(AssertionService.extractExpectedString('some text')).toEqual(AssertionService.quotedString('some text'));
+    });
+    it('should return not quoted string', () => {
+      const {extractExpectedString} = AssertionService;
+      expect(extractExpectedString(undefined)).toEqual(undefined);
+      expect(extractExpectedString('')).toEqual('');
+      expect(extractExpectedString('300')).toEqual('300');
+      expect(extractExpectedString('300.3')).toEqual('300.3');
+      expect(extractExpectedString('300ms')).toEqual('300ms');
+      expect(extractExpectedString('300.3ms')).toEqual('300.3ms');
+      expect(extractExpectedString('tracetest.span.duration')).toEqual('tracetest.span.duration');
+      expect(extractExpectedString('tracetest.span.duration + 30ms')).toEqual('tracetest.span.duration + 30ms');
+    });
+  });
   describe('getSpanIds', () => {
     it('should return a list of unique span ids', () => {
+      const {getSpanIds} = AssertionService;
       const id1 = faker.datatype.uuid();
       const id2 = faker.datatype.uuid();
       const id3 = faker.datatype.uuid();
@@ -17,7 +34,7 @@ describe('AssertionService', () => {
           AssertionSpanResultMock.raw({spanId: id3}),
         ],
       });
-      const result = AssertionService.getSpanIds([assertionResult]);
+      const result = getSpanIds([assertionResult]);
 
       expect(result).toEqual([id1, id2, id3]);
     });


### PR DESCRIPTION
This PR make necessary changes to support assertions expressions on the frontend

## Changes

- The backend to fix some implementation bug
- Add new Code Mirror component for expected assertion value
- Removes Duration Field
- Format expected assertion value the proper way so backend works

## Fixes

- #1009 
- #1160 

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [x] added a test
