### PR TITLE
fix: validate mappings instead of ignoring errors

### DIFF
--- a/server/http/mappings/mappings_test.go
+++ b/server/http/mappings/mappings_test.go
@@ -91,7 +91,9 @@ func TestSpecOrder(t *testing.T) {
 	attempts := 50
 	for i := 0; i < attempts; i++ {
 		maps := mappings.New(traces.ConversionConfig{}, comparator.DefaultRegistry())
-		actual := maps.Out.Specs(maps.In.Definition(input))
+		definition, err := maps.In.Definition(input)
+		require.NoError(t, err)
+		actual := maps.Out.Specs(definition)
 		actualJSON, err := json.Marshal(actual)
 
 		require.NoError(t, err)
@@ -202,7 +204,10 @@ func TestResultsOrder(t *testing.T) {
 	for i := 0; i < attempts; i++ {
 		maps := mappings.New(traces.ConversionConfig{}, comparator.DefaultRegistry())
 
-		actual := maps.Out.Result(maps.In.Result(input))
+		result, err := maps.In.Result(input)
+		require.NoError(t, err)
+
+		actual := maps.Out.Result(result)
 		actualJSON, err := json.Marshal(actual)
 
 		require.NoError(t, err)


### PR DESCRIPTION
This PR forces Tracetest to only accept valid mappings. So if an assertion is invalid, it will reject the request by returning a `400 response status` instead of silently failing the request when running the test. 

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
