### PR TITLE
Move local dogfood tests to use otlp dataStore

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -24,10 +24,6 @@ services:
     depends_on:
       postgres:
         condition: service_healthy
-      jaeger:
-        condition: service_healthy
-      otel-collector:
-        condition: service_started
 
   postgres:
     image: postgres
@@ -43,177 +39,13 @@ services:
       retries: 60
 
   otel-collector:
-    image: otel/opentelemetry-collector:0.54.0
-    restart: unless-stopped
+    image: otel/opentelemetry-collector-contrib:0.59.0
     ports:
-      - "55679:55679"
-      - "4317:4317"
-      - "8888:8888"
-      - "4318:4318"
+        - "55679:55679"
+        - "4317:4317"
+        - "8888:8888"
     command:
-      - "--config"
-      - "/otel-local-config.yaml"
+        - "--config"
+        - "/otel-local-config.yaml"
     volumes:
-      - ./local-config/collector.config.yaml:/otel-local-config.yaml
-    environment:
-      - JAEGER_ENDPOINT=jaeger:14250
-    depends_on:
-      jaeger:
-        condition: service_healthy
-
-  jaeger:
-    image: jaegertracing/all-in-one:latest
-    restart: unless-stopped
-    ports:
-      - 16686:16686
-      - 16685:16685
-      - 6831:6831/udp
-      - 6832:6832/udp
-    healthcheck:
-      test: ["CMD", "wget", "--spider", "localhost:16686"]
-      interval: 1s
-      timeout: 3s
-      retries: 60
-
-  cache:
-    image: redis:6
-    restart: unless-stopped
-    ports:
-      - 6379:6379
-    healthcheck:
-      test: ["CMD", "redis-cli", "ping"]
-      interval: 1s
-      timeout: 3s
-      retries: 60
-
-  queue:
-    image: rabbitmq:3.9
-    restart: unless-stopped
-    ports:
-      - 5672:5672
-      - 15672:15672
-    healthcheck:
-      test: rabbitmq-diagnostics -q check_running
-      interval: 1s
-      timeout: 5s
-      retries: 60
-
-  demo-api:
-    image: kubeshop/demo-pokemon-api:latest
-    restart: unless-stopped
-    pull_policy: always
-    environment:
-      REDIS_URL: cache
-      DATABASE_URL: postgresql://postgres:postgres@postgres:5432/postgres?schema=public
-      RABBITMQ_HOST: queue
-      POKE_API_BASE_URL: https://pokeapi.co/api/v2
-      COLLECTOR_ENDPOINT: http://otel-collector:4317
-      NPM_RUN_COMMAND: api
-    ports:
-      - "8081:8081"
-    healthcheck:
-      test: ["CMD", "wget", "--spider", "localhost:8081"]
-      interval: 1s
-      timeout: 3s
-      retries: 60
-    depends_on:
-      postgres:
-        condition: service_healthy
-      cache:
-        condition: service_healthy
-      queue:
-        condition: service_healthy
-      jaeger:
-        condition: service_healthy
-
-  demo-worker:
-    image: kubeshop/demo-pokemon-api:latest
-    restart: unless-stopped
-    pull_policy: always
-    environment:
-      REDIS_URL: cache
-      DATABASE_URL: postgresql://postgres:postgres@postgres:5432/postgres?schema=public
-      RABBITMQ_HOST: queue
-      POKE_API_BASE_URL: https://pokeapi.co/api/v2
-      COLLECTOR_ENDPOINT: http://otel-collector:4317
-      NPM_RUN_COMMAND: worker
-    depends_on:
-      postgres:
-        condition: service_healthy
-      cache:
-        condition: service_healthy
-      queue:
-        condition: service_healthy
-      jaeger:
-        condition: service_healthy
-
-  demo-rpc:
-    image: kubeshop/demo-pokemon-api:latest
-    restart: unless-stopped
-    pull_policy: always
-    environment:
-      REDIS_URL: cache
-      DATABASE_URL: postgresql://postgres:postgres@postgres:5432/postgres?schema=public
-      RABBITMQ_HOST: queue
-      POKE_API_BASE_URL: https://pokeapi.co/api/v2
-      COLLECTOR_ENDPOINT: http://otel-collector:4317
-      NPM_RUN_COMMAND: rpc
-    ports:
-      - 8082:8082
-    healthcheck:
-      test: ["CMD", "lsof", "-i", "8082"]
-      interval: 1s
-      timeout: 3s
-      retries: 60
-    depends_on:
-      postgres:
-        condition: service_healthy
-      cache:
-        condition: service_healthy
-      queue:
-        condition: service_healthy
-      jaeger:
-        condition: service_healthy
-
-  data-prepper:
-    restart: unless-stopped
-    image: opensearchproject/data-prepper:latest
-    volumes:
-      - ./local-config/opensearch/opensearch-analytics.yaml:/usr/share/data-prepper/pipelines.yaml
-      - ./local-config/opensearch/opensearch-data-prepper-config.yaml:/usr/share/data-prepper/data-prepper-config.yaml
-    ports:
-      - "21890:21890"
-    depends_on:
-      - "opensearch"
-
-  opensearch:
-    image: opensearchproject/opensearch:latest
-    environment:
-      - discovery.type=single-node
-      - bootstrap.memory_lock=true # along with the memlock settings below, disables swapping
-      - "OPENSEARCH_JAVA_OPTS=-Xms512m -Xmx512m" # minimum and maximum Java heap size, recommend setting both to 50% of system RAM
-    volumes:
-      - ./local-config/opensearch/opensearch.yaml:/usr/share/opensearch/config/opensearch.yml
-    ulimits:
-      memlock:
-        soft: -1
-        hard: -1
-      nofile:
-        soft: 65536 # maximum number of open files for the OpenSearch user, set to at least 65536 on modern systems
-        hard: 65536
-    ports:
-      - 9200:9200
-      - 9600:9600 # required for Performance Analyzer
-
-  dashboards:
-    image: opensearchproject/opensearch-dashboards:latest
-    ports:
-      - 5601:5601
-    expose:
-      - "5601"
-    environment:
-      OPENSEARCH_HOSTS: '["http://opensearch:9200"]'
-      OPENSEARCH_USERNAME: admin
-      OPENSEARCH_PASSWORD: admin
-    depends_on:
-      - opensearch
+        - ./local-config/collector.config.yaml:/otel-local-config.yaml

