### PR TITLE
Add timeline view in test mode

### DIFF
--- a/web/src/components/RunDetailTest/RunDetailTest.styled.ts
+++ b/web/src/components/RunDetailTest/RunDetailTest.styled.ts
@@ -1,43 +1,4 @@
-import styled, {css} from 'styled-components';
-
-export const Aside = styled.div<{$isOpen: boolean}>`
-  background-color: ${({theme}) => theme.color.white};
-  box-shadow: 0 20px 24px rgba(153, 155, 168, 0.18);
-  height: 100%;
-  min-width: 30px;
-  overflow: visible;
-  position: relative;
-  transition: width ease 0.2s, min-width ease 0.2s;
-  width: 30px;
-  z-index: 2;
-
-  > div:first-child {
-    opacity: 0;
-  }
-
-  ${({$isOpen}) =>
-    $isOpen &&
-    css`
-      min-width: 270px;
-      transition: width ease 0.2s 0.05s, min-width ease 0.2s 0.05s;
-      width: 270px;
-
-      > div:first-child {
-        opacity: 1;
-      }
-    `}
-`;
-
-export const AsideButtonContainer = styled.div`
-  position: absolute;
-  right: -12px;
-  top: 48px;
-`;
-
-export const AsideContent = styled.div`
-  height: 100%;
-  overflow: hidden;
-`;
+import styled from 'styled-components';
 
 export const Container = styled.div`
   display: flex;
@@ -57,6 +18,13 @@ export const SectionLeft = styled(Section)`
 export const SectionRight = styled(Section)<{$shouldScroll: boolean}>`
   background-color: ${({theme}) => theme.color.white};
   box-shadow: 0 20px 24px rgba(153, 155, 168, 0.18);
-  overflow-y: ${({$shouldScroll}) => $shouldScroll ? 'scroll' : 'hidden'};
+  overflow-y: ${({$shouldScroll}) => ($shouldScroll ? 'scroll' : 'hidden')};
   z-index: 2;
+`;
+
+export const SwitchContainer = styled.div`
+  bottom: 163px;
+  left: 16px;
+  position: absolute;
+  z-index: 9;
 `;

--- a/web/src/components/RunDetailTest/RunDetailTest.tsx
+++ b/web/src/components/RunDetailTest/RunDetailTest.tsx
@@ -1,10 +1,15 @@
+import {useState} from 'react';
+
 import Drawer from 'components/Drawer';
+import {VisualizationType} from 'components/RunDetailTrace/RunDetailTrace';
 import SpanDetail from 'components/SpanDetail';
 import TestResults from 'components/TestResults';
 import TestSpecForm from 'components/TestSpecForm';
 import {useTestSpecForm} from 'components/TestSpecForm/TestSpecForm.provider';
+import Switch from 'components/Visualization/components/Switch';
 import {useSpan} from 'providers/Span/Span.provider';
 import {useTestSpecs} from 'providers/TestSpecs/TestSpecs.provider';
+import TraceAnalyticsService from 'services/Analytics/TraceAnalytics.service';
 import {TTestRun} from 'types/TestRun.types';
 import * as S from './RunDetailTest.styled';
 import Visualization from './Visualization';
@@ -18,6 +23,7 @@ const RunDetailTest = ({run, testId}: IProps) => {
   const {selectedSpan} = useSpan();
   const {selectedTestSpec} = useTestSpecs();
   const {isOpen: isTestSpecFormOpen, formProps, onSubmit, close} = useTestSpecForm();
+  const [visualizationType, setVisualizationType] = useState(VisualizationType.Dag);
 
   return (
     <S.Container>
@@ -26,8 +32,19 @@ const RunDetailTest = ({run, testId}: IProps) => {
         rightPanel={
           <S.Container>
             <S.SectionLeft>
-              <Visualization runState={run.state} spans={run?.trace?.spans ?? []} />
+              <S.SwitchContainer>
+                <Switch
+                  onChange={type => {
+                    TraceAnalyticsService.onSwitchDiagramView(type);
+                    setVisualizationType(type);
+                  }}
+                  type={visualizationType}
+                />
+              </S.SwitchContainer>
+
+              <Visualization runState={run.state} spans={run?.trace?.spans ?? []} type={visualizationType} />
             </S.SectionLeft>
+
             <S.SectionRight $shouldScroll={!selectedTestSpec}>
               {isTestSpecFormOpen ? (
                 <TestSpecForm

--- a/web/src/components/RunDetailTrace/RunDetailTrace.styled.ts
+++ b/web/src/components/RunDetailTrace/RunDetailTrace.styled.ts
@@ -24,11 +24,11 @@ export const VisualizationContainer = styled.div`
   position: relative;
 `;
 
-export const SwitchContainer = styled.div<{$hasSpace: boolean}>`
+export const SwitchContainer = styled.div`
+  bottom: 163px;
+  left: 16px;
   position: absolute;
   z-index: 9;
-  left: 16px;
-  bottom: 163px;
 `;
 
 export const ClearSearchIcon = styled(CloseCircleFilled)`

--- a/web/src/components/RunDetailTrace/RunDetailTrace.tsx
+++ b/web/src/components/RunDetailTrace/RunDetailTrace.tsx
@@ -46,7 +46,7 @@ const RunDetailTrace = ({run, testId}: IProps) => {
             </S.SearchContainer>
 
             <S.VisualizationContainer>
-              <S.SwitchContainer $hasSpace={visualizationType === VisualizationType.Timeline}>
+              <S.SwitchContainer>
                 {run.state === TestState.FINISHED && (
                   <Switch
                     onChange={type => {

--- a/web/src/components/Visualization/components/Timeline/Label.tsx
+++ b/web/src/components/Visualization/components/Timeline/Label.tsx
@@ -58,7 +58,6 @@ const Label = ({duration, kind, name, service, system, totalFailedChecks, totalP
           <tspan>{`${service} ${SpanKindToText[kind]}`}</tspan>
           {Boolean(system) && <tspan>{` - ${system}`}</tspan>}
           <tspan>{` - ${duration}`}</tspan>
-          <tspan>{` - ${totalPassedChecks} ${totalFailedChecks}`}</tspan>
         </S.TextDescription>
       </Group>
     </Group>


### PR DESCRIPTION
This PR adds the visualization switch to the `test mode` to include the timeline view.

## Changes

- Add timeline view to test mode

## Fixes

- fixes #1238 

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Screenshot

<img width="1624" alt="Screen Shot 2022-09-26 at 16 41 30" src="https://user-images.githubusercontent.com/3879892/192385870-fb7abc0e-8931-4050-99e6-d7f70a4acdb9.png">