### PR TITLE
Format CLI tests list

### DIFF
--- a/cli/actions/list_tests_action.go
+++ b/cli/actions/list_tests_action.go
@@ -2,11 +2,10 @@ package actions
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
-	"os"
 
 	"github.com/kubeshop/tracetest/cli/config"
+	"github.com/kubeshop/tracetest/cli/formatters"
 	"github.com/kubeshop/tracetest/cli/openapi"
 	"go.uber.org/zap"
 )
@@ -31,12 +30,10 @@ func (a listTestsAction) Run(ctx context.Context, args ListTestConfig) error {
 		return err
 	}
 
-	bytes, err := json.Marshal(tests)
-	if err != nil {
-		return err
-	}
+	formatter := formatters.TestsList(a.config)
+	formattedOutput := formatter.Format(tests)
+	fmt.Println(formattedOutput)
 
-	fmt.Fprintln(os.Stdout, string(bytes))
 	return nil
 }
 

--- a/cli/formatters/test_list_test.go
+++ b/cli/formatters/test_list_test.go
@@ -1,0 +1,52 @@
+package formatters_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/kubeshop/tracetest/cli/config"
+	"github.com/kubeshop/tracetest/cli/formatters"
+	"github.com/kubeshop/tracetest/cli/openapi"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestListOutput(t *testing.T) {
+	cases := []struct {
+		name     string
+		tests    []openapi.Test
+		expected string
+	}{
+		{
+			name:     "NoTests",
+			tests:    []openapi.Test{},
+			expected: `No tests`,
+		},
+		{
+			name: "HaveTests",
+			tests: []openapi.Test{
+				{
+					Id:   strp("123456"),
+					Name: strp("Test One"),
+				},
+				{
+					Id:   strp("456789"),
+					Name: strp("Test Two"),
+				},
+			},
+			expected: "" + // vs code trims the last whitespace on save. this awful method avoids that\
+				" ID       NAME       URL                               \n" +
+				"-------- ---------- -----------------------------------\n" +
+				" 123456   Test One   http://localhost:8080/test/123456 \n" +
+				" 456789   Test Two   http://localhost:8080/test/456789 \n",
+		},
+	}
+
+	formatter := formatters.TestsList(config.Config{
+		Scheme:   "http",
+		Endpoint: "localhost:8080",
+	})
+	for _, c := range cases {
+		output := formatter.Format(c.tests)
+		assert.Equal(t, strings.Trim(c.expected, "\n"), output)
+	}
+}

--- a/cli/formatters/test_run_test.go
+++ b/cli/formatters/test_run_test.go
@@ -46,7 +46,7 @@ func TestJSON(t *testing.T) {
 	formatters.SetOutput(formatters.DefaultOutput)
 }
 
