### PR TITLE
cli installer: lower default retry delay

### DIFF
--- a/cli/installer/tracetest.go
+++ b/cli/installer/tracetest.go
@@ -154,7 +154,7 @@ func getTracetestConfigFileContents(psql string, ui UI, config configuration) []
 		PostgresConnString: psql,
 		PoolingConfig: serverConfig.PoolingConfig{
 			MaxWaitTimeForTrace: "2m",
-			RetryDelay:          "1s",
+			RetryDelay:          "3s",
 		},
 		GA: serverConfig.GoogleAnalytics{
 			Enabled: config.Bool("tracetest.analytics"),

--- a/k8s/deploy.sh
+++ b/k8s/deploy.sh
@@ -1,6 +1,6 @@
 #/bin/bash
 
-set -x
+set -ex
 
 if [ -z "$NAME" ];then
   echo '$NAME is required'


### PR DESCRIPTION
This PR changes the `retryDelay` config set by the installer. It was set to `1s`, and it's too low to get consistent results. Setting it to `3s` makes it more consistent.

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
