### PR TITLE
ci: release CLI on Chocolatey when a new tag is released

### DIFF
--- a/.github/workflows/release-version.yml
+++ b/.github/workflows/release-version.yml
@@ -253,3 +253,44 @@ jobs:
         SLACK_LINK_NAMES: true
         SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
         SLACK_FOOTER: "Kubeshop --> Tracetest"
+
+  chocolatey-release:
+    name: Release on Chocolatey
+    runs-on: windows-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Download newest version
+        id: cliDownload
+        run: |
+          $tag = $env:TAG
+          $version = $tag.trimStart("v")
+          echo "$version"
+          Invoke-Webrequest -URI "https://github.com/kubeshop/tracetest/releases/download/v${version}/tracetest_${version}_windows_amd64.tar.gz" -OutFile tracetest.tar.gz
+          $hash = Get-FileHash tracetest.tar.gz | Select -ExpandProperty Hash
+
+          echo '::echo::on'
+          echo "::set-output name=hash::$hash"
+          echo "::set-output name=version::$version"
+        env:
+          TAG: ${{ github.ref_name }}
+      - name: Generate release files
+        run: |
+          (Get-Content scripts/choco/tools/chocolateyinstall.ps1) -Replace '%checksum%', $env:PACKAGE_CHECKSUM | Set-Content scripts/choco/tools/chocolateyinstall.ps1
+          (Get-Content scripts/choco/tracetest.nuspec) -Replace '%version%', $env:PACKAGE_VERSION | Set-Content scripts/choco/tracetest.nuspec
+        env:
+          PACKAGE_CHECKSUM: ${{ steps.cliDownload.outputs.hash }}
+          PACKAGE_VERSION: ${{ steps.cliDownload.outputs.version }}
+      - name: Pack and release
+        run: |
+          # install choco
+          Set-ExecutionPolicy Bypass -Scope Process -Force; [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072; iex ((New-Object System.Net.WebClient).DownloadString('https://community.chocolatey.org/install.ps1'))
+
+          cd scripts/choco
+          choco pack
+
+          choco apikey --key $env:CHOCOLATEY_API_KEY --source https://push.chocolatey.org/
+          choco push tracetest.${env:PACKAGE_VERSION}.nupkg --source https://push.chocolatey.org/
+        env:
+          CHOCOLATEY_API_KEY: ${{ secrets.CHOCOLATEY_API_KEY }}
+          PACKAGE_VERSION: ${{ steps.cliDownload.outputs.version }}

--- a/.github/workflows/release-version.yml
+++ b/.github/workflows/release-version.yml
@@ -255,6 +255,7 @@ jobs:
         SLACK_FOOTER: "Kubeshop --> Tracetest"
 
   chocolatey-release:
+    needs: release-cli
     name: Release on Chocolatey
     runs-on: windows-latest
     steps:

--- a/scripts/choco/tools/chocolateyinstall.ps1
+++ b/scripts/choco/tools/chocolateyinstall.ps1
@@ -1,0 +1,21 @@
+$ErrorActionPreference = 'Stop'; # stop on all errors
+$toolsDir   = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
+$url64      = "https://github.com/kubeshop/tracetest/releases/download/v${env:chocolateyPackageVersion}/tracetest_${env:chocolateyPackageVersion}_windows_amd64.tar.gz" # 64bit URL here (HTTPS preferred) or remove - if installer contains both (very rare), use $url
+
+$packageArgs = @{
+  packageName   = $env:ChocolateyPackageName
+  unzipLocation = $toolsDir
+  fileType      = 'exe'
+  url64bit      = $url64
+
+  softwareName  = 'tracetest*'
+
+  # %placeholder% will be replaced by the correct value in the CI pipeline
+  checksum      = '%checksum%'
+  checksumType  = 'sha256'
+  checksum64    = '%checksum%'
+  checksumType64= 'sha256'
+}
+
+Install-ChocolateyZipPackage @packageArgs
+Get-ChocolateyUnzip -FileFullPath "$toolsDir/tracetest_${env:chocolateyPackageVersion}_windows_amd64.tar" -Destination $toolsDir

--- a/scripts/choco/tools/chocolateyuninstall.ps1
+++ b/scripts/choco/tools/chocolateyuninstall.ps1
@@ -1,0 +1,31 @@
+﻿$ErrorActionPreference = 'Stop';
+$packageArgs = @{
+  packageName   = $env:ChocolateyPackageName
+  softwareName  = 'tracetest*'
+  fileType      = 'exe'
+  # MSI
+  silentArgs    = "/qn /norestart"
+  validExitCodes= @(0, 3010, 1605, 1614, 1641) # https://msdn.microsoft.com/en-us/library/aa376931(v=vs.85).aspx
+}
+
+[array]$key = Get-UninstallRegistryKey -SoftwareName $packageArgs['softwareName']
+
+if ($key.Count -eq 1) {
+  $key | % {
+    $packageArgs['file'] = "$($_.UninstallString)"
+
+    if ($packageArgs['fileType'] -eq 'MSI') {
+      $packageArgs['silentArgs'] = "$($_.PSChildName) $($packageArgs['silentArgs'])"
+      $packageArgs['file'] = ''
+    }
+
+    Uninstall-ChocolateyPackage @packageArgs
+  }
+} elseif ($key.Count -eq 0) {
+  Write-Warning "$packageName has already been uninstalled by other means."
+} elseif ($key.Count -gt 1) {
+  Write-Warning "$($key.Count) matches found!"
+  Write-Warning "To prevent accidental data loss, no programs will be uninstalled."
+  Write-Warning "Please alert package maintainer the following keys were matched:"
+  $key | % {Write-Warning "- $($_.DisplayName)"}
+}

--- a/scripts/choco/tracetest.nuspec
+++ b/scripts/choco/tracetest.nuspec
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
+  <metadata>
+    <id>tracetest</id>
+    <!-- %placeholder% will be replaced by the correct value in the CI pipeline -->
+    <version>%version%</version>
+    <title>tracetest</title>
+    <authors>Kubeshop</authors>
+    <projectUrl>https://tracetest.io</projectUrl>
+    <tags>tracetest opentelemetry trace-based-testing testing</tags>
+    <summary>Tracetest - the best way to develop and test your distributed system with OpenTelemetry</summary>
+    <description>Tracetest - the best way to develop and test your distributed system with OpenTelemetry</description>
+  </metadata>
+  <files>
+    <file src="tools\**" target="tools" />
+  </files>
+</package>


### PR DESCRIPTION
This PR creates a new choco package and releases it when a new tag is created.

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
