### PR TITLE
fix: disable analytics from examples

### DIFF
--- a/examples/tracetest-jaeger/tracetest-config.yaml
+++ b/examples/tracetest-jaeger/tracetest-config.yaml
@@ -5,7 +5,7 @@ poolingConfig:
   retryDelay: 5s
 
 googleAnalytics:
-  enabled: true
+  enabled: false
 
 telemetry:
   dataStores:

--- a/examples/tracetest-opensearch/tracetest-config.yaml
+++ b/examples/tracetest-opensearch/tracetest-config.yaml
@@ -5,7 +5,7 @@ poolingConfig:
   retryDelay: 5s
 
 googleAnalytics:
-  enabled: true
+  enabled: false
 
 telemetry:
   dataStores:

--- a/examples/tracetest-signalfx/tracetest-config.yaml
+++ b/examples/tracetest-signalfx/tracetest-config.yaml
@@ -5,7 +5,7 @@ poolingConfig:
   retryDelay: 5s
 
 googleAnalytics:
-  enabled: true
+  enabled: false
 
 telemetry:
   dataStores:

--- a/examples/tracetest-tempo/tracetest-config.yaml
+++ b/examples/tracetest-tempo/tracetest-config.yaml
@@ -5,7 +5,7 @@ poolingConfig:
   retryDelay: 5s
 
 googleAnalytics:
-  enabled: true
+  enabled: false
 
 telemetry:
   dataStores:


### PR DESCRIPTION
This PR disables the analytics from all examples

## Checklist

- [ ] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
