### PR TITLE
Fix darwin CLI install 

### DIFF
--- a/.github/workflows/pull-request-installer.yaml
+++ b/.github/workflows/pull-request-installer.yaml
@@ -30,5 +30,5 @@ jobs:
               ;;
           esac
 
-          curl -L https://raw.githubusercontent.com/kubeshop/tracetest/${GITHUB_SHA}/install-cli.sh | sh
+          curl -L https://raw.githubusercontent.com/kubeshop/tracetest/${GITHUB_SHA}/install-cli.sh | bash
           tracetest

--- a/.github/workflows/pull-request-installer.yaml
+++ b/.github/workflows/pull-request-installer.yaml
@@ -26,7 +26,7 @@ jobs:
               yum install -y curl --refresh
               ;;
             alpine)
-              apk add --update curl
+              apk add --update curl bash
               ;;
           esac
 

--- a/docs/installing.md
+++ b/docs/installing.md
@@ -135,7 +135,7 @@ You can find the latest version [here](https://github.com/kubeshop/tracetest/rel
 
 Tracetest CLI can be installed automatically using the following script:
 ```sh
-curl -L https://raw.githubusercontent.com/kubeshop/tracetest/main/install-cli.sh | sh
+curl -L https://raw.githubusercontent.com/kubeshop/tracetest/main/install-cli.sh | bash
 ```
 
 It works for systems with Hombrew, `apt-get`, `dpkg`, `yum`, `rpm` installed, and if no package manager is available, it will try to download the build and install it manually.

--- a/install-cli.sh
+++ b/install-cli.sh
@@ -75,9 +75,13 @@ install_tar() {
   file_path="/tmp/cli.tar.gz"
   download_file "$download_link" "$file_path"
 
-  tar -xvf $file_path -C /tmp
+  echo "Extracting file"
+  tar -xf $file_path -C /tmp
+  echo "Installing to /usr/local/bin/tracetest"
   $SUDO mv /tmp/tracetest /usr/local/bin/tracetest
   rm -f $file_path
+  echo
+  echo "Succesfull install"
 }
 
 install_dpkg() {

--- a/install-cli.sh
+++ b/install-cli.sh
@@ -129,7 +129,7 @@ run() {
   ensure_dependency_exist "uname"
   if cmd_exists brew; then
     install_brew
-  if cmd_exists apt-get; then
+  elif cmd_exists apt-get; then
     install_apt
   elif cmd_exists yum; then
     install_yum

--- a/install-cli.sh
+++ b/install-cli.sh
@@ -127,8 +127,8 @@ install_brew() {
 
 run() {
   ensure_dependency_exist "uname"
-  # if cmd_exists brew; then
-  #   install_brew
+  if cmd_exists brew; then
+    install_brew
   if cmd_exists apt-get; then
     install_apt
   elif cmd_exists yum; then

--- a/install-cli.sh
+++ b/install-cli.sh
@@ -35,7 +35,7 @@ get_arch() {
       echo "amd64"
       ;;
 
-    "arm"|"aarch64")
+    "arm"*|"aarch64")
       echo "arm64"
       ;;
 
@@ -51,6 +51,8 @@ get_download_link() {
   arch=$(get_arch)
   raw_version=`echo $version | sed 's/v//'`
   pkg=$1
+
+  if [[ "$(get_os)" = "darwin" ]]; then arch="all";fi
 
   echo "https://github.com/kubeshop/tracetest/releases/download/${version}/tracetest_${raw_version}_${os}_${arch}.${pkg}"
 }
@@ -115,10 +117,14 @@ EOF
   $SUDO yum install -y tracetest --refresh
 }
 
-run() {
-  os=$(get_os)
+install_brew() {
+  brew install kubeshop/tracetest/tracetest
+}
 
+run() {
   ensure_dependency_exist "uname"
+  # if cmd_exists brew; then
+  #   install_brew
   if cmd_exists apt-get; then
     install_apt
   elif cmd_exists yum; then
@@ -127,11 +133,10 @@ run() {
     install_dpkg
   elif cmd_exists rpm; then
     install_rpm
-  elif [ "$os" = "linux" ]; then
-    if [ "$(get_arch)" == "unknown" ]; then
-      echo "unknown system architecture. Try manual install. See https://kubeshop.github.io/tracetest/installing/#cli-installation"
-      exit 1;
-    fi
+  elif [ "$(get_arch)" == "unknown" ]; then
+    echo "unknown system architecture. Try manual install. See https://kubeshop.github.io/tracetest/installing/#cli-installation"
+    exit 1;
+  elif [[ "$(get_os)" =~ ^(darwin|linux)$ ]]; then
     install_tar
   else
     echo 'OS not supported by this script. See https://kubeshop.github.io/tracetest/installing/#cli-installation'

--- a/install-cli.sh
+++ b/install-cli.sh
@@ -80,8 +80,6 @@ install_tar() {
   echo "Installing to /usr/local/bin/tracetest"
   $SUDO mv /tmp/tracetest /usr/local/bin/tracetest
   rm -f $file_path
-  echo
-  echo "Succesfull install"
 }
 
 install_dpkg() {
@@ -146,6 +144,13 @@ run() {
     echo 'OS not supported by this script. See https://kubeshop.github.io/tracetest/installing/#cli-installation'
     exit 1
   fi
+
+  echo
+  echo "Succesfull install!"
+  echo
+  echo "run 'tracetest --help' to see what you can do"
+  echo
+  echo "To setup a new server, run 'tracetest server install'"
 }
 
 SUDO=""


### PR DESCRIPTION
This PR fixes the CLI installer script. It was incorrectly detecting the arch on darwin arm, and generating a wrong download link for that arch

## Changes

-

## Fixes

-

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
