### PR TITLE
Show DAG with elements ordered left to right based on time

### DIFF
--- a/web/src/models/DAG.model.ts
+++ b/web/src/models/DAG.model.ts
@@ -14,6 +14,7 @@ function getNodesDatumFromSpans(spans: TSpan[]): INodeDatum<INodeDataSpan>[] {
       name: span.name,
       programmingLanguage: span.attributes?.[Attributes.TELEMETRY_SDK_LANGUAGE]?.value ?? '',
       service: span.service,
+      startTime: span.startTime,
       system: span.system,
       totalAttributes: span.attributeList.length,
       type: span.type,
@@ -25,7 +26,7 @@ function getNodesDatumFromSpans(spans: TSpan[]): INodeDatum<INodeDataSpan>[] {
 }
 
 function DAG(spans: TSpan[]) {
-  const nodesDatum = getNodesDatumFromSpans(spans);
+  const nodesDatum = getNodesDatumFromSpans(spans).sort((a, b) => b.data.startTime - a.data.startTime);
   return DAGService.getEdgesAndNodes(nodesDatum);
 }
 

--- a/web/src/types/DAG.types.ts
+++ b/web/src/types/DAG.types.ts
@@ -17,6 +17,7 @@ export interface INodeDataSpan {
   name: string;
   programmingLanguage: string;
   service: string;
+  startTime: number;
   system: string;
   totalAttributes: number;
   type: SemanticGroupNames;


### PR DESCRIPTION
This PR sorts the DAG nodes based on the startTime attribute.

## Changes

- Sorting DAG nodes

## Fixes

- fixes #1243 

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
