### PR TITLE
👀 1207 Selecting a test spec should show the attributes for the first span

### DIFF
--- a/web/src/components/AttributeRow/AttributeCheck.tsx
+++ b/web/src/components/AttributeRow/AttributeCheck.tsx
@@ -16,7 +16,7 @@ const AttributeCheck = ({items, type}: IProps) => {
   const handleOnClick = (id: string) => {
     TraceAnalyticsService.onAttributeCheckClick();
     const {assertionResult} = items.find(item => item.id === id)!;
-    setSelectedSpec(assertionResult);
+    setSelectedSpec(assertionResult.selector);
   };
 
   const menuLayout = (

--- a/web/src/components/RunCard/RunCard.styled.ts
+++ b/web/src/components/RunCard/RunCard.styled.ts
@@ -13,6 +13,8 @@ export const Container = styled.div`
 `;
 
 export const HeaderDetail = styled(Typography.Text)`
+  display: flex;
+  align-items: center;
   color: ${({theme}) => theme.color.textSecondary};
   font-size: ${({theme}) => theme.size.md};
   margin-right: 8px;
@@ -59,4 +61,8 @@ export const Title = styled(Typography.Title).attrs({level: 3})`
   && {
     margin: 0;
   }
+`;
+
+export const ResultContainer = styled.div`
+  display: flex;
 `;

--- a/web/src/components/RunCard/RunCard.tsx
+++ b/web/src/components/RunCard/RunCard.tsx
@@ -56,7 +56,7 @@ const ResultCard = ({
           </div>
         </S.Info>
 
-        <div>
+        <S.ResultContainer>
           <Tooltip title="Passed assertions">
             <S.HeaderDetail>
               <S.HeaderDot $passed />
@@ -69,7 +69,7 @@ const ResultCard = ({
               {failedAssertionCount}
             </S.HeaderDetail>
           </Tooltip>
-        </div>
+        </S.ResultContainer>
 
         <S.TestStateContainer data-cy={`test-run-result-status-${runId}`}>
           <TestState testState={state} />

--- a/web/src/components/RunDetailTest/RunDetailTest.styled.ts
+++ b/web/src/components/RunDetailTest/RunDetailTest.styled.ts
@@ -54,9 +54,9 @@ export const SectionLeft = styled(Section)`
   z-index: 1;
 `;
 
-export const SectionRight = styled(Section)`
+export const SectionRight = styled(Section)<{$shouldScroll: boolean}>`
   background-color: ${({theme}) => theme.color.white};
   box-shadow: 0 20px 24px rgba(153, 155, 168, 0.18);
-  overflow-y: scroll;
+  overflow-y: ${({$shouldScroll}) => $shouldScroll ? 'scroll' : 'hidden'};
   z-index: 2;
 `;

--- a/web/src/components/RunDetailTest/RunDetailTest.tsx
+++ b/web/src/components/RunDetailTest/RunDetailTest.tsx
@@ -5,6 +5,7 @@ import TestSpecForm from 'components/TestSpecForm';
 import {useTestSpecForm} from 'components/TestSpecForm/TestSpecForm.provider';
 import {useSpan} from 'providers/Span/Span.provider';
 import {TTestRun} from 'types/TestRun.types';
+import { useTestSpecs } from '../../providers/TestSpecs/TestSpecs.provider';
 import * as S from './RunDetailTest.styled';
 import Visualization from './Visualization';
 
@@ -15,6 +16,7 @@ interface IProps {
 
 const RunDetailTest = ({run, testId}: IProps) => {
   const {selectedSpan} = useSpan();
+  const {selectedTestSpec} = useTestSpecs();
   const {isOpen: isTestSpecFormOpen, formProps, onSubmit, close} = useTestSpecForm();
 
   return (
@@ -27,7 +29,7 @@ const RunDetailTest = ({run, testId}: IProps) => {
         <S.SectionLeft>
           <Visualization runState={run.state} spans={run?.trace?.spans ?? []} />
         </S.SectionLeft>
-        <S.SectionRight>
+        <S.SectionRight $shouldScroll={!selectedTestSpec}>
           {isTestSpecFormOpen ? (
             <TestSpecForm
               onSubmit={onSubmit}

--- a/web/src/components/TestResults/TestResults.tsx
+++ b/web/src/components/TestResults/TestResults.tsx
@@ -15,22 +15,20 @@ import * as S from './TestResults.styled';
 
 const TestResults = () => {
   const {open} = useTestSpecForm();
-  const {isLoading, assertionResults, remove, revert, setSelectedSpec} = useTestSpecs();
-  const {selectedSpan, onSetFocusedSpan} = useSpan();
+  const {isLoading, assertionResults, remove, revert, setSelectedSpec, selectedTestSpec} = useTestSpecs();
+  const {selectedSpan, onSetFocusedSpan, onSelectSpan} = useSpan();
   const {totalFailedSpecs, totalPassedSpecs} = useAppSelector(TestSpecsSelectors.selectTotalSpecs);
-  const selectedSpec = useAppSelector(TestSpecsSelectors.selectSelectedSpec);
-  const selectedTestSpec = useAppSelector(state =>
-    TestSpecsSelectors.selectAssertionBySelector(state, selectedSpec ?? '')
-  );
 
   const handleOpen = useCallback(
     (selector: string) => {
       AssertionAnalyticsService.onAssertionClick();
       const testSpec = assertionResults?.resultList?.find(specResult => specResult.selector === selector);
+
       onSetFocusedSpan('');
-      setSelectedSpec(testSpec);
+      onSelectSpan(testSpec?.spanIds[0] || '');
+      setSelectedSpec(testSpec?.selector);
     },
-    [assertionResults?.resultList, onSetFocusedSpan, setSelectedSpec]
+    [assertionResults?.resultList, onSelectSpan, onSetFocusedSpan, setSelectedSpec]
   );
 
   const handleClose = useCallback(() => {
@@ -72,9 +70,10 @@ const TestResults = () => {
 
   const handleSelectSpan = useCallback(
     (spanId: string) => {
+      onSelectSpan(spanId);
       onSetFocusedSpan(spanId);
     },
-    [onSetFocusedSpan]
+    [onSelectSpan, onSetFocusedSpan]
   );
 
   return (
@@ -98,7 +97,7 @@ const TestResults = () => {
       )}
 
       <TestSpecDetail
-        isOpen={Boolean(selectedSpec)}
+        isOpen={Boolean(selectedTestSpec)}
         onClose={handleClose}
         onDelete={handleDelete}
         onEdit={handleEdit}

--- a/web/src/components/TestSpecDetail/TestSpecDetail.styled.ts
+++ b/web/src/components/TestSpecDetail/TestSpecDetail.styled.ts
@@ -31,6 +31,7 @@ export const CardContainer = styled(Card)<{$isSelected: boolean; $type: Semantic
 
 export const DrawerContainer = styled(Drawer)`
   position: absolute;
+  overflow: hidden;
 `;
 
 export const GridContainer = styled.div`

--- a/web/src/components/TestSpecDetail/TestSpecDetail.tsx
+++ b/web/src/components/TestSpecDetail/TestSpecDetail.tsx
@@ -32,6 +32,7 @@ const TestSpecDetail = ({
       placement="right"
       visible={isOpen}
       width="100%"
+      height="100%"
     >
       {testSpec && (
         <Content

--- a/web/src/components/TestSpecForm/TestSpecForm.provider.tsx
+++ b/web/src/components/TestSpecForm/TestSpecForm.provider.tsx
@@ -78,7 +78,7 @@ const TestSpecFormProvider: React.FC<{testId: string}> = ({children}) => {
         setIsOpen(true);
       }
 
-      dispatch(RouterActions.updateSearch({[RouterSearchFields.SelectedAssertion]: ''}));
+      dispatch(RouterActions.updateSearch({[RouterSearchFields.SelectedAssertion]: undefined}));
     },
     [dispatch, specs, isDraftMode, run.testVersion, test?.version]
   );

--- a/web/src/components/Visualization/components/DAG/Actions.tsx
+++ b/web/src/components/Visualization/components/DAG/Actions.tsx
@@ -43,13 +43,17 @@ const Actions = ({
   const handleOnNavigateToSpan = useCallback(
     (spanId: string) => {
       onNavigateToSpan(spanId);
-
-      const {nodeInternals} = getState();
-      const {x, y} = getNodePosition(spanId, nodeInternals);
-      setCenter(x, y, {zoom: 1.0, duration: 1000});
     },
-    [getState, onNavigateToSpan, setCenter]
+    [onNavigateToSpan]
   );
+
+  useEffect(() => {
+    if (selectedSpan) {
+      const {nodeInternals} = getState();
+      const {x, y} = getNodePosition(selectedSpan, nodeInternals);
+      setCenter(x, y, {zoom: 1.0, duration: 1000});
+    }
+  }, [getState, selectedSpan, setCenter]);
 
   return (
     <>

--- a/web/src/redux/actions/Router.actions.ts
+++ b/web/src/redux/actions/Router.actions.ts
@@ -18,13 +18,12 @@ const RouterActions = () => ({
   updateSelectedAssertion: createAsyncThunk<void, IQuery>(
     'router/addAssertionResult',
     async ({search}, {getState, dispatch}) => {
-      const {[RouterSearchFields.SelectedAssertion]: positionIndex = ''} = search;
+      const {[RouterSearchFields.SelectedAssertion]: positionIndex} = search;
 
-      if (!positionIndex) {
+      if (typeof positionIndex === 'undefined') {
         dispatch(setSelectedSpec());
         return;
       }
-
       const assertionResult = TestSpecsSelectors.selectAssertionByPositionIndex(
         getState() as RootState,
         Number(positionIndex)

--- a/web/src/redux/actions/Router.actions.ts
+++ b/web/src/redux/actions/Router.actions.ts
@@ -2,12 +2,13 @@ import {createAsyncThunk} from '@reduxjs/toolkit';
 import {parse, ParsedQuery, stringify} from 'query-string';
 import {Params} from 'react-router-dom';
 import {push} from 'redux-first-history';
+import {RouterSearchFields} from 'constants/Common.constants';
 import TestSpecsSelectors from 'selectors/TestSpecs.selectors';
-import {RouterSearchFields} from '../../constants/Common.constants';
-import SpanSelectors from '../../selectors/Span.selectors';
-import {setSelectedSpan} from '../slices/Span.slice';
-import {setSelectedSpec} from '../slices/TestSpecs.slice';
-import {RootState} from '../store';
+import DAGSelectors from 'selectors/DAG.selectors';
+import SpanSelectors from 'selectors/Span.selectors';
+import {setSelectedSpan} from 'redux/slices/Span.slice';
+import {setSelectedSpec} from 'redux/slices/TestSpecs.slice';
+import {RootState} from 'redux/store';
 
 export interface IQuery {
   search: ParsedQuery<string>;
@@ -29,9 +30,10 @@ const RouterActions = () => ({
         Number(positionIndex)
       );
       const selectedSpec = TestSpecsSelectors.selectSelectedSpec(getState() as RootState);
+      const isDagReady = DAGSelectors.selectNodes(getState() as RootState).length > 0;
 
       if (selectedSpec === assertionResult?.selector) return;
-      if (assertionResult) dispatch(setSelectedSpec(assertionResult));
+      if (assertionResult && isDagReady) dispatch(setSelectedSpec(assertionResult));
     }
   ),
   updateSelectedSpan: createAsyncThunk<void, IQuery>(

--- a/web/src/selectors/TestSpecs.selectors.ts
+++ b/web/src/selectors/TestSpecs.selectors.ts
@@ -87,7 +87,7 @@ const selectTotalSpecs = createSelector(selectAssertionResults, assertionResults
 const TestSpecsSelectors = () => ({
   selectSpecs,
   selectSpecsSelectorList,
-  selectIsSelectorExist: createSelector(selectSpecsSelectorList, selectorSelector, (selectorList, selector) =>
+  selectIsSelectorExist: createSelector(selectSpecsSelectorList, selectorSelector, (selectorList, selector = '') =>
     selectorList.includes(selector)
   ),
   selectIsLoading: createSelector(stateSelector, ({isLoading}) => isLoading),


### PR DESCRIPTION
This PR fixes multiple UX issues we had with the run detail test mode, including:

## Changes

- When selecting a spec the first span is targeted and autoselected.
- When creating a spec with an empty selector the app should allow users to navigate correctly.
- Fixed issue when clicking on a span from a assertion result was doing nothing.

## Fixes

- #1207 

## Checklist

- [x] tested locally
- [] added new dependencies
- [ ] updated the docs
- [ ] added a test


https://www.loom.com/share/7fd3a5a758434308b07b3f76682f2cb8