--- a/local-config/collector.config.yaml
+++ b/local-config/collector.config.yaml
@@ -6,30 +6,32 @@ receivers:
 
 
 processors:
+  tail_sampling:
+    decision_wait: 5s
+    policies:
+      - name: tracetest-spans
+        type: trace_state
+        trace_state: { key: tracetest, values: ["true"] }
+
   batch:
     timeout: 100ms
 
-  # Data sources: traces
-  probabilistic_sampler:
-    hash_seed: 22
-    sampling_percentage: 100
-
 exporters:
   logging:
-    logLevel: debug
-  jaeger:
-    endpoint: ${JAEGER_ENDPOINT}
+    loglevel: debug
+
+  otlp/1:
+    endpoint: tracetest:21321
     tls:
       insecure: true
-  otlp/2:
-    endpoint: data-prepper:21890
-    tls:
-      insecure: true
-      insecure_skip_verify: true
+
+extensions:
+  health_check: {}
 
 service:
+  extensions: [health_check]
   pipelines:
-    traces:
+    traces/1:
       receivers: [otlp]
-      processors: [probabilistic_sampler, batch]
-      exporters: [logging, jaeger, otlp/2]
+      processors: [tail_sampling, batch]
+      exporters: [otlp/1]

--- a/local-config/collector.config.yaml
+++ b/local-config/collector.config.yaml
@@ -7,7 +7,7 @@ receivers:
 
 processors:
   tail_sampling:
-    decision_wait: 5s
+    decision_wait: 1s
     policies:
       - name: tracetest-spans
         type: trace_state

--- a/local-config/config.tests.yaml
+++ b/local-config/config.tests.yaml
@@ -15,12 +15,8 @@ demo:
 
 telemetry:
   dataStores:
-    jaeger:
-      type: jaeger
-      jaeger:
-        endpoint: jaeger:16685
-        tls:
-          insecure: true
+    otlp:
+      type: otlp
 
   exporters:
     collector:
@@ -33,6 +29,6 @@ telemetry:
 
 server:
   telemetry:
+    dataStore: otlp
     exporter: collector
-    dataStore: jaeger
     applicationExporter: collector

