### PR TITLE
fix formatting when not waiting for results

### DIFF
--- a/cli/actions/run_test_action.go
+++ b/cli/actions/run_test_action.go
@@ -130,8 +130,9 @@ func (a runTestAction) runDefinition(ctx context.Context, params runTestParams) 
 	}
 
 	tro := formatters.TestRunOutput{
-		Test: test,
-		Run:  testRun,
+		HasResults: params.WaitForResult,
+		Test:       test,
+		Run:        testRun,
 	}
 
 	formatter := formatters.TestRun(a.config, true)

--- a/cli/formatters/test_run.go
+++ b/cli/formatters/test_run.go
@@ -28,7 +28,7 @@ func TestRun(config config.Config, colorsEnabled bool) testRun {
 }
 
 type TestRunOutput struct {
-	HasResults bool
+	HasResults bool            `json:"-"`
 	Test       openapi.Test    `json:"test"`
 	Run        openapi.TestRun `json:"testRun"`
 	RunWebURL  string          `json:"testRunWebUrl"`
@@ -47,13 +47,12 @@ func (f testRun) Format(output TestRunOutput) string {
 
 func (f testRun) json(output TestRunOutput) string {
 	output.RunWebURL = f.getRunLink(output.Test.GetId(), output.Run.GetId())
-	bytes, err := json.Marshal(output)
+	bytes, err := json.MarshalIndent(output, "", "  ")
 	if err != nil {
 		panic(fmt.Errorf("could not marshal output json: %w", err))
 	}
 
-	return string(bytes)
-
+	return string(bytes) + "\n"
 }
 
 func (f testRun) pretty(output TestRunOutput) string {

--- a/cli/formatters/test_run.go
+++ b/cli/formatters/test_run.go
@@ -28,9 +28,10 @@ func TestRun(config config.Config, colorsEnabled bool) testRun {
 }
 
 type TestRunOutput struct {
-	Test      openapi.Test    `json:"test"`
-	Run       openapi.TestRun `json:"testRun"`
-	RunWebURL string          `json:"testRunWebUrl"`
+	HasResults bool
+	Test       openapi.Test    `json:"test"`
+	Run        openapi.TestRun `json:"testRun"`
+	RunWebURL  string          `json:"testRunWebUrl"`
 }
 
 func (f testRun) Format(output TestRunOutput) string {
@@ -58,6 +59,10 @@ func (f testRun) json(output TestRunOutput) string {
 func (f testRun) pretty(output TestRunOutput) string {
 	if output.Run.State != nil && *output.Run.State == "FAILED" {
 		return f.getColoredText(false, fmt.Sprintf("Failed to execute test: %s", *output.Run.LastErrorState))
+	}
+
+	if !output.HasResults {
+		return f.formatSuccessfulTest(output.Test, output.Run)
 	}
 
 	if output.Run.Result.AllPassed == nil || !*output.Run.Result.AllPassed {

--- a/cli/formatters/test_run_test.go
+++ b/cli/formatters/test_run_test.go
@@ -69,8 +69,29 @@ func TestSuccessfulTestRunOutput(t *testing.T) {
 	assert.Equal(t, "✔ Testcase 1 (http://localhost:11633/test/9876543/run/1/test)\n", output)
 }
 
+func TestSuccessfulTestRunOutputNoResult(t *testing.T) {
+	in := formatters.TestRunOutput{
+		HasResults: false,
+		Test: openapi.Test{
+			Id:   strp("9876543"),
+			Name: strp("Testcase 1"),
+		},
+		Run: openapi.TestRun{
+			Id: strp("1"),
+		},
+	}
+	formatter := formatters.TestRun(config.Config{
+		Scheme:   "http",
+		Endpoint: "localhost:11633",
+	}, false)
+	output := formatter.Format(in)
+
+	assert.Equal(t, "✔ Testcase 1 (http://localhost:11633/test/9876543/run/1/test)\n", output)
+}
+
 func TestFailingTestOutput(t *testing.T) {
 	in := formatters.TestRunOutput{
+		HasResults: true,
 		Test: openapi.Test{
 			Id:   strp("9876543"),
 			Name: strp("Testcase 2"),

--- a/cli/openapi/api_api.go
+++ b/cli/openapi/api_api.go
@@ -1537,11 +1537,13 @@ func (a *ApiApiService) GetTestVersionDefinitionFileExecute(r ApiGetTestVersionD
 }
 
 type ApiGetTestsRequest struct {
-	ctx        context.Context
-	ApiService *ApiApiService
-	take       *int32
-	skip       *int32
-	query      *string
+	ctx           context.Context
+	ApiService    *ApiApiService
+	take          *int32
+	skip          *int32
+	query         *string
+	sortBy        *string
+	sortDirection *string
 }
 
 // indicates how many tests can be returned by each page
@@ -1559,6 +1561,18 @@ func (r ApiGetTestsRequest) Skip(skip int32) ApiGetTestsRequest {
 // query to search tests, based on test name and description
 func (r ApiGetTestsRequest) Query(query string) ApiGetTestsRequest {
 	r.query = &query
+	return r
+}
+
+// indicates the sort field for the tests
+func (r ApiGetTestsRequest) SortBy(sortBy string) ApiGetTestsRequest {
+	r.sortBy = &sortBy
+	return r
+}
+
+// indicates the sort direction for the tests
+func (r ApiGetTestsRequest) SortDirection(sortDirection string) ApiGetTestsRequest {
+	r.sortDirection = &sortDirection
 	return r
 }
 
@@ -1611,6 +1625,12 @@ func (a *ApiApiService) GetTestsExecute(r ApiGetTestsRequest) ([]Test, *http.Res
 	}
 	if r.query != nil {
 		localVarQueryParams.Add("query", parameterToString(*r.query, ""))
+	}
+	if r.sortBy != nil {
+		localVarQueryParams.Add("sortBy", parameterToString(*r.sortBy, ""))
+	}
+	if r.sortDirection != nil {
+		localVarQueryParams.Add("sortDirection", parameterToString(*r.sortDirection, ""))
 	}
 	// to determine the Content-Type header
 	localVarHTTPContentTypes := []string{}

--- a/cli/openapi/model_test_specs_specs.go
+++ b/cli/openapi/model_test_specs_specs.go
@@ -16,8 +16,9 @@ import (
 
 // TestSpecsSpecs struct for TestSpecsSpecs
 type TestSpecsSpecs struct {
-	Selector   *Selector   `json:"selector,omitempty"`
-	Assertions []Assertion `json:"assertions,omitempty"`
+	Name       NullableString `json:"name,omitempty"`
+	Selector   *Selector      `json:"selector,omitempty"`
+	Assertions []Assertion    `json:"assertions,omitempty"`
 }
 
 // NewTestSpecsSpecs instantiates a new TestSpecsSpecs object
@@ -35,6 +36,49 @@ func NewTestSpecsSpecs() *TestSpecsSpecs {
 func NewTestSpecsSpecsWithDefaults() *TestSpecsSpecs {
 	this := TestSpecsSpecs{}
 	return &this
+}
+
+// GetName returns the Name field value if set, zero value otherwise (both if not set or set to explicit null).
+func (o *TestSpecsSpecs) GetName() string {
+	if o == nil || o.Name.Get() == nil {
+		var ret string
+		return ret
+	}
+	return *o.Name.Get()
+}
+
+// GetNameOk returns a tuple with the Name field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+// NOTE: If the value is an explicit nil, `nil, true` will be returned
+func (o *TestSpecsSpecs) GetNameOk() (*string, bool) {
+	if o == nil {
+		return nil, false
+	}
+	return o.Name.Get(), o.Name.IsSet()
+}
+
+// HasName returns a boolean if a field has been set.
+func (o *TestSpecsSpecs) HasName() bool {
+	if o != nil && o.Name.IsSet() {
+		return true
+	}
+
+	return false
+}
+
+// SetName gets a reference to the given NullableString and assigns it to the Name field.
+func (o *TestSpecsSpecs) SetName(v string) {
+	o.Name.Set(&v)
+}
+
+// SetNameNil sets the value for Name to be an explicit nil
+func (o *TestSpecsSpecs) SetNameNil() {
+	o.Name.Set(nil)
+}
+
+// UnsetName ensures that no value is present for Name, not even an explicit nil
+func (o *TestSpecsSpecs) UnsetName() {
+	o.Name.Unset()
 }
 
 // GetSelector returns the Selector field value if set, zero value otherwise.
@@ -103,6 +147,9 @@ func (o *TestSpecsSpecs) SetAssertions(v []Assertion) {
 
 func (o TestSpecsSpecs) MarshalJSON() ([]byte, error) {
 	toSerialize := map[string]interface{}{}
+	if o.Name.IsSet() {
+		toSerialize["name"] = o.Name.Get()
+	}
 	if o.Selector != nil {
 		toSerialize["selector"] = o.Selector
 	}

--- a/server/openapi/api_api.go
+++ b/server/openapi/api_api.go
@@ -480,11 +480,10 @@ func (c *ApiApiController) GetTests(w http.ResponseWriter, r *http.Request) {
 		c.errorHandler(w, r, &ParsingError{Err: err}, nil)
 		return
 	}
-
 	queryParam := query.Get("query")
-	sortBy := query.Get("sortBy")
-	sortDirection := query.Get("sortDirection")
-	result, err := c.service.GetTests(r.Context(), takeParam, skipParam, queryParam, sortBy, sortDirection)
+	sortByParam := query.Get("sortBy")
+	sortDirectionParam := query.Get("sortDirection")
+	result, err := c.service.GetTests(r.Context(), takeParam, skipParam, queryParam, sortByParam, sortDirectionParam)
 	// If an error occurred, encode the error with the status code
 	if err != nil {
 		c.errorHandler(w, r, err, &result)

--- a/server/openapi/impl.go
+++ b/server/openapi/impl.go
@@ -9,7 +9,7 @@
 
 package openapi
 
-//Implementation response defines an error code with the associated body
+// Implementation response defines an error code with the associated body
 type ImplResponse struct {
 	Code int
 	Body interface{}


### PR DESCRIPTION
This PR makes the CLI show tests as successful when not waiting for resutls. Before, when a test was run without the `--wait-for-result` option, it would show the test as FAILED, when in fact it still didn't have the result.

Also it pretty prints json so it is easier to read while still being parseable

Before: 
![Screen Shot 2022-10-12 at 10 50 36](https://user-images.githubusercontent.com/314548/195360817-daec4768-9c5d-4002-8a86-254323eed859.png)

After:
![Screen Shot 2022-10-12 at 10 54 33](https://user-images.githubusercontent.com/314548/195361906-1f7b5841-9cb2-4bf8-bb55-c5280754c2fd.png)

JSON indented:
![Screen Shot 2022-10-12 at 10 57 40](https://user-images.githubusercontent.com/314548/195362762-07f2ba5c-f944-4779-b7d6-1213c160620c.png)

## Changes

-

## Fixes

-

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [x] added a test
