### PR TITLE
fix: convert service port to int in generated docker-compose file

### DIFF
--- a/cli/installer/docker_compose.go
+++ b/cli/installer/docker_compose.go
@@ -180,9 +180,17 @@ func getDockerComposeFileContents(ui cliUI.UI, config configuration) []byte {
 		ui.Exit(fmt.Sprintf("cannot encode docker-compose file: %s", err.Error()))
 	}
 
-	sout := strings.ReplaceAll(string(output), "$", "$$")
+	sout := fixPortConfig(string(output))
+	sout = strings.ReplaceAll(sout, "$", "$$")
 
 	return []byte(sout)
+}
+
+func fixPortConfig(output string) string {
+	publishedPortRegex := regexp.MustCompile(`published: "\d+"`)
+	return publishedPortRegex.ReplaceAllStringFunc(output, func(s string) string {
+		return strings.ReplaceAll(s, `"`, ``)
+	})
 }
 
 func filterContainers(ui cliUI.UI, project *types.Project, included []string) {


### PR DESCRIPTION
This PR fixes the problem @kdhamric found when installing tracetest on windows using docker-compose

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
