### PR TITLE
add json output option to CLI

### DIFF
--- a/cli/actions/run_test_action.go
+++ b/cli/actions/run_test_action.go
@@ -69,8 +69,6 @@ func (a runTestAction) Run(ctx context.Context, args RunTestConfig) error {
 
 	allPassed := output.Run.Result.AllPassed
 
-	fmt.Printf("%+v\n%+v\n%+v\n%+v\n", output, output.Run, output.Run.Result, output.Run.Result.AllPassed)
-
 	if args.WaitForResult && (allPassed == nil || !*allPassed) {
 		// It failed, so we have to return an error status
 		os.Exit(1)
@@ -118,11 +116,6 @@ func (a runTestAction) runDefinition(ctx context.Context, params runTestParams) 
 		return formatters.TestRunOutput{}, fmt.Errorf("could not run test: %w", err)
 	}
 
-	tro := formatters.TestRunOutput{
-		Test: test,
-		Run:  testRun,
-	}
-
 	if params.WaitForResult {
 		updatedTestRun, err := a.waitForResult(ctx, definition.Id, *testRun.Id)
 		if err != nil {
@@ -134,6 +127,11 @@ func (a runTestAction) runDefinition(ctx context.Context, params runTestParams) 
 		if err := a.saveJUnitFile(ctx, definition.Id, *testRun.Id, params.JunitFile); err != nil {
 			return formatters.TestRunOutput{}, fmt.Errorf("could not save junit file: %w", err)
 		}
+	}
+
+	tro := formatters.TestRunOutput{
+		Test: test,
+		Run:  testRun,
 	}
 
 	formatter := formatters.TestRun(a.config, true)

--- a/cli/actions/run_test_action.go
+++ b/cli/actions/run_test_action.go
@@ -68,7 +68,10 @@ func (a runTestAction) Run(ctx context.Context, args RunTestConfig) error {
 	}
 
 	allPassed := output.Run.Result.AllPassed
-	if allPassed == nil || !*allPassed {
+
+	fmt.Printf("%+v\n%+v\n%+v\n%+v\n", output, output.Run, output.Run.Result, output.Run.Result.AllPassed)
+
+	if args.WaitForResult && (allPassed == nil || !*allPassed) {
 		// It failed, so we have to return an error status
 		os.Exit(1)
 	}

--- a/cli/cmd/config.go
+++ b/cli/cmd/config.go
@@ -17,16 +17,19 @@ var cliConfig config.Config
 var cliLogger *zap.Logger
 
 func setupCommand(cmd *cobra.Command, args []string) {
+	setupOutputFormat()
+	setupLogger(cmd, args)
+	loadConfig(cmd, args)
+	analytics.Init(cliConfig)
+}
+
+func setupOutputFormat() {
 	o := formatters.Output(output)
 	if !formatters.ValidOutput(o) {
 		fmt.Fprintf(os.Stderr, "Invalid output format %s. Available formats are [%s]\n", output, outputFormatsString)
 		os.Exit(1)
 	}
 	formatters.SetOutput(o)
-
-	setupLogger(cmd, args)
-	loadConfig(cmd, args)
-	analytics.Init(cliConfig)
 }
 
 func loadConfig(cmd *cobra.Command, args []string) {

--- a/cli/cmd/config.go
+++ b/cli/cmd/config.go
@@ -1,10 +1,12 @@
 package cmd
 
 import (
+	"fmt"
 	"os"
 
 	"github.com/kubeshop/tracetest/cli/analytics"
 	"github.com/kubeshop/tracetest/cli/config"
+	"github.com/kubeshop/tracetest/cli/formatters"
 	"github.com/kubeshop/tracetest/cli/openapi"
 	"github.com/spf13/cobra"
 	"go.uber.org/zap"
@@ -15,6 +17,13 @@ var cliConfig config.Config
 var cliLogger *zap.Logger
 
 func setupCommand(cmd *cobra.Command, args []string) {
+	o := formatters.Output(output)
+	if !formatters.ValidOutput(o) {
+		fmt.Fprintf(os.Stderr, "Invalid output format %s. Available formats are [%s]\n", output, outputFormatsString)
+		os.Exit(1)
+	}
+	formatters.SetOutput(o)
+
 	setupLogger(cmd, args)
 	loadConfig(cmd, args)
 	analytics.Init(cliConfig)

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -27,13 +27,6 @@ var rootCmd = &cobra.Command{
 }
 
 func Execute() {
-	o := formatters.Output(output)
-	if !formatters.ValidOutput(o) {
-		fmt.Fprintf(os.Stderr, "Invalid output format %s. Available formats are [%s]\n", output, outputFormatsString)
-		os.Exit(1)
-	}
-	formatters.SetOutput(o)
-
 	if err := rootCmd.Execute(); err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
@@ -41,7 +34,7 @@ func Execute() {
 }
 
 func init() {
+	rootCmd.PersistentFlags().StringVarP(&output, "output", "o", string(formatters.DefaultOutput), fmt.Sprintf("output format [%s]", outputFormatsString))
 	rootCmd.PersistentFlags().StringVarP(&configFile, "config", "c", "config.yml", "config file will be used by the CLI")
 	rootCmd.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, "display debug information")
-	rootCmd.PersistentFlags().StringVarP(&output, "output", "o", string(formatters.DefaultOutput), fmt.Sprintf("output format [%s]", outputFormatsString))
 }

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -3,12 +3,20 @@ package cmd
 import (
 	"fmt"
 	"os"
+	"strings"
 
+	"github.com/kubeshop/tracetest/cli/formatters"
 	"github.com/spf13/cobra"
 )
 
-var verbose bool
-var configFile string
+var (
+	verbose    bool
+	configFile string
+	output     string
+
+	outputFormats       = formatters.OuputsStr()
+	outputFormatsString = strings.Join(outputFormats, "|")
+)
 
 var rootCmd = &cobra.Command{
 	Use:     "tracetest",
@@ -19,6 +27,13 @@ var rootCmd = &cobra.Command{
 }
 
 func Execute() {
+	o := formatters.Output(output)
+	if !formatters.ValidOutput(o) {
+		fmt.Fprintf(os.Stderr, "Invalid output format %s. Available formats are [%s]\n", output, outputFormatsString)
+		os.Exit(1)
+	}
+	formatters.SetOutput(o)
+
 	if err := rootCmd.Execute(); err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
@@ -28,4 +43,5 @@ func Execute() {
 func init() {
 	rootCmd.PersistentFlags().StringVarP(&configFile, "config", "c", "config.yml", "config file will be used by the CLI")
 	rootCmd.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, "display debug information")
+	rootCmd.PersistentFlags().StringVarP(&output, "output", "o", string(formatters.DefaultOutput), fmt.Sprintf("output format [%s]", outputFormatsString))
 }

--- a/cli/formatters/outputs.go
+++ b/cli/formatters/outputs.go
@@ -1,0 +1,36 @@
+package formatters
+
+import "golang.org/x/exp/slices"
+
+type Output string
+
+var (
+	currentOutput = DefaultOutput
+
+	Outputs = []Output{
+		Pretty,
+		JSON,
+	}
+
+	DefaultOutput = Pretty
+
+	Pretty Output = "pretty"
+	JSON   Output = "json"
+)
+
+func SetOutput(o Output) {
+	currentOutput = o
+}
+
+func OuputsStr() []string {
+	out := make([]string, len(Outputs))
+	for i, o := range Outputs {
+		out[i] = string(o)
+	}
+
+	return out
+}
+
+func ValidOutput(o Output) bool {
+	return slices.Contains(Outputs, o)
+}

--- a/cli/formatters/outputs.go
+++ b/cli/formatters/outputs.go
@@ -5,7 +5,7 @@ import "golang.org/x/exp/slices"
 type Output string
 
 var (
-	currentOutput = DefaultOutput
+	CurrentOutput = DefaultOutput
 
 	Outputs = []Output{
 		Pretty,
@@ -19,7 +19,7 @@ var (
 )
 
 func SetOutput(o Output) {
-	currentOutput = o
+	CurrentOutput = o
 }
 
 func OuputsStr() []string {

--- a/k8s/collector.yml
+++ b/k8s/collector.yml
@@ -23,14 +23,9 @@ data:
       logging:
         logLevel: debug
       jaeger:
-        endpoint: jaeger-collector.tracetest.svc.cluster.local:14250
+        endpoint: jaeger-collector.tracetest:14250
         tls:
           insecure: true
-      otlphttp:
-        traces_endpoint: https://ingest.lightstep.com:443/traces/otlp/v0.6
-        metrics_endpoint: https://ingest.lightstep.com:443/metrics/otlp/v0.9
-        headers: {"lightstep-access-token": "${LIGHTSTEP_TOKEN}"}
-        compression: gzip
 
     service:
       pipelines:

--- a/k8s/tracetest.beta.yaml
+++ b/k8s/tracetest.beta.yaml
@@ -38,4 +38,5 @@ telemetry:
 server:
   telemetry:
     exporter: collector
+    applicationExporter: collector
     dataStore: jaeger

--- a/k8s/tracetest.demo.yaml
+++ b/k8s/tracetest.demo.yaml
@@ -38,4 +38,5 @@ telemetry:
 server:
   telemetry:
     exporter: collector
+    applicationExporter: collector
     dataStore: jaeger

--- a/k8s/tracetest.integration.yaml
+++ b/k8s/tracetest.integration.yaml
@@ -38,4 +38,5 @@ telemetry:
 server:
   telemetry:
     exporter: collector
+    applicationExporter: collector
     dataStore: jaeger

--- a/local-config/collector.config.yaml
+++ b/local-config/collector.config.yaml
@@ -21,11 +21,6 @@ exporters:
     endpoint: ${JAEGER_ENDPOINT}
     tls:
       insecure: true
-  otlphttp:
-    traces_endpoint: https://ingest.lightstep.com:443/traces/otlp/v0.6
-    metrics_endpoint: https://ingest.lightstep.com:443/metrics/otlp/v0.9
-    headers: {"lightstep-access-token": "${LIGHTSTEP_TOKEN}"}
-    compression: gzip
   otlp/2:
     endpoint: data-prepper:21890
     tls:

--- a/local-config/config.tests.yaml
+++ b/local-config/config.tests.yaml
@@ -1,18 +1,17 @@
----
 postgresConnString: "host=postgres user=postgres password=postgres port=5432 sslmode=disable"
 
 poolingConfig:
   maxWaitTimeForTrace: 30s
   retryDelay: 500ms
 
+googleAnalytics:
+  enabled: false
+
 demo:
   enabled: [pokeshop]
   endpoints:
     pokeshopHttp: http://demo-api:8081
     pokeshopGrpc: demo-rpc:8082
-
-googleAnalytics:
-  enabled: false
 
 telemetry:
   dataStores:

--- a/tracetesting/grpc.bash
+++ b/tracetesting/grpc.bash
@@ -6,13 +6,13 @@ EXIT_STATUS=0
 
 
 test "grpc_test_create" ./definitions/grpc_test_create.yml || EXIT_STATUS=$?
-export TEST_ID=$(tracetest_target test list | jq -rc '.[0].id')
+export TEST_ID=$(tracetest_target -o json test list | jq -rc '.[0].id')
 require_not_empty $TEST_ID "requires TEST_ID, got $TEST_ID " || exit $?
 test "grpc_test_run" ./definitions/grpc_test_run.yml || EXIT_STATUS=$?
 
 
 test "grpc_test_create_invalid_metadata" ./definitions/grpc_test_create_invalid_metadata.yml || EXIT_STATUS=$?
-export TEST_ID=$(tracetest_target test list | jq -rc '.[0].id')
+export TEST_ID=$(tracetest_target -o json test list | jq -rc '.[0].id')
 require_not_empty $TEST_ID "requires TEST_ID, got $TEST_ID " || exit $?
 test "grpc_test_run_invalid_metadata" ./definitions/grpc_test_run_invalid_metadata.yml || EXIT_STATUS=$?
 


### PR DESCRIPTION
This PR adds a new `output` flag to the CLI, so users can choose between pretty and json output

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [x] added a test
