### PR TITLE
fix: prefer apt over brew

### DIFF
--- a/cli/installer/util.go
+++ b/cli/installer/util.go
@@ -63,10 +63,10 @@ func detectPkgManager() pkgManager {
 	}
 
 	switch true {
+	case commandExists("apt"):
+		lastDetectedPkgManager = apt
 	case commandExists("brew"):
 		lastDetectedPkgManager = homebrew
-	case commandExists("apt-get"):
-		lastDetectedPkgManager = apt
 	case commandExists("dnf"):
 		lastDetectedPkgManager = dnf
 	case commandExists("yum"):

--- a/cli/installer/util.go
+++ b/cli/installer/util.go
@@ -63,7 +63,7 @@ func detectPkgManager() pkgManager {
 	}
 
 	switch true {
-	case commandExists("apt"):
+	case commandExists("apt-get"):
 		lastDetectedPkgManager = apt
 	case commandExists("brew"):
 		lastDetectedPkgManager = homebrew

--- a/cli/installer/util.go
+++ b/cli/installer/util.go
@@ -65,12 +65,12 @@ func detectPkgManager() pkgManager {
 	switch true {
 	case commandExists("apt-get"):
 		lastDetectedPkgManager = apt
-	case commandExists("brew"):
-		lastDetectedPkgManager = homebrew
 	case commandExists("dnf"):
 		lastDetectedPkgManager = dnf
 	case commandExists("yum"):
 		lastDetectedPkgManager = yum
+	case commandExists("brew"):
+		lastDetectedPkgManager = homebrew
 	case runtime.GOOS == "darwin" && detectArchitecture() == "amd64":
 		lastDetectedPkgManager = macIntelChipManual
 	case runtime.GOOS == "darwin" && detectArchitecture() == "arm64":


### PR DESCRIPTION
This PR fixes docker-compose installation on Linux when brew is available.

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
