### PR TITLE
fix: assertion parsing infering wrong type of field

### DIFF
--- a/server/encoding/yaml/conversion/definition_openapi_conversion.go
+++ b/server/encoding/yaml/conversion/definition_openapi_conversion.go
@@ -138,9 +138,19 @@ func convertStringIntoAssertion(assertion string) (openapi.Assertion, error) {
 		return openapi.Assertion{}, err
 	}
 
+	value := parsedAssertion.Value.String()
+	if parsedAssertion.Value.IsSimple() {
+		if parsedAssertion.Value.LiteralValue.Type() == "string" {
+			// This is a simple string comparasion, so we need to wrap it
+			// in quotes for it to work. Otherwise the parser will think
+			// this is an attribute
+			value = fmt.Sprintf(`"%s"`, value)
+		}
+	}
+
 	return openapi.Assertion{
 		Attribute:  parsedAssertion.Attribute,
 		Comparator: parsedAssertion.Operator,
-		Expected:   parsedAssertion.Value.String(),
+		Expected:   value,
 	}, nil
 }

--- a/server/encoding/yaml/conversion/definition_openapi_conversion.go
+++ b/server/encoding/yaml/conversion/definition_openapi_conversion.go
@@ -141,7 +141,7 @@ func convertStringIntoAssertion(assertion string) (openapi.Assertion, error) {
 	value := parsedAssertion.Value.String()
 	if parsedAssertion.Value.IsSimple() {
 		if parsedAssertion.Value.LiteralValue.Type() == "string" {
-			// This is a simple string comparasion, so we need to wrap it
+			// This is a simple string comparison, so we need to wrap it
 			// in quotes for it to work. Otherwise the parser will think
 			// this is an attribute
 			value = fmt.Sprintf(`"%s"`, value)

--- a/server/encoding/yaml/conversion/parser/assertion_parser.go
+++ b/server/encoding/yaml/conversion/parser/assertion_parser.go
@@ -20,6 +20,10 @@ type Expression struct {
 	Expression   *Expression
 }
 
+func (e *Expression) IsSimple() bool {
+	return e.Expression == nil
+}
+
 func (e *Expression) String() string {
 	if e.Expression == nil {
 		return e.LiteralValue.String()


### PR DESCRIPTION
This PR fixes string fields conversion in expressions

## Checklist

- [ ] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
