### PR TITLE
Fix docker compose installer

### DIFF
--- a/cli/installer/docker_compose.go
+++ b/cli/installer/docker_compose.go
@@ -113,8 +113,10 @@ func getDockerComposeFileContents(ui UI, config configuration) []byte {
 		ui.Exit(fmt.Sprintf("cannot configure tracetest container: %s", err.Error()))
 	}
 
-	if err := fixOtelCollectorContainer(project); err != nil {
-		ui.Exit(fmt.Sprintf("cannot configure otel-collector container: %s", err.Error()))
+	if config.Bool("tracetest.collector.install") {
+		if err := fixOtelCollectorContainer(project); err != nil {
+			ui.Exit(fmt.Sprintf("cannot configure otel-collector container: %s", err.Error()))
+		}
 	}
 
 	output, err := yaml.Marshal(project)

--- a/cli/installer/docker_compose.go
+++ b/cli/installer/docker_compose.go
@@ -110,16 +110,16 @@ func getDockerComposeFileContents(ui UI, config configuration) []byte {
 	filterContainers(ui, project, include)
 
 	if err := fixTracetestContainer(project, cliConfig.Version); err != nil {
-		ui.Exit(err.Error())
+		ui.Exit(fmt.Sprintf("cannot configure tracetest container: %s", err.Error()))
 	}
 
 	if err := fixOtelCollectorContainer(project); err != nil {
-		ui.Exit(err.Error())
+		ui.Exit(fmt.Sprintf("cannot configure otel-collector container: %s", err.Error()))
 	}
 
 	output, err := yaml.Marshal(project)
 	if err != nil {
-		ui.Exit(err.Error())
+		ui.Exit(fmt.Sprintf("cannot encode docker-compose file: %s", err.Error()))
 	}
 
 	sout := strings.ReplaceAll(string(output), "$", "$$")


### PR DESCRIPTION
This PR fixes a bug when installing with docker compose, using an exsiting otel collector. It was failing with this message:

![Screen Shot 2022-09-08 at 11 51 51](https://user-images.githubusercontent.com/314548/189154367-290ea127-0529-49be-a2e1-1eb08ab2fd8f.png)

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
