### PR TITLE
Revert "fix: don't break if response is not a json response"

### DIFF
--- a/server/executor/trigger/http.go
+++ b/server/executor/trigger/http.go
@@ -3,7 +3,6 @@ package trigger
 import (
 	"bytes"
 	"context"
-	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
@@ -107,11 +106,7 @@ func mapResp(resp *http.Response) model.HTTPResponse {
 	}
 	var body string
 	if b, err := io.ReadAll(resp.Body); err == nil {
-		if isJson(b) {
-			body = string(b)
-		} else {
-			body = fmt.Sprintf(`{"content": "%s"}`, string(b))
-		}
+		body = string(b)
 	} else {
 		fmt.Println(err)
 	}
@@ -122,11 +117,4 @@ func mapResp(resp *http.Response) model.HTTPResponse {
 		Headers:    mappedHeaders,
 		Body:       body,
 	}
-}
-
-func isJson(content []byte) bool {
-	var ignored map[string]interface{}
-	err := json.Unmarshal(content, &ignored)
-
-	return err == nil
 }

--- a/server/executor/trigger/http_test.go
+++ b/server/executor/trigger/http_test.go
@@ -65,7 +65,7 @@ func TestTriggerGet(t *testing.T) {
 	assert.NoError(t, err)
 
 	assert.Equal(t, 200, resp.Result.HTTP.StatusCode)
-	assert.Equal(t, `{"content": "OK"}`, resp.Result.HTTP.Body)
+	assert.Equal(t, "OK", resp.Result.HTTP.Body)
 }
 
 func TestTriggerPost(t *testing.T) {
@@ -112,7 +112,7 @@ func TestTriggerPost(t *testing.T) {
 	assert.NoError(t, err)
 
 	assert.Equal(t, 200, resp.Result.HTTP.StatusCode)
-	assert.Equal(t, `{"content": "OK"}`, resp.Result.HTTP.Body)
+	assert.Equal(t, "OK", resp.Result.HTTP.Body)
 }
 
 func TestTriggerPostWithApiKeyAuth(t *testing.T) {
@@ -173,7 +173,7 @@ func TestTriggerPostWithApiKeyAuth(t *testing.T) {
 	assert.NoError(t, err)
 
 	assert.Equal(t, 200, resp.Result.HTTP.StatusCode)
-	assert.Equal(t, `{"content": "OK"}`, resp.Result.HTTP.Body)
+	assert.Equal(t, "OK", resp.Result.HTTP.Body)
 }
 
 func TestTriggerPostWithBasicAuth(t *testing.T) {
@@ -233,7 +233,7 @@ func TestTriggerPostWithBasicAuth(t *testing.T) {
 	assert.NoError(t, err)
 
 	assert.Equal(t, 200, resp.Result.HTTP.StatusCode)
-	assert.Equal(t, `{"content": "OK"}`, resp.Result.HTTP.Body)
+	assert.Equal(t, "OK", resp.Result.HTTP.Body)
 }
 
 func TestTriggerPostWithBearerAuth(t *testing.T) {
@@ -292,5 +292,5 @@ func TestTriggerPostWithBearerAuth(t *testing.T) {
 	assert.NoError(t, err)
 
 	assert.Equal(t, 200, resp.Result.HTTP.StatusCode)
-	assert.Equal(t, `{"content": "OK"}`, resp.Result.HTTP.Body)
+	assert.Equal(t, "OK", resp.Result.HTTP.Body)
 }


### PR DESCRIPTION
Reverts kubeshop/tracetest#1198