### PR TITLE
fix examples to support network request to host

### DIFF
--- a/examples/collector/docker-compose.yml
+++ b/examples/collector/docker-compose.yml
@@ -9,11 +9,18 @@ services:
               target: /app/config.yaml
         ports:
             - 11633:11633
+        extra_hosts:
+          - "host.docker.internal:host-gateway"
         depends_on:
             postgres:
                 condition: service_healthy
             otel-collector:
                 condition: service_started
+        healthcheck:
+            test: ["CMD", "wget", "--spider", "localhost:11633"]
+            interval: 1s
+            timeout: 3s
+            retries: 60
 
     postgres:
         image: postgres:14

--- a/examples/tracetest-jaeger/docker-compose.yml
+++ b/examples/tracetest-jaeger/docker-compose.yml
@@ -9,6 +9,8 @@ services:
               target: /app/config.yaml
         ports:
             - 11633:11633
+        extra_hosts:
+          - "host.docker.internal:host-gateway"
         depends_on:
             postgres:
                 condition: service_healthy

--- a/examples/tracetest-opensearch/docker-compose.yml
+++ b/examples/tracetest-opensearch/docker-compose.yml
@@ -9,6 +9,8 @@ services:
               target: /app/config.yaml
         ports:
             - 11633:11633
+        extra_hosts:
+          - "host.docker.internal:host-gateway"
         depends_on:
             postgres:
                 condition: service_healthy

--- a/examples/tracetest-signalfx/docker-compose.yml
+++ b/examples/tracetest-signalfx/docker-compose.yml
@@ -9,6 +9,8 @@ services:
               target: /app/config.yaml
         ports:
             - 11633:11633
+        extra_hosts:
+          - "host.docker.internal:host-gateway"
         depends_on:
             postgres:
                 condition: service_healthy

--- a/examples/tracetest-tempo/docker-compose.yml
+++ b/examples/tracetest-tempo/docker-compose.yml
@@ -9,6 +9,8 @@ services:
               target: /app/config.yaml
         ports:
             - 11633:11633
+        extra_hosts:
+          - "host.docker.internal:host-gateway"
         depends_on:
             postgres:
                 condition: service_healthy


### PR DESCRIPTION
This PR fixes the docker configuration for examples to support making requests to host. this is needed for the feature to work on setups created with the installer

## Changes

-

## Fixes

-

## Checklist

- [ ] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
