### PR TITLE
Change links to point to new docs.tracetest.io domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Tracetest is a OpenTelemetry based tool that helps you develop and test your dis
 - [Add assertions](https://docs.tracetest.io/adding-assertions/) based on return data from trigger call and/or data contained in the spans in your distributed trace.
 - Specifying which spans to check in assertions via the [advanced selector language](https://docs.tracetest.io/advanced-selectors/).
 - Define checks against the attributes in these spans, including properties, return status, or timing.
-- Tests can be created via graphical UI or via [YAML-based test definition file](https://docs.tracetest.io/test-definition-file/).
+- Create tests via graphical UI or via [YAML-based test definition file](https://docs.tracetest.io/test-definition-file/).
 - Use the test definition file to [enable Gitops flows](https://tracetest.io/blog/integrating-tracetest-with-github-actions-in-a-ci-pipeline).
 - [Tracetest CLI](https://docs.tracetest.io/command-line-tool/) allows importing & exporting tests, running tests, and more.
 - [Version tests](https://docs.tracetest.io/versioning/) as the definition of the test is altered.

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Tracetest is a OpenTelemetry based tool that helps you develop and test your dis
 - Visualize the changes you are making to your trace as you develop, enabling Observability-Driven Development.
 - [Add assertions](https://docs.tracetest.io/adding-assertions/) based on return data from trigger call and/or data contained in the spans in your distributed trace.
 - Specifying which spans to check in assertions via the [advanced selector language](https://docs.tracetest.io/advanced-selectors/).
-- Defining checks against the attributes in these spans, including properties, return status, or timing.
+- Define checks against the attributes in these spans, including properties, return status, or timing.
 - Tests can be created via graphical UI or via [YAML-based test definition file](https://docs.tracetest.io/test-definition-file/).
 - Use the test definition file to [enable Gitops flows](https://tracetest.io/blog/integrating-tracetest-with-github-actions-in-a-ci-pipeline).
 - [Tracetest CLI](https://docs.tracetest.io/command-line-tool/) allows importing & exporting tests, running tests, and more.

--- a/README.md
+++ b/README.md
@@ -44,16 +44,16 @@ Tracetest is a OpenTelemetry based tool that helps you develop and test your dis
 
 # Features
 
+- Works out of the box with your existing OTel instrumentation, supporting [numerous backend trace datastores](https://docs.tracetest.io/supported-backends/), including Jeager and Grafana Tempo. In addition, supports adding Tracetest as an [additional pipeline](https://docs.tracetest.io/supported-backends/#using-tracetest-without-a-backend) via your OpenTelemetry Collector config. Tell us others backend datastores you want supported!
 - Supporting multiple ways of creating a test, including HTTP, GRPC and Postman Collections.
 - Visualize the changes you are making to your trace as you develop, enabling Observability-Driven Development.
-- [Adding assertions](https://kubeshop.github.io/tracetest/adding-assertions/) based on return data from trigger call and/or data contained in the spans in your distributed trace.
-- Specifying which spans to check in assertions via the [advanced selector language](https://kubeshop.github.io/tracetest/advanced-selectors/).
+- [Adding assertions](https://docs.tracetest.io/adding-assertions/) based on return data from trigger call and/or data contained in the spans in your distributed trace.
+- Specifying which spans to check in assertions via the [advanced selector language](https://docs.tracetest.io/advanced-selectors/).
 - Defining checks against the attributes in these spans, including properties, return status, or timing.
-- Tests can be created via graphical UI or via [YAML-based test definition file](https://kubeshop.github.io/tracetest/test-definition-file/).
+- Tests can be created via graphical UI or via [YAML-based test definition file](https://docs.tracetest.io/test-definition-file/).
 - Use the test definition file to [enable Gitops flows](https://tracetest.io/blog/integrating-tracetest-with-github-actions-in-a-ci-pipeline).
-- [Tracetest CLI](https://kubeshop.github.io/tracetest/command-line-tool/) allows importing & exporting tests, running tests, and more.
-- Tests are [versioned](https://kubeshop.github.io/tracetest/versioning/) as the definition of the test is altered.
-- Supports [numerous backend trace datastores](https://kubeshop.github.io/tracetest/architecture/), including Jeager and Grafana Tempo. Tell us which others you want!
+- [Tracetest CLI](https://docs.tracetest.io/command-line-tool/) allows importing & exporting tests, running tests, and more.
+- Tests are [versioned](https://docs.tracetest.io/versioning/) as the definition of the test is altered.
 - Install can include [an example microservice](https://kubeshop.github.io/tracetest/pokeshop/) that is instrumented with OpenTelemetry to use as an example application under test.
 
 # Getting Started
@@ -65,10 +65,10 @@ curl -L https://raw.githubusercontent.com/kubeshop/tracetest/main/install-cli.sh
 tracetest server install
 ```
 
-> :gear: To customize your Tracetest installation. Go to our [installation guide](https://kubeshop.github.io/tracetest/installing/) for more information.
+> :gear: To customize your Tracetest installation. Go to our [installation guide](https://docs.tracetest.io/installing/) for more information.
 
 Installation only takes a few minutes and is done with via a Helm command. After installing, take a look at the
-[Accessing the Dashboard](https://kubeshop.github.io/tracetest/accessing-dashboard/) guide to access the Tracetest Dashboard and
+[Accessing the Dashboard](https://docs.tracetest.io/accessing-dashboard/) guide to access the Tracetest Dashboard and
 create and run your first test.
 
 # How does Tracetest work?
@@ -84,7 +84,7 @@ Once the test is built, it can be run automatically as part of a build process. 
 
 # What does the test definition file look like?
 
-The Tracetest [test definition files](https://kubeshop.github.io/tracetest/test-definition-file/) are written in a simple YAML format. You can write them directly or build them graphically via the UI. Here is an example of a test which:
+The Tracetest [test definition files](https://docs.tracetest.io/test-definition-file/) are written in a simple YAML format. You can write them directly or build them graphically via the UI. Here is an example of a test which:
 
 - executes POST against the pokemon/import endpoint.
 - verifies that the HTTP blocks return a 200 status code.
@@ -133,7 +133,7 @@ Give us a star on Github if you're interested in the project!
 
 # Documentation
 
-Is available at [https://kubeshop.github.io/tracetest](https://kubeshop.github.io/tracetest)
+Is available at [https://docs.tracetest.io/](https://docs.tracetest.io/)
 
 # Tests
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Tracetest is a OpenTelemetry based tool that helps you develop and test your dis
 - Supporting multiple ways of creating a test, including HTTP, GRPC and Postman Collections.
 - Visualize the changes you are making to your trace as you develop, enabling Observability-Driven Development.
 - [Add assertions](https://docs.tracetest.io/adding-assertions/) based on return data from trigger call and/or data contained in the spans in your distributed trace.
-- Specifying which spans to check in assertions via the [advanced selector language](https://docs.tracetest.io/advanced-selectors/).
+- Specify which spans to check in assertions via the [advanced selector language](https://docs.tracetest.io/advanced-selectors/).
 - Define checks against the attributes in these spans, including properties, return status, or timing.
 - Create tests via graphical UI or via [YAML-based test definition file](https://docs.tracetest.io/test-definition-file/).
 - Use the test definition file to [enable Gitops flows](https://tracetest.io/blog/integrating-tracetest-with-github-actions-in-a-ci-pipeline).

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Tracetest is a OpenTelemetry based tool that helps you develop and test your dis
 - Tests can be created via graphical UI or via [YAML-based test definition file](https://docs.tracetest.io/test-definition-file/).
 - Use the test definition file to [enable Gitops flows](https://tracetest.io/blog/integrating-tracetest-with-github-actions-in-a-ci-pipeline).
 - [Tracetest CLI](https://docs.tracetest.io/command-line-tool/) allows importing & exporting tests, running tests, and more.
-- Tests are [versioned](https://docs.tracetest.io/versioning/) as the definition of the test is altered.
+- [Version tests](https://docs.tracetest.io/versioning/) as the definition of the test is altered.
 - Install can include [an example microservice](https://kubeshop.github.io/tracetest/pokeshop/) that is instrumented with OpenTelemetry to use as an example application under test.
 
 # Getting Started

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Tracetest is a OpenTelemetry based tool that helps you develop and test your dis
 - Works out of the box with your existing OTel instrumentation, supporting [numerous backend trace datastores](https://docs.tracetest.io/supported-backends/), including Jeager and Grafana Tempo. In addition, supports adding Tracetest as an [additional pipeline](https://docs.tracetest.io/supported-backends/#using-tracetest-without-a-backend) via your OpenTelemetry Collector config. Tell us others backend datastores you want supported!
 - Supporting multiple ways of creating a test, including HTTP, GRPC and Postman Collections.
 - Visualize the changes you are making to your trace as you develop, enabling Observability-Driven Development.
-- [Adding assertions](https://docs.tracetest.io/adding-assertions/) based on return data from trigger call and/or data contained in the spans in your distributed trace.
+- [Add assertions](https://docs.tracetest.io/adding-assertions/) based on return data from trigger call and/or data contained in the spans in your distributed trace.
 - Specifying which spans to check in assertions via the [advanced selector language](https://docs.tracetest.io/advanced-selectors/).
 - Defining checks against the attributes in these spans, including properties, return status, or timing.
 - Tests can be created via graphical UI or via [YAML-based test definition file](https://docs.tracetest.io/test-definition-file/).

--- a/docs/command-line-tool.md
+++ b/docs/command-line-tool.md
@@ -48,12 +48,12 @@ tracetest test list
 
 ### **Run a Test**
 
-Allows you to run a test by referencing a [test definition file](/docs/test-definition-file.md).
+Allows you to run a test by referencing a [test definition file](/test-definition-file/).
 
 > Note: If the definition file contains the field `id`, this command will not create a new test. Instead, it will update the test with that ID. If that test doesn't exist, a new one will be created with that ID on the server.
 
 
-Every time the test is run, changes are detected and, if any change is introduced, we use Tractest's [versioning](/docs/versioning.md) mechanism to ensure that it will not cause problems with previous test runs.
+Every time the test is run, changes are detected and, if any change is introduced, we use Tractest's [versioning](/versioning/) mechanism to ensure that it will not cause problems with previous test runs.
 
 **How to Use**:
 

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -45,7 +45,7 @@ In Tracetest, an Test Spec is comprised of two parts:
 ### **What is a Selector?**
 
 
-A selector contains criteria to limit the scope of the spans from a trace that we wish to assert against. A selector can be very narrow, only selecting on one span, or very wide, selecting all spans or all spans of a certain type or other characteristics. Underlying this capability is a [selector language](/docs/advanced-selectors.md).
+A selector contains criteria to limit the scope of the spans from a trace that we wish to assert against. A selector can be very narrow, only selecting on one span, or very wide, selecting all spans or all spans of a certain type or other characteristics. Underlying this capability is a [selector language](/advanced-selectors/).
 
 
 ### **What is a Check?**

--- a/docs/run-locally.md
+++ b/docs/run-locally.md
@@ -5,7 +5,7 @@ Tracetest depends on a postgres database and a trace store backend (Jaeger or Te
 ## **Run on Local Kubernetes**
 
 Tracetest and its dependencies can be installed in a local Kubernetes cluster (microk8s, minikube, Kubernetes for Docker Desktop, etc).
-Following the [install steps](/installing/) will get a running instance of Tracetest and postgres. Installing Jaeger is the easiest way to get a trace store backend.
+Following the [install steps](/installing/) will install a running instance of Tracetest and Postgres. Installing Jaeger is the easiest way to get a trace store backend.
 
 The Tracetest install can be exposed with a `LoadBalancer`, `NodePort` or any similar mechanism. It can also be kept internally, only expose the Jaeger and postgres port,
 and use them to run local development builds. This is useful to quickly test changes on both the front and back end.

--- a/docs/run-locally.md
+++ b/docs/run-locally.md
@@ -5,7 +5,7 @@ Tracetest depends on a postgres database and a trace store backend (Jaeger or Te
 ## **Run on Local Kubernetes**
 
 Tracetest and its dependencies can be installed in a local Kubernetes cluster (microk8s, minikube, Kubernetes for Docker Desktop, etc).
-Following the [install steps](/docs/installing.md) will get a running instance of Tracetest and postgres. Installing Jaeger is the easiest way to get a trace store backend.
+Following the [install steps](/installing/) will get a running instance of Tracetest and postgres. Installing Jaeger is the easiest way to get a trace store backend.
 
 The Tracetest install can be exposed with a `LoadBalancer`, `NodePort` or any similar mechanism. It can also be kept internally, only expose the Jaeger and postgres port,
 and use them to run local development builds. This is useful to quickly test changes on both the front and back end.
@@ -39,7 +39,7 @@ EOF
 
 ### **Install Tracetest**
 
-Follow the [install steps](/docs/installing.md):
+Follow the [install steps](/installing/):
 
 ```sh
 helm repo add kubeshop https://kubeshop.github.io/helm-charts

--- a/docs/supported-backends.md
+++ b/docs/supported-backends.md
@@ -7,7 +7,7 @@ Currently, Tracetest supports the following backend data stores:
 - OpenSearch
 - SignalFX
 
-Details of configuring Tracetest to access these is discussed in the [installation instructions](/docs/installing.md).
+Details of configuring Tracetest to access these is discussed in the [installation instructions](/installing/).
 
 We will be adding new data stores over the next couple of months - [let us know](https://github.com/kubeshop/tracetest/issues/new/choose) the ones you would to see us add support for.
 

--- a/examples/tracetest-jaeger/README.md
+++ b/examples/tracetest-jaeger/README.md
@@ -4,7 +4,7 @@ This repository objective is to show how you can configure your tracetest instan
 
 ## Steps
 
-1. [Install the tracetest CLI](https://github.com/kubeshop/tracetest/blob/main/docs/installing.md#cli-installation)
+1. [Install the tracetest CLI](https://docs.tracetest.io/installing/)
 2. Run `tracetest configure --endpoint http://localhost:11633` on a terminal
 3. Run the project by using docker-compose: `docker-compose up` (Linux) or `docker compose up` (Mac)
 4. Test if it works by running: `tracetest test run -d tests/list-tests.yaml`. This would trigger a test that will send and retrieve spans from the opensearch instance that is running on your machine.

--- a/examples/tracetest-opensearch/README.md
+++ b/examples/tracetest-opensearch/README.md
@@ -4,7 +4,7 @@ This repository objective is to show how you can configure your tracetest instan
 
 ## Steps
 
-1. [Install the tracetest CLI](https://github.com/kubeshop/tracetest/blob/main/docs/installing.md#cli-installation)
+1. [Install the tracetest CLI](https://docs.tracetest.io/installing/)
 2. Run `tracetest configure --endpoint http://localhost:11633` on a terminal to configure the CLI to send all commands to that address
 3. Run the project by using docker-compose: `docker-compose up` (Linux) or `docker compose up` (Mac)
 4. Test if it works by running: `tracetest test run -d tests/list-tests.yaml`. This would trigger a test that will send and retrieve spans from the opensearch instance that is running on your machine.

--- a/examples/tracetest-signalfx/README.md
+++ b/examples/tracetest-signalfx/README.md
@@ -4,7 +4,7 @@ This repository objective is to show how you can configure your tracetest instan
 
 ## Steps
 
-1. [Install the tracetest CLI](https://github.com/kubeshop/tracetest/blob/main/docs/installing.md#cli-installation)
+1. [Install the tracetest CLI](https://docs.tracetest.io/installing/)
 2. Run `tracetest configure --endpoint http://localhost:11633` on a terminal to configure the CLI to send all commands to that address
 3. Update the `collector.config.yaml` and `tracetest-config.yaml` with the `token` and `realm` of your SignalFX account.
 4. Run the project by using docker-compose: `docker-compose up` (Linux) or `docker compose up` (Mac)


### PR DESCRIPTION
Change links to point to new docs.tracetest.io domain.

Also altered the line talking about supported backends to emphasis 'we just work'

