### PR TITLE
fix: opensearch install

### DIFF
--- a/cli/installer/docker_compose.go
+++ b/cli/installer/docker_compose.go
@@ -327,8 +327,6 @@ func fixOtelCollectorContainer(config configuration, project *types.Project) err
 	}
 
 	ocs.Volumes[0].Source = path.Join(config.String("output.dir"), otelCollectorConfigFilename)
-	je := config.String("tracetest.backend.endpoint.collector")
-	ocs.Environment["JAEGER_ENDPOINT"] = &je
 
 	return nil
 }


### PR DESCRIPTION
This PR fixes the flow for installing Tracetest with an existing tracing backend

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
