### PR TITLE
CLI installer: add k8s config questions

### DIFF
--- a/cli/installer/kubernetes.go
+++ b/cli/installer/kubernetes.go
@@ -52,6 +52,13 @@ func configureKubernetes(conf configuration, ui UI) configuration {
 	conf.set("k8s.kubeconfig", ui.TextInput("Kubeconfig file", "${HOME}/.kube/config"))
 
 	contexts := getK8sContexts(conf, ui)
+	if len(contexts) == 0 {
+		ui.Exit(
+			"We didn't detect any kubectl contexts available. " +
+				"Make sure your kubectl tool is correctly configured and try again. \n" +
+				createIssueMsg,
+		)
+	}
 	options := []option{}
 	defaultIndex := 0
 	for i, c := range contexts {

--- a/cli/installer/util.go
+++ b/cli/installer/util.go
@@ -171,6 +171,14 @@ func (c cmd) exec(ui UI, args ...interface{}) interface{} {
 	return nil
 }
 
+func getCmdOutput(cmd string) string {
+	execCmd := exec.Command("/bin/sh", "-c", cmd)
+
+	out, _ := execCmd.CombinedOutput()
+
+	return string(out)
+}
+
 func fileExists(path string) bool {
 	if _, err := os.Stat(path); err == nil {
 		return true


### PR DESCRIPTION
This PR adds k8s config questions. It asks the common tracetest settings, plus the specific options for k8s:
- Kubeconfig file
- kubectl context
- expose via ingress

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
