### PR TITLE
feat: concatenate multiple header values together using commas

### DIFF
--- a/server/executor/trigger/http.go
+++ b/server/executor/trigger/http.go
@@ -69,7 +69,7 @@ func (te *httpTriggerer) Trigger(ctx context.Context, test model.Test, opts *Tri
 		return response, err
 	}
 	for _, h := range tReq.Headers {
-		req.Header.Set(h.Key, h.Value)
+		req.Header.Add(h.Key, h.Value)
 	}
 
 	tReq.Authenticate(req)


### PR DESCRIPTION
This PR allows users to send multiple headers with the same name.

Implementation was based on HTTP [RFC 2616](https://www.rfc-editor.org/rfc/rfc2616#section-4.2) which states:

> Multiple message-header fields with the same field-name MAY be
   present in a message if and only if the entire field-value for that
   header field is defined as a comma-separated list [i.e., #(values)].

Therefore, sending multiple headers with the same name results in a single header with all values concatenated and separated by commas.

Related to issue #1372 

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
