### PR TITLE
Add DAG tooltips and fix minimap position

### DIFF
--- a/web/src/components/Visualization/components/DAG/Actions.tsx
+++ b/web/src/components/Visualization/components/DAG/Actions.tsx
@@ -1,4 +1,5 @@
 import {ApartmentOutlined, ExpandOutlined, ZoomInOutlined, ZoomOutOutlined} from '@ant-design/icons';
+import {Tooltip} from 'antd';
 import {noop} from 'lodash';
 import {useCallback, useEffect} from 'react';
 import {NodeInternals, useReactFlow, useStoreApi} from 'react-flow-renderer';
@@ -60,15 +61,23 @@ const Actions = ({
       <Navigation matchedSpans={matchedSpans} onNavigateToSpan={handleOnNavigateToSpan} selectedSpan={selectedSpan} />
 
       <S.ActionsContainer>
-        <S.ActionButton icon={<ZoomInOutlined />} onClick={() => zoomIn()} type="text" />
-        <S.ActionButton icon={<ZoomOutOutlined />} onClick={() => zoomOut()} type="text" />
-        <S.ActionButton icon={<ExpandOutlined />} onClick={() => fitView()} type="text" />
-        <S.ActionButton
-          icon={<ApartmentOutlined />}
-          onClick={onMiniMapToggle}
-          type="text"
-          $isActive={isMiniMapActive}
-        />
+        <Tooltip placement="right" title="Zoom In">
+          <S.ActionButton icon={<ZoomInOutlined />} onClick={() => zoomIn()} type="text" />
+        </Tooltip>
+        <Tooltip placement="right" title="Zoom Out">
+          <S.ActionButton icon={<ZoomOutOutlined />} onClick={() => zoomOut()} type="text" />
+        </Tooltip>
+        <Tooltip placement="right" title="Fit View">
+          <S.ActionButton icon={<ExpandOutlined />} onClick={() => fitView()} type="text" />
+        </Tooltip>
+        <Tooltip placement="right" title="Mini Map">
+          <S.ActionButton
+            icon={<ApartmentOutlined />}
+            onClick={onMiniMapToggle}
+            type="text"
+            $isActive={isMiniMapActive}
+          />
+        </Tooltip>
       </S.ActionsContainer>
     </>
   );

--- a/web/src/components/Visualization/components/DAG/DAG.styled.tsx
+++ b/web/src/components/Visualization/components/DAG/DAG.styled.tsx
@@ -38,9 +38,9 @@ export const Container = styled.div<{$showMatched: boolean}>`
   }
 
   .react-flow__minimap {
-    bottom: 0;
+    bottom: 25px;
     background-color: ${({theme}) => theme.color.background};
-    right: 0;
+    left: 66px;
   }
 
   ${({$showMatched}) =>


### PR DESCRIPTION
This PR adds `tooltips` for the DAG actions and also fixes the `mini map` position in the Trace/Test modes.

## Changes

- Add tooltips and css changes.

## Fixes

- fixes #1237

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Demo

![2022-09-19 17 19 20](https://user-images.githubusercontent.com/3879892/191054426-207d7dd2-0eed-4ee6-a5ba-2261cf4fdf2b.gif)