### PR TITLE
feat: support assertion names

### DIFF
--- a/api/tests.yaml
+++ b/api/tests.yaml
@@ -52,6 +52,9 @@ components:
           items:
             type: object
             properties:
+              name:
+                type: string
+                nullable: true
               selector:
                 $ref: "#/components/schemas/Selector"
               assertions:

--- a/cli/definition/test.go
+++ b/cli/definition/test.go
@@ -48,6 +48,7 @@ func (t TestTrigger) Validate() error {
 }
 
 type TestSpec struct {
+	Name       string   `yaml:"name"`
 	Selector   string   `yaml:"selector"`
 	Assertions []string `yaml:"assertions"`
 }

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -2,7 +2,7 @@ version: "3.2"
 services:
   tracetest:
     restart: unless-stopped
-    image: kubeshop/tracetest
+    image: kubeshop/tracetest:latest
     extra_hosts:
       - "host.docker.internal:host-gateway"
     build:

--- a/server/assertions/assertions.go
+++ b/server/assertions/assertions.go
@@ -10,13 +10,13 @@ import (
 	"go.opentelemetry.io/otel/trace"
 )
 
-func Assert(defs model.OrderedMap[model.SpanQuery, []model.Assertion], trace traces.Trace) (model.OrderedMap[model.SpanQuery, []model.AssertionResult], bool) {
+func Assert(defs model.OrderedMap[model.SpanQuery, model.NamedAssertions], trace traces.Trace) (model.OrderedMap[model.SpanQuery, []model.AssertionResult], bool) {
 	testResult := model.OrderedMap[model.SpanQuery, []model.AssertionResult]{}
 	allPassed := true
-	defs.Map(func(spanQuery model.SpanQuery, asserts []model.Assertion) {
+	defs.Map(func(spanQuery model.SpanQuery, asserts model.NamedAssertions) {
 		spans := selector(spanQuery).Filter(trace)
 		assertionResults := make([]model.AssertionResult, 0)
-		for _, assertion := range asserts {
+		for _, assertion := range asserts.Assertions {
 			res := assert(assertion, spans)
 			if !res.AllPassed {
 				allPassed = false

--- a/server/assertions/assetions_test.go
+++ b/server/assertions/assetions_test.go
@@ -17,21 +17,23 @@ func TestAssertion(t *testing.T) {
 	spanID := id.NewRandGenerator().SpanID()
 	cases := []struct {
 		name              string
-		testDef           model.OrderedMap[model.SpanQuery, []model.Assertion]
+		testDef           model.OrderedMap[model.SpanQuery, model.NamedAssertions]
 		trace             traces.Trace
 		expectedResult    model.OrderedMap[model.SpanQuery, []model.AssertionResult]
 		expectedAllPassed bool
 	}{
 		{
 			name: "CanAssert",
-			testDef: (model.OrderedMap[model.SpanQuery, []model.Assertion]{}).MustAdd(`span[service.name="Pokeshop"]`, []model.Assertion{
-				{
-					Attribute:  "tracetest.span.duration",
-					Comparator: comparator.Eq,
-					Value: &model.AssertionExpression{
-						LiteralValue: model.LiteralValue{
-							Value: "2000ns",
-							Type:  "duration",
+			testDef: (model.OrderedMap[model.SpanQuery, model.NamedAssertions]{}).MustAdd(`span[service.name="Pokeshop"]`, model.NamedAssertions{
+				Assertions: []model.Assertion{
+					{
+						Attribute:  "tracetest.span.duration",
+						Comparator: comparator.Eq,
+						Value: &model.AssertionExpression{
+							LiteralValue: model.LiteralValue{
+								Value: "2000ns",
+								Type:  "duration",
+							},
 						},
 					},
 				},
@@ -70,29 +72,32 @@ func TestAssertion(t *testing.T) {
 		},
 		{
 			name: "CanAssertOnSpanMatchCount",
-			testDef: (model.OrderedMap[model.SpanQuery, []model.Assertion]{}).MustAdd(`span[service.name="Pokeshop"]`, []model.Assertion{
-				{
-					Attribute:  "tracetest.selected_spans.count",
-					Comparator: comparator.Eq,
-					Value: &model.AssertionExpression{
-						LiteralValue: model.LiteralValue{
-							Value: "1",
-							Type:  "number",
+			testDef: (model.OrderedMap[model.SpanQuery, model.NamedAssertions]{}).MustAdd(`span[service.name="Pokeshop"]`, model.NamedAssertions{
+				Assertions: []model.Assertion{
+					{
+						Attribute:  "tracetest.selected_spans.count",
+						Comparator: comparator.Eq,
+						Value: &model.AssertionExpression{
+							LiteralValue: model.LiteralValue{
+								Value: "1",
+								Type:  "number",
+							},
 						},
 					},
 				},
-			}).MustAdd(`span[service.name="NotExists"]`, []model.Assertion{
-				{
-					Attribute:  "tracetest.selected_spans.count",
-					Comparator: comparator.Eq,
-					Value: &model.AssertionExpression{
-						LiteralValue: model.LiteralValue{
-							Value: "0",
-							Type:  "number",
+			}).MustAdd(`span[service.name="NotExists"]`, model.NamedAssertions{
+				Assertions: []model.Assertion{
+					{
+						Attribute:  "tracetest.selected_spans.count",
+						Comparator: comparator.Eq,
+						Value: &model.AssertionExpression{
+							LiteralValue: model.LiteralValue{
+								Value: "0",
+								Type:  "number",
+							},
 						},
 					},
-				},
-			}),
+				}}),
 			trace: traces.Trace{
 				RootSpan: traces.Span{
 					ID: spanID,
@@ -148,28 +153,29 @@ func TestAssertion(t *testing.T) {
 		// https://github.com/kubeshop/tracetest/issues/617
 		{
 			name: "ContainsWithJSON",
-			testDef: (model.OrderedMap[model.SpanQuery, []model.Assertion]{}).MustAdd(`span[service.name="Pokeshop"]`, []model.Assertion{
-				{
-					Attribute:  "http.response.body",
-					Comparator: comparator.Contains,
-					Value: &model.AssertionExpression{
-						LiteralValue: model.LiteralValue{
-							Value: "52",
-							Type:  "number",
+			testDef: (model.OrderedMap[model.SpanQuery, model.NamedAssertions]{}).MustAdd(`span[service.name="Pokeshop"]`, model.NamedAssertions{
+				Assertions: []model.Assertion{
+					{
+						Attribute:  "http.response.body",
+						Comparator: comparator.Contains,
+						Value: &model.AssertionExpression{
+							LiteralValue: model.LiteralValue{
+								Value: "52",
+								Type:  "number",
+							},
 						},
 					},
-				},
-				{
-					Attribute:  "tracetest.span.duration",
-					Comparator: comparator.Lt,
-					Value: &model.AssertionExpression{
-						LiteralValue: model.LiteralValue{
-							Value: "2001",
-							Type:  "number",
+					{
+						Attribute:  "tracetest.span.duration",
+						Comparator: comparator.Lt,
+						Value: &model.AssertionExpression{
+							LiteralValue: model.LiteralValue{
+								Value: "2001",
+								Type:  "number",
+							},
 						},
 					},
-				},
-			}),
+				}}),
 			trace: traces.Trace{
 				RootSpan: traces.Span{
 					ID: spanID,
@@ -225,18 +231,19 @@ func TestAssertion(t *testing.T) {
 		// https://github.com/kubeshop/tracetest/issues/1203
 		{
 			name: "DurationComparison",
-			testDef: (model.OrderedMap[model.SpanQuery, []model.Assertion]{}).MustAdd(`span[service.name="Pokeshop"]`, []model.Assertion{
-				{
-					Attribute:  "tracetest.span.duration",
-					Comparator: comparator.Lte,
-					Value: &model.AssertionExpression{
-						LiteralValue: model.LiteralValue{
-							Value: "25ms",
-							Type:  "duration",
+			testDef: (model.OrderedMap[model.SpanQuery, model.NamedAssertions]{}).MustAdd(`span[service.name="Pokeshop"]`, model.NamedAssertions{
+				Assertions: []model.Assertion{
+					{
+						Attribute:  "tracetest.span.duration",
+						Comparator: comparator.Lte,
+						Value: &model.AssertionExpression{
+							LiteralValue: model.LiteralValue{
+								Value: "25ms",
+								Type:  "duration",
+							},
 						},
 					},
-				},
-			}),
+				}}),
 			trace: traces.Trace{
 				RootSpan: traces.Span{
 					ID: spanID,

--- a/server/encoding/yaml/conversion/definition_openapi_conversion.go
+++ b/server/encoding/yaml/conversion/definition_openapi_conversion.go
@@ -119,6 +119,7 @@ func convertTestSpecIntoOpenAPIObject(testSpec []definition.TestSpec) (openapi.T
 		}
 
 		definitions = append(definitions, openapi.TestSpecsSpecs{
+			Name: &testSpec.Name,
 			Selector: openapi.Selector{
 				Query: testSpec.Selector,
 			},

--- a/server/encoding/yaml/conversion/definition_openapi_conversion.go
+++ b/server/encoding/yaml/conversion/definition_openapi_conversion.go
@@ -118,8 +118,12 @@ func convertTestSpecIntoOpenAPIObject(testSpec []definition.TestSpec) (openapi.T
 			assertions = append(assertions, assertionObject)
 		}
 
+		var name *string
+		if testSpec.Name != "" {
+			name = &testSpec.Name
+		}
 		definitions = append(definitions, openapi.TestSpecsSpecs{
-			Name: &testSpec.Name,
+			Name: name,
 			Selector: openapi.Selector{
 				Query: testSpec.Selector,
 			},

--- a/server/encoding/yaml/conversion/openapi_definition_conversion.go
+++ b/server/encoding/yaml/conversion/openapi_definition_conversion.go
@@ -109,7 +109,12 @@ func convertOpenAPITestSpecIntoSpecArray(testSpec openapi.TestSpecs) []definitio
 			assertions = append(assertions, assertionString)
 		}
 
+		name := ""
+		if def.Name != nil {
+			name = *def.Name
+		}
 		newDefinition := definition.TestSpec{
+			Name:       name,
 			Selector:   def.Selector.Query,
 			Assertions: assertions,
 		}

--- a/server/encoding/yaml/definition/test.go
+++ b/server/encoding/yaml/definition/test.go
@@ -50,6 +50,7 @@ func (t TestTrigger) Validate() error {
 }
 
 type TestSpec struct {
+	Name       string   `yaml:"name" json:"name"`
 	Selector   string   `yaml:"selector" json:"selector"`
 	Assertions []string `yaml:"assertions" json:"assertions"`
 }

--- a/server/executor/assertion_executor.go
+++ b/server/executor/assertion_executor.go
@@ -11,12 +11,12 @@ import (
 )
 
 type AssertionExecutor interface {
-	Assert(context.Context, model.OrderedMap[model.SpanQuery, []model.Assertion], traces.Trace) (model.OrderedMap[model.SpanQuery, []model.AssertionResult], bool)
+	Assert(context.Context, model.OrderedMap[model.SpanQuery, model.NamedAssertions], traces.Trace) (model.OrderedMap[model.SpanQuery, []model.AssertionResult], bool)
 }
 
 type defaultAssertionExecutor struct{}
 
-func (e defaultAssertionExecutor) Assert(ctx context.Context, defs model.OrderedMap[model.SpanQuery, []model.Assertion], trace traces.Trace) (model.OrderedMap[model.SpanQuery, []model.AssertionResult], bool) {
+func (e defaultAssertionExecutor) Assert(ctx context.Context, defs model.OrderedMap[model.SpanQuery, model.NamedAssertions], trace traces.Trace) (model.OrderedMap[model.SpanQuery, []model.AssertionResult], bool) {
 	return assertions.Assert(defs, trace)
 }
 
@@ -25,7 +25,7 @@ type instrumentedAssertionExecutor struct {
 	tracer            trace.Tracer
 }
 
-func (e instrumentedAssertionExecutor) Assert(ctx context.Context, defs model.OrderedMap[model.SpanQuery, []model.Assertion], trace traces.Trace) (model.OrderedMap[model.SpanQuery, []model.AssertionResult], bool) {
+func (e instrumentedAssertionExecutor) Assert(ctx context.Context, defs model.OrderedMap[model.SpanQuery, model.NamedAssertions], trace traces.Trace) (model.OrderedMap[model.SpanQuery, []model.AssertionResult], bool) {
 	ctx, span := e.tracer.Start(ctx, "Execute assertions")
 	defer span.End()
 

--- a/server/http/mappings/mappings_test.go
+++ b/server/http/mappings/mappings_test.go
@@ -11,10 +11,15 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func strp(in string) *string {
+	return &in
+}
+
 func TestSpecOrder(t *testing.T) {
 	input := openapi.TestSpecs{
 		Specs: []openapi.TestSpecsSpecs{
 			{
+				Name: strp("name 1"),
 				Selector: openapi.Selector{
 					Query: "selector 1",
 				},
@@ -32,6 +37,7 @@ func TestSpecOrder(t *testing.T) {
 				},
 			},
 			{
+				Name: strp("name 2"),
 				Selector: openapi.Selector{
 					Query: "selector 2",
 				},
@@ -53,6 +59,7 @@ func TestSpecOrder(t *testing.T) {
 
 	expectedJSON := `{
 		"specs": [{
+			    "name": "name 1",
 				"selector": {
 					"query": "selector 1"
 				},
@@ -69,6 +76,7 @@ func TestSpecOrder(t *testing.T) {
 				]
 			},
 			{
+				"name": "name 2",
 				"selector": {
 					"query": "selector 2"
 				},

--- a/server/model/json.go
+++ b/server/model/json.go
@@ -71,6 +71,29 @@ func (a Assertion) MarshalJSON() ([]byte, error) {
 	})
 }
 
+func (na *NamedAssertions) UnmarshalJSON(data []byte) error {
+	type encodedNamedAssertions struct {
+		Name       string
+		Assertions []Assertion
+	}
+
+	var namedAssertion encodedNamedAssertions
+	if err := json.Unmarshal(data, &namedAssertion); err != nil {
+		// this might be an []Assertion from the older format
+		// try to parse []Assertions instead
+
+		err = json.Unmarshal(data, &namedAssertion.Assertions)
+		if err != nil {
+			return err
+		}
+	}
+
+	na.Name = namedAssertion.Name
+	na.Assertions = namedAssertion.Assertions
+
+	return nil
+}
+
 func (a *Assertion) UnmarshalJSON(data []byte) error {
 	aux := struct {
 		Attribute  string

--- a/server/model/test_changes.go
+++ b/server/model/test_changes.go
@@ -17,7 +17,7 @@ func BumpTestVersionIfNeeded(in, updated Test) (Test, error) {
 	return updated, nil
 }
 
-func BumpVersionIfDefinitionChanged(test Test, newDef OrderedMap[SpanQuery, []Assertion]) (Test, error) {
+func BumpVersionIfDefinitionChanged(test Test, newDef OrderedMap[SpanQuery, NamedAssertions]) (Test, error) {
 	definitionHasChanged, err := testFieldHasChanged(test.Specs, newDef)
 	if err != nil {
 		return test, err

--- a/server/model/tests.go
+++ b/server/model/tests.go
@@ -18,8 +18,13 @@ type (
 		Description      string
 		Version          int
 		ServiceUnderTest Trigger
-		Specs            OrderedMap[SpanQuery, []Assertion]
+		Specs            OrderedMap[SpanQuery, NamedAssertions]
 		Summary          Summary
+	}
+
+	NamedAssertions struct {
+		Name       string
+		Assertions []Assertion
 	}
 
 	Summary struct {

--- a/server/model/tests_test.go
+++ b/server/model/tests_test.go
@@ -95,7 +95,9 @@ func TestSpec(t *testing.T) {
 
 		spec := generateSpec()
 
-		expected := []model.Assertion{{"1", comparator.Eq, createExpressionFromNumber("1")}}
+		expected := model.NamedAssertions{
+			Assertions: []model.Assertion{{"1", comparator.Eq, createExpressionFromNumber("1")}},
+		}
 		actual := spec.Get(model.SpanQuery("1"))
 
 		assert.Equal(t, expected, actual)
@@ -111,7 +113,7 @@ func TestSpec(t *testing.T) {
 		encoded, err := json.Marshal(spec)
 		require.NoError(t, err)
 
-		decoded := model.OrderedMap[model.SpanQuery, []model.Assertion]{}
+		decoded := model.OrderedMap[model.SpanQuery, model.NamedAssertions]{}
 		err = json.Unmarshal(encoded, &decoded)
 		require.NoError(t, err)
 

--- a/server/model/tests_test.go
+++ b/server/model/tests_test.go
@@ -40,24 +40,35 @@ func TestSpec(t *testing.T) {
 	t.Run("Add", func(t *testing.T) {
 		spec := (model.Test{}).Specs
 
-		spec, err := spec.Add(model.SpanQuery("1"), []model.Assertion{{"1", comparator.Eq, createExpressionFromNumber("1")}})
+		spec, err := spec.Add(model.SpanQuery("1"), model.NamedAssertions{
+			Assertions: []model.Assertion{{"1", comparator.Eq, createExpressionFromNumber("1")}},
+		})
 		require.NoError(t, err)
 
-		spec, err = spec.Add(model.SpanQuery("2"), []model.Assertion{{"2", comparator.Eq, createExpressionFromNumber("2")}})
+		spec, err = spec.Add(model.SpanQuery("2"), model.NamedAssertions{
+			Assertions: []model.Assertion{{"2", comparator.Eq, createExpressionFromNumber("2")}},
+		})
 		require.NoError(t, err)
 		assert.Equal(t, 2, spec.Len())
 
-		spec, err = spec.Add(model.SpanQuery("2"), []model.Assertion{{"2", comparator.Eq, createExpressionFromNumber("2")}})
+		spec, err = spec.Add(model.SpanQuery("2"), model.NamedAssertions{
+			Assertions: []model.Assertion{{"2", comparator.Eq, createExpressionFromNumber("2")}},
+		})
 		assert.ErrorContains(t, err, "selector already exists")
 		assert.Equal(t, 0, spec.Len())
 
 	})
 
-	generateSpec := func() model.OrderedMap[model.SpanQuery, []model.Assertion] {
+	generateSpec := func() model.OrderedMap[model.SpanQuery, model.NamedAssertions] {
 		spec := (model.Test{}).Specs
 
-		spec, _ = spec.Add(model.SpanQuery("1"), []model.Assertion{{"1", comparator.Eq, createExpressionFromNumber("1")}})
-		spec, _ = spec.Add(model.SpanQuery("2"), []model.Assertion{{"2", comparator.Eq, createExpressionFromNumber("2")}})
+		spec, _ = spec.Add(model.SpanQuery("1"), model.NamedAssertions{
+			Assertions: []model.Assertion{{"1", comparator.Eq, createExpressionFromNumber("1")}},
+		})
+
+		spec, _ = spec.Add(model.SpanQuery("2"), model.NamedAssertions{
+			Assertions: []model.Assertion{{"2", comparator.Eq, createExpressionFromNumber("2")}},
+		})
 
 		return spec
 	}
@@ -66,13 +77,13 @@ func TestSpec(t *testing.T) {
 
 		spec := generateSpec()
 
-		expected := map[string][]model.Assertion{
-			"1": {{"1", comparator.Eq, createExpressionFromNumber("1")}},
-			"2": {{"2", comparator.Eq, createExpressionFromNumber("2")}},
+		expected := map[string]model.NamedAssertions{
+			"1": {Assertions: []model.Assertion{{"1", comparator.Eq, createExpressionFromNumber("1")}}},
+			"2": {Assertions: []model.Assertion{{"2", comparator.Eq, createExpressionFromNumber("2")}}},
 		}
 
-		actual := map[string][]model.Assertion{}
-		spec.Map(func(spanQuery model.SpanQuery, asserts []model.Assertion) {
+		actual := make(map[string]model.NamedAssertions)
+		spec.Map(func(spanQuery model.SpanQuery, asserts model.NamedAssertions) {
 			actual[string(spanQuery)] = asserts
 		})
 

--- a/server/openapi/impl.go
+++ b/server/openapi/impl.go
@@ -9,7 +9,7 @@
 
 package openapi
 
-// Implementation response defines an error code with the associated body
+//Implementation response defines an error code with the associated body
 type ImplResponse struct {
 	Code int
 	Body interface{}

--- a/server/openapi/model_test_specs_specs.go
+++ b/server/openapi/model_test_specs_specs.go
@@ -10,6 +10,8 @@
 package openapi
 
 type TestSpecsSpecs struct {
+	Name *string `json:"name,omitempty"`
+
 	Selector Selector `json:"selector,omitempty"`
 
 	Assertions []Assertion `json:"assertions,omitempty"`


### PR DESCRIPTION
This PR enables the user to define a name to a group of assertions. This is retro-compatible with the existing test spec format.

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [x] added a test
