### PR TITLE
fix: don't break if response is not a json response

### DIFF
--- a/server/executor/trigger/http.go
+++ b/server/executor/trigger/http.go
@@ -3,6 +3,7 @@ package trigger
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
@@ -105,7 +106,11 @@ func mapResp(resp *http.Response) model.HTTPResponse {
 	}
 	var body string
 	if b, err := io.ReadAll(resp.Body); err == nil {
-		body = string(b)
+		if isJson(b) {
+			body = string(b)
+		} else {
+			body = fmt.Sprintf(`{"content": "%s"}`, string(b))
+		}
 	} else {
 		fmt.Println(err)
 	}
@@ -116,4 +121,11 @@ func mapResp(resp *http.Response) model.HTTPResponse {
 		Headers:    mappedHeaders,
 		Body:       body,
 	}
+}
+
+func isJson(content []byte) bool {
+	var ignored map[string]interface{}
+	err := json.Unmarshal(content, &ignored)
+
+	return err == nil
 }

--- a/server/executor/trigger/http_test.go
+++ b/server/executor/trigger/http_test.go
@@ -65,7 +65,7 @@ func TestTriggerGet(t *testing.T) {
 	assert.NoError(t, err)
 
 	assert.Equal(t, 200, resp.Result.HTTP.StatusCode)
-	assert.Equal(t, "OK", resp.Result.HTTP.Body)
+	assert.Equal(t, `{"content": "OK"}`, resp.Result.HTTP.Body)
 }
 
 func TestTriggerPost(t *testing.T) {
@@ -112,7 +112,7 @@ func TestTriggerPost(t *testing.T) {
 	assert.NoError(t, err)
 
 	assert.Equal(t, 200, resp.Result.HTTP.StatusCode)
-	assert.Equal(t, "OK", resp.Result.HTTP.Body)
+	assert.Equal(t, `{"content": "OK"}`, resp.Result.HTTP.Body)
 }
 
 func TestTriggerPostWithApiKeyAuth(t *testing.T) {
@@ -173,7 +173,7 @@ func TestTriggerPostWithApiKeyAuth(t *testing.T) {
 	assert.NoError(t, err)
 
 	assert.Equal(t, 200, resp.Result.HTTP.StatusCode)
-	assert.Equal(t, "OK", resp.Result.HTTP.Body)
+	assert.Equal(t, `{"content": "OK"}`, resp.Result.HTTP.Body)
 }
 
 func TestTriggerPostWithBasicAuth(t *testing.T) {
@@ -233,7 +233,7 @@ func TestTriggerPostWithBasicAuth(t *testing.T) {
 	assert.NoError(t, err)
 
 	assert.Equal(t, 200, resp.Result.HTTP.StatusCode)
-	assert.Equal(t, "OK", resp.Result.HTTP.Body)
+	assert.Equal(t, `{"content": "OK"}`, resp.Result.HTTP.Body)
 }
 
 func TestTriggerPostWithBearerAuth(t *testing.T) {
@@ -292,5 +292,5 @@ func TestTriggerPostWithBearerAuth(t *testing.T) {
 	assert.NoError(t, err)
 
 	assert.Equal(t, 200, resp.Result.HTTP.StatusCode)
-	assert.Equal(t, "OK", resp.Result.HTTP.Body)
+	assert.Equal(t, `{"content": "OK"}`, resp.Result.HTTP.Body)
 }


### PR DESCRIPTION
This PR fixes the issue #1194 

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
