### PR TITLE
fix: duration comparators

### DIFF
--- a/server/model/tests.go
+++ b/server/model/tests.go
@@ -132,6 +132,23 @@ func (e *AssertionExpression) String() string {
 	return fmt.Sprintf("%s %s %s", e.LiteralValue.Value, e.Operation, e.Expression.String())
 }
 
+func (e *AssertionExpression) Type() string {
+	if e == nil {
+		return "string"
+	}
+
+	if e.Expression == nil {
+		return e.LiteralValue.Type
+	}
+
+	if e.LiteralValue.Type == "attribute" {
+		// in case of attributes, we check the rest of the expression to know its type
+		return e.Expression.Type()
+	}
+
+	return e.LiteralValue.Type
+}
+
 type RunState string
 
 const (

--- a/server/model/tests_test.go
+++ b/server/model/tests_test.go
@@ -5,6 +5,8 @@ import (
 	"testing"
 
 	"github.com/kubeshop/tracetest/server/assertions/comparator"
+	"github.com/kubeshop/tracetest/server/encoding/yaml/conversion/parser"
+	"github.com/kubeshop/tracetest/server/http/mappings"
 	"github.com/kubeshop/tracetest/server/model"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -178,4 +180,65 @@ func TestResults(t *testing.T) {
 		assert.Equal(t, def, decoded)
 	})
 
+}
+
+func TestExpressionType(t *testing.T) {
+	testCases := []struct {
+		Name         string
+		Expression   string
+		ExpectedType string
+	}{
+		{
+			Name:         "simple string",
+			Expression:   `"my string"`,
+			ExpectedType: "string",
+		},
+		{
+			Name:         "integer",
+			Expression:   `12`,
+			ExpectedType: "number",
+		},
+		{
+			Name:         "float",
+			Expression:   `12.75`,
+			ExpectedType: "number",
+		},
+		{
+			Name:         "attribute",
+			Expression:   `tracetest.myattribute`,
+			ExpectedType: "attribute",
+		},
+		{
+			Name:         "duration",
+			Expression:   `17ms`,
+			ExpectedType: "duration",
+		},
+		{
+			Name:         "attribute with duration",
+			Expression:   `my.duration.attr + 17ms`,
+			ExpectedType: "duration",
+		},
+		{
+			Name:         "attribute with number",
+			Expression:   `my.number.attr + 28`,
+			ExpectedType: "number",
+		},
+		{
+			Name:         "attribute with attribute",
+			Expression:   `my.attr + my.other.attribute`,
+			ExpectedType: "attribute",
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.Name, func(t *testing.T) {
+			mapping := mappings.OpenAPI{}
+			parserExpression, err := parser.ParseAssertionExpression(testCase.Expression)
+			require.NoError(t, err)
+
+			expression := mapping.AssertionExpression(parserExpression)
+
+			assert.Equal(t, testCase.ExpectedType, expression.Type())
+		})
+	}
 }


### PR DESCRIPTION
This PR converts duration fields before comparing them, so we don't have problems with precision when comparing two duration values.

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [x] added a test
