### PR TITLE
Hide step #3 (Test Spec name) in create Test Spec form

### DIFF
--- a/web/src/components/TestSpecForm/TestSpecForm.tsx
+++ b/web/src/components/TestSpecForm/TestSpecForm.tsx
@@ -1,4 +1,4 @@
-import {Button, Form, Input, Tag} from 'antd';
+import {Button, Form, Tag} from 'antd';
 import React, {useState} from 'react';
 
 import {ADVANCE_SELECTORS_DOCUMENTATION_URL} from 'constants/Common.constants';
@@ -111,16 +111,6 @@ const TestSpecForm = ({
               />
             )}
           </Form.List>
-        </S.FormSection>
-
-        <S.FormSection>
-          <S.FormSectionTitle>3. Test Spec name (optional)</S.FormSectionTitle>
-          <S.FormSectionRow>
-            <S.FormSectionText>Identify your spec by giving it a name</S.FormSectionText>
-          </S.FormSectionRow>
-          <Form.Item name="name">
-            <Input placeholder="Test Spec name" />
-          </Form.Item>
         </S.FormSection>
 
         <S.AssertionFromActions>


### PR DESCRIPTION
This PR removes the `Test Spec name` step in the `Test Spec form`.

## Changes

- Removes unused field.

## Fixes

- fixes #1258 

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Screenshot

<img width="1490" alt="Screen Shot 2022-09-20 at 16 25 13" src="https://user-images.githubusercontent.com/3879892/191284354-def88edf-f100-4711-bd67-bc9bae25b147.png">