### PR TITLE
disable otel demo on beta and demo envs

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -157,7 +157,7 @@ jobs:
           ./tracetest configure -g --endpoint http://localhost:11633 --analytics=false
       - name: Run example test
         run: |
-          timeout 60 bash -c 'while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' localhost:11633)" != "200" ]]; do sleep 5; done' || false
+          ./scripts/wait-for-port.sh 11633
           ./cli/tracetest test run -d examples/${{ matrix.example_dir }}/tests/list-tests.yaml --wait-for-result
 
   deploy:

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -153,12 +153,12 @@ jobs:
       - name: Build CLI
         run: |
           cd cli
-          go build -o ./tracetest main.go
-          ./tracetest configure -g --endpoint http://localhost:11633 --analytics=false
+          make build
+          ./dist/tracetest configure -g --endpoint http://localhost:11633 --analytics=false
       - name: Run example test
         run: |
           ./scripts/wait-for-port.sh 11633
-          ./cli/tracetest test run -d examples/${{ matrix.example_dir }}/tests/list-tests.yaml --wait-for-result
+          ./cli/dist/tracetest test run -d examples/${{ matrix.example_dir }}/tests/list-tests.yaml --wait-for-result
 
   deploy:
     needs:  [unit-test-frontend, unit-test-backend, unit-test-cli, build-docker]

--- a/examples/docker-compose.opensearch.yaml
+++ b/examples/docker-compose.opensearch.yaml
@@ -2,7 +2,7 @@ version: "3.2"
 services:
   data-prepper:
     restart: unless-stopped
-    image: opensearchproject/data-prepper:latest
+    image: opensearchproject/data-prepper:2.3.0
     volumes:
       - ./local-config/opensearch/opensearch-analytics.yaml:/usr/share/data-prepper/pipelines.yaml
       - ./local-config/opensearch/opensearch-data-prepper-config.yaml:/usr/share/data-prepper/data-prepper-config.yaml
@@ -10,7 +10,7 @@ services:
       - "opensearch"
 
   opensearch:
-    image: opensearchproject/opensearch:latest
+    image: opensearchproject/opensearch:2.3.0
     environment:
       - discovery.type=single-node
       - bootstrap.memory_lock=true # along with the memlock settings below, disables swapping
@@ -26,7 +26,7 @@ services:
         hard: 65536
 
   dashboards:
-    image: opensearchproject/opensearch-dashboards:latest
+    image: opensearchproject/opensearch-dashboards:2.3.0
     environment:
       OPENSEARCH_HOSTS: '["http://opensearch:9200"]'
       OPENSEARCH_USERNAME: admin

--- a/k8s/tracetest.beta.yaml
+++ b/k8s/tracetest.beta.yaml
@@ -8,7 +8,7 @@ googleAnalytics:
   enabled: false
 
 demo:
-  enabled: [pokeshop, otel]
+  enabled: [pokeshop]
   endpoints:
     pokeshopHttp: http://demo-pokemon-api.demo
     pokeshopGrpc: demo-pokemon-api.demo:8082

--- a/k8s/tracetest.demo.yaml
+++ b/k8s/tracetest.demo.yaml
@@ -8,7 +8,7 @@ googleAnalytics:
   enabled: true
 
 demo:
-  enabled: [pokeshop, otel]
+  enabled: [pokeshop]
   endpoints:
     pokeshopHttp: http://demo-pokemon-api.demo
     pokeshopGrpc: demo-pokemon-api.demo:8082


### PR DESCRIPTION
This PR disables otel demo on beta and demo envs. The config of our otel-demo deployment is not yet ready to correctly interact with these tracetest deployments

## Checklist

- [ ] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
