### PR TITLE
1268 keeping the same mode when running a test

### DIFF
--- a/web/src/providers/Test/hooks/useTestCrud.ts
+++ b/web/src/providers/Test/hooks/useTestCrud.ts
@@ -1,5 +1,5 @@
 import {useCallback} from 'react';
-import {useNavigate} from 'react-router-dom';
+import {useMatch, useNavigate} from 'react-router-dom';
 import {useAppDispatch} from 'redux/hooks';
 import {reset} from 'redux/slices/TestSpecs.slice';
 import {TDraftTest, TTest} from 'types/Test.types';
@@ -17,6 +17,7 @@ const useTestCrud = () => {
   const [editTest, {isLoading: isLoadingEditTest}] = useEditTestMutation();
   const [runTestAction, {isLoading: isLoadingRunTest}] = useRunTestMutation();
   const isEditLoading = isLoadingEditTest || isLoadingRunTest;
+  const match = useMatch('/test/:testId/run/:runId/:mode');
 
   const runTest = useCallback(
     async (testId: string) => {
@@ -24,9 +25,11 @@ const useTestCrud = () => {
       const run = await runTestAction({testId}).unwrap();
       dispatch(reset());
 
-      navigate(`/test/${testId}/run/${run.id}`);
+      const mode = match?.params.mode || 'trigger';
+
+      navigate(`/test/${testId}/run/${run.id}/${mode}`);
     },
-    [dispatch, navigate, runTestAction]
+    [dispatch, match?.params.mode, navigate, runTestAction]
   );
 
   const edit = useCallback(


### PR DESCRIPTION
This PR updates the useTestCrud to match the mode from the location and if a mode already exists it is used when rerunning a test.

## Fixes

- https://github.com/kubeshop/tracetest/issues/1268

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
