### PR TITLE
make installer check run on push to main only

### DIFF
--- a/.github/workflows/pull-request-installer.yaml
+++ b/.github/workflows/pull-request-installer.yaml
@@ -1,5 +1,8 @@
 name: Installer Pull Request
-on: [push]
+on:
+  push:
+    branches:
+      - master
 
 jobs:
   linux:


### PR DESCRIPTION
This PR fixes GHA settings for installer check

## Changes

-

## Fixes

-

## Checklist

- [ ] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
