### PR TITLE
📄 1217 [Implementation] Need a 'copy to clipboard' option when viewing a test definition#1217

### DIFF
--- a/web/src/components/FileViewerModal/FileViewerModal.styled.ts
+++ b/web/src/components/FileViewerModal/FileViewerModal.styled.ts
@@ -1,7 +1,9 @@
+import {CopyOutlined} from '@ant-design/icons';
 import {Modal} from 'antd';
 import styled from 'styled-components';
 
 export const CodeContainer = styled.div`
+  position: relative;
   border: ${({theme}) => `1px solid ${theme.color.border}`};
   min-height: 370px;
 
@@ -19,4 +21,19 @@ export const FileViewerModal = styled(Modal)`
 
 export const SubtitleContainer = styled.div`
   margin-bottom: 8px;
+`;
+
+export const CopyIcon = styled(CopyOutlined)`
+  color: ${({theme}) => theme.color.primary};
+`;
+
+export const CopyIconContainer = styled.div`
+  position: absolute;
+  right: 8px;
+  top: 9px;
+  padding: 0 2px;
+  border-radius: 2px;
+  cursor: pointer;
+  background-color: ${({theme}) => theme.color.textHighlight};
+  z-index: 99999;
 `;

--- a/web/src/components/FileViewerModal/FileViewerModal.tsx
+++ b/web/src/components/FileViewerModal/FileViewerModal.tsx
@@ -1,5 +1,5 @@
 import {useCallback} from 'react';
-import {Button, Typography} from 'antd';
+import {Button, message, Typography} from 'antd';
 import SyntaxHighlighter from 'react-syntax-highlighter';
 import {arduinoLight} from 'react-syntax-highlighter/dist/cjs/styles/hljs';
 import {DownloadOutlined} from '@ant-design/icons';
@@ -21,6 +21,11 @@ const FileViewerModal = ({data, isOpen, onClose, title, language = 'javascript',
   const onDownload = useCallback(() => {
     downloadFile(data, fileName);
   }, [data, fileName]);
+
+  const onCopy = () => {
+    message.success('Content copied to the clipboard');
+    navigator.clipboard.writeText(data);
+  };
 
   const footer = (
     <>
@@ -49,6 +54,9 @@ const FileViewerModal = ({data, isOpen, onClose, title, language = 'javascript',
         <Typography.Text>{subtitle}</Typography.Text>
       </S.SubtitleContainer>
       <S.CodeContainer data-cy="file-viewer-code-container">
+        <S.CopyIconContainer onClick={onCopy}>
+          <S.CopyIcon />
+        </S.CopyIconContainer>
         <SyntaxHighlighter language={language} style={arduinoLight}>
           {data}
         </SyntaxHighlighter>


### PR DESCRIPTION
This PR allows users to copy the content of the file to clipboard when looking at the test definition or the JUnit reports.

## Changes

- Adds copy to clipboard from the file viewer modal.

## Fixes

- https://github.com/kubeshop/tracetest/issues/1217

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test


https://www.loom.com/share/400b39d978564c3e978bb97d226d1242