### PR TITLE
Add FE env configuration layer

### DIFF
--- a/web/public/index.html
+++ b/web/public/index.html
@@ -23,7 +23,7 @@
     -->
     <title>Tracetest</title>
     <script>
-      const getParser = {
+      const parser = {
         toArray(value) {
           try {
             return JSON.parse(value) || [];
@@ -60,15 +60,15 @@
 
       function injectVariables() {
         window.ENV = {
-          measurementId: getTemplateValue('{{ .AnalyticsKey }}', '', getParser.toString),
-          analyticsEnabled: getTemplateValue('{{ .AnalyticsEnabled }}', 'false', getParser.toBoolean),
-          serverPathPrefix: getTemplateValue('{{ .ServerPathPrefix }}', '/', getParser.toString),
-          serverID: getTemplateValue('{{ .ServerID }}', '', getParser.toString),
-          appVersion: getTemplateValue('{{ .AppVersion }}', '', getParser.toString),
-          env: getTemplateValue('{{ .Env }}', '', getParser.toString),
-          demoEnabled: getTemplateValue('{{ .DemoEnabled }}', '["pokeshop", "otel"]', getParser.toArray),
-          demoEndpoints: getTemplateValue('{{ .DemoEndpoints }}', '{"PokeshopHttp": "http://demo-pokemon-api.demo.svc.cluster.local", "PokeshopGrpc": "demo-pokemon-api.demo.svc.cluster.local:8082", "OtelFrontend": "http://otel-frontend:8084" }', getParser.toObject),
-          experimentalFeatures: getTemplateValue('{{ .ExperimentalFeatures }}', '["transactions"]', getParser.toArray),
+          measurementId: getTemplateValue('{{ .AnalyticsKey }}', '', parser.toString),
+          analyticsEnabled: getTemplateValue('{{ .AnalyticsEnabled }}', 'false', parser.toBoolean),
+          serverPathPrefix: getTemplateValue('{{ .ServerPathPrefix }}', '/', parser.toString),
+          serverID: getTemplateValue('{{ .ServerID }}', '', parser.toString),
+          appVersion: getTemplateValue('{{ .AppVersion }}', '', parser.toString),
+          env: getTemplateValue('{{ .Env }}', '', parser.toString),
+          demoEnabled: getTemplateValue('{{ .DemoEnabled }}', '["pokeshop", "otel"]', parser.toArray),
+          demoEndpoints: getTemplateValue('{{ .DemoEndpoints }}', '{"PokeshopHttp": "http://demo-pokemon-api.demo.svc.cluster.local", "PokeshopGrpc": "demo-pokemon-api.demo.svc.cluster.local:8082", "OtelFrontend": "http://otel-frontend:8084" }', parser.toObject),
+          experimentalFeatures: getTemplateValue('{{ .ExperimentalFeatures }}', '["transactions"]', parser.toArray),
         };
 
         var base = document.createElement('base');

--- a/web/public/index.html
+++ b/web/public/index.html
@@ -23,29 +23,52 @@
     -->
     <title>Tracetest</title>
     <script>
-      function getTemplateValue(value, defaultValue) {
+      const getParser = {
+        toArray(value) {
+          try {
+            return JSON.parse(value) || [];
+          } catch (error) {
+            return [];
+          }
+        },
+        toBoolean(value) {
+          return value === 'true';
+        },
+        toObject(value) {
+          try {
+            return JSON.parse(value) || {};
+          } catch (error) {
+            return {};
+          }
+        },
+        toString(value) {
+          return value;
+        },
+      };
+
+      function getTemplateValue(value, defaultValue, parser) {
         // hack: we cannot add double curly brackets on our code otherwise the go template
         // module will try to parse it and it will fail.
         var curlyBracket = String.fromCharCode(123);
         var startingTemplateToken = `${curlyBracket}${curlyBracket}`;
         if (!value || value.startsWith(startingTemplateToken)) {
-          return defaultValue;
+          return parser(defaultValue);
         }
 
-        return value;
+        return parser(value);
       }
 
       function injectVariables() {
         window.ENV = {
-          measurementId: getTemplateValue('{{ .AnalyticsKey }}', ''),
-          analyticsEnabled: getTemplateValue('{{ .AnalyticsEnabled }}', 'false'),
-          serverPathPrefix: getTemplateValue('{{ .ServerPathPrefix }}', '/'),
-          serverID: getTemplateValue('{{ .ServerID }}', ''),
-          appVersion: getTemplateValue('{{ .AppVersion }}', ''),
-          env: getTemplateValue('{{ .Env }}', ''),
-          demoEnabled: getTemplateValue('{{ .DemoEnabled }}', '["pokeshop", "otel"]'),
-          demoEndpoints: getTemplateValue('{{ .DemoEndpoints }}', '{"PokeshopHttp": "http://demo-pokemon-api.demo.svc.cluster.local", "PokeshopGrpc": "demo-pokemon-api.demo.svc.cluster.local:8082", "OtelFrontend": "http://otel-frontend:8084" }'),
-          experimentalFeatures: getTemplateValue('{{ .ExperimentalFeatures }}', '["transactions"]'),
+          measurementId: getTemplateValue('{{ .AnalyticsKey }}', '', getParser.toString),
+          analyticsEnabled: getTemplateValue('{{ .AnalyticsEnabled }}', 'false', getParser.toBoolean),
+          serverPathPrefix: getTemplateValue('{{ .ServerPathPrefix }}', '/', getParser.toString),
+          serverID: getTemplateValue('{{ .ServerID }}', '', getParser.toString),
+          appVersion: getTemplateValue('{{ .AppVersion }}', '', getParser.toString),
+          env: getTemplateValue('{{ .Env }}', '', getParser.toString),
+          demoEnabled: getTemplateValue('{{ .DemoEnabled }}', '["pokeshop", "otel"]', getParser.toArray),
+          demoEndpoints: getTemplateValue('{{ .DemoEndpoints }}', '{"PokeshopHttp": "http://demo-pokemon-api.demo.svc.cluster.local", "PokeshopGrpc": "demo-pokemon-api.demo.svc.cluster.local:8082", "OtelFrontend": "http://otel-frontend:8084" }', getParser.toObject),
+          experimentalFeatures: getTemplateValue('{{ .ExperimentalFeatures }}', '["transactions"]', getParser.toArray),
         };
 
         var base = document.createElement('base');
@@ -55,7 +78,7 @@
 
       injectVariables();
 
-      if (window.ENV.analyticsEnabled === 'true') {
+      if (window.ENV.analyticsEnabled) {
         !function(){var analytics=window.analytics=window.analytics||[];if(!analytics.initialize)if(analytics.invoked)window.console&&console.error&&console.error("Segment snippet included twice.");else{analytics.invoked=!0;analytics.methods=["trackSubmit","trackClick","trackLink","trackForm","pageview","identify","reset","group","track","ready","alias","debug","page","once","off","on","addSourceMiddleware","addIntegrationMiddleware","setAnonymousId","addDestinationMiddleware"];analytics.factory=function(e){return function(){var t=Array.prototype.slice.call(arguments);t.unshift(e);analytics.push(t);return analytics}};for(var e=0;e<analytics.methods.length;e++){var key=analytics.methods[e];analytics[key]=analytics.factory(key)}analytics.load=function(key,e){var t=document.createElement("script");t.type="text/javascript";t.async=!0;t.src="https://cdn.segment.com/analytics.js/v1/" + key + "/analytics.min.js";var n=document.getElementsByTagName("script")[0];n.parentNode.insertBefore(t,n);analytics._loadOptions=e};analytics._writeKey="X2vwYODI1vb8g6QpzL9OBxuv5vK7dGan";analytics.SNIPPET_VERSION="4.15.3";
         analytics.load(window.ENV.measurementId);
         }}();

--- a/web/src/components/CreateTestPlugins/Default/steps/BasicDetails/BasicDetailsForm.tsx
+++ b/web/src/components/CreateTestPlugins/Default/steps/BasicDetails/BasicDetailsForm.tsx
@@ -3,15 +3,13 @@ import {noop} from 'lodash';
 import {Steps} from 'components/GuidedTour/homeStepList';
 import GuidedTourService, {GuidedTours} from 'services/GuidedTour.service';
 import {TDraftTest} from 'types/Test.types';
+import Env from 'utils/Env';
 import BasicDetailsDemoHelper from './BasicDetailsDemoHelper';
 import * as S from './BasicDetails.styled';
 
 export const FORM_ID = 'create-test';
-
-// TODO: create config abstraction with checks and default values
-const {demoEnabled = '[]'} = window.ENV || {};
-const parsedDemoEnabled = JSON.parse(demoEnabled);
-const isDemoEnabled = Boolean(parsedDemoEnabled && parsedDemoEnabled.length > 0);
+const demoEnabled = Env.get('demoEnabled');
+const isDemoEnabled = demoEnabled.length > 0;
 
 interface IProps {
   onSelectDemo?(demo: TDraftTest): void;

--- a/web/src/components/Router/Router.tsx
+++ b/web/src/components/Router/Router.tsx
@@ -6,10 +6,12 @@ import Envs from 'pages/Environments';
 import Home from 'pages/Home';
 import RunDetail from 'pages/RunDetail';
 import Test from 'pages/Test';
+
 import Transaction from 'pages/Transaction';
+import Env from 'utils/Env';
 import ExperimentalFeature from 'utils/ExperimentalFeature';
 
-const {serverPathPrefix = '/'} = window.ENV || {};
+const serverPathPrefix = Env.get('serverPathPrefix');
 const isTransactionsFeatureEnabled = ExperimentalFeature.isEnabled('transactions');
 
 const Router = () => (

--- a/web/src/components/Router/Router.tsx
+++ b/web/src/components/Router/Router.tsx
@@ -6,7 +6,6 @@ import Envs from 'pages/Environments';
 import Home from 'pages/Home';
 import RunDetail from 'pages/RunDetail';
 import Test from 'pages/Test';
-
 import Transaction from 'pages/Transaction';
 import Env from 'utils/Env';
 import ExperimentalFeature from 'utils/ExperimentalFeature';

--- a/web/src/constants/Demo.constants.ts
+++ b/web/src/constants/Demo.constants.ts
@@ -1,7 +1,7 @@
-import pokeshopProtoData from 'assets/pokeshop.proto.json';
-import otelProtoData from 'assets/otel-demo.proto.json';
-import pokeshopPostmanData from 'assets/pokeshop.postman_collection.json';
 import Env from 'utils/Env';
+import pokeshopProtoData from '../assets/pokeshop.proto.json';
+import otelProtoData from '../assets/otel-demo.proto.json';
+import pokeshopPostmanData from '../assets/pokeshop.postman_collection.json';
 import {HTTP_METHOD, SupportedPlugins} from './Common.constants';
 
 const pokeshopProtoFile = new File([pokeshopProtoData?.proto], 'pokeshop.proto');

--- a/web/src/constants/Demo.constants.ts
+++ b/web/src/constants/Demo.constants.ts
@@ -1,8 +1,8 @@
-import Env from 'utils/Env';
+import {HTTP_METHOD, SupportedPlugins} from './Common.constants';
 import pokeshopProtoData from '../assets/pokeshop.proto.json';
 import otelProtoData from '../assets/otel-demo.proto.json';
 import pokeshopPostmanData from '../assets/pokeshop.postman_collection.json';
-import {HTTP_METHOD, SupportedPlugins} from './Common.constants';
+import Env from '../utils/Env';
 
 const pokeshopProtoFile = new File([pokeshopProtoData?.proto], 'pokeshop.proto');
 const otelProtoFile = new File([otelProtoData?.proto], 'otel-demo.proto');

--- a/web/src/constants/Demo.constants.ts
+++ b/web/src/constants/Demo.constants.ts
@@ -1,13 +1,15 @@
-import pokeshopProtoData from '../assets/pokeshop.proto.json';
-import otelProtoData from '../assets/otel-demo.proto.json';
-import pokeshopPostmanData from '../assets/pokeshop.postman_collection.json';
+import pokeshopProtoData from 'assets/pokeshop.proto.json';
+import otelProtoData from 'assets/otel-demo.proto.json';
+import pokeshopPostmanData from 'assets/pokeshop.postman_collection.json';
+import Env from 'utils/Env';
 import {HTTP_METHOD, SupportedPlugins} from './Common.constants';
 
 const pokeshopProtoFile = new File([pokeshopProtoData?.proto], 'pokeshop.proto');
 const otelProtoFile = new File([otelProtoData?.proto], 'otel-demo.proto');
 const pokeshopPostmanFile = new File([JSON.stringify(pokeshopPostmanData)], 'pokeshop.postman_collection.json');
 
-const {demoEndpoints = '{}', demoEnabled = '[]'} = window.ENV || {};
+const demoEnabled = Env.get('demoEnabled');
+const demoEndpoints = Env.get('demoEndpoints');
 
 const isPokeshopEnabled = demoEnabled.includes('pokeshop');
 const isOtelEnabled = demoEnabled.includes('otel');
@@ -19,7 +21,7 @@ const {
   OtelProductCatalog = '',
   OtelCart = '',
   OtelCheckout = '',
-}: Record<string, string> = JSON.parse(demoEndpoints);
+} = demoEndpoints;
 const userId = '2491f868-88f1-4345-8836-d5d8511a9f83';
 
 export const PokeshopDemo = {

--- a/web/src/gateways/WebSocket.gateway.ts
+++ b/web/src/gateways/WebSocket.gateway.ts
@@ -1,3 +1,5 @@
+import Env from 'utils/Env';
+
 interface IData<T> {
   event: T;
   resource: string;
@@ -161,7 +163,7 @@ const WebSocketGateway = ({url}: IParams): IWebSocketGateway => {
 };
 
 function getWebSocketURL() {
-  const {serverPathPrefix = '/'} = window.ENV || {};
+  const serverPathPrefix = Env.get('serverPathPrefix');
   const protocol = window.location.protocol === 'https:' ? 'wss' : 'ws';
   const hostname = window.location.hostname;
   const port = process.env.NODE_ENV === 'development' ? '11633' : window.location.port;

--- a/web/src/providers/Transaction/Transaction.provider.tsx
+++ b/web/src/providers/Transaction/Transaction.provider.tsx
@@ -50,7 +50,7 @@ const TransactionProvider = ({children, transactionId}: IProps) => {
 
       onOpen(`Are you sure you want to delete “${name}”?`, onConfirmation);
     },
-    [navigate, onOpen]
+    [deleteTransaction, navigate, onOpen]
   );
 
   const value = useMemo<IContext>(

--- a/web/src/services/Analytics/Analytics.service.ts
+++ b/web/src/services/Analytics/Analytics.service.ts
@@ -1,9 +1,12 @@
-import {Categories} from '../../constants/Analytics.constants';
+import {Categories} from 'constants/Analytics.constants';
+import Env from 'utils/Env';
 
-const {analyticsEnabled = 'false', serverID = '', appVersion = '', env = ''} = window.ENV || {};
+const analyticsEnabled = Env.get('analyticsEnabled');
+const appVersion = Env.get('appVersion');
+const env = Env.get('env');
+const serverID = Env.get('serverID');
+
 const {analytics} = window;
-
-export const isEnabled = analyticsEnabled === 'true';
 
 type TAnalyticsService = {
   event<A>(category: Categories, action: A, label: string): void;
@@ -13,7 +16,7 @@ type TAnalyticsService = {
 
 const AnalyticsService = (): TAnalyticsService => ({
   event<A>(category: Categories, action: A, label: string) {
-    if (!isEnabled) return;
+    if (!analyticsEnabled) return;
     analytics.track(String(action), {
       serverID,
       appVersion,
@@ -23,7 +26,7 @@ const AnalyticsService = (): TAnalyticsService => ({
     });
   },
   page(name: string) {
-    if (!isEnabled) return;
+    if (!analyticsEnabled) return;
     analytics.page(name, {
       serverID,
       appVersion,
@@ -31,7 +34,7 @@ const AnalyticsService = (): TAnalyticsService => ({
     });
   },
   identify() {
-    if (!isEnabled) return;
+    if (!analyticsEnabled) return;
     analytics.identify({
       serverID,
       appVersion,

--- a/web/src/types/Common.types.ts
+++ b/web/src/types/Common.types.ts
@@ -5,16 +5,15 @@ export type TRecursivePartial<T> = {
 };
 
 export interface IEnv {
-  measurementId: string;
-  analyticsEnabled: string;
-  serverPathPrefix: string;
-  serverID: string;
+  analyticsEnabled: boolean;
   appVersion: string;
-  pokeApi: string;
+  demoEnabled: string[];
+  demoEndpoints: {[key: string]: string};
   env: string;
-  demoEnabled: string;
-  demoEndpoints: string;
-  experimentalFeatures: string;
+  experimentalFeatures: string[];
+  measurementId: string;
+  serverID: string;
+  serverPathPrefix: string;
 }
 
 export type Modify<T, R> = Omit<T, keyof R> & R;

--- a/web/src/utils/Env.ts
+++ b/web/src/utils/Env.ts
@@ -1,0 +1,25 @@
+import {IEnv} from 'types/Common.types';
+
+type TEnv = keyof IEnv;
+
+const emptyValues: IEnv = {
+  analyticsEnabled: false,
+  appVersion: '',
+  demoEnabled: [],
+  demoEndpoints: {},
+  env: '',
+  experimentalFeatures: [],
+  measurementId: '',
+  serverID: '',
+  serverPathPrefix: '/',
+};
+
+const initialEnv = window.ENV || {};
+
+const Env = {
+  get<Key extends TEnv>(key: Key) {
+    return initialEnv[key] ?? emptyValues[key];
+  },
+};
+
+export default Env;

--- a/web/src/utils/ExperimentalFeature.ts
+++ b/web/src/utils/ExperimentalFeature.ts
@@ -1,9 +1,10 @@
-const {experimentalFeatures = '[]'} = window.ENV || {};
-const parsedExperimentalFeatures = JSON.parse(experimentalFeatures);
+import Env from './Env';
+
+const experimentalFeatures = Env.get('experimentalFeatures');
 
 const ExperimentalFeature = {
   isEnabled(feature: string) {
-    return parsedExperimentalFeatures?.includes(feature);
+    return experimentalFeatures.includes(feature);
   },
 };
 


### PR DESCRIPTION
This PR adds a FE Env utility to read env variables used by Tracetest. It also parses the env variables to a proper type.

## Changes

- Env util to read parsed variables
- Parse env variables

Types support:

![Screen Shot 2022-10-11 at 17 38 15](https://user-images.githubusercontent.com/3879892/195211273-c9e747e0-7797-49a0-aba7-1ca7aabe9ace.png)
![Screen Shot 2022-10-11 at 17 37 39](https://user-images.githubusercontent.com/3879892/195211269-83585b38-b107-4e12-88d3-fc79f952ed98.png)

## Fixes

- fixes #1347 

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
