### PR TITLE
Add DeepLink to assertion/result on the CLI results output

### DIFF
--- a/cli/actions/run_test_action.go
+++ b/cli/actions/run_test_action.go
@@ -133,8 +133,8 @@ func (a runTestAction) runDefinition(ctx context.Context, params runTestParams) 
 			return runTestOutput{}, fmt.Errorf("could not save junit file: %w", err)
 		}
 
-		formatter := formatters.NewTestRunFormatter(a.config, true)
-		formattedOutput := formatter.FormatTestRunOutput(test, testRun)
+		formatter := formatters.TestRun(a.config, true)
+		formattedOutput := formatter.Format(test, testRun)
 		fmt.Print(formattedOutput)
 	}
 

--- a/cli/formatters/test_run.go
+++ b/cli/formatters/test_run.go
@@ -14,19 +14,19 @@ const (
 	FAILED_TEST_ICON = "✘"
 )
 
-type TestRunFormatter struct {
+type testRun struct {
 	config        config.Config
 	colorsEnabled bool
 }
 
-func NewTestRunFormatter(config config.Config, colorsEnabled bool) TestRunFormatter {
-	return TestRunFormatter{
+func TestRun(config config.Config, colorsEnabled bool) testRun {
+	return testRun{
 		config:        config,
 		colorsEnabled: colorsEnabled,
 	}
 }
 
-func (f TestRunFormatter) FormatTestRunOutput(test openapi.Test, run openapi.TestRun) string {
+func (f testRun) Format(test openapi.Test, run openapi.TestRun) string {
 	if run.State != nil && *run.State == "FAILED" {
 		return f.getColoredText(false, fmt.Sprintf("Failed to execute test: %s", *run.LastErrorState))
 	}
@@ -38,7 +38,7 @@ func (f TestRunFormatter) FormatTestRunOutput(test openapi.Test, run openapi.Tes
 	return f.formatSuccessfulTest(test, run)
 }
 
-func (f TestRunFormatter) formatSuccessfulTest(test openapi.Test, run openapi.TestRun) string {
+func (f testRun) formatSuccessfulTest(test openapi.Test, run openapi.TestRun) string {
 	link := f.getLink(test, run)
 	message := fmt.Sprintf("%s %s (%s)\n", PASSED_TEST_ICON, *test.Name, link)
 	return f.getColoredText(true, message)
@@ -55,7 +55,7 @@ type assertionResult struct {
 	passed        bool
 }
 
-func (f TestRunFormatter) formatFailedTest(test openapi.Test, run openapi.TestRun) string {
+func (f testRun) formatFailedTest(test openapi.Test, run openapi.TestRun) string {
 	var buffer bytes.Buffer
 
 	link := f.getLink(test, run)
@@ -130,7 +130,7 @@ func (f TestRunFormatter) formatFailedTest(test openapi.Test, run openapi.TestRu
 	return buffer.String()
 }
 
-func (f TestRunFormatter) generateSpanResult(buffer *bytes.Buffer, spanId string, spanResult spanAssertionResult) {
+func (f testRun) generateSpanResult(buffer *bytes.Buffer, spanId string, spanResult spanAssertionResult) {
 	icon := f.getStateIcon(spanResult.allPassed)
 	message := fmt.Sprintf("\t\t%s #%s\n", icon, spanId)
 	message = f.getColoredText(spanResult.allPassed, message)
@@ -150,7 +150,7 @@ func (f TestRunFormatter) generateSpanResult(buffer *bytes.Buffer, spanId string
 	}
 }
 
-func (f TestRunFormatter) getStateIcon(passed bool) string {
+func (f testRun) getStateIcon(passed bool) string {
 	if passed {
 		return PASSED_TEST_ICON
 	}
@@ -158,7 +158,7 @@ func (f TestRunFormatter) getStateIcon(passed bool) string {
 	return FAILED_TEST_ICON
 }
 
-func (f TestRunFormatter) getColoredText(passed bool, text string) string {
+func (f testRun) getColoredText(passed bool, text string) string {
 	if !f.colorsEnabled {
 		return text
 	}
@@ -170,6 +170,6 @@ func (f TestRunFormatter) getColoredText(passed bool, text string) string {
 	return pterm.FgRed.Sprintf(text)
 }
 
-func (f TestRunFormatter) getLink(test openapi.Test, run openapi.TestRun) string {
+func (f testRun) getLink(test openapi.Test, run openapi.TestRun) string {
 	return fmt.Sprintf("%s://%s/test/%s/run/%s", f.config.Scheme, f.config.Endpoint, *test.Id, *run.Id)
 }

--- a/cli/formatters/test_run.go
+++ b/cli/formatters/test_run.go
@@ -188,5 +188,10 @@ func (f testRun) getRunLink(test openapi.Test, run openapi.TestRun) string {
 }
 
 func (f testRun) getDeepLink(baseLink string, index int, spanID string) string {
-	return fmt.Sprintf("%s?selectedAssertion=%d&spanId=%s", baseLink, index, spanID)
+	link := fmt.Sprintf("%s?selectedAssertion=%d", baseLink, index)
+	if spanID != "meta" {
+		link = fmt.Sprintf("%s&spanId=%s", link, spanID)
+	}
+
+	return link
 }

--- a/cli/formatters/test_run_test.go
+++ b/cli/formatters/test_run_test.go
@@ -88,7 +88,7 @@ func TestFailingTestOutput(t *testing.T) {
 							AllPassed: boolp(true),
 							SpanResults: []openapi.AssertionSpanResult{
 								{
-									SpanId:        strp("456789"),
+									SpanId:        strp("123456"),
 									ObservedValue: strp("68ms"),
 									Passed:        boolp(true),
 									Error:         nil,
@@ -129,7 +129,7 @@ func TestFailingTestOutput(t *testing.T) {
 	✘ span[name = "my other span"]
 		✘ #456789
 			✔ tracetest.span.duration <= 200ms (68ms)
-			✘ http.status = 200 (404)
+			✘ http.status = 200 (404) (http://localhost:8080/test/9876543/run/123456??selectedAssertion=1&spanId=456789)
 `
 	assert.Equal(t, expectedOutput, output)
 }

--- a/cli/formatters/test_run_test.go
+++ b/cli/formatters/test_run_test.go
@@ -31,11 +31,11 @@ func TestSuccessfulTestOutput(t *testing.T) {
 		},
 	}
 
-	formatter := formatters.NewTestRunFormatter(config.Config{
+	formatter := formatters.TestRun(config.Config{
 		Scheme:   "http",
 		Endpoint: "localhost:8080",
 	}, false)
-	output := formatter.FormatTestRunOutput(test, run)
+	output := formatter.Format(test, run)
 
 	assert.Equal(t, "✔ Testcase 1 (http://localhost:8080/test/9876543/run/123456)\n", output)
 }
@@ -117,11 +117,11 @@ func TestFailingTestOutput(t *testing.T) {
 		},
 	}
 
-	formatter := formatters.NewTestRunFormatter(config.Config{
+	formatter := formatters.TestRun(config.Config{
 		Scheme:   "http",
 		Endpoint: "localhost:8080",
 	}, false)
-	output := formatter.FormatTestRunOutput(test, run)
+	output := formatter.Format(test, run)
 	expectedOutput := `✘ Testcase 2 (http://localhost:8080/test/9876543/run/123456)
 	✔ span[name = "my span"]
 		✔ #123456

--- a/cli/formatters/test_run_test.go
+++ b/cli/formatters/test_run_test.go
@@ -88,7 +88,7 @@ func TestFailingTestOutput(t *testing.T) {
 							AllPassed: boolp(true),
 							SpanResults: []openapi.AssertionSpanResult{
 								{
-									SpanId:        strp("123456"),
+									SpanId:        strp("456789"),
 									ObservedValue: strp("68ms"),
 									Passed:        boolp(true),
 									Error:         nil,
@@ -129,7 +129,7 @@ func TestFailingTestOutput(t *testing.T) {
 	✘ span[name = "my other span"]
 		✘ #456789
 			✔ tracetest.span.duration <= 200ms (68ms)
-			✘ http.status = 200 (404) (http://localhost:8080/test/9876543/run/123456??selectedAssertion=1&spanId=456789)
+			✘ http.status = 200 (404) (http://localhost:8080/test/9876543/run/123456?selectedAssertion=1&spanId=456789)
 `
 	assert.Equal(t, expectedOutput, output)
 }


### PR DESCRIPTION
This PR adds DeepLink to assertion/result on the CLI results output. Example:

![Screen Shot 2022-09-16 at 10 19 28](https://user-images.githubusercontent.com/314548/190648265-0ad05545-2c92-4ede-a583-a671c726099f.png)

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [x] added a test