--- a/local-config/docker-compose.demo.yaml
+++ b/local-config/docker-compose.demo.yaml
@@ -1,0 +1,95 @@
+version: "3.2"
+services:
+  cache:
+    image: redis:6
+    restart: unless-stopped
+    ports:
+      - 6379:6379
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 1s
+      timeout: 3s
+      retries: 60
+
+  queue:
+    image: rabbitmq:3.9
+    restart: unless-stopped
+    ports:
+      - 5672:5672
+      - 15672:15672
+    healthcheck:
+      test: rabbitmq-diagnostics -q check_running
+      interval: 1s
+      timeout: 5s
+      retries: 60
+
+  demo-api:
+    image: kubeshop/demo-pokemon-api:latest
+    restart: unless-stopped
+    pull_policy: always
+    environment:
+      REDIS_URL: cache
+      DATABASE_URL: postgresql://postgres:postgres@postgres:5432/postgres?schema=public
+      RABBITMQ_HOST: queue
+      POKE_API_BASE_URL: https://pokeapi.co/api/v2
+      COLLECTOR_ENDPOINT: http://otel-collector:4317
+      NPM_RUN_COMMAND: api
+    ports:
+      - "8081:8081"
+    healthcheck:
+      test: ["CMD", "wget", "--spider", "localhost:8081"]
+      interval: 1s
+      timeout: 3s
+      retries: 60
+    depends_on:
+      postgres:
+        condition: service_healthy
+      cache:
+        condition: service_healthy
+      queue:
+        condition: service_healthy
+
+  demo-worker:
+    image: kubeshop/demo-pokemon-api:latest
+    restart: unless-stopped
+    pull_policy: always
+    environment:
+      REDIS_URL: cache
+      DATABASE_URL: postgresql://postgres:postgres@postgres:5432/postgres?schema=public
+      RABBITMQ_HOST: queue
+      POKE_API_BASE_URL: https://pokeapi.co/api/v2
+      COLLECTOR_ENDPOINT: http://otel-collector:4317
+      NPM_RUN_COMMAND: worker
+    depends_on:
+      postgres:
+        condition: service_healthy
+      cache:
+        condition: service_healthy
+      queue:
+        condition: service_healthy
+
+  demo-rpc:
+    image: kubeshop/demo-pokemon-api:latest
+    restart: unless-stopped
+    pull_policy: always
+    environment:
+      REDIS_URL: cache
+      DATABASE_URL: postgresql://postgres:postgres@postgres:5432/postgres?schema=public
+      RABBITMQ_HOST: queue
+      POKE_API_BASE_URL: https://pokeapi.co/api/v2
+      COLLECTOR_ENDPOINT: http://otel-collector:4317
+      NPM_RUN_COMMAND: rpc
+    ports:
+      - 8082:8082
+    healthcheck:
+      test: ["CMD", "lsof", "-i", "8082"]
+      interval: 1s
+      timeout: 3s
+      retries: 60
+    depends_on:
+      postgres:
+        condition: service_healthy
+      cache:
+        condition: service_healthy
+      queue:
+        condition: service_healthy

--- a/local-config/docker-compose.opensearch.yaml
+++ b/local-config/docker-compose.opensearch.yaml
@@ -1,0 +1,44 @@
+version: "3.2"
+services:
+  data-prepper:
+    restart: unless-stopped
+    image: opensearchproject/data-prepper:latest
+    volumes:
+      - ./local-config/opensearch/opensearch-analytics.yaml:/usr/share/data-prepper/pipelines.yaml
+      - ./local-config/opensearch/opensearch-data-prepper-config.yaml:/usr/share/data-prepper/data-prepper-config.yaml
+    ports:
+      - "21890:21890"
+    depends_on:
+      - "opensearch"
+
+  opensearch:
+    image: opensearchproject/opensearch:latest
+    environment:
+      - discovery.type=single-node
+      - bootstrap.memory_lock=true # along with the memlock settings below, disables swapping
+      - "OPENSEARCH_JAVA_OPTS=-Xms512m -Xmx512m" # minimum and maximum Java heap size, recommend setting both to 50% of system RAM
+    volumes:
+      - ./local-config/opensearch/opensearch.yaml:/usr/share/opensearch/config/opensearch.yml
+    ulimits:
+      memlock:
+        soft: -1
+        hard: -1
+      nofile:
+        soft: 65536 # maximum number of open files for the OpenSearch user, set to at least 65536 on modern systems
+        hard: 65536
+    ports:
+      - 9200:9200
+      - 9600:9600 # required for Performance Analyzer
+
+  dashboards:
+    image: opensearchproject/opensearch-dashboards:latest
+    ports:
+      - 5601:5601
+    expose:
+      - "5601"
+    environment:
+      OPENSEARCH_HOSTS: '["http://opensearch:9200"]'
+      OPENSEARCH_USERNAME: admin
+      OPENSEARCH_PASSWORD: admin
+    depends_on:
+      - opensearch

--- a/run-tracetesting-tests.sh
+++ b/run-tracetesting-tests.sh
@@ -22,13 +22,15 @@ while [[ $# -gt 0 ]]; do
 done
 
 
+opts="-f docker-compose.yaml -f local-config/docker-compose.demo.yaml"
+
 if [ "$RESTART" == "yes" ]; then
-  docker compose -f docker-compose.yaml -f local-config/docker-compose.testrunner.yaml down
+  docker compose $opts down
 fi
-docker compose -f docker-compose.yaml up -d --build --remove-orphans
-docker compose -f docker-compose.yaml -f local-config/docker-compose.testrunner.yaml build
-docker compose -f docker-compose.yaml -f local-config/docker-compose.testrunner.yaml run testrunner
+docker compose $opts up -d --build --remove-orphans
+docker compose $opts -f local-config/docker-compose.testrunner.yaml build
+docker compose $opts -f local-config/docker-compose.testrunner.yaml run testrunner
 
 if [ "$STOP" == "yes" ]; then
-  docker compose -f docker-compose.yaml stop
+  docker compose $opts stop
 fi


### PR DESCRIPTION
This PR uses the otlp dataStore when locally running dogfood tests.

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
