### PR TITLE
🦟 Adding demo enabled check for null values

### DIFF
--- a/web/src/components/CreateTestPlugins/Default/steps/BasicDetails/BasicDetailsForm.tsx
+++ b/web/src/components/CreateTestPlugins/Default/steps/BasicDetails/BasicDetailsForm.tsx
@@ -7,8 +7,11 @@ import BasicDetailsDemoHelper from './BasicDetailsDemoHelper';
 import * as S from './BasicDetails.styled';
 
 export const FORM_ID = 'create-test';
+
+// TODO: create config abstraction with checks and default values
 const {demoEnabled = '[]'} = window.ENV || {};
-const isDemoEnabled = JSON.parse(demoEnabled).length > 0;
+const parsedDemoEnabled = JSON.parse(demoEnabled);
+const isDemoEnabled = Boolean(parsedDemoEnabled && parsedDemoEnabled.length > 0);
 
 interface IProps {
   onSelectDemo?(demo: TDraftTest): void;


### PR DESCRIPTION
This PR fixes an issue with the k8 deployment when users wouldn't select a demo as part of the installation.

I'm creating a tech debt ticket to improve the config validation and parsing from the FE side.