### PR TITLE
Add clientID to analytics

### DIFF
--- a/cli/analytics/analytics.go
+++ b/cli/analytics/analytics.go
@@ -1,8 +1,6 @@
 package analytics
 
 import (
-	"fmt"
-
 	"github.com/denisbrodbeck/machineid"
 	"github.com/kubeshop/tracetest/cli/config"
 	segment "github.com/segmentio/analytics-go/v3"
@@ -21,10 +19,10 @@ func Init(conf config.Config) {
 
 	client = segment.New(SecretKey)
 	id, err := machineid.ProtectedID("tracetest")
-	if err != nil {
-		panic(fmt.Errorf("could not get machineID: %w", err))
-	}
-	mid = id
+	if err == nil {
+		// only use id if available.
+		mid = id
+	} // ignore errors and continue with an empty ID if neccesary
 
 	client.Enqueue(segment.Identify{
 		Traits: segment.NewTraits().

--- a/cli/analytics/analytics.go
+++ b/cli/analytics/analytics.go
@@ -12,6 +12,10 @@ var (
 	mid       string
 )
 
+func ClientID() string {
+	return mid
+}
+
 func Init(conf config.Config) {
 	if !conf.AnalyticsEnabled {
 		return

--- a/cli/cmd/config.go
+++ b/cli/cmd/config.go
@@ -53,6 +53,7 @@ func teardownCommand(cmd *cobra.Command, args []string) {
 
 func getAPIClient() *openapi.APIClient {
 	config := openapi.NewConfiguration()
+	config.AddDefaultHeader("x-client-id", analytics.ClientID())
 	config.Scheme = cliConfig.Scheme
 	config.Host = cliConfig.Endpoint
 	if cliConfig.ServerPath != nil {

--- a/server/analytics/analytics.go
+++ b/server/analytics/analytics.go
@@ -39,14 +39,17 @@ func Ready() bool {
 	return defaultClient != nil && defaultClient.Ready()
 }
 
-func SendEvent(name, category string) error {
+func SendEvent(name, category, clientID string) error {
 	fmt.Printf(`sending event "%s" (%s)%s`, name, category, "\n")
 	if !Ready() {
 		err := fmt.Errorf("uninitalized client. Call analytics.Init")
 		fmt.Printf(`could not send event "%s" (%s): %s%s`, name, category, err.Error(), "\n")
 		return err
 	}
-	err := defaultClient.Track(name, map[string]string{"category": category})
+	err := defaultClient.Track(name, map[string]string{
+		"category": category,
+		"clientID": clientID,
+	})
 	if err != nil {
 		fmt.Printf(`could not send event "%s" (%s): %s%s`, name, category, err.Error(), "\n")
 	} else {

--- a/server/app/app.go
+++ b/server/app/app.go
@@ -89,7 +89,7 @@ func (a *App) Start() error {
 	}
 
 	if isNewInstall {
-		err = analytics.SendEvent("Install", "beacon")
+		err = analytics.SendEvent("Install", "beacon", "")
 		if err != nil {
 			return err
 		}
@@ -166,7 +166,7 @@ func (a *App) Start() error {
 		),
 	)
 
-	err = analytics.SendEvent("Server Started", "beacon")
+	err = analytics.SendEvent("Server Started", "beacon", "")
 	if err != nil {
 		return err
 	}

--- a/server/http/controller.go
+++ b/server/http/controller.go
@@ -9,7 +9,6 @@ import (
 	"net/http"
 
 	"github.com/google/uuid"
-	"github.com/kubeshop/tracetest/server/analytics"
 	"github.com/kubeshop/tracetest/server/assertions"
 	"github.com/kubeshop/tracetest/server/assertions/selectors"
 	"github.com/kubeshop/tracetest/server/encoding/yaml/conversion"
@@ -57,7 +56,6 @@ func handleDBError(err error) openapi.ImplResponse {
 }
 
 func (c *controller) CreateTest(ctx context.Context, in openapi.Test) (openapi.ImplResponse, error) {
-	analytics.SendEvent("Test Created", "test")
 	test := c.mappers.In.Test(in)
 
 	// if they try to create a test with preset ID, we need to make sure that ID doesn't exists already
@@ -85,7 +83,6 @@ func (c *controller) CreateTest(ctx context.Context, in openapi.Test) (openapi.I
 }
 
 func (c *controller) DeleteTest(ctx context.Context, testID string) (openapi.ImplResponse, error) {
-	analytics.SendEvent("Test Deleted", "test")
 	id, err := uuid.Parse(testID)
 	if err != nil {
 		return openapi.Response(http.StatusUnprocessableEntity, err.Error()), err
@@ -105,7 +102,6 @@ func (c *controller) DeleteTest(ctx context.Context, testID string) (openapi.Imp
 }
 
 func (c *controller) GetTest(ctx context.Context, testID string) (openapi.ImplResponse, error) {
-	analytics.SendEvent("Test Get", "test")
 	id, err := uuid.Parse(testID)
 	if err != nil {
 		return openapi.Response(http.StatusUnprocessableEntity, err.Error()), err
@@ -120,7 +116,6 @@ func (c *controller) GetTest(ctx context.Context, testID string) (openapi.ImplRe
 }
 
 func (c *controller) GetTestSpecs(ctx context.Context, testID string) (openapi.ImplResponse, error) {
-	analytics.SendEvent("Test Get Definition", "test")
 	id, err := uuid.Parse(testID)
 	if err != nil {
 		return openapi.Response(http.StatusUnprocessableEntity, err.Error()), err
@@ -135,7 +130,6 @@ func (c *controller) GetTestSpecs(ctx context.Context, testID string) (openapi.I
 }
 
 func (c *controller) GetTestResultSelectedSpans(ctx context.Context, _ string, runID string, selectorQuery string) (openapi.ImplResponse, error) {
-	analytics.SendEvent("Test Test Result Selected Spans", "test")
 	rid, err := uuid.Parse(runID)
 	if err != nil {
 		return openapi.Response(http.StatusUnprocessableEntity, err.Error()), err
@@ -166,7 +160,6 @@ func (c *controller) GetTestResultSelectedSpans(ctx context.Context, _ string, r
 }
 
 func (c *controller) GetTestRun(ctx context.Context, _ string, runID string) (openapi.ImplResponse, error) {
-	analytics.SendEvent("Test Run Get", "test")
 	rid, err := uuid.Parse(runID)
 	if err != nil {
 		return openapi.Response(http.StatusUnprocessableEntity, err.Error()), err
@@ -181,7 +174,6 @@ func (c *controller) GetTestRun(ctx context.Context, _ string, runID string) (op
 }
 
 func (c *controller) DeleteTestRun(ctx context.Context, _ string, runID string) (openapi.ImplResponse, error) {
-	analytics.SendEvent("Test Run Deleted", "test")
 	rid, err := uuid.Parse(runID)
 	if err != nil {
 		return openapi.Response(http.StatusUnprocessableEntity, err.Error()), err
@@ -201,7 +193,6 @@ func (c *controller) DeleteTestRun(ctx context.Context, _ string, runID string) 
 }
 
 func (c *controller) GetTestRuns(ctx context.Context, testID string, take, skip int32) (openapi.ImplResponse, error) {
-	analytics.SendEvent("Test Runs List", "test")
 	if take == 0 {
 		take = 20
 	}
@@ -225,7 +216,6 @@ func (c *controller) GetTestRuns(ctx context.Context, testID string, take, skip 
 }
 
 func (c *controller) GetTests(ctx context.Context, take, skip int32, query string) (openapi.ImplResponse, error) {
-	analytics.SendEvent("Test List", "test")
 	if take == 0 {
 		take = 20
 	}
@@ -239,7 +229,6 @@ func (c *controller) GetTests(ctx context.Context, take, skip int32, query strin
 }
 
 func (c *controller) RerunTestRun(ctx context.Context, testID string, runID string) (openapi.ImplResponse, error) {
-	analytics.SendEvent("Test Rerun Start", "test")
 	id, err := uuid.Parse(testID)
 	if err != nil {
 		return openapi.Response(http.StatusUnprocessableEntity, err.Error()), err
@@ -282,7 +271,6 @@ func (c *controller) RerunTestRun(ctx context.Context, testID string, runID stri
 }
 
 func (c *controller) RunTest(ctx context.Context, testID string, runInformation openapi.TestRunInformation) (openapi.ImplResponse, error) {
-	analytics.SendEvent("Test Run Start", "test")
 	id, err := uuid.Parse(testID)
 	if err != nil {
 		return openapi.Response(http.StatusUnprocessableEntity, err.Error()), err
@@ -303,7 +291,6 @@ func (c *controller) RunTest(ctx context.Context, testID string, runInformation 
 }
 
 func (c *controller) SetTestSpecs(ctx context.Context, testID string, def openapi.TestSpecs) (openapi.ImplResponse, error) {
-	analytics.SendEvent("Test Definition Updated", "test")
 	id, err := uuid.Parse(testID)
 	if err != nil {
 		return openapi.Response(http.StatusUnprocessableEntity, err.Error()), err
@@ -336,7 +323,6 @@ func (c *controller) SetTestSpecs(ctx context.Context, testID string, def openap
 }
 
 func (c *controller) UpdateTest(ctx context.Context, testID string, in openapi.Test) (openapi.ImplResponse, error) {
-	analytics.SendEvent("Test Updated", "test")
 	id, err := uuid.Parse(testID)
 	if err != nil {
 		return openapi.Response(http.StatusUnprocessableEntity, err.Error()), err
@@ -361,7 +347,6 @@ func (c *controller) UpdateTest(ctx context.Context, testID string, in openapi.T
 }
 
 func (c *controller) DryRunAssertion(ctx context.Context, _, runID string, def openapi.TestSpecs) (openapi.ImplResponse, error) {
-	analytics.SendEvent("Test Dry Run", "test")
 	rid, err := uuid.Parse(runID)
 	if err != nil {
 		return openapi.Response(http.StatusUnprocessableEntity, err.Error()), err
@@ -386,7 +371,6 @@ func (c *controller) DryRunAssertion(ctx context.Context, _, runID string, def o
 }
 
 func (c *controller) GetRunResultJUnit(ctx context.Context, testID string, runID string) (openapi.ImplResponse, error) {
-	analytics.SendEvent("Test Get JUnit", "test")
 	rid, err := uuid.Parse(runID)
 	if err != nil {
 		return openapi.Response(http.StatusUnprocessableEntity, err.Error()), err
@@ -416,7 +400,6 @@ func (c *controller) GetRunResultJUnit(ctx context.Context, testID string, runID
 }
 
 func (c controller) GetTestVersion(ctx context.Context, testID string, version int32) (openapi.ImplResponse, error) {
-	analytics.SendEvent("Test Get Definition File", "test")
 	tid, err := uuid.Parse(testID)
 	if err != nil {
 		return openapi.Response(http.StatusUnprocessableEntity, err.Error()), err
@@ -431,7 +414,6 @@ func (c controller) GetTestVersion(ctx context.Context, testID string, version i
 }
 
 func (c controller) GetTestVersionDefinitionFile(ctx context.Context, testID string, version int32) (openapi.ImplResponse, error) {
-	analytics.SendEvent("Test Get Definition File", "test")
 	tid, err := uuid.Parse(testID)
 	if err != nil {
 		return openapi.Response(http.StatusUnprocessableEntity, err.Error()), err
@@ -478,7 +460,6 @@ func getYamlFileFromDefinition(def definition.Test) ([]byte, error) {
 }
 
 func (c controller) ExportTestRun(ctx context.Context, testID string, runID string) (openapi.ImplResponse, error) {
-	analytics.SendEvent("Test Export", "test")
 	rid, err := uuid.Parse(runID)
 	if err != nil {
 		return openapi.Response(http.StatusUnprocessableEntity, err.Error()), err
@@ -508,7 +489,6 @@ func (c controller) ExportTestRun(ctx context.Context, testID string, runID stri
 }
 
 func (c controller) ImportTestRun(ctx context.Context, exportedTest openapi.ExportedTestInformation) (openapi.ImplResponse, error) {
-	analytics.SendEvent("Test Import", "test")
 	test := c.mappers.In.Test(exportedTest.Test)
 	run := c.mappers.In.Run(exportedTest.Run)
 
@@ -538,7 +518,6 @@ func (c controller) ImportTestRun(ctx context.Context, exportedTest openapi.Expo
 }
 
 func (c *controller) CreateTestFromDefinition(ctx context.Context, testDefinition openapi.TextDefinition) (openapi.ImplResponse, error) {
-	analytics.SendEvent("Test Create From Definition", "test")
 	var definitionObject definition.Test
 	err := yaml.Unmarshal([]byte(testDefinition.Content), &definitionObject)
 	if err != nil {
@@ -554,7 +533,6 @@ func (c *controller) CreateTestFromDefinition(ctx context.Context, testDefinitio
 }
 
 func (c *controller) UpdateTestFromDefinition(ctx context.Context, testId string, testDefinition openapi.TextDefinition) (openapi.ImplResponse, error) {
-	analytics.SendEvent("Test Update From Definition", "test")
 	var definitionObject definition.Test
 	err := yaml.Unmarshal([]byte(testDefinition.Content), &definitionObject)
 	if err != nil {

--- a/server/http/custom_routes.go
+++ b/server/http/custom_routes.go
@@ -124,6 +124,8 @@ func (c *customController) analytics(name string, f http.HandlerFunc) http.Handl
 	return func(w http.ResponseWriter, r *http.Request) {
 		machineID := r.Header.Get("x-client-id")
 		analytics.SendEvent(toWords(name), "test", machineID)
+
+		f(w, r)
 	}
 }
 

--- a/server/http/custom_routes.go
+++ b/server/http/custom_routes.go
@@ -5,9 +5,11 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"regexp"
 	"strconv"
 
 	"github.com/gorilla/mux"
+	"github.com/kubeshop/tracetest/server/analytics"
 	"github.com/kubeshop/tracetest/server/openapi"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
@@ -36,8 +38,12 @@ func (c *customController) Routes() openapi.Routes {
 
 	for index, route := range routes {
 		routeName := fmt.Sprintf("%s %s", route.Method, route.Pattern)
-		newRouteHandlerFunc := c.instrumentRoute(routeName, route.Pattern, route.HandlerFunc)
-		route.HandlerFunc = newRouteHandlerFunc
+		hf := route.HandlerFunc
+
+		hf = c.instrumentRoute(routeName, route.Pattern, hf)
+		hf = c.analytics(route.Name, hf)
+
+		route.HandlerFunc = hf
 
 		routes[index] = route
 	}
@@ -101,6 +107,24 @@ func parseInt32Parameter(param string, required bool) (int32, error) {
 	}
 
 	return int32(val), nil
+}
+
+var (
+	matchFirstCap = regexp.MustCompile("(.)([A-Z][a-z]+)")
+	matchAllCap   = regexp.MustCompile("([a-z0-9])([A-Z])")
+)
+
+func toWords(str string) string {
+	words := matchFirstCap.ReplaceAllString(str, "${1} ${2}")
+	words = matchAllCap.ReplaceAllString(words, "${1} ${2}")
+	return words
+}
+
+func (c *customController) analytics(name string, f http.HandlerFunc) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		machineID := r.Header.Get("x-client-id")
+		analytics.SendEvent(toWords(name), "test", machineID)
+	}
 }
 
 func (c *customController) instrumentRoute(name string, route string, f http.HandlerFunc) http.HandlerFunc {


### PR DESCRIPTION
This PR updates the server and CLI so the client can pass its machineID to the server and use that info to relate events from cli/server

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
