### PR TITLE
CLI Installer: Docker Compose improvements

### DIFF
--- a/cli/installer/docker_compose.go
+++ b/cli/installer/docker_compose.go
@@ -215,13 +215,14 @@ func filterContainers(ui UI, project *types.Project, included []string) {
 	project.Services = containers
 }
 
+type msa = map[string]any
+
 func getCollectorConfigFileContents(ui UI, config configuration) []byte {
 	contents, err := getFileContentsForVersion("local-config/collector.config.yaml", cliConfig.Version)
 	if err != nil {
 		ui.Exit(fmt.Errorf("cannot get collector config file: %w", err).Error())
 	}
 
-	type msa = map[string]any
 	otelConfig := msa{}
 
 	err = yaml.Unmarshal(contents, &otelConfig)

--- a/cli/installer/docker_compose.go
+++ b/cli/installer/docker_compose.go
@@ -58,8 +58,23 @@ func dockerComposeInstaller(config configuration, ui UI) {
 	})
 
 	dir := config.String("output.dir")
+	force := Force
+	if fileExists(dir) && !force {
+		ui.Warning(fmt.Sprintf(`Directory "%s" already exists.`, dir))
+		force = ui.Confirm("Do you want to overwrite it?", true)
 
-	if Force {
+		if !force {
+			ui.Exit(fmt.Sprintf(`
+Output directory "%s" already exists. Choose a diferent output dir or manually remove it.
+
+You can run this command again with the -f option to overwrite it.
+
+%s`, dir, createIssueMsg),
+			)
+		}
+	}
+
+	if force {
 		err := os.RemoveAll(dir)
 		if err != nil {
 			ui.Exit(err.Error())

--- a/cli/installer/docker_compose.go
+++ b/cli/installer/docker_compose.go
@@ -236,7 +236,7 @@ func getCollectorConfigFileContents(ui UI, config configuration) []byte {
 	case "jaeger":
 		exporter = "jaeger"
 		exporters["jaeger"] = msa{
-			"endpoint": config.String("tracetest.backend.endpoint"),
+			"endpoint": config.String("tracetest.backend.endpoint.query"),
 			"tls": msa{
 				"insecure": config.Bool("tracetest.backend.tls.insecure"),
 			},
@@ -331,6 +331,8 @@ func fixOtelCollectorContainer(config configuration, project *types.Project) err
 	}
 
 	ocs.Volumes[0].Source = path.Join(config.String("output.dir"), otelCollectorConfigFilename)
+	je := config.String("tracetest.backend.endpoint.collector")
+	ocs.Environment["JAEGER_ENDPOINT"] = &je
 
 	return nil
 }

--- a/cli/installer/tracetest.go
+++ b/cli/installer/tracetest.go
@@ -70,7 +70,8 @@ See https://kubeshop.github.io/tracetest/supported-backends/
 
 		// default values
 		conf.set("tracetest.backend.type", "jaeger")
-		conf.set("tracetest.backend.endpoint", "jaeger:16685")
+		conf.set("tracetest.backend.endpoint.query", "jaeger:16685")
+		conf.set("tracetest.backend.endpoint.collector", "jaeger:14250")
 		conf.set("tracetest.backend.tls.insecure", true)
 	}
 
@@ -83,7 +84,9 @@ func configureBackendOptions(conf configuration, ui UI) configuration {
 	option := ui.Select("Which tracing backend do you want to use?", []option{
 		{"Jaeger", func(ui UI) {
 			conf.set("tracetest.backend.type", "jaeger")
-			conf.set("tracetest.backend.endpoint", ui.TextInput("Endpoint", "jaeger-query:16685"))
+			conf.set("tracetest.backend.endpoint.query", ui.TextInput("Query Endpoint", "jaeger:16685"))
+			conf.set("tracetest.backend.endpoint.collector", ui.TextInput("Collector Endpoint", "jaeger:14250"))
+			conf.set("tracetest.backend.endpoint.exporter", "")
 			conf.set("tracetest.backend.tls.insecure", ui.Confirm("TLS/Insecure", true))
 		}},
 		{"Tempo", func(ui UI) {
@@ -169,7 +172,7 @@ func dataStoreConfig(ui UI, conf configuration) map[string]serverConfig.TracingB
 		c = serverConfig.TracingBackendDataStoreConfig{
 			Type: dstype,
 			Jaeger: configgrpc.GRPCClientSettings{
-				Endpoint: conf.String("tracetest.backend.endpoint"),
+				Endpoint: conf.String("tracetest.backend.endpoint.query"),
 				TLSSetting: configtls.TLSClientSetting{
 					Insecure: conf.Bool("tracetest.backend.tls.insecure"),
 				},

--- a/cli/installer/tracetest.go
+++ b/cli/installer/tracetest.go
@@ -173,10 +173,8 @@ func fixConfigs(conf []byte) ([]byte, error) {
 		return yaml.Marshal(encoded)
 	}
 
-	fmt.Printf("1 **** \n %+v\n", target["tlssetting"])
 	target["tls"] = target["tlssetting"]
 	delete(target, "tlssetting")
-	fmt.Printf("1 **** \n %+v\n", target["tls"])
 
 	encoded["telemetry"].(msa)["datastores"].(msa)[key].(msa)[key] = target
 

--- a/cli/installer/ui.go
+++ b/cli/installer/ui.go
@@ -18,6 +18,7 @@ type UI interface {
 	Panic(error)
 	Exit(string)
 
+	Error(string)
 	Warning(string)
 	Info(string)
 	Success(string)
@@ -58,6 +59,10 @@ func (ui ptermUI) Panic(err error) {
 func (ui ptermUI) Exit(msg string) {
 	pterm.Error.Println(msg)
 	os.Exit(1)
+}
+
+func (ui ptermUI) Error(msg string) {
+	pterm.Error.Println(msg)
 }
 
 func (ui ptermUI) Warning(msg string) {


### PR DESCRIPTION
This PR adds improvements and bugfix to docker compose installer

- fixes the file mount path for configs
- enforces and helps creating a base docker-compose file
- fixes the otelcol jaeger config
- fixes jaeger/tempo tls config

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
