### PR TITLE
set higher timeout for deployments

### DIFF
--- a/k8s/deploy.sh
+++ b/k8s/deploy.sh
@@ -50,4 +50,4 @@ kubectl --namespace $NAME create configmap $NAME --from-file=$CONFIG_FILE -o yam
 
 kubectl --namespace $NAME delete pods -l app.kubernetes.io/name=tracetest
 
-kubectl --namespace $NAME wait --for=condition=ready pod -l app.kubernetes.io/name=tracetest --timeout 10m
+kubectl --namespace $NAME wait --for=condition=ready pod -l app.kubernetes.io/name=tracetest --timeout 30m


### PR DESCRIPTION
This PR sets a higher timeout for the deploy script. This should help prevent false negatives in deployments.
We get a lot of timeout fails because the cluster sometimes takes a long time to scale the nodes up.