### PR TITLE
fix: remove mermaid css file

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -72,7 +72,6 @@ markdown_extensions:
           format: !!python/name:pymdownx.superfences.fence_div_format
 
 extra_css:
-  - https://unpkg.com/mermaid@9.1.3/dist/mermaid.css
   - css/extra.css
 extra_javascript:
   - https://unpkg.com/mermaid@9.1.3/dist/mermaid.min.js


### PR DESCRIPTION
The CSS file was removed on version 8.0 and afterward. This was here because we were using version 7 before.

## Checklist

- [ ] tested locally
- [ ] added new dependencies
- [x] updated the docs
- [ ] added a test
