### PR TITLE
1235 [Transactions] Wire up environment dropdown with the app

### DIFF
--- a/cli/actions/run_test_action.go
+++ b/cli/actions/run_test_action.go
@@ -8,7 +8,7 @@ import (
 	"sync"
 	"time"
 
-	cienvironment "github.com/cucumber/ci-environment/go"
+	cTEnvironment "github.com/cucumber/ci-environment/go"
 	"github.com/kubeshop/tracetest/cli/config"
 	"github.com/kubeshop/tracetest/cli/definition"
 	"github.com/kubeshop/tracetest/cli/file"
@@ -280,7 +280,7 @@ func (a runTestAction) isTestReady(ctx context.Context, testId, testRunId string
 }
 
 func (a runTestAction) getMetadata() map[string]string {
-	ci := cienvironment.DetectCIEnvironment()
+	ci := cTEnvironment.DetectCTEnvironment()
 	if ci == nil {
 		return map[string]string{}
 	}

--- a/cli/actions/run_test_action.go
+++ b/cli/actions/run_test_action.go
@@ -8,7 +8,7 @@ import (
 	"sync"
 	"time"
 
-	cTEnvironment "github.com/cucumber/ci-environment/go"
+	cienvironment "github.com/cucumber/ci-environment/go"
 	"github.com/kubeshop/tracetest/cli/config"
 	"github.com/kubeshop/tracetest/cli/definition"
 	"github.com/kubeshop/tracetest/cli/file"
@@ -280,7 +280,7 @@ func (a runTestAction) isTestReady(ctx context.Context, testId, testRunId string
 }
 
 func (a runTestAction) getMetadata() map[string]string {
-	ci := cTEnvironment.DetectCTEnvironment()
+	ci := cienvironment.DetectCIEnvironment()
 	if ci == nil {
 		return map[string]string{}
 	}

--- a/web/src/components/EnvironmentForm/EnvironmentForm.tsx
+++ b/web/src/components/EnvironmentForm/EnvironmentForm.tsx
@@ -1,13 +1,13 @@
 import {Button, Form, FormInstance, Input} from 'antd';
 import RequestDetailsHeadersInput from 'components/CreateTestPlugins/Rest/steps/RequestDetails/RequestDetailsHeadersInput';
 import {useEffect, useMemo} from 'react';
-import {IEnvironment} from '../../pages/Environments/IEnvironment';
+import {TEnvironment} from '../../types/Environment.types';
 import {useCreateEnvironmentMutation, useLazyGetEnvironmentSecretListQuery} from '../../redux/apis/TraceTest.api';
 import {Footer} from './EnvironmentForm.styled';
 
 interface IProps {
-  form: FormInstance<IEnvironment>;
-  environment?: IEnvironment;
+  form: FormInstance<TEnvironment>;
+  environment?: TEnvironment;
   onCancel: () => void;
 }
 
@@ -26,7 +26,7 @@ const EnvironmentForm: React.FC<IProps> = ({environment, form, onCancel}) => {
     form.setFieldsValue({name: environment?.name, description: environment?.description});
   }, [form, environment?.name, environment?.description]);
   return (
-    <Form<IEnvironment>
+    <Form<TEnvironment>
       name="basic"
       layout="vertical"
       form={form}

--- a/web/src/components/EnvironmentSelector/EnvironmentSelector.tsx
+++ b/web/src/components/EnvironmentSelector/EnvironmentSelector.tsx
@@ -1,0 +1,30 @@
+import {DownOutlined} from '@ant-design/icons';
+import {Dropdown, Menu, Space} from 'antd';
+import {useEnvironment} from 'providers/Environment/Environment.provider';
+
+const EnvironmentSelector = () => {
+  const {environmentList, selectedEnvironment, setSelectedEnvironment} = useEnvironment();
+
+  const menu = (
+    <Menu
+      items={environmentList.map(environment => ({
+        key: environment.id,
+        label: environment.name,
+        onClick: () => setSelectedEnvironment(environment),
+      }))}
+    />
+  );
+
+  return (
+    <Dropdown overlay={menu}>
+      <a onClick={e => e.preventDefault()}>
+        <Space>
+          {selectedEnvironment?.name || 'All Environments'}
+          <DownOutlined />
+        </Space>
+      </a>
+    </Dropdown>
+  );
+};
+
+export default EnvironmentSelector;

--- a/web/src/components/EnvironmentSelector/EnvironmentSelector.tsx
+++ b/web/src/components/EnvironmentSelector/EnvironmentSelector.tsx
@@ -3,28 +3,36 @@ import {Dropdown, Menu, Space} from 'antd';
 import {useEnvironment} from 'providers/Environment/Environment.provider';
 
 const EnvironmentSelector = () => {
-  const {environmentList, selectedEnvironment, setSelectedEnvironment} = useEnvironment();
+  const {environmentList, selectedEnvironment, setSelectedEnvironment, isLoading} = useEnvironment();
 
   const menu = (
     <Menu
-      items={environmentList.map(environment => ({
-        key: environment.id,
-        label: environment.name,
-        onClick: () => setSelectedEnvironment(environment),
-      }))}
+      items={[
+        {
+          key: 'no-env',
+          label: 'No environment',
+          onClick: () => setSelectedEnvironment(),
+        },
+      ].concat(
+        environmentList.map(environment => ({
+          key: environment.id,
+          label: environment.name,
+          onClick: () => setSelectedEnvironment(environment),
+        }))
+      )}
     />
   );
 
-  return (
+  return !isLoading ? (
     <Dropdown overlay={menu}>
       <a onClick={e => e.preventDefault()}>
         <Space>
-          {selectedEnvironment?.name || 'All Environments'}
+          {selectedEnvironment?.name || 'No environment'}
           <DownOutlined />
         </Space>
       </a>
     </Dropdown>
-  );
+  ) : null;
 };
 
 export default EnvironmentSelector;

--- a/web/src/components/EnvironmentSelector/index.ts
+++ b/web/src/components/EnvironmentSelector/index.ts
@@ -1,0 +1,2 @@
+// eslint-disable-next-line no-restricted-exports
+export {default} from './EnvironmentSelector';

--- a/web/src/components/Header/Header.tsx
+++ b/web/src/components/Header/Header.tsx
@@ -1,39 +1,14 @@
-import {DownOutlined} from '@ant-design/icons';
-import {Dropdown, Menu, Space} from 'antd';
-
+import {Space} from 'antd';
 import {Link} from 'react-router-dom';
-
 import Logo from 'assets/Logo.svg';
 import * as S from './Header.styled';
 import HeaderMenu from './HeaderMenu';
+import EnvironmentSelector from '../EnvironmentSelector';
 
 interface IProps {
   hasEnvironments?: boolean;
   hasLogo?: boolean;
 }
-
-const menu = (
-  <Menu
-    items={[
-      {
-        key: '1',
-        label: (
-          <a target="_blank" rel="noopener noreferrer" href="#">
-            Env 1
-          </a>
-        ),
-      },
-      {
-        key: '2',
-        label: (
-          <a target="_blank" rel="noopener noreferrer" href="#">
-            Env 2
-          </a>
-        ),
-      },
-    ]}
-  />
-);
 
 const Header = ({hasEnvironments = false, hasLogo = false}: IProps) => (
   <S.Header>
@@ -46,16 +21,7 @@ const Header = ({hasEnvironments = false, hasLogo = false}: IProps) => (
     </div>
 
     <Space>
-      {hasEnvironments && (
-        <Dropdown overlay={menu}>
-          <a onClick={e => e.preventDefault()}>
-            <Space>
-              All environments
-              <DownOutlined />
-            </Space>
-          </a>
-        </Dropdown>
-      )}
+      {hasEnvironments && <EnvironmentSelector />}
 
       <HeaderMenu />
     </Space>

--- a/web/src/components/Layout/Layout.tsx
+++ b/web/src/components/Layout/Layout.tsx
@@ -6,6 +6,7 @@ import FileViewerModalProvider from 'components/FileViewerModal/FileViewerModal.
 import Header from 'components/Header';
 import useRouterSync from 'hooks/useRouterSync';
 import ConfirmationModalProvider from 'providers/ConfirmationModal';
+import EnvironmentProvider from 'providers/Environment';
 import {MenuInfo} from 'rc-menu/es/interface';
 import React from 'react';
 import {Link, useLocation, useNavigate} from 'react-router-dom';
@@ -47,32 +48,34 @@ const Layout = ({children, hasMenu = false}: IProps) => {
   return (
     <FileViewerModalProvider>
       <ConfirmationModalProvider>
-        <S.Layout hasSider>
-          {hasMenu && (
-            <S.Sider width={256}>
-              <S.LogoContainer>
-                <Link to="/">
-                  <img alt="Tracetest logo" src={logoAsset} />
-                </Link>
-              </S.LogoContainer>
+        <EnvironmentProvider>
+          <S.Layout hasSider>
+            {hasMenu && (
+              <S.Sider width={256}>
+                <S.LogoContainer>
+                  <Link to="/">
+                    <img alt="Tracetest logo" src={logoAsset} />
+                  </Link>
+                </S.LogoContainer>
 
-              <S.MenuContainer>
-                <Menu
-                  defaultSelectedKeys={[menuItems.findIndex(value => value.path === pathname).toString() || '0']}
-                  items={menuItems}
-                  mode="inline"
-                  onClick={handleOnClickMenu}
-                  theme="dark"
-                />
-              </S.MenuContainer>
-            </S.Sider>
-          )}
+                <S.MenuContainer>
+                  <Menu
+                    defaultSelectedKeys={[menuItems.findIndex(value => value.path === pathname).toString() || '0']}
+                    items={menuItems}
+                    mode="inline"
+                    onClick={handleOnClickMenu}
+                    theme="dark"
+                  />
+                </S.MenuContainer>
+              </S.Sider>
+            )}
 
-          <S.Layout>
-            <Header hasEnvironments={ExperimentalFeature.isEnabled('transactions')} hasLogo={!hasMenu} />
-            <S.Content $hasMenu={hasMenu}>{children}</S.Content>
+            <S.Layout>
+              <Header hasEnvironments={ExperimentalFeature.isEnabled('transactions')} hasLogo={!hasMenu} />
+              <S.Content $hasMenu={hasMenu}>{children}</S.Content>
+            </S.Layout>
           </S.Layout>
-        </S.Layout>
+        </EnvironmentProvider>
       </ConfirmationModalProvider>
     </FileViewerModalProvider>
   );

--- a/web/src/constants/Test.constants.ts
+++ b/web/src/constants/Test.constants.ts
@@ -43,3 +43,12 @@ export const sortOptions = [
     params: {sortDirection: SortDirection.Desc, sortBy: SortBy.Name},
   },
 ] as const;
+
+export enum TracetestApiTags {
+  ENVIRONMENT = 'environment',
+  TRANSACTION = 'transaction',
+  TEST = 'test',
+  TEST_DEFINITION = 'testDefinition',
+  TEST_RUN = 'testRun',
+  SPAN = 'span',
+}

--- a/web/src/models/Environment.model.ts
+++ b/web/src/models/Environment.model.ts
@@ -1,7 +1,10 @@
-import {IEnvironment} from '../pages/Environments/IEnvironment';
+import {TEnvironment, TRawEnvironment} from 'types/Environment.types';
 
-const Environment = (props: IEnvironment): IEnvironment => ({
-  ...props,
+const Environment = ({id = '', name = '', description = '', variables = []}: TRawEnvironment): TEnvironment => ({
+  id,
+  name,
+  description,
+  variables,
 });
 
 export default Environment;

--- a/web/src/models/__mocks__/Environment.mock.ts
+++ b/web/src/models/__mocks__/Environment.mock.ts
@@ -1,9 +1,9 @@
 import faker from '@faker-js/faker';
-import {IEnvironment} from '../../pages/Environments/IEnvironment';
+import {TEnvironment} from '../../types/Environment.types';
 import {IMockFactory} from '../../types/Common.types';
 import Environment from '../Environment.model';
 
-const EnvironmentMock: IMockFactory<IEnvironment, IEnvironment> = () => ({
+const EnvironmentMock: IMockFactory<TEnvironment, TEnvironment> = () => ({
   raw(data = {}) {
     return {
       id: faker.datatype.uuid(),

--- a/web/src/pages/Environments/EnvironmentCard.tsx
+++ b/web/src/pages/Environments/EnvironmentCard.tsx
@@ -5,12 +5,12 @@ import {useLazyGetEnvironmentSecretListQuery} from 'redux/apis/TraceTest.api';
 import * as T from '../../components/TestCard/TestCard.styled';
 import EnvironmentsAnalytics from '../../services/Analytics/EnvironmentsAnalytics.service';
 import * as E from './Environment.styled';
-import {IEnvironment} from './IEnvironment';
+import {TEnvironment} from '../../types/Environment.types';
 
 interface IProps {
   setIsFormOpen: Dispatch<SetStateAction<boolean>>;
-  environment: IEnvironment;
-  setEnvironment: Dispatch<SetStateAction<IEnvironment | undefined>>;
+  environment: TEnvironment;
+  setEnvironment: Dispatch<SetStateAction<TEnvironment | undefined>>;
 }
 
 export const EnvironmentCard = ({

--- a/web/src/pages/Environments/EnvironmentContent.tsx
+++ b/web/src/pages/Environments/EnvironmentContent.tsx
@@ -4,12 +4,12 @@ import * as S from './Environment.styled';
 import EnvironmentActions from './EnvironmentActions';
 import EnvironmentList from './EnvironmentList';
 import {EnvironmentModal} from './EnvironmentModal';
-import {IEnvironment} from './IEnvironment';
+import {TEnvironment} from '../../types/Environment.types';
 
 const EnvironmentContent: React.FC = () => {
   const [query, setQuery] = useState<string>('');
   const [isFormOpen, setIsFormOpen] = useState<boolean>(false);
-  const [environment, setEnvironment] = useState<IEnvironment | undefined>(undefined);
+  const [environment, setEnvironment] = useState<TEnvironment | undefined>(undefined);
   const onSearch = useCallback((value: string) => setQuery(value), [setQuery]);
   return (
     <S.Wrapper>

--- a/web/src/pages/Environments/EnvironmentList.tsx
+++ b/web/src/pages/Environments/EnvironmentList.tsx
@@ -6,16 +6,16 @@ import Loading from '../Home/Loading';
 import NoResults from '../Home/NoResults';
 import * as S from './Environment.styled';
 import {EnvironmentCard} from './EnvironmentCard';
-import {IEnvironment} from './IEnvironment';
+import {TEnvironment} from '../../types/Environment.types';
 
 interface IProps {
   query: string;
   setIsFormOpen: Dispatch<SetStateAction<boolean>>;
-  setEnvironment: Dispatch<SetStateAction<IEnvironment | undefined>>;
+  setEnvironment: Dispatch<SetStateAction<TEnvironment | undefined>>;
 }
 
 const EnvironmentList = ({query, setEnvironment, setIsFormOpen}: IProps) => {
-  const pagination = usePagination<IEnvironment, {query: string}>(useGetEnvListQuery, {query});
+  const pagination = usePagination<TEnvironment, {query: string}>(useGetEnvListQuery, {query});
   return (
     <Pagination emptyComponent={<NoResults />} loadingComponent={<Loading />} {...pagination}>
       <S.TestListContainer data-cy="test-list">

--- a/web/src/pages/Environments/EnvironmentModal.tsx
+++ b/web/src/pages/Environments/EnvironmentModal.tsx
@@ -2,17 +2,17 @@ import {Form} from 'antd';
 import EnvironmentForm from 'components/EnvironmentForm';
 import {Dispatch, SetStateAction} from 'react';
 import {CustomModal} from './EnvironmentModal.styled';
-import {IEnvironment} from './IEnvironment';
+import {TEnvironment} from '../../types/Environment.types';
 
 interface IProps {
   setIsFormOpen: Dispatch<SetStateAction<boolean>>;
   isFormOpen: boolean;
-  setEnvironment: Dispatch<SetStateAction<IEnvironment | undefined>>;
-  environment?: IEnvironment;
+  setEnvironment: Dispatch<SetStateAction<TEnvironment | undefined>>;
+  environment?: TEnvironment;
 }
 
 export const EnvironmentModal = ({setEnvironment, setIsFormOpen, isFormOpen, environment}: IProps) => {
-  const [form] = Form.useForm<IEnvironment>();
+  const [form] = Form.useForm<TEnvironment>();
   const onCancel = () => {
     form.setFieldsValue({variables: []});
     setEnvironment(undefined);

--- a/web/src/pages/Environments/IEnvironment.ts
+++ b/web/src/pages/Environments/IEnvironment.ts
@@ -1,8 +1,0 @@
-import {IKeyValue} from 'constants/Test.constants';
-
-export interface IEnvironment {
-  id: string;
-  name: string;
-  description: string;
-  variables?: IKeyValue[];
-}

--- a/web/src/providers/Environment/Environment.provider.tsx
+++ b/web/src/providers/Environment/Environment.provider.tsx
@@ -9,13 +9,15 @@ import EnvironmentSelectors from 'selectors/Environment.selectors';
 interface IContext {
   environmentList: TEnvironment[];
   selectedEnvironment?: TEnvironment;
-  setSelectedEnvironment(environment: TEnvironment): void;
+  setSelectedEnvironment(environment?: TEnvironment): void;
+  isLoading: boolean;
 }
 
 export const Context = createContext<IContext>({
   environmentList: [],
   selectedEnvironment: undefined,
   setSelectedEnvironment: noop,
+  isLoading: true,
 });
 
 interface IProps {
@@ -25,16 +27,16 @@ interface IProps {
 export const useEnvironment = () => useContext(Context);
 
 const EnvironmentProvider = ({children}: IProps) => {
-  const {data: {items: environmentList = []} = {}} = useGetEnvListQuery({});
+  const {data: {items: environmentList = []} = {}, isLoading} = useGetEnvListQuery({});
   const dispatch = useAppDispatch();
   const selectedEnvironment: TEnvironment | undefined = useAppSelector(EnvironmentSelectors.selectSelectedEnvironment);
 
   const setSelectedEnvironment = useCallback(
-    (environment: TEnvironment) => {
+    (environment?: TEnvironment) => {
       dispatch(
         setUserPreference({
           key: 'environmentId',
-          value: environment.id,
+          value: environment?.id || '',
         })
       );
     },
@@ -46,8 +48,9 @@ const EnvironmentProvider = ({children}: IProps) => {
       environmentList,
       selectedEnvironment,
       setSelectedEnvironment,
+      isLoading,
     }),
-    [environmentList, selectedEnvironment, setSelectedEnvironment]
+    [environmentList, isLoading, selectedEnvironment, setSelectedEnvironment]
   );
 
   return <Context.Provider value={value}>{children}</Context.Provider>;

--- a/web/src/providers/Environment/Environment.provider.tsx
+++ b/web/src/providers/Environment/Environment.provider.tsx
@@ -1,0 +1,56 @@
+import {createContext, useContext, useMemo, useCallback} from 'react';
+import {noop} from 'lodash';
+import {TEnvironment} from 'types/Environment.types';
+import {useGetEnvListQuery} from 'redux/apis/TraceTest.api';
+import {useAppDispatch, useAppSelector} from 'redux/hooks';
+import {setUserPreference} from 'redux/slices/User.slice';
+import EnvironmentSelectors from 'selectors/Environment.selectors';
+
+interface IContext {
+  environmentList: TEnvironment[];
+  selectedEnvironment?: TEnvironment;
+  setSelectedEnvironment(environment: TEnvironment): void;
+}
+
+export const Context = createContext<IContext>({
+  environmentList: [],
+  selectedEnvironment: undefined,
+  setSelectedEnvironment: noop,
+});
+
+interface IProps {
+  children: React.ReactNode;
+}
+
+export const useEnvironment = () => useContext(Context);
+
+const EnvironmentProvider = ({children}: IProps) => {
+  const {data: {items: environmentList = []} = {}} = useGetEnvListQuery({});
+  const dispatch = useAppDispatch();
+  const selectedEnvironment: TEnvironment | undefined = useAppSelector(EnvironmentSelectors.selectSelectedEnvironment);
+
+  const setSelectedEnvironment = useCallback(
+    (environment: TEnvironment) => {
+      dispatch(
+        setUserPreference({
+          key: 'environmentId',
+          value: environment.id,
+        })
+      );
+    },
+    [dispatch]
+  );
+
+  const value = useMemo<IContext>(
+    () => ({
+      environmentList,
+      selectedEnvironment,
+      setSelectedEnvironment,
+    }),
+    [environmentList, selectedEnvironment, setSelectedEnvironment]
+  );
+
+  return <Context.Provider value={value}>{children}</Context.Provider>;
+};
+
+export default EnvironmentProvider;

--- a/web/src/providers/Environment/index.ts
+++ b/web/src/providers/Environment/index.ts
@@ -1,0 +1,2 @@
+// eslint-disable-next-line no-restricted-exports
+export {default} from './Environment.provider';

--- a/web/src/redux/apis/TraceTest.api.ts
+++ b/web/src/redux/apis/TraceTest.api.ts
@@ -1,240 +1,27 @@
 import {createApi, fetchBaseQuery} from '@reduxjs/toolkit/query/react';
-import {HTTP_METHOD} from 'constants/Common.constants';
-import {PaginationResponse} from 'hooks/usePagination';
-import {uniq} from 'lodash';
-import Environment from 'models/__mocks__/Environment.mock';
-import KeyValueMock from 'models/__mocks__/KeyValue.mock';
-import TransactionMock from 'models/__mocks__/Transaction.mock';
-import AssertionResults from 'models/AssertionResults.model';
-import Test from 'models/Test.model';
-import TestRun from 'models/TestRun.model';
-import {IEnvironment} from 'pages/Environments/IEnvironment';
-import WebSocketService, {IListenerFunction} from 'services/WebSocket.service';
-import {TAssertion, TAssertionResults, TRawAssertionResults} from 'types/Assertion.types';
-import {TRawTest, TTest} from 'types/Test.types';
-import {TRawTestRun, TTestRun} from 'types/TestRun.types';
-import {TRawTestSpecs} from 'types/TestSpecs.types';
-import {TTransaction} from 'types/Transaction.types';
-import {IKeyValue, SortBy, SortDirection} from '../../constants/Test.constants';
+import {TracetestApiTags} from 'constants/Test.constants';
+import {TTestApiEndpointBuilder} from '../../types/Test.types';
+import EnvironmentEndpoint from './endpoints/Environment.endpoint';
+import TestEndpoint from './endpoints/Test.endpoint';
+import TestRunEndpoint from './endpoints/TestRun.endpoints';
+import TransactionEndpoint from './endpoints/Transaction.endpoint';
 
 const PATH = `${document.baseURI}api/`;
-
-enum Tags {
-  ENVIRONMENT = 'environment',
-  TRANSACTION = 'transaction',
-  TEST = 'test',
-  TEST_DEFINITION = 'testDefinition',
-  TEST_RUN = 'testRun',
-  SPAN = 'span',
-}
-
-function getTotalCountFromHeaders(meta: any) {
-  return Number(meta?.response?.headers.get('x-total-count') || 0);
-}
 
 const TraceTestAPI = createApi({
   reducerPath: 'tests',
   baseQuery: fetchBaseQuery({
     baseUrl: PATH,
   }),
-  tagTypes: Object.values(Tags),
-  endpoints: build => ({
-    // Tests
-    createTest: build.mutation<TTest, TRawTest>({
-      query: newTest => ({
-        url: '/tests',
-        method: HTTP_METHOD.POST,
-        body: newTest,
-      }),
-      transformResponse: (rawTest: TRawTest) => Test(rawTest),
-      invalidatesTags: [{type: Tags.TEST, id: 'LIST'}],
-    }),
-    editTest: build.mutation<TTest, {test: TRawTest; testId: string}>({
-      query: ({test, testId}) => ({
-        url: `/tests/${testId}`,
-        method: HTTP_METHOD.PUT,
-        body: test,
-      }),
-      invalidatesTags: test => [
-        {type: Tags.TEST, id: 'LIST'},
-        {type: Tags.TEST, id: test?.id},
-      ],
-    }),
-    getEnvList: build.query<PaginationResponse<IEnvironment>, {take?: number; skip?: number; query?: string}>({
-      query: ({take = 25, skip = 0, query = ''}) => `/tests?take=${take}&skip=${skip}&query=${query}`,
-      providesTags: () => [{type: Tags.ENVIRONMENT, id: 'LIST'}],
-      transformResponse: () => {
-        const items = [
-          Environment.model({name: 'Production', description: 'Production environment'}),
-          Environment.model({
-            id: 'ae7162b3-54e0-4603-9d33-423b12cf67c8',
-            name: 'Development',
-            description: 'Developing environment',
-          }),
-        ];
-        return {
-          total: items.length,
-          items,
-        };
-      },
-    }),
-    getEnvironmentSecretList: build.query<IKeyValue[], {environmentId: string; take?: number; skip?: number}>({
-      query: ({take = 25, skip = 0}) => `/tests?take=${take}&skip=${skip}`,
-      providesTags: (result, error, {environmentId}) => [{type: Tags.ENVIRONMENT, id: `${environmentId}-LIST`}],
-      transformResponse: (raw, meta, args) => {
-        return args.environmentId === 'ae7162b3-54e0-4603-9d33-423b12cf67c8'
-          ? [KeyValueMock.model()]
-          : [
-              KeyValueMock.model({key: 'user', value: 'testAdmin'}),
-              KeyValueMock.model({key: 'password', value: '1234'}),
-            ];
-      },
-    }),
-    createEnvironment: build.mutation<undefined, IEnvironment>({
-      query: newEnvironment => ({
-        url: '/environments',
-        method: HTTP_METHOD.POST,
-        body: newEnvironment,
-      }),
-      transformResponse: () => undefined,
-      invalidatesTags: [{type: Tags.ENVIRONMENT, id: 'LIST'}],
-    }),
-    getTestList: build.query<
-      PaginationResponse<TTest>,
-      {take?: number; skip?: number; query?: string; sortBy?: SortBy; sortDirection?: SortDirection}
-    >({
-      query: ({take = 25, skip = 0, query = '', sortBy = '', sortDirection = ''}) =>
-        `/tests?take=${take}&skip=${skip}&query=${query}&sortBy=${sortBy}&sortDirection=${sortDirection}`,
-      providesTags: () => [{type: Tags.TEST, id: 'LIST'}],
-      transformResponse: (rawTestList: TTest[], meta) => {
-        return {
-          items: rawTestList.map(rawTest => Test(rawTest)),
-          total: getTotalCountFromHeaders(meta),
-        };
-      },
-    }),
-    getTransactionRunById: build.query<TTransaction, {transactionId: string; runId?: string}>({
-      query: () => `/tests`,
-      providesTags: result => [{type: Tags.TRANSACTION, id: result?.id}],
-      transformResponse: () => TransactionMock.model(),
-    }),
-    getTransactionById: build.query<TTransaction, {transactionId: string}>({
-      query: () => `/tests`,
-      providesTags: result => [{type: Tags.TRANSACTION, id: result?.id}],
-      transformResponse: () => TransactionMock.model(),
-    }),
-    getTestById: build.query<TTest, {testId: string}>({
-      query: ({testId}) => `/tests/${testId}`,
-      providesTags: result => [{type: Tags.TEST, id: result?.id}],
-      transformResponse: (rawTest: TRawTest) => Test(rawTest),
-    }),
-    getTestVersionById: build.query<TTest, {testId: string; version: number}>({
-      query: ({testId, version}) => `/tests/${testId}/version/${version}`,
-      providesTags: result => [{type: Tags.TEST, id: result?.id}],
-      transformResponse: (rawTest: TRawTest) => Test(rawTest),
-    }),
-    deleteTestById: build.mutation<TTest, {testId: string}>({
-      query: ({testId}) => ({url: `/tests/${testId}`, method: 'DELETE'}),
-      invalidatesTags: [{type: Tags.TEST, id: 'LIST'}],
-    }),
-
-    // Test Definition
-    setTestDefinition: build.mutation<TAssertion, {testId: string; testDefinition: Partial<TRawTestSpecs>}>({
-      query: ({testId, testDefinition}) => ({
-        url: `/tests/${testId}/definition`,
-        method: HTTP_METHOD.PUT,
-        body: testDefinition,
-      }),
-      invalidatesTags: (result, error, {testId}) => [
-        {type: Tags.TEST, id: testId},
-        {type: Tags.TEST_DEFINITION, id: testId},
-      ],
-    }),
-
-    // Test Runs
-    runTest: build.mutation<TTestRun, {testId: string}>({
-      query: ({testId}) => ({
-        url: `/tests/${testId}/run`,
-        method: HTTP_METHOD.POST,
-        body: {},
-      }),
-      invalidatesTags: (response, error, {testId}) => [
-        {type: Tags.TEST_RUN, id: `${testId}-LIST`},
-        {type: Tags.TEST, id: 'LIST'},
-      ],
-      transformResponse: (rawTestRun: TRawTestRun) => TestRun(rawTestRun),
-    }),
-    getRunList: build.query<PaginationResponse<TTestRun>, {testId: string; take?: number; skip?: number}>({
-      query: ({testId, take = 25, skip = 0}) => `/tests/${testId}/run?take=${take}&skip=${skip}`,
-      providesTags: (result, error, {testId}) => [{type: Tags.TEST_RUN, id: `${testId}-LIST`}],
-      transformResponse: (rawTestResultList: TRawTestRun[], meta) => ({
-        total: getTotalCountFromHeaders(meta),
-        items: rawTestResultList.map(rawTestResult => TestRun(rawTestResult)),
-      }),
-    }),
-    getRunById: build.query<TTestRun, {runId: string; testId: string}>({
-      query: ({testId, runId}) => `/tests/${testId}/run/${runId}`,
-      providesTags: result => (result ? [{type: Tags.TEST_RUN, id: result?.id}] : []),
-      transformResponse: (rawTestResult: TRawTestRun) => TestRun(rawTestResult),
-      async onCacheEntryAdded(arg, {cacheDataLoaded, cacheEntryRemoved, updateCachedData}) {
-        const listener: IListenerFunction<TRawTestRun> = data => {
-          updateCachedData(() => TestRun(data.event));
-        };
-        await WebSocketService.initWebSocketSubscription({
-          listener,
-          resource: `test/${arg.testId}/run/${arg.runId}`,
-          waitToCleanSubscription: cacheEntryRemoved,
-          waitToInitSubscription: cacheDataLoaded,
-        });
-      },
-    }),
-    reRun: build.mutation<TTestRun, {testId: string; runId: string}>({
-      query: ({testId, runId}) => ({
-        url: `/tests/${testId}/run/${runId}/rerun`,
-        method: HTTP_METHOD.POST,
-      }),
-      invalidatesTags: (response, error, {testId, runId}) => [
-        {type: Tags.TEST_RUN, id: `${testId}-LIST`},
-        {type: Tags.TEST_RUN, id: runId},
-      ],
-      transformResponse: (rawTestRun: TRawTestRun) => TestRun(rawTestRun),
-    }),
-    dryRun: build.mutation<TAssertionResults, {testId: string; runId: string; testDefinition: Partial<TRawTestSpecs>}>({
-      query: ({testId, runId, testDefinition}) => ({
-        url: `/tests/${testId}/run/${runId}/dry-run`,
-        method: HTTP_METHOD.PUT,
-        body: testDefinition,
-      }),
-      transformResponse: (rawTestResults: TRawAssertionResults) => AssertionResults(rawTestResults),
-    }),
-    deleteRunById: build.mutation<TTest, {testId: string; runId: string}>({
-      query: ({testId, runId}) => ({url: `/tests/${testId}/run/${runId}`, method: 'DELETE'}),
-      invalidatesTags: (result, error, {testId}) => [{type: Tags.TEST_RUN}, {type: Tags.TEST, id: `${testId}-LIST`}],
-    }),
-    getJUnitByRunId: build.query<string, {testId: string; runId: string}>({
-      query: ({testId, runId}) => ({url: `/tests/${testId}/run/${runId}/junit.xml`, responseHandler: 'text'}),
-      providesTags: (result, error, {testId, runId}) => [{type: Tags.TEST_RUN, id: `${testId}-${runId}-junit`}],
-    }),
-    getTestDefinitionYamlByRunId: build.query<string, {testId: string; version: number}>({
-      query: ({testId, version}) => ({
-        url: `/tests/${testId}/version/${version}/definition.yaml`,
-        responseHandler: 'text',
-      }),
-      providesTags: (result, error, {testId, version}) => [
-        {type: Tags.TEST_RUN, id: `${testId}-${version}-definition`},
-      ],
-    }),
-    // Spans
-    getSelectedSpans: build.query<string[], {testId: string; runId: string; query: string}>({
-      query: ({testId, runId, query}) => `/tests/${testId}/run/${runId}/select?query=${encodeURIComponent(query)}`,
-      providesTags: (result, error, {query}) => (result ? [{type: Tags.SPAN, id: `${query}-LIST`}] : []),
-      transformResponse: (rawSpanList: string[]) => uniq(rawSpanList),
-    }),
-    deleteTransactionById: build.mutation<TTransaction, {transactionId: string}>({
-      query: ({transactionId}) => ({url: `/transactions/${transactionId}`, method: 'DELETE'}),
-      invalidatesTags: [{type: Tags.TRANSACTION, id: 'LIST'}],
-    }),
-  }),
+  tagTypes: Object.values(TracetestApiTags),
+  endpoints(builder: TTestApiEndpointBuilder) {
+    return {
+      ...TransactionEndpoint(builder),
+      ...TestRunEndpoint(builder),
+      ...TestEndpoint(builder),
+      ...EnvironmentEndpoint(builder),
+    };
+  },
 });
 
 export const {

--- a/web/src/redux/apis/endpoints/Environment.endpoint.ts
+++ b/web/src/redux/apis/endpoints/Environment.endpoint.ts
@@ -1,0 +1,55 @@
+import {HTTP_METHOD} from 'constants/Common.constants';
+import {PaginationResponse} from 'hooks/usePagination';
+import Environment from 'models/__mocks__/Environment.mock';
+import KeyValueMock from 'models/__mocks__/KeyValue.mock';
+import {TEnvironment} from 'types/Environment.types';
+import {IKeyValue, TracetestApiTags} from 'constants/Test.constants';
+import {TTestApiEndpointBuilder} from 'types/Test.types';
+
+const environmentList = [
+  Environment.model({id: 'ae7162b3-54e0-4603-9d33-12345', name: 'Production', description: 'Production environment'}),
+  Environment.model({
+    id: 'ae7162b3-54e0-4603-9d33-423b12cf67c8',
+    name: 'Development',
+    description: 'Developing environment',
+  }),
+];
+
+const keyValueListOne = [KeyValueMock.model()];
+const keyValueListTwo = [
+  KeyValueMock.model({key: 'user', value: 'testAdmin'}),
+  KeyValueMock.model({key: 'password', value: '1234'}),
+];
+
+const EnvironmentEndpoint = (builder: TTestApiEndpointBuilder) => ({
+  getEnvList: builder.query<PaginationResponse<TEnvironment>, {take?: number; skip?: number; query?: string}>({
+    query: ({take = 25, skip = 0, query = ''}) => `/tests?take=${take}&skip=${skip}&query=${query}`,
+    providesTags: () => [{type: TracetestApiTags.ENVIRONMENT, id: 'LIST'}],
+    transformResponse: () => {
+      return {
+        total: environmentList.length,
+        items: environmentList,
+      };
+    },
+  }),
+  getEnvironmentSecretList: builder.query<IKeyValue[], {environmentId: string; take?: number; skip?: number}>({
+    query: ({take = 25, skip = 0}) => `/tests?take=${take}&skip=${skip}`,
+    providesTags: (result, error, {environmentId}) => [
+      {type: TracetestApiTags.ENVIRONMENT, id: `${environmentId}-LIST`},
+    ],
+    transformResponse: (raw, meta, args) => {
+      return args.environmentId === 'ae7162b3-54e0-4603-9d33-423b12cf67c8' ? keyValueListOne : keyValueListTwo;
+    },
+  }),
+  createEnvironment: builder.mutation<undefined, TEnvironment>({
+    query: newEnvironment => ({
+      url: '/environments',
+      method: HTTP_METHOD.POST,
+      body: newEnvironment,
+    }),
+    transformResponse: () => undefined,
+    invalidatesTags: [{type: TracetestApiTags.ENVIRONMENT, id: 'LIST'}],
+  }),
+});
+
+export default EnvironmentEndpoint;

--- a/web/src/redux/apis/endpoints/Test.endpoint.ts
+++ b/web/src/redux/apis/endpoints/Test.endpoint.ts
@@ -1,0 +1,76 @@
+import {TRawTest, TTest, TTestApiEndpointBuilder} from 'types/Test.types';
+import {HTTP_METHOD} from 'constants/Common.constants';
+import {SortBy, SortDirection, TracetestApiTags} from 'constants/Test.constants';
+import Test from 'models/Test.model';
+import {PaginationResponse} from 'hooks/usePagination';
+import {TAssertion} from 'types/Assertion.types';
+import {TRawTestSpecs} from 'types/TestSpecs.types';
+
+function getTotalCountFromHeaders(meta: any) {
+  return Number(meta?.response?.headers.get('x-total-count') || 0);
+}
+
+const TestEndpoint = (builder: TTestApiEndpointBuilder) => ({
+  createTest: builder.mutation<TTest, TRawTest>({
+    query: newTest => ({
+      url: '/tests',
+      method: HTTP_METHOD.POST,
+      body: newTest,
+    }),
+    transformResponse: (rawTest: TRawTest) => Test(rawTest),
+    invalidatesTags: [{type: TracetestApiTags.TEST, id: 'LIST'}],
+  }),
+  editTest: builder.mutation<TTest, {test: TRawTest; testId: string}>({
+    query: ({test, testId}) => ({
+      url: `/tests/${testId}`,
+      method: HTTP_METHOD.PUT,
+      body: test,
+    }),
+    invalidatesTags: test => [
+      {type: TracetestApiTags.TEST, id: 'LIST'},
+      {type: TracetestApiTags.TEST, id: test?.id},
+    ],
+  }),
+  getTestList: builder.query<
+    PaginationResponse<TTest>,
+    {take?: number; skip?: number; query?: string; sortBy?: SortBy; sortDirection?: SortDirection}
+  >({
+    query: ({take = 25, skip = 0, query = '', sortBy = '', sortDirection = ''}) =>
+      `/tests?take=${take}&skip=${skip}&query=${query}&sortBy=${sortBy}&sortDirection=${sortDirection}`,
+    providesTags: () => [{type: TracetestApiTags.TEST, id: 'LIST'}],
+    transformResponse: (rawTestList: TTest[], meta) => {
+      return {
+        items: rawTestList.map(rawTest => Test(rawTest)),
+        total: getTotalCountFromHeaders(meta),
+      };
+    },
+  }),
+  getTestById: builder.query<TTest, {testId: string}>({
+    query: ({testId}) => `/tests/${testId}`,
+    providesTags: result => [{type: TracetestApiTags.TEST, id: result?.id}],
+    transformResponse: (rawTest: TRawTest) => Test(rawTest),
+  }),
+  getTestVersionById: builder.query<TTest, {testId: string; version: number}>({
+    query: ({testId, version}) => `/tests/${testId}/version/${version}`,
+    providesTags: result => [{type: TracetestApiTags.TEST, id: result?.id}],
+    transformResponse: (rawTest: TRawTest) => Test(rawTest),
+  }),
+  deleteTestById: builder.mutation<TTest, {testId: string}>({
+    query: ({testId}) => ({url: `/tests/${testId}`, method: 'DELETE'}),
+    invalidatesTags: [{type: TracetestApiTags.TEST, id: 'LIST'}],
+  }),
+
+  setTestDefinition: builder.mutation<TAssertion, {testId: string; testDefinition: Partial<TRawTestSpecs>}>({
+    query: ({testId, testDefinition}) => ({
+      url: `/tests/${testId}/definition`,
+      method: HTTP_METHOD.PUT,
+      body: testDefinition,
+    }),
+    invalidatesTags: (result, error, {testId}) => [
+      {type: TracetestApiTags.TEST, id: testId},
+      {type: TracetestApiTags.TEST_DEFINITION, id: testId},
+    ],
+  }),
+});
+
+export default TestEndpoint;

--- a/web/src/redux/apis/endpoints/TestRun.endpoints.ts
+++ b/web/src/redux/apis/endpoints/TestRun.endpoints.ts
@@ -1,0 +1,104 @@
+import {uniq} from 'lodash';
+import {HTTP_METHOD} from 'constants/Common.constants';
+import {PaginationResponse} from 'hooks/usePagination';
+import AssertionResults from 'models/AssertionResults.model';
+import TestRun from 'models/TestRun.model';
+
+import WebSocketService, {IListenerFunction} from 'services/WebSocket.service';
+import {TAssertionResults, TRawAssertionResults} from 'types/Assertion.types';
+import {TTest, TTestApiEndpointBuilder} from 'types/Test.types';
+import {TRawTestRun, TTestRun} from 'types/TestRun.types';
+import {TRawTestSpecs} from 'types/TestSpecs.types';
+import {TracetestApiTags} from 'constants/Test.constants';
+
+function getTotalCountFromHeaders(meta: any) {
+  return Number(meta?.response?.headers.get('x-total-count') || 0);
+}
+
+const TestRunEndpoint = (builder: TTestApiEndpointBuilder) => ({
+  runTest: builder.mutation<TTestRun, {testId: string}>({
+    query: ({testId}) => ({
+      url: `/tests/${testId}/run`,
+      method: HTTP_METHOD.POST,
+      body: {},
+    }),
+    invalidatesTags: (response, error, {testId}) => [
+      {type: TracetestApiTags.TEST_RUN, id: `${testId}-LIST`},
+      {type: TracetestApiTags.TEST, id: 'LIST'},
+    ],
+    transformResponse: (rawTestRun: TRawTestRun) => TestRun(rawTestRun),
+  }),
+  getRunList: builder.query<PaginationResponse<TTestRun>, {testId: string; take?: number; skip?: number}>({
+    query: ({testId, take = 25, skip = 0}) => `/tests/${testId}/run?take=${take}&skip=${skip}`,
+    providesTags: (result, error, {testId}) => [{type: TracetestApiTags.TEST_RUN, id: `${testId}-LIST`}],
+    transformResponse: (rawTestResultList: TRawTestRun[], meta) => ({
+      total: getTotalCountFromHeaders(meta),
+      items: rawTestResultList.map(rawTestResult => TestRun(rawTestResult)),
+    }),
+  }),
+  getRunById: builder.query<TTestRun, {runId: string; testId: string}>({
+    query: ({testId, runId}) => `/tests/${testId}/run/${runId}`,
+    providesTags: result => (result ? [{type: TracetestApiTags.TEST_RUN, id: result?.id}] : []),
+    transformResponse: (rawTestResult: TRawTestRun) => TestRun(rawTestResult),
+    async onCacheEntryAdded(arg, {cacheDataLoaded, cacheEntryRemoved, updateCachedData}) {
+      const listener: IListenerFunction<TRawTestRun> = data => {
+        updateCachedData(() => TestRun(data.event));
+      };
+      await WebSocketService.initWebSocketSubscription({
+        listener,
+        resource: `test/${arg.testId}/run/${arg.runId}`,
+        waitToCleanSubscription: cacheEntryRemoved,
+        waitToInitSubscription: cacheDataLoaded,
+      });
+    },
+  }),
+  reRun: builder.mutation<TTestRun, {testId: string; runId: string}>({
+    query: ({testId, runId}) => ({
+      url: `/tests/${testId}/run/${runId}/rerun`,
+      method: HTTP_METHOD.POST,
+    }),
+    invalidatesTags: (response, error, {testId, runId}) => [
+      {type: TracetestApiTags.TEST_RUN, id: `${testId}-LIST`},
+      {type: TracetestApiTags.TEST_RUN, id: runId},
+    ],
+    transformResponse: (rawTestRun: TRawTestRun) => TestRun(rawTestRun),
+  }),
+  dryRun: builder.mutation<TAssertionResults, {testId: string; runId: string; testDefinition: Partial<TRawTestSpecs>}>({
+    query: ({testId, runId, testDefinition}) => ({
+      url: `/tests/${testId}/run/${runId}/dry-run`,
+      method: HTTP_METHOD.PUT,
+      body: testDefinition,
+    }),
+    transformResponse: (rawTestResults: TRawAssertionResults) => AssertionResults(rawTestResults),
+  }),
+  deleteRunById: builder.mutation<TTest, {testId: string; runId: string}>({
+    query: ({testId, runId}) => ({url: `/tests/${testId}/run/${runId}`, method: 'DELETE'}),
+    invalidatesTags: (result, error, {testId}) => [
+      {type: TracetestApiTags.TEST_RUN},
+      {type: TracetestApiTags.TEST, id: `${testId}-LIST`},
+    ],
+  }),
+  getJUnitByRunId: builder.query<string, {testId: string; runId: string}>({
+    query: ({testId, runId}) => ({url: `/tests/${testId}/run/${runId}/junit.xml`, responseHandler: 'text'}),
+    providesTags: (result, error, {testId, runId}) => [
+      {type: TracetestApiTags.TEST_RUN, id: `${testId}-${runId}-junit`},
+    ],
+  }),
+  getTestDefinitionYamlByRunId: builder.query<string, {testId: string; version: number}>({
+    query: ({testId, version}) => ({
+      url: `/tests/${testId}/version/${version}/definition.yaml`,
+      responseHandler: 'text',
+    }),
+    providesTags: (result, error, {testId, version}) => [
+      {type: TracetestApiTags.TEST_RUN, id: `${testId}-${version}-definition`},
+    ],
+  }),
+
+  getSelectedSpans: builder.query<string[], {testId: string; runId: string; query: string}>({
+    query: ({testId, runId, query}) => `/tests/${testId}/run/${runId}/select?query=${encodeURIComponent(query)}`,
+    providesTags: (result, error, {query}) => (result ? [{type: TracetestApiTags.SPAN, id: `${query}-LIST`}] : []),
+    transformResponse: (rawSpanList: string[]) => uniq(rawSpanList),
+  }),
+});
+
+export default TestRunEndpoint;

--- a/web/src/redux/apis/endpoints/Transaction.endpoint.ts
+++ b/web/src/redux/apis/endpoints/Transaction.endpoint.ts
@@ -1,0 +1,23 @@
+import TransactionMock from 'models/__mocks__/Transaction.mock';
+import {TTransaction} from 'types/Transaction.types';
+import {TTestApiEndpointBuilder} from 'types/Test.types';
+import {TracetestApiTags} from 'constants/Test.constants';
+
+const TransactionEndpoint = (builder: TTestApiEndpointBuilder) => ({
+  deleteTransactionById: builder.mutation<TTransaction, {transactionId: string}>({
+    query: ({transactionId}) => ({url: `/transactions/${transactionId}`, method: 'DELETE'}),
+    invalidatesTags: [{type: TracetestApiTags.TRANSACTION, id: 'LIST'}],
+  }),
+  getTransactionRunById: builder.query<TTransaction, {transactionId: string; runId?: string}>({
+    query: () => `/tests`,
+    providesTags: result => [{type: TracetestApiTags.TRANSACTION, id: result?.id}],
+    transformResponse: () => TransactionMock.model(),
+  }),
+  getTransactionById: builder.query<TTransaction, {transactionId: string}>({
+    query: () => `/tests`,
+    providesTags: result => [{type: TracetestApiTags.TRANSACTION, id: result?.id}],
+    transformResponse: () => TransactionMock.model(),
+  }),
+});
+
+export default TransactionEndpoint;

--- a/web/src/redux/slices/User.slice.ts
+++ b/web/src/redux/slices/User.slice.ts
@@ -1,0 +1,32 @@
+import {createAction, createSlice} from '@reduxjs/toolkit';
+import UserPreferencesService from 'services/UserPreferences.service';
+import {IUserState, TUserPreferenceKey, TUserPreferenceValue} from 'types/User.types';
+
+export const initialState: IUserState = {
+  preferences: UserPreferencesService.get(),
+};
+
+interface ISetUserPreferencesProps {
+  key: TUserPreferenceKey;
+  value: TUserPreferenceValue;
+}
+
+export const setUserPreference = createAction('user/setUserPreference', ({key, value}: ISetUserPreferencesProps) => {
+  return {
+    payload: {preferences: UserPreferencesService.set(key, value)},
+  };
+});
+
+const testDefinitionSlice = createSlice({
+  name: 'user',
+  initialState,
+  reducers: {},
+  extraReducers: builder => {
+    builder.addCase(setUserPreference, (state, {payload: {preferences}}) => {
+      state.preferences = preferences;
+    });
+  },
+});
+
+// export const {} = testDefinitionSlice.actions;
+export default testDefinitionSlice.reducer;

--- a/web/src/redux/store.tsx
+++ b/web/src/redux/store.tsx
@@ -8,6 +8,7 @@ import CreateTest from 'redux/slices/CreateTest.slice';
 import DAG from 'redux/slices/DAG.slice';
 import Trace from 'redux/slices/Trace.slice';
 import CreateTransaction from 'redux/slices/CreateTransaction.slice';
+import User from 'redux/slices/User.slice';
 import RouterMiddleware from './Router.middleware';
 import OtelRepoApi from './apis/OtelRepo.api';
 
@@ -27,6 +28,7 @@ export const store = configureStore({
     testSpecs: TestSpecs,
     createTest: CreateTest,
     createTransaction: CreateTransaction,
+    user: User,
   },
   middleware: getDefaultMiddleware =>
     getDefaultMiddleware()

--- a/web/src/selectors/Environment.selectors.ts
+++ b/web/src/selectors/Environment.selectors.ts
@@ -1,0 +1,23 @@
+import {createSelector} from '@reduxjs/toolkit';
+import {RootState} from 'redux/store';
+import {endpoints} from 'redux/apis/TraceTest.api';
+import UserSelectors from './User.selectors';
+
+const stateSelector = (state: RootState) => state;
+
+const selectEnvironmentList = createSelector(stateSelector, state => {
+  const {data: {items = []} = {}} = endpoints.getEnvList.select({})(state);
+
+  return items;
+});
+
+const EnvironmentSelectors = () => ({
+  selectEnvironmentList,
+  selectSelectedEnvironment: createSelector(selectEnvironmentList, stateSelector, (environmentList, state) => {
+    const environmentId = UserSelectors.selectUserPreference(state, 'environmentId');
+
+    return environmentList.find(({id}) => id === environmentId);
+  }),
+});
+
+export default EnvironmentSelectors();

--- a/web/src/selectors/User.selectors.ts
+++ b/web/src/selectors/User.selectors.ts
@@ -1,0 +1,14 @@
+import {createSelector} from '@reduxjs/toolkit';
+import {RootState} from 'redux/store';
+import {TUserPreferenceKey} from 'types/User.types';
+
+const stateSelector = (state: RootState) => state;
+const preferenceKeySelector = (state: RootState, key: TUserPreferenceKey) => key;
+
+const UserSelectors = () => ({
+  selectUserPreference: createSelector(stateSelector, preferenceKeySelector, ({user}, key) => {
+    return user.preferences[key];
+  }),
+});
+
+export default UserSelectors();

--- a/web/src/services/UserPreferences.service.ts
+++ b/web/src/services/UserPreferences.service.ts
@@ -1,30 +1,28 @@
 import LocalStorageGateway from 'gateways/LocalStorage.gateway';
+import {IUserPreferences} from 'types/User.types';
 
 const storageKey = 'user_preferences';
-
-interface IUserPreferences {
-  lang: string;
-}
 
 const localStorageGateway = LocalStorageGateway<IUserPreferences>(storageKey);
 
 const initialUserPreferences: IUserPreferences = {
   lang: 'en',
+  environmentId: '',
 };
 
 const UserPreferencesService = () => ({
-  getUserPreferences(): IUserPreferences {
+  get(): IUserPreferences {
     const userPreferences = localStorageGateway.get() || initialUserPreferences;
 
     return userPreferences;
   },
-  getUserPreference<K extends keyof IUserPreferences>(key: K): IUserPreferences[K] {
-    const preferences = this.getUserPreferences();
+  getEntry<K extends keyof IUserPreferences>(key: K): IUserPreferences[K] {
+    const preferences = this.get();
 
     return preferences[key];
   },
-  setPreference<K extends keyof IUserPreferences>(key: K, value: IUserPreferences[K]) {
-    const preferences = this.getUserPreferences();
+  set<K extends keyof IUserPreferences>(key: K, value: IUserPreferences[K]) {
+    const preferences = this.get();
 
     const updatedUserPreferences = {
       ...preferences,

--- a/web/src/types/Environment.types.ts
+++ b/web/src/types/Environment.types.ts
@@ -1,0 +1,11 @@
+import {IKeyValue} from 'constants/Test.constants';
+import {Model} from 'types/Common.types';
+
+export type TRawEnvironment = {
+  id?: string;
+  name?: string;
+  description?: string;
+  variables?: IKeyValue[];
+}
+
+export type TEnvironment = Model<TRawEnvironment, {}>;

--- a/web/src/types/Test.types.ts
+++ b/web/src/types/Test.types.ts
@@ -1,7 +1,9 @@
 import {FormInstance} from 'antd';
 import {VariableDefinition, Request} from 'postman-collection';
 import {CaseReducer, PayloadAction} from '@reduxjs/toolkit';
-import {TriggerTypes} from 'constants/Test.constants';
+import {BaseQueryFn, FetchArgs, FetchBaseQueryError, FetchBaseQueryMeta} from '@reduxjs/toolkit/dist/query';
+import {EndpointBuilder} from '@reduxjs/toolkit/dist/query/endpointDefinitions';
+import {TracetestApiTags, TriggerTypes} from 'constants/Test.constants';
 import {HTTP_METHOD, SupportedPlugins} from 'constants/Common.constants';
 import {Model, TGrpcSchemas, THttpSchemas, TTestSchemas, TTriggerSchemas} from './Common.types';
 import {TTestSpecs} from './TestSpecs.types';
@@ -137,3 +139,9 @@ export type TCreateTestSliceActions = {
   setDraftTest: CaseReducer<ICreateTestState, PayloadAction<{draftTest: TDraftTest}>>;
   setIsFormValid: CaseReducer<ICreateTestState, PayloadAction<{isValid: boolean}>>;
 };
+
+export type TTestApiEndpointBuilder = EndpointBuilder<
+  BaseQueryFn<string | FetchArgs, unknown, FetchBaseQueryError, {}, FetchBaseQueryMeta>,
+  TracetestApiTags,
+  'tests'
+>;

--- a/web/src/types/User.types.ts
+++ b/web/src/types/User.types.ts
@@ -1,0 +1,11 @@
+export interface IUserPreferences {
+  lang: string;
+  environmentId: string;
+}
+
+export type TUserPreferenceKey = keyof IUserPreferences;
+export type TUserPreferenceValue<K extends TUserPreferenceKey = TUserPreferenceKey> = IUserPreferences[K];
+
+export interface IUserState {
+  preferences: IUserPreferences;
+}


### PR DESCRIPTION
This PR wires up the environment dropdown from the header to the rest of the application, it adds the user state to redux where we are going to be storing preferences and in the future things like username, email, roles etc.

The requests are mocked and return stale data, in the future we'll have to revisit the changes to include the BE requests.

## Changes

- User and user preferences state management
- Environment selector wiring up
- Refactored tracetest endpoints to a folder.

## Fixes

- #1235 

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test


https://www.loom.com/share/7e948e0930264cc9892ab4e4cd8b9939