### PR TITLE
Fix format of expected field

### DIFF
--- a/web/src/redux/actions/TestSpecs.actions.ts
+++ b/web/src/redux/actions/TestSpecs.actions.ts
@@ -1,12 +1,13 @@
 import {createAsyncThunk} from '@reduxjs/toolkit';
 import {PatchCollection} from '@reduxjs/toolkit/dist/query/core/buildThunks';
-import TestSpecsGateway from '../../gateways/TestSpecs.gateway';
-import TestRunGateway from '../../gateways/TestRun.gateway';
-import TestSpecsSelectors from '../../selectors/TestSpecs.selectors';
-import TestDefinitionService from '../../services/TestDefinition.service';
-import {TAssertionResults} from '../../types/Assertion.types';
-import {TRawTestSpecEntry, TTestSpecEntry} from '../../types/TestSpecs.types';
-import {TTestRun} from '../../types/TestRun.types';
+
+import TestRunGateway from 'gateways/TestRun.gateway';
+import TestSpecsGateway from 'gateways/TestSpecs.gateway';
+import TestSpecsSelectors from 'selectors/TestSpecs.selectors';
+import TestDefinitionService from 'services/TestDefinition.service';
+import {TAssertionResults} from 'types/Assertion.types';
+import {TTestRun} from 'types/TestRun.types';
+import {TRawTestSpecEntry, TTestSpecEntry} from 'types/TestSpecs.types';
 import {RootState} from '../store';
 
 export type TChange = {
@@ -28,12 +29,9 @@ const TestSpecsActions = () => ({
         (list, def) => (!def.isDeleted ? list.concat([TestDefinitionService.toRaw(def)]) : list),
         []
       );
+      const specs = TestDefinitionService.formatExpectedField(rawDefinitionList);
 
-      await dispatch(
-        TestSpecsGateway.set(testId, {
-          specs: rawDefinitionList,
-        })
-      );
+      await dispatch(TestSpecsGateway.set(testId, {specs}));
 
       return dispatch(TestRunGateway.reRun(testId, runId)).unwrap();
     }
@@ -42,8 +40,9 @@ const TestSpecsActions = () => ({
     'testDefinition/dryRun',
     ({definitionList, testId, runId}, {dispatch}) => {
       const rawDefinitionList = definitionList.map(def => TestDefinitionService.toRaw(def));
+      const specs = TestDefinitionService.formatExpectedField(rawDefinitionList);
 
-      return dispatch(TestRunGateway.dryRun(testId, runId, {specs: rawDefinitionList})).unwrap();
+      return dispatch(TestRunGateway.dryRun(testId, runId, {specs})).unwrap();
     }
   ),
 });

--- a/web/src/redux/apis/TraceTest.api.ts
+++ b/web/src/redux/apis/TraceTest.api.ts
@@ -9,7 +9,6 @@ import {TAssertion, TAssertionResults, TRawAssertionResults} from 'types/Asserti
 import {TRawTest, TTest} from 'types/Test.types';
 import {TRawTestRun, TTestRun} from 'types/TestRun.types';
 import {TRawTestSpecs} from 'types/TestSpecs.types';
-import AssertionService from '../../services/Assertion.service';
 
 const PATH = `${document.baseURI}api/`;
 
@@ -128,20 +127,11 @@ const TraceTestAPI = createApi({
       transformResponse: (rawTestRun: TRawTestRun) => TestRun(rawTestRun),
     }),
     dryRun: build.mutation<TAssertionResults, {testId: string; runId: string; testDefinition: Partial<TRawTestSpecs>}>({
-      query: ({testId, runId, testDefinition}) => {
-        return {
-          url: `/tests/${testId}/run/${runId}/dry-run`,
-          method: HTTP_METHOD.PUT,
-          body: {
-            specs: (testDefinition?.specs || []).map(spec => ({
-              ...spec,
-              assertions: (spec?.assertions || []).map(assertion => {
-                return {...assertion, expected: AssertionService.extractExpectedString(assertion.expected)};
-              }),
-            })),
-          },
-        };
-      },
+      query: ({testId, runId, testDefinition}) => ({
+        url: `/tests/${testId}/run/${runId}/dry-run`,
+        method: HTTP_METHOD.PUT,
+        body: testDefinition,
+      }),
       transformResponse: (rawTestResults: TRawAssertionResults) => AssertionResults(rawTestResults),
     }),
     deleteRunById: build.mutation<TTest, {testId: string; runId: string}>({

--- a/web/src/services/TestDefinition.service.ts
+++ b/web/src/services/TestDefinition.service.ts
@@ -1,4 +1,5 @@
-import {TRawTestSpecEntry, TTestSpecEntry} from '../types/TestSpecs.types';
+import {TRawTestSpecEntry, TTestSpecEntry} from 'types/TestSpecs.types';
+import AssertionService from './Assertion.service';
 
 const TestDefinitionService = () => ({
   toRaw({selector, assertions}: TTestSpecEntry): TRawTestSpecEntry {
@@ -6,6 +7,15 @@ const TestDefinitionService = () => ({
       selector: {query: selector},
       assertions,
     };
+  },
+  formatExpectedField(rawTestSpecs: TRawTestSpecEntry[]) {
+    return rawTestSpecs.map(spec => ({
+      ...spec,
+      assertions: spec.assertions.map(assertion => ({
+        ...assertion,
+        expected: AssertionService.extractExpectedString(assertion.expected),
+      })),
+    }));
   },
 });
 


### PR DESCRIPTION
This PR fixes a bug in the Test Spec form by adding the proper format to the `expected` field.

## Changes

- Format expected field.

## Fixes

-

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
