### PR TITLE
feat: cmd configure uses ui package and enable setting values from flags

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -154,7 +154,7 @@ jobs:
         run: |
           cd cli
           go build -o ./tracetest main.go
-          echo "http://localhost:11633" | ./tracetest configure -g
+          ./tracetest configure -g --endpoint http://localhost:11633 --analytics=false
       - name: Run example test
         run: |
           timeout 60 bash -c 'while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' localhost:11633)" != "200" ]]; do sleep 5; done' || false

--- a/cli/cmd/configure_cmd_test.go
+++ b/cli/cmd/configure_cmd_test.go
@@ -9,24 +9,44 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestConfigureCmd(t *testing.T) {
+func TestConfigureWithAnalytics(t *testing.T) {
 	cli := e2e.NewCLI()
 
-	configureCommand := cli.NewCommand("configure")
+	configureCommand := cli.NewCommand("configure", "--endpoint", "https://localhost:1234", "--analytics")
 
 	t.Cleanup(func() {
 		deleteFile("./config.yml")
 	})
 
-	output, err := configureCommand.Run("https://localhost:1234")
+	_, err := configureCommand.Run()
 	assert.NoError(t, err)
-	assert.NotEmpty(t, output)
 
 	tracetestConfig, err := config.LoadConfig("./config.yml")
 	require.NoError(t, err)
 
 	assert.Equal(t, "https", tracetestConfig.Scheme)
 	assert.Equal(t, "localhost:1234", tracetestConfig.Endpoint)
+	assert.True(t, tracetestConfig.AnalyticsEnabled)
 	assert.Nil(t, tracetestConfig.ServerPath)
+}
 
+func TestConfigureWithoutAnalytics(t *testing.T) {
+	cli := e2e.NewCLI()
+
+	configureCommand := cli.NewCommand("configure", "--endpoint", "https://localhost:1234", "--analytics=false")
+
+	t.Cleanup(func() {
+		deleteFile("./config.yml")
+	})
+
+	_, err := configureCommand.Run()
+	assert.NoError(t, err)
+
+	tracetestConfig, err := config.LoadConfig("./config.yml")
+	require.NoError(t, err)
+
+	assert.Equal(t, "https", tracetestConfig.Scheme)
+	assert.Equal(t, "localhost:1234", tracetestConfig.Endpoint)
+	assert.False(t, tracetestConfig.AnalyticsEnabled)
+	assert.Nil(t, tracetestConfig.ServerPath)
 }

--- a/cli/installer/cmd.go
+++ b/cli/installer/cmd.go
@@ -6,6 +6,8 @@ import (
 	"os"
 	"os/exec"
 	"strings"
+
+	"github.com/kubeshop/tracetest/cli/ui"
 )
 
 type cmd struct {
@@ -23,7 +25,7 @@ type cmd struct {
 	other              string
 }
 
-func (c cmd) exec(ui UI, args ...interface{}) interface{} {
+func (c cmd) exec(ui ui.UI, args ...interface{}) interface{} {
 	cmd := ""
 	switch detectPkgManager() {
 	case apt:
@@ -79,13 +81,13 @@ func (c cmd) exec(ui UI, args ...interface{}) interface{} {
 	return nil
 }
 
-func execCmd(cmd string, ui UI) {
+func execCmd(cmd string, ui ui.UI) {
 	if err := _execCmd(cmd); err != nil {
 		ui.Panic(err)
 	}
 }
 
-func execCmdIgnoreError(cmd string, ui UI) {
+func execCmdIgnoreError(cmd string, ui ui.UI) {
 	_execCmd(cmd)
 }
 

--- a/cli/installer/constants.go
+++ b/cli/installer/constants.go
@@ -1,0 +1,3 @@
+package installer
+
+const createIssueMsg = "If you need help, please create an issue: https://github.com/kubeshop/tracetest/issues/new/choose"

--- a/cli/installer/constants.go
+++ b/cli/installer/constants.go
@@ -1,3 +1,0 @@
-package installer
-
-const createIssueMsg = "If you need help, please create an issue: https://github.com/kubeshop/tracetest/issues/new/choose"

--- a/cli/installer/installer.go
+++ b/cli/installer/installer.go
@@ -11,6 +11,8 @@ var (
 	Force = false
 )
 
+const createIssueMsg = "If you need help, please create an issue: https://github.com/kubeshop/tracetest/issues/new/choose"
+
 func Start() {
 	analytics.Track("Start", "installer", map[string]string{})
 	ui := cliUI.DefaultUI

--- a/cli/installer/installer.go
+++ b/cli/installer/installer.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/kubeshop/tracetest/cli/analytics"
+	cliUI "github.com/kubeshop/tracetest/cli/ui"
 )
 
 var (
@@ -12,7 +13,7 @@ var (
 
 func Start() {
 	analytics.Track("Start", "installer", map[string]string{})
-	ui := DefaultUI
+	ui := cliUI.DefaultUI
 
 	ui.Banner()
 
@@ -27,22 +28,22 @@ or reach us on Discord https://discord.gg/6zupCZFQbe
 
 `)
 
-	option := ui.Select("How do you want to run TraceTest?", []option{
+	option := ui.Select("How do you want to run TraceTest?", []cliUI.Option{
 		{"Using Docker Compose", dockerCompose.Install},
 		{"Using Kubernetes", kubernetes.Install},
 	}, 0)
 
-	option.fn(ui)
+	option.Fn(ui)
 }
 
 type installer struct {
 	name      string
 	preChecks []preChecker
 	configs   []configurator
-	installFn func(config configuration, ui UI)
+	installFn func(config configuration, ui cliUI.UI)
 }
 
-func (i installer) PreCheck(ui UI) {
+func (i installer) PreCheck(ui cliUI.UI) {
 	ui.Title("Let's check if your system has everything we need")
 	for _, pc := range i.preChecks {
 		pc(ui)
@@ -51,7 +52,7 @@ func (i installer) PreCheck(ui UI) {
 	ui.Title("Your system is ready! Now, let's configure TraceTest")
 }
 
-func (i installer) Configure(ui UI) configuration {
+func (i installer) Configure(ui cliUI.UI) configuration {
 	config := newConfiguration(ui)
 	config.set("installer", i.name)
 	for _, confFn := range i.configs {
@@ -61,7 +62,7 @@ func (i installer) Configure(ui UI) configuration {
 	return config
 }
 
-func (i installer) Install(ui UI) {
+func (i installer) Install(ui cliUI.UI) {
 	analytics.Track("PreCheck", "installer", map[string]string{})
 	i.PreCheck(ui)
 
@@ -73,14 +74,14 @@ func (i installer) Install(ui UI) {
 	i.installFn(conf, ui)
 }
 
-type preChecker func(ui UI)
+type preChecker func(ui cliUI.UI)
 
 type configuration struct {
 	db map[string]interface{}
-	ui UI
+	ui cliUI.UI
 }
 
-func newConfiguration(ui UI) configuration {
+func newConfiguration(ui cliUI.UI) configuration {
 	return configuration{
 		db: map[string]interface{}{},
 		ui: ui,
@@ -122,7 +123,7 @@ func (c configuration) String(key string) string {
 	return s
 }
 
-type configurator func(config configuration, ui UI) configuration
+type configurator func(config configuration, ui cliUI.UI) configuration
 
 func trackInstall(name string, config configuration, extra map[string]string) {
 	props := map[string]string{

--- a/cli/installer/util.go
+++ b/cli/installer/util.go
@@ -3,10 +3,12 @@ package installer
 import (
 	"os"
 	"runtime"
+
+	cliUI "github.com/kubeshop/tracetest/cli/ui"
 )
 
-func exitOption(msg string) func(ui UI) {
-	return func(ui UI) {
+func exitOption(msg string) func(ui cliUI.UI) {
+	return func(ui cliUI.UI) {
 		ui.Exit(msg)
 	}
 }

--- a/cli/installer/windows.go
+++ b/cli/installer/windows.go
@@ -1,12 +1,16 @@
 package installer
 
-import "runtime"
+import (
+	"runtime"
+
+	cliUI "github.com/kubeshop/tracetest/cli/ui"
+)
 
 func isWindows() bool {
 	return runtime.GOOS == "windows"
 }
 
-func installChocolatey(ui UI) {
+func installChocolatey(ui cliUI.UI) {
 	(cmd{
 		sudo:          true,
 		notConfirmMsg: "No worries. You can try installing Chocolatey manually. See https://chocolatey.org/install#individual",
@@ -15,7 +19,7 @@ func installChocolatey(ui UI) {
 	}).exec(ui)
 }
 
-func chocolateyForWindowsChecker(ui UI) {
+func chocolateyForWindowsChecker(ui cliUI.UI) {
 	if !isWindows() {
 		return
 	}
@@ -26,14 +30,14 @@ func chocolateyForWindowsChecker(ui UI) {
 	}
 
 	ui.Warning("I didn't find chocolatey in your system")
-	option := ui.Select("What do you want to do?", []option{
+	option := ui.Select("What do you want to do?", []cliUI.Option{
 		{"Install Chocolatey", installChocolatey},
 		{"Fix manually", exitOption(
 			"Check the chocolatey install docs on https://chocolatey.org/install#individual",
 		)},
 	}, 0)
 
-	option.fn(ui)
+	option.Fn(ui)
 
 	refreshEnvVariables()
 
@@ -44,7 +48,7 @@ func chocolateyForWindowsChecker(ui UI) {
 	}
 }
 
-func wslChecker(ui UI) {
+func wslChecker(ui cliUI.UI) {
 	if !isWindows() {
 		return
 	}

--- a/cli/ui/ui.go
+++ b/cli/ui/ui.go
@@ -1,4 +1,4 @@
-package installer
+package ui
 
 import (
 	"fmt"
@@ -7,8 +7,6 @@ import (
 	"github.com/pterm/pterm"
 	"github.com/pterm/pterm/putils"
 )
-
-const createIssueMsg = "If you need help, please create an issue: https://github.com/kubeshop/tracetest/issues/new/choose"
 
 var DefaultUI UI = &ptermUI{}
 
@@ -30,13 +28,13 @@ type UI interface {
 	Red(string) string
 
 	Confirm(prompt string, defaultValue bool) bool
-	Select(prompt string, options []option, defaultIndex int) (selected option)
+	Select(prompt string, options []Option, defaultIndex int) (selected Option)
 	TextInput(msg, defaultValue string) string
 }
 
-type option struct {
-	text string
-	fn   func(ui UI)
+type Option struct {
+	Text string
+	Fn   func(ui UI)
 }
 
 type ptermUI struct{}
@@ -131,16 +129,16 @@ func (ui ptermUI) TextInput(msg, defaultValue string) string {
 	return text
 }
 
-func (ui ptermUI) Select(prompt string, options []option, defaultIndex int) (selected option) {
+func (ui ptermUI) Select(prompt string, options []Option, defaultIndex int) (selected Option) {
 	textOpts := make([]string, len(options))
 	lookupMap := make(map[string]int)
 
 	for ix, opt := range options {
-		textOpts[ix] = opt.text
-		if _, ok := lookupMap[opt.text]; ok {
-			panic(fmt.Sprintf("duplicated option %s", opt.text))
+		textOpts[ix] = opt.Text
+		if _, ok := lookupMap[opt.Text]; ok {
+			panic(fmt.Sprintf("duplicated option %s", opt.Text))
 		}
-		lookupMap[opt.text] = ix
+		lookupMap[opt.Text] = ix
 	}
 
 	selectedText, err := (&pterm.InteractiveSelectPrinter{

--- a/docs/command-line-tool.md
+++ b/docs/command-line-tool.md
@@ -12,16 +12,25 @@ Here is a list of all available commands and how to use them:
 Configure your CLI to connect to your Tracetest server.
 
 
-**How to Use**: 
+**How to Use**:
 
 
 ```sh
 tracetest configure
 ```
 
-or 
+If you want to set values without having to answer questions from a prompt, you can provide the flags `--endpoint` to define the server endpoint and `--analytics` to turn the analytics on and off.
+
+
 ```sh
-echo "your-server-url" | tracetest configure
+# This will prompt a question to ask if you want to enable or not analytics
+tracetest configure --endpoint http://my-tracetest-server:11633
+
+# Analytics enabled
+tracetest configure --endpoint http://my-tracetest-server:11633 --analytics
+
+# Analytics disabled
+tracetest configure --endpoint http://my-tracetest-server:11633 --analytics=false
 ```
 
 ### **Test List**

--- a/examples/tracetest-jaeger/README.md
+++ b/examples/tracetest-jaeger/README.md
@@ -5,6 +5,6 @@ This repository objective is to show how you can configure your tracetest instan
 ## Steps
 
 1. [Install the tracetest CLI](https://github.com/kubeshop/tracetest/blob/main/docs/installing.md#cli-installation)
-2. Run `tracetest configure` on a terminal and type: `http://localhost:11633` to make your CLI send all requests to that address
+2. Run `tracetest configure --endpoint http://localhost:11633` on a terminal
 3. Run the project by using docker-compose: `docker-compose up` (Linux) or `docker compose up` (Mac)
 4. Test if it works by running: `tracetest test run -d tests/list-tests.yaml`. This would trigger a test that will send and retrieve spans from the opensearch instance that is running on your machine.

--- a/examples/tracetest-opensearch/README.md
+++ b/examples/tracetest-opensearch/README.md
@@ -5,7 +5,7 @@ This repository objective is to show how you can configure your tracetest instan
 ## Steps
 
 1. [Install the tracetest CLI](https://github.com/kubeshop/tracetest/blob/main/docs/installing.md#cli-installation)
-2. Run `tracetest configure` on a terminal and type: `http://localhost:11633` to make your CLI send all requests to that address
+2. Run `tracetest configure --endpoint http://localhost:11633` on a terminal to configure the CLI to send all commands to that address
 3. Run the project by using docker-compose: `docker-compose up` (Linux) or `docker compose up` (Mac)
 4. Test if it works by running: `tracetest test run -d tests/list-tests.yaml`. This would trigger a test that will send and retrieve spans from the opensearch instance that is running on your machine.
 

--- a/examples/tracetest-otel-demo/README.md
+++ b/examples/tracetest-otel-demo/README.md
@@ -4,7 +4,7 @@ This repository objective is to show how you can configure your tracetest instan
 
 ## Steps
 
-1. Run `tracetest configure` on a terminal and type: <http://localhost:11633> to make your CLI send all requests to that address
+1. Run `tracetest configure --endpoint http://localhost:11633` on a terminal to configure the CLI to send all commands to that address
 2. Run the project by using docker-compose: `docker-compose up` (Linux) or `docker compose up` (Mac)
 3. Validate that the otel demo is running at <http://localhost:8084>
 4. Log into the Tracetest front end and create a test using one of the otel demo examples

--- a/examples/tracetest-signalfx/README.md
+++ b/examples/tracetest-signalfx/README.md
@@ -5,7 +5,7 @@ This repository objective is to show how you can configure your tracetest instan
 ## Steps
 
 1. [Install the tracetest CLI](https://github.com/kubeshop/tracetest/blob/main/docs/installing.md#cli-installation)
-2. Run `tracetest configure` on a terminal and type: `http://localhost:11633` to make your CLI send all requests to that address
+2. Run `tracetest configure --endpoint http://localhost:11633` on a terminal to configure the CLI to send all commands to that address
 3. Update the `collector.config.yaml` and `tracetest-config.yaml` with the `token` and `realm` of your SignalFX account.
 4. Run the project by using docker-compose: `docker-compose up` (Linux) or `docker compose up` (Mac)
 5. Test if it works by running: `tracetest test run -d tests/list-tests.yaml`. This would trigger a test that will send and retrieve spans from the opensearch instance that is running on your machine.

--- a/examples/tracetest-tempo/README.md
+++ b/examples/tracetest-tempo/README.md
@@ -5,7 +5,7 @@ This repository objective is to show how you can configure your tracetest instan
 ## Steps
 
 1. [Install the tracetest CLI](https://github.com/kubeshop/tracetest/blob/main/docs/installing.md#cli-installation)
-2. Run `tracetest configure` on a terminal and type: `http://localhost:11633` to make your CLI send all requests to that address
+2. Run `tracetest configure --endpoint http://localhost:11633` on a terminal to configure the CLI to send all commands to that address
 3. Run the project by using docker-compose: `docker-compose up` (Linux) or `docker compose up` (Mac)
 4. Test if it works by running: `tracetest test run -d tests/list-tests.yaml`. This would trigger a test that will send and retrieve spans from the opensearch instance that is running on your machine.
 


### PR DESCRIPTION
This PR extracts the UI code used in the installer to its own package and changes the configure cmd to use that package instead of using the fmt package directly.

Also, it enables setting values using the flags `--endpoint` and `--analytics`

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [x] updated the docs
- [ ] added a test
