### PR TITLE
fix body input bugs

### DIFF
--- a/web/src/components/CreateTestPlugins/Postman/steps/UploadCollection/UploadCollectionForm.tsx
+++ b/web/src/components/CreateTestPlugins/Postman/steps/UploadCollection/UploadCollectionForm.tsx
@@ -33,7 +33,7 @@ const UploadCollectionForm = ({form}: IProps) => {
           <RequestDetailsUrlInput />
         </Col>
         <Col span={12}>
-          <BodyField />
+          <BodyField body={Form.useWatch('body', form)} setBody={body => form.setFieldsValue({body})} />
         </Col>
       </Row>
       <Row gutter={12}>

--- a/web/src/components/CreateTestPlugins/Rest/steps/RequestDetails/BodyField/BodyField.tsx
+++ b/web/src/components/CreateTestPlugins/Rest/steps/RequestDetails/BodyField/BodyField.tsx
@@ -1,24 +1,38 @@
 import CodeMirror from '@uiw/react-codemirror';
 import {Form, Radio} from 'antd';
+import {useState} from 'react';
 import {BodyFieldContainer} from './BodyFieldContainer';
 import {SingleLabel} from './SingleLabel';
 import {useBodyMode} from './useBodyMode';
 import {useLanguageExtensionsMemo} from './useLanguageExtensionsMemo';
 
 interface IProps {
-  isEditing?: boolean;
   body?: string;
+  setBody: (body?: string) => void;
 }
 
-export const BodyField = ({isEditing = false, body}: IProps): React.ReactElement => {
-  const [bodyMode, setBodyMode] = useBodyMode(isEditing, body);
+export const BodyField = ({body, setBody}: IProps): React.ReactElement => {
+  const [bodyMode, setBodyMode] = useBodyMode(body);
+  const [buffer, setBuffer] = useState<undefined | string>(undefined);
   const extensions = useLanguageExtensionsMemo(bodyMode);
   const hasNoBody = bodyMode === 'none';
   return (
     <>
       <span>
-        <SingleLabel label="Request body">{null}</SingleLabel>
-        <Radio.Group value={bodyMode} onChange={e => setBodyMode(e.target.value)}>
+        <SingleLabel label="Request body">{buffer}</SingleLabel>
+        <Radio.Group
+          value={bodyMode}
+          onChange={e => {
+            if (e.target.value === 'none') {
+              setBuffer(body);
+              setBody(undefined);
+            } else if (buffer) {
+              setBody(buffer);
+              setBuffer(undefined);
+            }
+            setBodyMode(e.target.value);
+          }}
+        >
           <Radio value="none" data-cy="bodyMode-none">
             None
           </Radio>

--- a/web/src/components/CreateTestPlugins/Rest/steps/RequestDetails/BodyField/useBodyMode.tsx
+++ b/web/src/components/CreateTestPlugins/Rest/steps/RequestDetails/BodyField/useBodyMode.tsx
@@ -3,22 +3,18 @@ import Validator from 'utils/Validator';
 
 export type BodyMode = 'json' | 'xml' | 'raw' | 'none';
 
-function useGuessBodyModeEffect(
-  isEditing: undefined | boolean,
-  setBodyMode: Dispatch<SetStateAction<BodyMode>>,
-  body?: string
-) {
+function useGuessBodyModeEffect(setBodyMode: Dispatch<SetStateAction<BodyMode>>, body?: string) {
   const [initialized, setInitialized] = useState(false);
   useEffect(() => {
-    if (!initialized && isEditing && body) {
+    if (!initialized && body) {
       setInitialized(true);
       setBodyMode(Validator.getBodyType(body));
     }
-  }, [isEditing, setBodyMode, body, initialized, setInitialized]);
+  }, [setBodyMode, body, initialized, setInitialized]);
 }
 
-export function useBodyMode(isEditing?: boolean, body?: string): [BodyMode, Dispatch<SetStateAction<BodyMode>>] {
+export function useBodyMode(body?: string): [BodyMode, Dispatch<SetStateAction<BodyMode>>] {
   const [bodyMode, setBodyMode] = useState<BodyMode>('none');
-  useGuessBodyModeEffect(isEditing, setBodyMode, body);
+  useGuessBodyModeEffect(setBodyMode, body);
   return [bodyMode, setBodyMode];
 }

--- a/web/src/components/CreateTestPlugins/Rest/steps/RequestDetails/RequestDetailsForm.tsx
+++ b/web/src/components/CreateTestPlugins/Rest/steps/RequestDetails/RequestDetailsForm.tsx
@@ -19,7 +19,7 @@ const RequestDetailsForm = ({form, isEditing = false}: IProps) => {
       <RequestDetailsUrlInput />
       <RequestDetailsAuthInput form={form} />
       <RequestDetailsHeadersInput />
-      <BodyField body={Form.useWatch('body', form)} isEditing={isEditing} />
+      <BodyField setBody={body => form.setFieldsValue({body})} body={Form.useWatch('body', form)} />
     </S.InputContainer>
   );
 };


### PR DESCRIPTION
This PR fixes 2 bugs
- First one is described [here](https://github.com/kubeshop/tracetest/issues/1281)
- The second one is when trying to set the body to none, would not make the frontend send the body as empty to the backend. It would still send the same body as before.

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
