### PR TITLE
make run IDs sequence independant for each test

### DIFF
--- a/server/http/controller.go
+++ b/server/http/controller.go
@@ -112,13 +112,13 @@ func (c *controller) GetTestSpecs(ctx context.Context, testID string) (openapi.I
 	return openapi.Response(200, c.mappers.Out.Specs(test.Specs)), nil
 }
 
-func (c *controller) GetTestResultSelectedSpans(ctx context.Context, _ string, runID int32, selectorQuery string) (openapi.ImplResponse, error) {
+func (c *controller) GetTestResultSelectedSpans(ctx context.Context, testID string, runID int32, selectorQuery string) (openapi.ImplResponse, error) {
 	selector, err := selectors.New(selectorQuery)
 	if err != nil {
 		return handleDBError(err), err
 	}
 
-	run, err := c.testDB.GetRun(ctx, int(runID))
+	run, err := c.testDB.GetRun(ctx, id.ID(testID), int(runID))
 	if err != nil {
 		return openapi.Response(http.StatusInternalServerError, ""), nil
 	}
@@ -137,8 +137,8 @@ func (c *controller) GetTestResultSelectedSpans(ctx context.Context, _ string, r
 	return openapi.Response(http.StatusOK, selectedSpanIds), nil
 }
 
-func (c *controller) GetTestRun(ctx context.Context, _ string, runID int32) (openapi.ImplResponse, error) {
-	run, err := c.testDB.GetRun(ctx, int(runID))
+func (c *controller) GetTestRun(ctx context.Context, testID string, runID int32) (openapi.ImplResponse, error) {
+	run, err := c.testDB.GetRun(ctx, id.ID(testID), int(runID))
 	if err != nil {
 		return handleDBError(err), err
 	}
@@ -146,8 +146,8 @@ func (c *controller) GetTestRun(ctx context.Context, _ string, runID int32) (ope
 	return openapi.Response(200, c.mappers.Out.Run(&run)), nil
 }
 
-func (c *controller) DeleteTestRun(ctx context.Context, _ string, runID int32) (openapi.ImplResponse, error) {
-	run, err := c.testDB.GetRun(ctx, int(runID))
+func (c *controller) DeleteTestRun(ctx context.Context, testID string, runID int32) (openapi.ImplResponse, error) {
+	run, err := c.testDB.GetRun(ctx, id.ID(testID), int(runID))
 	if err != nil {
 		return handleDBError(err), err
 	}
@@ -198,7 +198,7 @@ func (c *controller) RerunTestRun(ctx context.Context, testID string, runID int3
 		return handleDBError(err), err
 	}
 
-	run, err := c.testDB.GetRun(ctx, int(runID))
+	run, err := c.testDB.GetRun(ctx, id.ID(testID), int(runID))
 	if err != nil {
 		return handleDBError(err), err
 	}
@@ -284,8 +284,8 @@ func (c *controller) UpdateTest(ctx context.Context, testID string, in openapi.T
 	return openapi.Response(204, nil), nil
 }
 
-func (c *controller) DryRunAssertion(ctx context.Context, _ string, runID int32, def openapi.TestSpecs) (openapi.ImplResponse, error) {
-	run, err := c.testDB.GetRun(ctx, int(runID))
+func (c *controller) DryRunAssertion(ctx context.Context, testID string, runID int32, def openapi.TestSpecs) (openapi.ImplResponse, error) {
+	run, err := c.testDB.GetRun(ctx, id.ID(testID), int(runID))
 	if err != nil {
 		return openapi.Response(http.StatusInternalServerError, ""), nil
 	}
@@ -304,7 +304,7 @@ func (c *controller) DryRunAssertion(ctx context.Context, _ string, runID int32,
 }
 
 func (c *controller) GetRunResultJUnit(ctx context.Context, testID string, runID int32) (openapi.ImplResponse, error) {
-	run, err := c.testDB.GetRun(ctx, int(runID))
+	run, err := c.testDB.GetRun(ctx, id.ID(testID), int(runID))
 	if err != nil {
 		return handleDBError(err), err
 	}
@@ -346,7 +346,7 @@ func (c controller) GetTestVersionDefinitionFile(ctx context.Context, testID str
 }
 
 func (c controller) ExportTestRun(ctx context.Context, testID string, runID int32) (openapi.ImplResponse, error) {
-	run, err := c.testDB.GetRun(ctx, int(runID))
+	run, err := c.testDB.GetRun(ctx, id.ID(testID), int(runID))
 	if err != nil {
 		return handleDBError(err), err
 	}

--- a/server/http/controller_test.go
+++ b/server/http/controller_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/kubeshop/tracetest/server/assertions/comparator"
 	"github.com/kubeshop/tracetest/server/http"
 	"github.com/kubeshop/tracetest/server/http/mappings"
+	"github.com/kubeshop/tracetest/server/id"
 	"github.com/kubeshop/tracetest/server/model"
 	"github.com/kubeshop/tracetest/server/openapi"
 	"github.com/kubeshop/tracetest/server/testdb"
@@ -18,6 +19,7 @@ import (
 var (
 	exampleRun = model.Run{
 		ID:      1,
+		TestID:  id.ID("abc123"),
 		TraceID: http.IDGen.TraceID(),
 		Trace: &traces.Trace{
 			ID: http.IDGen.TraceID(),
@@ -107,7 +109,7 @@ func TestContains_Issue617(t *testing.T) {
 	f := setupController(t)
 	f.expectGetRun(exampleRun)
 
-	actual, err := f.c.DryRunAssertion(context.TODO(), "", int32(exampleRun.ID), spec)
+	actual, err := f.c.DryRunAssertion(context.TODO(), exampleRun.TestID.String(), int32(exampleRun.ID), spec)
 	require.NoError(t, err)
 
 	assert.Equal(t, 200, actual.Code)
@@ -130,6 +132,6 @@ type controllerFixture struct {
 
 func (f controllerFixture) expectGetRun(r model.Run) {
 	f.db.
-		On("GetRun", r.ID).
+		On("GetRun", r.TestID, r.ID).
 		Return(r, nil)
 }

--- a/server/id/generator.go
+++ b/server/id/generator.go
@@ -11,6 +11,10 @@ import (
 
 type ID string
 
+func (id ID) String() string {
+	return string(id)
+}
+
 type Generator interface {
 	UUID() uuid.UUID
 	ID() ID

--- a/server/migrations/8_new_db_schema.down.sql
+++ b/server/migrations/8_new_db_schema.down.sql
@@ -1,26 +1,29 @@
-ALTER TABLE "test_runs" DROP CONSTRAINT fk_test_runs_tests;
-DROP TABLE "test_runs";
-DROP TABLE "tests";
+BEGIN;
+  ALTER TABLE "test_runs" DROP CONSTRAINT fk_test_runs_tests;
+  DROP TABLE "test_runs";
+  DROP TABLE "tests";
 
-CREATE TABLE runs (
-    id uuid NOT NULL,
-    test_id uuid NOT NULL,
-    run json NOT NULL,
-    test_version integer DEFAULT 1 NOT NULL
-);
+  CREATE TABLE runs (
+      id uuid NOT NULL,
+      test_id uuid NOT NULL,
+      run json NOT NULL,
+      test_version integer DEFAULT 1 NOT NULL
+  );
 
-CREATE TABLE tests (
-    id uuid NOT NULL,
-    test json NOT NULL,
-    version integer DEFAULT 1 NOT NULL
-);
+  CREATE TABLE tests (
+      id uuid NOT NULL,
+      test json NOT NULL,
+      version integer DEFAULT 1 NOT NULL
+  );
 
-ALTER TABLE ONLY runs
-    ADD CONSTRAINT runs_pkey PRIMARY KEY (id);
+  ALTER TABLE ONLY runs
+      ADD CONSTRAINT runs_pkey PRIMARY KEY (id);
 
-ALTER TABLE ONLY tests
-    ADD CONSTRAINT tests_pkey PRIMARY KEY (id, version);
+  ALTER TABLE ONLY tests
+      ADD CONSTRAINT tests_pkey PRIMARY KEY (id, version);
 
 
-ALTER TABLE ONLY runs
-    ADD CONSTRAINT test_id_version_fk FOREIGN KEY (test_id, test_version) REFERENCES tests(id, version);
+  ALTER TABLE ONLY runs
+      ADD CONSTRAINT test_id_version_fk FOREIGN KEY (test_id, test_version) REFERENCES tests(id, version);
+
+COMMIT;

--- a/server/migrations/9_fix_test_runs_pkey.down.sql
+++ b/server/migrations/9_fix_test_runs_pkey.down.sql
@@ -1,0 +1,8 @@
+BEGIN;
+
+  ALTER TABLE test_runs
+    DROP CONSTRAINT test_runs_pkey,
+    DROP COLUMN id,
+    ADD COLUMN id SERIAL PRIMARY KEY;
+
+COMMIT;

--- a/server/migrations/9_fix_test_runs_pkey.up.sql
+++ b/server/migrations/9_fix_test_runs_pkey.up.sql
@@ -1,5 +1,7 @@
 BEGIN;
 
+  DELETE FROM test_runs;
+
   ALTER TABLE test_runs
     DROP CONSTRAINT test_runs_pkey,
     ALTER COLUMN id DROP DEFAULT,

--- a/server/migrations/9_fix_test_runs_pkey.up.sql
+++ b/server/migrations/9_fix_test_runs_pkey.up.sql
@@ -1,0 +1,10 @@
+BEGIN;
+
+  ALTER TABLE test_runs
+    DROP CONSTRAINT test_runs_pkey,
+    ALTER COLUMN id DROP DEFAULT,
+    ADD PRIMARY KEY ("id", "test_id");
+
+  DROP SEQUENCE "test_runs_id_seq";
+
+COMMIT;

--- a/server/model/repository.go
+++ b/server/model/repository.go
@@ -21,7 +21,7 @@ type RunRepository interface {
 	CreateRun(context.Context, Test, Run) (Run, error)
 	UpdateRun(context.Context, Run) error
 	DeleteRun(context.Context, Run) error
-	GetRun(context.Context, int) (Run, error)
+	GetRun(_ context.Context, testID id.ID, runID int) (Run, error)
 	GetTestRuns(_ context.Context, _ Test, take, skip int32) ([]Run, error)
 	GetRunByTraceID(context.Context, trace.TraceID) (Run, error)
 }

--- a/server/testdb/mock.go
+++ b/server/testdb/mock.go
@@ -86,8 +86,8 @@ func (m *MockRepository) DeleteRun(_ context.Context, run model.Run) error {
 	return args.Error(0)
 }
 
-func (m *MockRepository) GetRun(_ context.Context, id int) (model.Run, error) {
-	args := m.Called(id)
+func (m *MockRepository) GetRun(_ context.Context, testID id.ID, id int) (model.Run, error) {
+	args := m.Called(testID, id)
 	return args.Get(0).(model.Run), args.Error(1)
 }
 

--- a/server/testdb/runs.go
+++ b/server/testdb/runs.go
@@ -71,8 +71,18 @@ RETURNING "id"`
 
 const (
 	createSequeceQuery = `CREATE SEQUENCE IF NOT EXISTS "` + runSequenceName + `";`
+	dropSequeceQuery   = `DROP SEQUENCE IF EXISTS "` + runSequenceName + `";`
 	runSequenceName    = "%sequence_name%"
 )
+
+func dropSequece(ctx context.Context, tx *sql.Tx, testID id.ID) error {
+	_, err := tx.ExecContext(
+		ctx,
+		replaceRunSequenceName(createSequeceQuery, testID),
+	)
+
+	return err
+}
 
 func md5Hash(text string) string {
 	hash := md5.Sum([]byte(text))

--- a/server/testdb/runs_test.go
+++ b/server/testdb/runs_test.go
@@ -43,6 +43,37 @@ func TestCreateRun(t *testing.T) {
 	assert.Equal(t, run.Metadata, actual.Metadata)
 }
 
+func TestCreateRunIDsIncrementForTest(t *testing.T) {
+	db, clean := getDB()
+	defer clean()
+
+	run := model.Run{
+		TraceID: testdb.IDGen.TraceID(),
+		SpanID:  testdb.IDGen.SpanID(),
+	}
+
+	test1 := createTest(t, db)
+	test2 := createTest(t, db)
+
+	t1r1, err := db.CreateRun(context.TODO(), test1, run)
+	require.NoError(t, err)
+
+	t2r1, err := db.CreateRun(context.TODO(), test2, run)
+	require.NoError(t, err)
+
+	t1r2, err := db.CreateRun(context.TODO(), test1, run)
+	require.NoError(t, err)
+
+	t2r2, err := db.CreateRun(context.TODO(), test2, run)
+	require.NoError(t, err)
+
+	assert.Equal(t, 1, t1r1.ID)
+	assert.Equal(t, 2, t1r2.ID)
+	assert.Equal(t, 1, t2r1.ID)
+	assert.Equal(t, 2, t2r2.ID)
+
+}
+
 func TestUpdateRun(t *testing.T) {
 	db, clean := getDB()
 	defer clean()

--- a/server/testdb/runs_test.go
+++ b/server/testdb/runs_test.go
@@ -31,7 +31,7 @@ func TestCreateRun(t *testing.T) {
 	updated, err := db.CreateRun(context.TODO(), test, run)
 	require.NoError(t, err)
 
-	actual, err := db.GetRun(context.TODO(), updated.ID)
+	actual, err := db.GetRun(context.TODO(), test.ID, updated.ID)
 	require.NoError(t, err)
 
 	assert.NotEmpty(t, actual.ID)
@@ -71,7 +71,6 @@ func TestCreateRunIDsIncrementForTest(t *testing.T) {
 	assert.Equal(t, 2, t1r2.ID)
 	assert.Equal(t, 1, t2r1.ID)
 	assert.Equal(t, 2, t2r2.ID)
-
 }
 
 func TestUpdateRun(t *testing.T) {
@@ -123,7 +122,7 @@ func TestUpdateRun(t *testing.T) {
 	err := db.UpdateRun(context.TODO(), run)
 	require.NoError(t, err)
 
-	actual, err := db.GetRun(context.TODO(), run.ID)
+	actual, err := db.GetRun(context.TODO(), test.ID, run.ID)
 	require.NoError(t, err)
 
 	updatedList, err := db.GetTestRuns(context.TODO(), test, 20, 0)
@@ -131,6 +130,26 @@ func TestUpdateRun(t *testing.T) {
 
 	assert.Len(t, updatedList, 1)
 	modeltest.AssertRunEqual(t, updatedList[0], actual)
+}
+
+func TestUpdateRunWithNewIDs(t *testing.T) {
+	db, clean := getDB()
+	defer clean()
+
+	t1r1 := createRun(t, db, createTest(t, db))
+	t2r1 := createRun(t, db, createTest(t, db))
+
+	t1r1.Metadata = model.RunMetadata{"key": "val"}
+	db.UpdateRun(context.TODO(), t1r1)
+
+	t1r1Updated, err := db.GetRun(context.TODO(), t1r1.TestID, t1r1.ID)
+	require.NoError(t, err)
+
+	t2r1Updated, err := db.GetRun(context.TODO(), t2r1.TestID, t2r1.ID)
+	require.NoError(t, err)
+
+	assert.Equal(t, t1r1.Metadata, t1r1Updated.Metadata)
+	assert.Equal(t, t2r1.Metadata, t2r1Updated.Metadata)
 }
 
 func TestGetRunByTraceID(t *testing.T) {


### PR DESCRIPTION
This PR makes the run ID sequence to be independat for each test. That means that we can have something like:

- test A
  - run 1
  - run 2 
  - run 3
- test B
  - run 1
  - run 2 
  - run 3

This makes it impossible to gather any data from an URL, except the amount of runs a single test has had

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [x] added a test