-func TestSuccessfulTestOutput(t *testing.T) {
+func TestSuccessfulTestRunOutput(t *testing.T) {
 	in := formatters.TestRunOutput{
 		Test: openapi.Test{
 			Id:   strp("9876543"),

--- a/cli/formatters/tests_list.go
+++ b/cli/formatters/tests_list.go
@@ -1,0 +1,51 @@
+package formatters
+
+import (
+	"fmt"
+
+	"github.com/alexeyco/simpletable"
+	"github.com/kubeshop/tracetest/cli/config"
+	"github.com/kubeshop/tracetest/cli/openapi"
+)
+
+type testsList struct {
+	config config.Config
+}
+
+func TestsList(config config.Config) testsList {
+	return testsList{
+		config: config,
+	}
+}
+
+func (f testsList) Format(tests []openapi.Test) string {
+	if len(tests) == 0 {
+		return "No tests"
+	}
+
+	table := simpletable.New()
+
+	table.Header = &simpletable.Header{
+		Cells: []*simpletable.Cell{
+			{Text: "ID"},
+			{Text: "NAME"},
+			{Text: "URL"},
+		},
+	}
+
+	for _, t := range tests {
+		table.Body.Cells = append(table.Body.Cells, []*simpletable.Cell{
+			{Text: *t.Id},
+			{Text: *t.Name},
+			{Text: f.getTestLink(t)},
+		})
+	}
+
+	table.SetStyle(simpletable.StyleCompactLite)
+
+	return table.String()
+}
+
+func (f testsList) getTestLink(test openapi.Test) string {
+	return fmt.Sprintf("%s://%s/test/%s", f.config.Scheme, f.config.Endpoint, *test.Id)
+}

--- a/cli/formatters/tests_list.go
+++ b/cli/formatters/tests_list.go
@@ -1,6 +1,7 @@
 package formatters
 
 import (
+	"encoding/json"
 	"fmt"
 
 	"github.com/alexeyco/simpletable"
@@ -19,6 +20,26 @@ func TestsList(config config.Config) testsList {
 }
 
 func (f testsList) Format(tests []openapi.Test) string {
+	switch CurrentOutput {
+	case Pretty:
+		return f.pretty(tests)
+	case JSON:
+		return f.json(tests)
+	}
+
+	return ""
+}
+
+func (f testsList) json(tests []openapi.Test) string {
+	bytes, err := json.Marshal(tests)
+	if err != nil {
+		panic(fmt.Errorf("could not marshal output json: %w", err))
+	}
+
+	return string(bytes)
+}
+
+func (f testsList) pretty(tests []openapi.Test) string {
 	if len(tests) == 0 {
 		return "No tests"
 	}

--- a/cli/go.mod
+++ b/cli/go.mod
@@ -3,6 +3,7 @@ module github.com/kubeshop/tracetest/cli
 go 1.18
 
 require (
+	github.com/alexeyco/simpletable v1.0.0
 	github.com/compose-spec/compose-go v1.5.0
 	github.com/cucumber/ci-environment/go v0.0.0-20220824023145-61292c03da10
 	github.com/denisbrodbeck/machineid v1.0.1

--- a/cli/go.sum
+++ b/cli/go.sum
@@ -53,6 +53,8 @@ github.com/MarvinJWendt/testza v0.2.12/go.mod h1:JOIegYyV7rX+7VZ9r77L/eH6CfJHHzX
 github.com/MarvinJWendt/testza v0.3.0/go.mod h1:eFcL4I0idjtIx8P9C6KkAuLgATNKpX4/2oUqKc6bF2c=
 github.com/MarvinJWendt/testza v0.4.2 h1:Vbw9GkSB5erJI2BPnBL9SVGV9myE+XmUSFahBGUhW2Q=
 github.com/MarvinJWendt/testza v0.4.2/go.mod h1:mSdhXiKH8sg/gQehJ63bINcCKp7RtYewEjXsvsVUPbE=
+github.com/alexeyco/simpletable v1.0.0 h1:ZQ+LvJ4bmoeHb+dclF64d0LX+7QAi7awsfCrptZrpHk=
+github.com/alexeyco/simpletable v1.0.0/go.mod h1:VJWVTtGUnW7EKbMRH8cE13SigKGx/1fO2SeeOiGeBkk=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmVTwzkszR9V5SSuryQ31EELlFMUz1kKyl939pY=
 github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
@@ -270,6 +272,7 @@ github.com/magiconair/properties v1.8.6 h1:5ibWZ6iY0NctNGWo87LalDlEZ6R41TqbbDamh
 github.com/magiconair/properties v1.8.6/go.mod h1:y3VJvCyxH9uVvJTWEGAELF3aiYNyPKd5NZ3oSwXrF60=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
 github.com/mattn/go-isatty v0.0.3/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNxMWT7Zi4=
+github.com/mattn/go-runewidth v0.0.12/go.mod h1:RAqKPSqVFrSLVXbA8x7dzmKdmGzieGRCM46jaSJTDAk=
 github.com/mattn/go-runewidth v0.0.13 h1:lTGmDsbAYt5DmK6OnoV7EuIF1wEIFAcxld6ypU4OSgU=
 github.com/mattn/go-runewidth v0.0.13/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh153qUoGf23w=
 github.com/mattn/go-shellwords v1.0.12 h1:M2zGm7EW6UQJvDeQxo4T51eKPurbeFbe8WtebGE2xrk=
@@ -326,6 +329,7 @@ github.com/pterm/pterm v0.12.40/go.mod h1:ffwPLwlbXxP+rxT0GsgDTzS3y3rmpAO1NMjUkG
 github.com/pterm/pterm v0.12.45 h1:5HATKLTDjl9D74b0x7yiHzFI7OADlSXK3yHrJNhRwZE=
 github.com/pterm/pterm v0.12.45/go.mod h1:hJgLlBafm45w/Hr0dKXxY//POD7CgowhePaG1sdPNBg=
 github.com/rhnvrm/simples3 v0.6.1/go.mod h1:Y+3vYm2V7Y4VijFoJHHTrja6OgPrJ2cBti8dPGkC3sA=
+github.com/rivo/uniseg v0.1.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/rivo/uniseg v0.2.0 h1:S1pD9weZBuJdFmowNwbpi7BJ8TNftyUImj/0WQi72jY=
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=

--- a/tracetesting/tests.bash
+++ b/tracetesting/tests.bash
@@ -12,7 +12,7 @@ tracetest_target_curl "/api/tests/383d3dce-7b60-4a61-bdea-87f47263af5d" -X DELET
 
 test "test_create" ./definitions/test_create.yml || EXIT_STATUS=$?
 
-export TEST_ID=$(tracetest_target test list | jq -rc '.[0].id')
+export TEST_ID=$(tracetest_target test list -o json | jq -rc '.[0].id')
 require_not_empty $TEST_ID "requires TEST_ID, got $TEST_ID " || exit $?
 
 test "test_list" ./definitions/test_list.yml || EXIT_STATUS=$?


### PR DESCRIPTION
This PR adds formatting for CLI tests list. Examples:

No tests:
![Screen Shot 2022-09-19 at 12 32 38](https://user-images.githubusercontent.com/314548/191056651-98b27369-0018-41a0-ba38-7016668d863f.png)

With tests:
![Screen Shot 2022-09-19 at 12 31 48](https://user-images.githubusercontent.com/314548/191056713-a1dd4acd-0643-450d-b5a0-0f66d64771cf.png)

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [x] added a test
