### PR TITLE
feat: add "type" filter and support arrays in expressions

### DIFF
--- a/docs/expressions.md
+++ b/docs/expressions.md
@@ -88,14 +88,34 @@ You can select the last item from a list by specifying `'last'` as the argument 
 '{ "array": [1, 2, 3] }' | json_path '$.array[*]' | get_index 'last' = 3
 ```
 
-### **Count**
+### **Length**
 
 Return the size of the input array. If it's a single value, it will return 1. Otherwise it will return `length(input_array)`.
 
 ```
-'{ "array": [1, 2, 3] }' | json_path '$.array[*]' | count = 3
+'{ "array": [1, 2, 3] }' | json_path '$.array[*]' | length = 3
 ```
 
 ```
-"my string" | count = 1
+"my string" | length = 1
+```
+
+### **Type**
+
+Return the type of the input as a string.
+
+```
+2 | type = "number"
+```
+
+```
+2s | type = "duration"
+```
+
+```
+"something" | type = "string"
+```
+
+```
+[1, 2s, "this is a string"] | type = "array"
 ```

--- a/docs/expressions.md
+++ b/docs/expressions.md
@@ -119,3 +119,8 @@ Return the type of the input as a string.
 ```
 [1, 2s, "this is a string"] | type = "array"
 ```
+
+```
+# check if attribute is either a number of a string
+["number", "string"] contains attr:my_attribute | type
+```

--- a/docs/expressions.md
+++ b/docs/expressions.md
@@ -121,6 +121,10 @@ Return the type of the input as a string.
 ```
 
 ```
+attr:myapp.operations | get_index 2 | type = "string"
+```
+
+```
 # check if attribute is either a number of a string
 ["number", "string"] contains attr:my_attribute | type
 ```

--- a/server/executor/outputs_processor.go
+++ b/server/executor/outputs_processor.go
@@ -93,9 +93,9 @@ func extractAttr(span traces.Span, mads expression.MetaAttributesDataStore, expr
 	attributeDataStore := expression.AttributeDataStore{Span: span}
 	expressionExecutor := expression.NewExecutor(attributeDataStore, mads)
 
-	actualValue, _, _ := expressionExecutor.Expression(expr)
+	actualValue, _ := expressionExecutor.Expression(expr)
 
-	return actualValue
+	return actualValue.String()
 }
 
 type parsedOutput struct {

--- a/server/expression/comparison.go
+++ b/server/expression/comparison.go
@@ -1,0 +1,41 @@
+package expression
+
+import (
+	"fmt"
+
+	"github.com/kubeshop/tracetest/server/assertions/comparator"
+	"github.com/kubeshop/tracetest/server/expression/value"
+)
+
+func compare(comparatorName string, leftValue, rightValue value.Value) error {
+	comparatorFunction, err := comparator.DefaultRegistry().Get(comparatorName)
+	if err != nil {
+		return fmt.Errorf("comparator not supported: %w", err)
+	}
+
+	if leftValue.IsArray() && comparatorName == "contains" {
+		return compareArrayContains(leftValue, rightValue)
+	}
+
+	err = comparatorFunction.Compare(rightValue.String(), leftValue.String())
+	if err == comparator.ErrNoMatch {
+		return ErrNoMatch
+	}
+
+	return nil
+}
+
+func compareArrayContains(array, expected value.Value) error {
+	equalComparator, err := comparator.DefaultRegistry().Get("=")
+	if err != nil {
+		return fmt.Errorf("equal operator is not supported: %w", err)
+	}
+
+	for _, item := range array.Items {
+		if err = equalComparator.Compare(item.Value, expected.String()); err == nil {
+			return nil
+		}
+	}
+
+	return ErrNoMatch
+}

--- a/server/expression/executor.go
+++ b/server/expression/executor.go
@@ -1,7 +1,6 @@
 package expression
 
 import (
-	"encoding/json"
 	"errors"
 	"fmt"
 	"strconv"
@@ -39,20 +38,26 @@ func (e Executor) Statement(statement string) (string, string, error) {
 		return "", "", fmt.Errorf("could not parse statement: %w", err)
 	}
 
-	leftValue, leftType, err := e.Expression(parsedStatement.Left)
+	leftValue, err := e.Expression(parsedStatement.Left)
 	if err != nil {
 		return "", "", fmt.Errorf("could not parse left side expression: %w", err)
 	}
 
-	rightValue, rightType, err := e.Expression(parsedStatement.Right)
+	rightValue, err := e.Expression(parsedStatement.Right)
 	if err != nil {
 		return "", "", fmt.Errorf("could not parse left side expression: %w", err)
 	}
 
 	// https://github.com/kubeshop/tracetest/issues/1203
-	if leftType == types.TypeDuration || rightType == types.TypeDuration {
-		leftValue = getRoundedDurationValue(leftValue)
-		rightValue = getRoundedDurationValue(rightValue)
+	if leftValue.Value().Type == types.TypeDuration || rightValue.Value().Type == types.TypeDuration {
+		leftValue = value.New(types.TypedValue{
+			Value: getRoundedDurationValue(leftValue.String()),
+			Type:  types.TypeDuration,
+		})
+		rightValue = value.New(types.TypedValue{
+			Value: getRoundedDurationValue(rightValue.String()),
+			Type:  types.TypeDuration,
+		})
 	}
 
 	comparatorFunction, err := comparator.DefaultRegistry().Get(parsedStatement.Comparator)
@@ -60,53 +65,51 @@ func (e Executor) Statement(statement string) (string, string, error) {
 		return "", "", fmt.Errorf("comparator not supported: %w", err)
 	}
 
-	err = comparatorFunction.Compare(rightValue, leftValue)
+	err = comparatorFunction.Compare(rightValue.String(), leftValue.String())
 	if err == comparator.ErrNoMatch {
 		err = ErrNoMatch
 	}
 
-	if leftType == types.TypeDuration || rightType == types.TypeDuration {
+	if leftValue.Value().Type == types.TypeDuration || rightValue.Value().Type == types.TypeDuration {
 		// If any of the sides is a duration, there's a high change of the other side
 		// to be a duration as well. So try to format both before returning it
-		leftValue = maybeFormatDuration(leftValue, leftType)
-		rightValue = maybeFormatDuration(rightValue, rightType)
+		leftValue = value.NewFromString(maybeFormatDuration(leftValue))
+		rightValue = value.NewFromString(maybeFormatDuration(rightValue))
 	}
 
-	return leftValue, rightValue, err
+	return leftValue.String(), rightValue.String(), err
 }
 
-func (e Executor) Expression(expr Expr) (string, types.Type, error) {
-	currentValue, currentType, err := e.resolveTerm(expr.Left)
+func (e Executor) Expression(expr Expr) (value.Value, error) {
+	currentValue, err := e.resolveTerm(expr.Left)
 	if err != nil {
-		return "", types.TypeNil, fmt.Errorf("could not resolve term: %w", err)
+		return value.Nil, fmt.Errorf("could not resolve term: %w", err)
 	}
 
-	value := types.TypedValue{Value: currentValue, Type: currentType}
 	if expr.Right != nil {
 		for _, opTerm := range expr.Right {
-			currentValue, currentType, err = e.executeOperation(value, opTerm)
+			newValue, err := e.executeOperation(currentValue.Value(), opTerm)
 			if err != nil {
-				return "", types.TypeNil, fmt.Errorf("could not execute operation: %w", err)
+				return value.Nil, fmt.Errorf("could not execute operation: %w", err)
 			}
 
-			value = types.TypedValue{Value: currentValue, Type: currentType}
+			currentValue = newValue
 		}
 	}
 
 	if expr.Filters != nil {
-		newValue, err := e.executeFilters(value, expr.Filters)
+		newValue, err := e.executeFilters(currentValue, expr.Filters)
 		if err != nil {
-			return "", types.TypeNil, err
+			return value.Nil, err
 		}
 
-		value = newValue
-		currentType = types.GetType(value.Value)
+		currentValue = newValue
 	}
 
-	return value.Value, currentType, nil
+	return currentValue, nil
 }
 
-func (e Executor) resolveTerm(term *Term) (string, types.Type, error) {
+func (e Executor) resolveTerm(term *Term) (value.Value, error) {
 	if term.Attribute != nil {
 		return e.resolveAttribute(term.Attribute)
 	}
@@ -125,156 +128,153 @@ func (e Executor) resolveTerm(term *Term) (string, types.Type, error) {
 
 	if term.Duration != nil {
 		nanoSeconds := traces.ConvertTimeFieldIntoNanoSeconds(*term.Duration)
-		return fmt.Sprintf("%d", nanoSeconds), types.TypeDuration, nil
+		typedValue := types.TypedValue{
+			Value: fmt.Sprintf("%d", nanoSeconds),
+			Type:  types.TypeDuration,
+		}
+		return value.New(typedValue), nil
 	}
 
 	if term.Number != nil {
-		return *term.Number, types.TypeNumber, nil
+		typedValue := types.TypedValue{
+			Value: *term.Number,
+			Type:  types.TypeNumber,
+		}
+		return value.New(typedValue), nil
 	}
 
 	if term.Str != nil {
 		stringArgs := make([]any, 0, len(term.Str.Args))
 		for _, arg := range term.Str.Args {
-			stringArg, _, err := e.Expression(arg)
+			newValue, err := e.Expression(arg)
 			if err != nil {
-				return "", types.TypeNil, fmt.Errorf("could not execute expression: %w", err)
+				return value.Nil, fmt.Errorf("could not execute expression: %w", err)
 			}
 
-			stringArgs = append(stringArgs, stringArg)
+			stringArgs = append(stringArgs, newValue.String())
 		}
 
-		value := term.Str.Text
+		strValue := term.Str.Text
 		if len(stringArgs) > 0 {
-			value = fmt.Sprintf(term.Str.Text, stringArgs...)
+			strValue = fmt.Sprintf(term.Str.Text, stringArgs...)
 		}
 
-		return value, types.TypeString, nil
+		return value.NewFromString(strValue), nil
 	}
 
-	return "", types.TypeNil, fmt.Errorf("empty term")
+	return value.Nil, fmt.Errorf("empty term")
 }
 
-func (e Executor) resolveAttribute(attribute *Attribute) (string, types.Type, error) {
+func (e Executor) resolveAttribute(attribute *Attribute) (value.Value, error) {
 	if attribute.IsMeta() {
 		selectedSpansDataStore := e.Stores[metaPrefix]
-		value, err := selectedSpansDataStore.Get(attribute.Name())
+		attributeValue, err := selectedSpansDataStore.Get(attribute.Name())
 		if err != nil {
-			return "", types.TypeNil, fmt.Errorf("could not resolve meta attribute: %w", err)
+			return value.Nil, fmt.Errorf("could not resolve meta attribute: %w", err)
 		}
 
-		return value, types.GetType(value), nil
+		return value.NewFromString(attributeValue), nil
 	}
 
 	attributeDataStore := e.Stores["attr"]
-	value, err := attributeDataStore.Get(attribute.Name())
+	attributeValue, err := attributeDataStore.Get(attribute.Name())
 	if err != nil {
-		return "", types.TypeNil, fmt.Errorf("could not resolve attribute %s: %w", attribute.Name(), err)
+		return value.Nil, fmt.Errorf("could not resolve attribute %s: %w", attribute.Name(), err)
 	}
 
-	return value, types.GetType(value), nil
+	return value.NewFromString(attributeValue), nil
 }
 
-func (e Executor) resolveVariable(variable *Variable) (string, types.Type, error) {
+func (e Executor) resolveVariable(variable *Variable) (value.Value, error) {
 	variableDataStore := e.Stores["var"]
-	value, err := variableDataStore.Get(variable.Name())
+	variableValue, err := variableDataStore.Get(variable.Name())
 	if err != nil {
-		return "", types.TypeNil, fmt.Errorf("could not resolve variable %s: %w", variable.Name(), err)
+		return value.Nil, fmt.Errorf("could not resolve variable %s: %w", variable.Name(), err)
 	}
 
-	return value, types.GetType(value), nil
+	return value.NewFromString(variableValue), nil
 }
 
-func (e Executor) resolveFunctionCall(functionCall *FunctionCall) (string, types.Type, error) {
+func (e Executor) resolveFunctionCall(functionCall *FunctionCall) (value.Value, error) {
 	args := make([]types.TypedValue, 0, len(functionCall.Args))
 	for i, arg := range functionCall.Args {
-		argValue, argType, err := e.resolveTerm(arg)
+		functionValue, err := e.resolveTerm(arg)
 		if err != nil {
-			return "", types.TypeNil, fmt.Errorf("could not execute function %s: invalid argument on index %d: %w", functionCall.Name, i, err)
+			return value.Nil, fmt.Errorf("could not execute function %s: invalid argument on index %d: %w", functionCall.Name, i, err)
 		}
 
-		args = append(args, types.TypedValue{Type: argType, Value: argValue})
+		args = append(args, functionValue.Value())
 	}
 
 	function, err := functions.DefaultRegistry().Get(functionCall.Name)
 	if err != nil {
-		return "", types.TypeNil, fmt.Errorf("function %s doesn't exist", functionCall.Name)
+		return value.Nil, fmt.Errorf("function %s doesn't exist", functionCall.Name)
 	}
 
 	typedValue, err := function.Invoke(args...)
-	return typedValue.Value, typedValue.Type, err
+	return value.New(typedValue), err
 }
 
-func (e Executor) resolveArray(array *Array) (string, types.Type, error) {
-	arrayJson, err := json.Marshal(array)
-	if err != nil {
-		return "", types.TypeNil, fmt.Errorf("could not marshal array: %w", err)
+func (e Executor) resolveArray(array *Array) (value.Value, error) {
+	typedValues := make([]types.TypedValue, 0, len(array.Items))
+	for index, item := range array.Items {
+		termValue, err := e.resolveTerm(item)
+		if err != nil {
+			return value.Value{}, fmt.Errorf("could not resolve item at index %d: %w", index, err)
+		}
+
+		typedValues = append(typedValues, termValue.Value())
 	}
 
-	return string(arrayJson), types.TypeArray, nil
+	return value.NewArray(typedValues), nil
 }
 
-func (e Executor) executeOperation(left types.TypedValue, right *OpTerm) (string, types.Type, error) {
-	rightValue, rightType, err := e.resolveTerm(right.Term)
+func (e Executor) executeOperation(left types.TypedValue, right *OpTerm) (value.Value, error) {
+	rightValue, err := e.resolveTerm(right.Term)
 	if err != nil {
-		return "", types.TypeNil, err
+		return value.Nil, err
 	}
 
-	if left.Type != rightType {
-		return "", types.TypeNil, fmt.Errorf("types mismatch")
+	if left.Type != rightValue.Value().Type {
+		return value.Nil, fmt.Errorf("types mismatch")
 	}
 
 	operatorFunction, err := getOperationRegistry().Get(right.Operator)
 	if err != nil {
-		return "", types.TypeNil, err
+		return value.Nil, err
 	}
 
-	newValue, err := operatorFunction(left, types.TypedValue{Value: rightValue, Type: rightType})
+	newValue, err := operatorFunction(left, rightValue.Value())
 	if err != nil {
-		return "", types.TypeNil, err
+		return value.Nil, err
 	}
 
-	return newValue.Value, newValue.Type, nil
+	return value.New(newValue), nil
 }
 
-func (e Executor) executeFilters(input types.TypedValue, f []*Filter) (types.TypedValue, error) {
-	var filterInput value.Value
-	if input.Type == types.TypeArray {
-		inputValue, err := e.convertArrayIntoFilterValue(input)
-		if err != nil {
-			return types.TypedValue{}, err
-		}
-		filterInput = inputValue
-	} else {
-		filterInput = value.New(input)
-	}
-
+func (e Executor) executeFilters(input value.Value, f []*Filter) (value.Value, error) {
+	filterInput := input
 	for _, filter := range f {
 		output, err := e.executeFilter(filterInput, filter)
 		if err != nil {
-			return types.TypedValue{}, err
+			return value.Nil, err
 		}
 
 		filterInput = output
 	}
 
-	if filterInput.IsArray() {
-		// we don't have to deal with arrays when doing comparisons
-		// transform it into a string instead for the simplicity's sake
-		return types.GetTypedValue(filterInput.String()), nil
-	}
-
-	return filterInput.Value(), nil
+	return filterInput, nil
 }
 
 func (e Executor) executeFilter(input value.Value, filter *Filter) (value.Value, error) {
 	args := make([]string, 0, len(filter.Args))
 	for _, arg := range filter.Args {
-		resolvedArg, _, err := e.resolveTerm(arg)
+		resolvedArg, err := e.resolveTerm(arg)
 		if err != nil {
 			return value.Value{}, err
 		}
 
-		args = append(args, resolvedArg)
+		args = append(args, resolvedArg.Value().Value)
 	}
 
 	newValue, err := executeFilter(input, filter.Name, args)
@@ -285,26 +285,6 @@ func (e Executor) executeFilter(input value.Value, filter *Filter) (value.Value,
 	return newValue, nil
 }
 
-func (e Executor) convertArrayIntoFilterValue(input types.TypedValue) (value.Value, error) {
-	var array Array
-	err := json.Unmarshal([]byte(input.Value), &array)
-	if err != nil {
-		return value.Value{}, fmt.Errorf("could not transform array into value: %w", err)
-	}
-
-	typedValues := make([]types.TypedValue, 0, len(array.Items))
-	for index, item := range array.Items {
-		itemValue, itemType, err := e.resolveTerm(item)
-		if err != nil {
-			return value.Value{}, fmt.Errorf("could not resolve item at index %d: %w", index, err)
-		}
-
-		typedValues = append(typedValues, types.TypedValue{Value: itemValue, Type: itemType})
-	}
-
-	return value.NewArray(typedValues), nil
-}
-
 func getRoundedDurationValue(value string) string {
 	numberValue, _ := strconv.Atoi(value)
 	valueAsDuration := traces.ConvertNanoSecondsIntoProperTimeUnit(numberValue)
@@ -313,14 +293,14 @@ func getRoundedDurationValue(value string) string {
 	return fmt.Sprintf("%d", roundedValue)
 }
 
-func maybeFormatDuration(value string, vType types.Type) string {
+func maybeFormatDuration(input value.Value) string {
 	// Any type other than duration and number is certain to not be a duration field
 	// We still try to convert types.TYPE_NUMBER because we store durations as long numbers,
 	// so it's worth trying converting it.
-	if vType != types.TypeDuration && vType != types.TypeNumber {
-		return value
+	if input.Value().Type != types.TypeDuration && input.Value().Type != types.TypeNumber {
+		return input.String()
 	}
 
-	intValue, _ := strconv.Atoi(value)
+	intValue, _ := strconv.Atoi(input.String())
 	return traces.ConvertNanoSecondsIntoProperTimeUnit(intValue)
 }

--- a/server/expression/executor.go
+++ b/server/expression/executor.go
@@ -49,7 +49,7 @@ func (e Executor) Statement(statement string) (string, string, error) {
 	}
 
 	// https://github.com/kubeshop/tracetest/issues/1203
-	if leftValue.Value().Type == types.TypeDuration || rightValue.Value().Type == types.TypeDuration {
+	if leftValue.Type() == types.TypeDuration || rightValue.Type() == types.TypeDuration {
 		leftValue = value.New(types.TypedValue{
 			Value: getRoundedDurationValue(leftValue.String()),
 			Type:  types.TypeDuration,
@@ -70,7 +70,7 @@ func (e Executor) Statement(statement string) (string, string, error) {
 		err = ErrNoMatch
 	}
 
-	if leftValue.Value().Type == types.TypeDuration || rightValue.Value().Type == types.TypeDuration {
+	if leftValue.Type() == types.TypeDuration || rightValue.Type() == types.TypeDuration {
 		// If any of the sides is a duration, there's a high change of the other side
 		// to be a duration as well. So try to format both before returning it
 		leftValue = value.NewFromString(maybeFormatDuration(leftValue))
@@ -235,7 +235,7 @@ func (e Executor) executeOperation(left types.TypedValue, right *OpTerm) (value.
 		return value.Nil, err
 	}
 
-	if left.Type != rightValue.Value().Type {
+	if left.Type != rightValue.Type() {
 		return value.Nil, fmt.Errorf("types mismatch")
 	}
 
@@ -297,7 +297,7 @@ func maybeFormatDuration(input value.Value) string {
 	// Any type other than duration and number is certain to not be a duration field
 	// We still try to convert types.TYPE_NUMBER because we store durations as long numbers,
 	// so it's worth trying converting it.
-	if input.Value().Type != types.TypeDuration && input.Value().Type != types.TypeNumber {
+	if input.Type() != types.TypeDuration && input.Type() != types.TypeNumber {
 		return input.String()
 	}
 

--- a/server/expression/executor.go
+++ b/server/expression/executor.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"strconv"
 
-	"github.com/kubeshop/tracetest/server/assertions/comparator"
 	"github.com/kubeshop/tracetest/server/expression/functions"
 	"github.com/kubeshop/tracetest/server/expression/types"
 	"github.com/kubeshop/tracetest/server/expression/value"
@@ -60,14 +59,9 @@ func (e Executor) Statement(statement string) (string, string, error) {
 		})
 	}
 
-	comparatorFunction, err := comparator.DefaultRegistry().Get(parsedStatement.Comparator)
+	err = compare(parsedStatement.Comparator, leftValue, rightValue)
 	if err != nil {
-		return "", "", fmt.Errorf("comparator not supported: %w", err)
-	}
-
-	err = comparatorFunction.Compare(rightValue.String(), leftValue.String())
-	if err == comparator.ErrNoMatch {
-		err = ErrNoMatch
+		return leftValue.String(), rightValue.String(), err
 	}
 
 	if leftValue.Type() == types.TypeDuration || rightValue.Type() == types.TypeDuration {

--- a/server/expression/executor_test.go
+++ b/server/expression/executor_test.go
@@ -280,6 +280,11 @@ func TestArrayExecution(t *testing.T) {
 			Query:      `[1,2,3] = [1, 2]`,
 			ShouldPass: false,
 		},
+		{
+			Name:       "arrays_can_be_compared_with_other_arrays_generated_by_filters",
+			Query:      `'{ "array": [{ "name": "john", "age": 37 }, { "name": "jonas", "age": 38 }]}' | json_path '$.array[*].age' = [37, 38]`,
+			ShouldPass: true,
+		},
 	}
 
 	executeTestCases(t, testCases)

--- a/server/expression/executor_test.go
+++ b/server/expression/executor_test.go
@@ -285,6 +285,16 @@ func TestArrayExecution(t *testing.T) {
 			Query:      `'{ "array": [{ "name": "john", "age": 37 }, { "name": "jonas", "age": 38 }]}' | json_path '$.array[*].age' = [37, 38]`,
 			ShouldPass: true,
 		},
+		{
+			Name:       "should_check_if_array_contains_value",
+			Query:      `[31,35,39] contains 35`,
+			ShouldPass: true,
+		},
+		{
+			Name:       "should_check_if_array_contains_value_and_fail_if_not",
+			Query:      `[31,35,39] contains 42`,
+			ShouldPass: false,
+		},
 	}
 
 	executeTestCases(t, testCases)

--- a/server/expression/executor_test.go
+++ b/server/expression/executor_test.go
@@ -243,6 +243,43 @@ func TestFunctionExecution(t *testing.T) {
 	executeTestCases(t, testCases)
 }
 
+func TestArrayExecution(t *testing.T) {
+	testCases := []executorTestCase{
+		{
+			Name:       "should_compare_two_empty_arrays",
+			Query:      `[] = []`,
+			ShouldPass: true,
+		},
+		{
+			Name:       "should_compare_two_filled_arrays",
+			Query:      `[1, 2, 3] = [1, 2, 3]`,
+			ShouldPass: true,
+		},
+		{
+			Name:       "should_fail_to_compare_different_arrays",
+			Query:      `[1, 2, 3] = [3, 2, 1]`,
+			ShouldPass: false,
+		},
+		{
+			Name:       "should_be_able_to_run_filters_on_arrays",
+			Query:      `[1, 2, 3] | length = 3`,
+			ShouldPass: true,
+		},
+		{
+			Name:       "should_be_able_to_chain_filters_on_arrays",
+			Query:      `["this", "is", "sparta"] | get_index 2 | length = 6`,
+			ShouldPass: true,
+		},
+		{
+			Name:       "arrays_should_be_of_type_array",
+			Query:      `["this", "is", "sparta"] | type = "array"`,
+			ShouldPass: true,
+		},
+	}
+
+	executeTestCases(t, testCases)
+}
+
 func executeTestCases(t *testing.T, testCases []executorTestCase) {
 	for _, testCase := range testCases {
 		t.Run(testCase.Name, func(t *testing.T) {

--- a/server/expression/executor_test.go
+++ b/server/expression/executor_test.go
@@ -275,6 +275,11 @@ func TestArrayExecution(t *testing.T) {
 			Query:      `["this", "is", "sparta"] | type = "array"`,
 			ShouldPass: true,
 		},
+		{
+			Name:       "incomplete_arrays_should_not_be_equal",
+			Query:      `[1,2,3] = [1, 2]`,
+			ShouldPass: false,
+		},
 	}
 
 	executeTestCases(t, testCases)

--- a/server/expression/filters.go
+++ b/server/expression/filters.go
@@ -14,6 +14,7 @@ var filterFunctions = map[string]filterFn{
 	"regex_group": filters.RegexGroup,
 	"get_index":   filters.GetIndex,
 	"length":      filters.Length,
+	"type":        filters.Type,
 }
 
 func executeFilter(input filters.Value, filterName string, args []string) (filters.Value, error) {

--- a/server/expression/filters.go
+++ b/server/expression/filters.go
@@ -4,9 +4,10 @@ import (
 	"fmt"
 
 	"github.com/kubeshop/tracetest/server/expression/filters"
+	"github.com/kubeshop/tracetest/server/expression/value"
 )
 
-type filterFn func(input filters.Value, args ...string) (filters.Value, error)
+type filterFn func(input value.Value, args ...string) (value.Value, error)
 
 var filterFunctions = map[string]filterFn{
 	"json_path":   filters.JSON_path,
@@ -17,15 +18,15 @@ var filterFunctions = map[string]filterFn{
 	"type":        filters.Type,
 }
 
-func executeFilter(input filters.Value, filterName string, args []string) (filters.Value, error) {
+func executeFilter(input value.Value, filterName string, args []string) (value.Value, error) {
 	fn, found := filterFunctions[filterName]
 	if !found {
-		return filters.Value{}, fmt.Errorf("filter %s was not found", filterName)
+		return value.Value{}, fmt.Errorf("filter %s was not found", filterName)
 	}
 
 	output, err := fn(input, args...)
 	if err != nil {
-		return filters.Value{}, fmt.Errorf("%s: %w", filterName, err)
+		return value.Value{}, fmt.Errorf("%s: %w", filterName, err)
 	}
 
 	return output, nil

--- a/server/expression/filters/get_index.go
+++ b/server/expression/filters/get_index.go
@@ -3,27 +3,29 @@ package filters
 import (
 	"fmt"
 	"strconv"
+
+	"github.com/kubeshop/tracetest/server/expression/value"
 )
 
-func GetIndex(input Value, args ...string) (Value, error) {
+func GetIndex(input value.Value, args ...string) (value.Value, error) {
 	if len(args) != 1 {
-		return Value{}, fmt.Errorf("wrong number of args. Expected 1, got %d", len(args))
+		return value.Value{}, fmt.Errorf("wrong number of args. Expected 1, got %d", len(args))
 	}
 
 	index, err := getIndex(input, args...)
 	if err != nil {
-		return Value{}, err
+		return value.Value{}, err
 	}
 
 	if index < 0 || index >= input.Len() {
-		return Value{}, fmt.Errorf("index out of boundaries: %d out of %d", index, input.Len())
+		return value.Value{}, fmt.Errorf("index out of boundaries: %d out of %d", index, input.Len())
 	}
 
-	value := input.ValueAt(index)
-	return NewValue(value), nil
+	v := input.ValueAt(index)
+	return value.New(v), nil
 }
 
-func getIndex(input Value, args ...string) (int, error) {
+func getIndex(input value.Value, args ...string) (int, error) {
 	if args[0] == "last" {
 		return input.Len() - 1, nil
 	}

--- a/server/expression/filters/get_index_test.go
+++ b/server/expression/filters/get_index_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/kubeshop/tracetest/server/expression/filters"
 	"github.com/kubeshop/tracetest/server/expression/types"
+	"github.com/kubeshop/tracetest/server/expression/value"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -12,14 +13,14 @@ import (
 func TestGetIndex(t *testing.T) {
 	testCases := []struct {
 		Name           string
-		Input          filters.Value
+		Input          value.Value
 		Index          string
 		ExpectedOutput string
 		ShouldFail     bool
 	}{
 		{
 			Name: "should_fail_with_invalid_argument",
-			Input: filters.NewArrayValue([]types.TypedValue{
+			Input: value.NewArray([]types.TypedValue{
 				types.GetTypedValue("28"),
 				types.GetTypedValue("29"),
 				types.GetTypedValue("30"),
@@ -29,13 +30,13 @@ func TestGetIndex(t *testing.T) {
 		},
 		{
 			Name:       "should_fail_with_index_out_of_boundaries",
-			Input:      filters.NewValue(types.GetTypedValue("abc")),
+			Input:      value.New(types.GetTypedValue("abc")),
 			Index:      `1`,
 			ShouldFail: true,
 		},
 		{
 			Name: "should_get_correct_item",
-			Input: filters.NewArrayValue([]types.TypedValue{
+			Input: value.NewArray([]types.TypedValue{
 				types.GetTypedValue("abc"),
 				types.GetTypedValue("def"),
 				types.GetTypedValue("ghi"),
@@ -46,7 +47,7 @@ func TestGetIndex(t *testing.T) {
 		},
 		{
 			Name: "should_get_last_item",
-			Input: filters.NewArrayValue([]types.TypedValue{
+			Input: value.NewArray([]types.TypedValue{
 				types.GetTypedValue("abc"),
 				types.GetTypedValue("def"),
 				types.GetTypedValue("ghi"),
@@ -59,7 +60,7 @@ func TestGetIndex(t *testing.T) {
 
 	for _, testCase := range testCases {
 		t.Run(testCase.Name, func(t *testing.T) {
-			input := filters.NewArrayValue(testCase.Input.Items)
+			input := value.NewArray(testCase.Input.Items)
 			output, err := filters.GetIndex(input, testCase.Index)
 			if testCase.ShouldFail {
 				require.Error(t, err)

--- a/server/expression/filters/json_path.go
+++ b/server/expression/filters/json_path.go
@@ -3,38 +3,39 @@ package filters
 import (
 	"fmt"
 
+	"github.com/kubeshop/tracetest/server/expression/value"
 	"github.com/ohler55/ojg/jp"
 	"github.com/ohler55/ojg/oj"
 )
 
-func JSON_path(input Value, args ...string) (Value, error) {
+func JSON_path(input value.Value, args ...string) (value.Value, error) {
 	if len(args) != 1 {
-		return Value{}, fmt.Errorf("wrong number of args. Expected 1, got %d", len(args))
+		return value.Value{}, fmt.Errorf("wrong number of args. Expected 1, got %d", len(args))
 	}
 
 	if input.IsArray() {
-		return Value{}, fmt.Errorf("cannot process array of json objects")
+		return value.Value{}, fmt.Errorf("cannot process array of json objects")
 	}
 
 	jsonPathQuery, err := jp.ParseString(args[0])
 	if err != nil {
-		return Value{}, fmt.Errorf("invalid json_path: %w", err)
+		return value.Value{}, fmt.Errorf("invalid json_path: %w", err)
 	}
 
 	jsonObject, err := oj.ParseString(input.Value().Value)
 	if err != nil {
-		return Value{}, fmt.Errorf("invalid JSON input: %w", err)
+		return value.Value{}, fmt.Errorf("invalid JSON input: %w", err)
 	}
 
 	results := jsonPathQuery.Get(jsonObject)
 	if len(results) == 0 {
-		return Value{}, nil
+		return value.Value{}, nil
 	}
 
 	if len(results) == 1 {
 		result := fmt.Sprintf("%v", results[0])
-		return NewValueFromString(result), nil
+		return value.NewFromString(result), nil
 	}
 
-	return NewArrayValueFromStrings(toStringSlice(results)), nil
+	return value.NewArrayFromStrings(toStringSlice(results)), nil
 }

--- a/server/expression/filters/json_path_test.go
+++ b/server/expression/filters/json_path_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/kubeshop/tracetest/server/expression/filters"
+	"github.com/kubeshop/tracetest/server/expression/value"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -43,7 +44,7 @@ func TestJSONPath(t *testing.T) {
 
 	for _, testCase := range testCases {
 		t.Run(testCase.Name, func(t *testing.T) {
-			input := filters.NewValueFromString(testCase.JSON)
+			input := value.NewFromString(testCase.JSON)
 			output, err := filters.JSON_path(input, testCase.Query)
 			require.NoError(t, err)
 

--- a/server/expression/filters/length.go
+++ b/server/expression/filters/length.go
@@ -4,25 +4,26 @@ import (
 	"fmt"
 
 	"github.com/kubeshop/tracetest/server/expression/types"
+	"github.com/kubeshop/tracetest/server/expression/value"
 )
 
-func Length(input Value, args ...string) (Value, error) {
+func Length(input value.Value, args ...string) (value.Value, error) {
 	if len(args) != 0 {
-		return Value{}, fmt.Errorf("wrong number of args. Expected 0, got %d", len(args))
+		return value.Value{}, fmt.Errorf("wrong number of args. Expected 0, got %d", len(args))
 	}
 
 	length, err := getLength(input)
 	if err != nil {
-		return Value{}, err
+		return value.Value{}, err
 	}
 
-	return NewValue(types.TypedValue{
+	return value.New(types.TypedValue{
 		Type:  types.TypeNumber,
 		Value: fmt.Sprintf("%d", length),
 	}), nil
 }
 
-func getLength(input Value) (int, error) {
+func getLength(input value.Value) (int, error) {
 	if input.IsArray() {
 		return input.Len(), nil
 	}

--- a/server/expression/filters/length_test.go
+++ b/server/expression/filters/length_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/kubeshop/tracetest/server/expression/filters"
 	"github.com/kubeshop/tracetest/server/expression/types"
+	"github.com/kubeshop/tracetest/server/expression/value"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -12,24 +13,24 @@ import (
 func TestLength(t *testing.T) {
 	testCases := []struct {
 		Name           string
-		Input          filters.Value
+		Input          value.Value
 		ExpectedOutput string
 	}{
 		{
 			Name:           "should_get_zero_from_empty_list",
-			Input:          filters.NewArrayValue([]types.TypedValue{}),
+			Input:          value.NewArray([]types.TypedValue{}),
 			ExpectedOutput: "0",
 		},
 		{
 			Name: "should_get_one_from_single_item_list",
-			Input: filters.NewArrayValue([]types.TypedValue{
+			Input: value.NewArray([]types.TypedValue{
 				types.GetTypedValue("a"),
 			}),
 			ExpectedOutput: "1",
 		},
 		{
 			Name: "should_count_multiple_item_list",
-			Input: filters.NewArrayValue([]types.TypedValue{
+			Input: value.NewArray([]types.TypedValue{
 				types.GetTypedValue("a"),
 				types.GetTypedValue("b"),
 				types.GetTypedValue("c"),
@@ -40,7 +41,7 @@ func TestLength(t *testing.T) {
 
 	for _, testCase := range testCases {
 		t.Run(testCase.Name, func(t *testing.T) {
-			input := filters.NewArrayValue(testCase.Input.Items)
+			input := value.NewArray(testCase.Input.Items)
 			output, err := filters.Length(input)
 			require.NoError(t, err)
 			assert.Equal(t, testCase.ExpectedOutput, output.String())

--- a/server/expression/filters/regex.go
+++ b/server/expression/filters/regex.go
@@ -5,31 +5,32 @@ import (
 	"regexp"
 
 	"github.com/kubeshop/tracetest/server/expression/types"
+	"github.com/kubeshop/tracetest/server/expression/value"
 )
 
-func Regex(input Value, args ...string) (Value, error) {
+func Regex(input value.Value, args ...string) (value.Value, error) {
 	if len(args) != 1 {
-		return Value{}, fmt.Errorf("wrong number of args. Expected 1, got %d", len(args))
+		return value.Value{}, fmt.Errorf("wrong number of args. Expected 1, got %d", len(args))
 	}
 
 	if input.IsArray() {
-		return Value{}, fmt.Errorf("cannot process array of json objects")
+		return value.Value{}, fmt.Errorf("cannot process array of json objects")
 	}
 
 	regex, err := regexp.Compile(args[0])
 	if err != nil {
-		return Value{}, fmt.Errorf("invalid regex: %w", err)
+		return value.Value{}, fmt.Errorf("invalid regex: %w", err)
 	}
 
 	results := regex.FindAllString(input.Value().Value, -1)
 	if results == nil {
-		return NewArrayValue([]types.TypedValue{}), nil
+		return value.NewArray([]types.TypedValue{}), nil
 	}
 
 	if len(results) == 1 {
 		typedValue := types.GetTypedValue(results[0])
-		return NewValue(typedValue), nil
+		return value.New(typedValue), nil
 	}
 
-	return NewArrayValueFromStrings(results), nil
+	return value.NewArrayFromStrings(results), nil
 }

--- a/server/expression/filters/regex_group.go
+++ b/server/expression/filters/regex_group.go
@@ -5,25 +5,26 @@ import (
 	"regexp"
 
 	"github.com/kubeshop/tracetest/server/expression/types"
+	"github.com/kubeshop/tracetest/server/expression/value"
 )
 
-func RegexGroup(input Value, args ...string) (Value, error) {
+func RegexGroup(input value.Value, args ...string) (value.Value, error) {
 	if len(args) != 1 {
-		return Value{}, fmt.Errorf("wrong number of args. Expected 1, got %d", len(args))
+		return value.Value{}, fmt.Errorf("wrong number of args. Expected 1, got %d", len(args))
 	}
 
 	if input.IsArray() {
-		return Value{}, fmt.Errorf("cannot process array of json objects")
+		return value.Value{}, fmt.Errorf("cannot process array of json objects")
 	}
 
 	regex, err := regexp.Compile(args[0])
 	if err != nil {
-		return Value{}, fmt.Errorf("invalid regex: %w", err)
+		return value.Value{}, fmt.Errorf("invalid regex: %w", err)
 	}
 
 	groups := regex.FindAllStringSubmatch(input.Value().Value, -1)
 	if groups == nil {
-		return NewArrayValue([]types.TypedValue{}), nil
+		return value.NewArray([]types.TypedValue{}), nil
 	}
 
 	output := make([]string, 0)
@@ -33,8 +34,8 @@ func RegexGroup(input Value, args ...string) (Value, error) {
 
 	if len(output) == 1 {
 		typedValue := types.GetTypedValue(output[0])
-		return NewValue(typedValue), nil
+		return value.New(typedValue), nil
 	}
 
-	return NewArrayValueFromStrings(output), nil
+	return value.NewArrayFromStrings(output), nil
 }

--- a/server/expression/filters/regex_group_test.go
+++ b/server/expression/filters/regex_group_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/kubeshop/tracetest/server/expression/filters"
+	"github.com/kubeshop/tracetest/server/expression/value"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -37,7 +38,7 @@ func TestRegexGroup(t *testing.T) {
 
 	for _, testCase := range testCases {
 		t.Run(testCase.Name, func(t *testing.T) {
-			input := filters.NewValueFromString(testCase.Input)
+			input := value.NewFromString(testCase.Input)
 			output, err := filters.RegexGroup(input, testCase.Regex)
 			require.NoError(t, err)
 

--- a/server/expression/filters/regex_test.go
+++ b/server/expression/filters/regex_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/kubeshop/tracetest/server/expression/filters"
+	"github.com/kubeshop/tracetest/server/expression/value"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -31,7 +32,7 @@ func TestRegex(t *testing.T) {
 
 	for _, testCase := range testCases {
 		t.Run(testCase.Name, func(t *testing.T) {
-			input := filters.NewValueFromString(testCase.Input)
+			input := value.NewFromString(testCase.Input)
 			output, err := filters.Regex(input, testCase.Regex)
 			require.NoError(t, err)
 

--- a/server/expression/filters/type.go
+++ b/server/expression/filters/type.go
@@ -1,0 +1,24 @@
+package filters
+
+import (
+	"fmt"
+
+	"github.com/kubeshop/tracetest/server/expression/types"
+)
+
+func Type(input Value, args ...string) (Value, error) {
+	if len(args) != 0 {
+		return Value{}, fmt.Errorf("wrong number of args. Expected 0, got %d", len(args))
+	}
+
+	if input.IsArray() {
+		return NewValueFromString(types.TypeArray.String()), nil
+	}
+
+	if input.Len() == 0 {
+		return NewValueFromString(types.TypeNil.String()), nil
+	}
+
+	item := input.ValueAt(0)
+	return NewValueFromString(item.Type.String()), nil
+}

--- a/server/expression/filters/type.go
+++ b/server/expression/filters/type.go
@@ -4,21 +4,22 @@ import (
 	"fmt"
 
 	"github.com/kubeshop/tracetest/server/expression/types"
+	"github.com/kubeshop/tracetest/server/expression/value"
 )
 
-func Type(input Value, args ...string) (Value, error) {
+func Type(input value.Value, args ...string) (value.Value, error) {
 	if len(args) != 0 {
-		return Value{}, fmt.Errorf("wrong number of args. Expected 0, got %d", len(args))
+		return value.Value{}, fmt.Errorf("wrong number of args. Expected 0, got %d", len(args))
 	}
 
 	if input.IsArray() {
-		return NewValueFromString(types.TypeArray.String()), nil
+		return value.NewFromString(types.TypeArray.String()), nil
 	}
 
 	if input.Len() == 0 {
-		return NewValueFromString(types.TypeNil.String()), nil
+		return value.NewFromString(types.TypeNil.String()), nil
 	}
 
 	item := input.ValueAt(0)
-	return NewValueFromString(item.Type.String()), nil
+	return value.NewFromString(item.Type.String()), nil
 }

--- a/server/expression/filters/type_test.go
+++ b/server/expression/filters/type_test.go
@@ -9,39 +9,40 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestLength(t *testing.T) {
+func TestType(t *testing.T) {
 	testCases := []struct {
 		Name           string
 		Input          filters.Value
 		ExpectedOutput string
 	}{
 		{
-			Name:           "should_get_zero_from_empty_list",
+			Name:           "should_return_array_for_empty_array",
 			Input:          filters.NewArrayValue([]types.TypedValue{}),
-			ExpectedOutput: "0",
+			ExpectedOutput: "array",
 		},
 		{
-			Name: "should_get_one_from_single_item_list",
+			Name: "should_return_array_for_an_array",
 			Input: filters.NewArrayValue([]types.TypedValue{
-				types.GetTypedValue("a"),
+				types.GetTypedValue("1"),
+				types.GetTypedValue("2"),
 			}),
-			ExpectedOutput: "1",
+			ExpectedOutput: "array",
 		},
 		{
-			Name: "should_count_multiple_item_list",
-			Input: filters.NewArrayValue([]types.TypedValue{
-				types.GetTypedValue("a"),
-				types.GetTypedValue("b"),
-				types.GetTypedValue("c"),
-			}),
-			ExpectedOutput: "3",
+			Name:           "should_return_number_for_number",
+			Input:          filters.NewValue(types.GetTypedValue("1")),
+			ExpectedOutput: "number",
+		},
+		{
+			Name:           "should_return_duration_for_duration",
+			Input:          filters.NewValue(types.GetTypedValue("25ms")),
+			ExpectedOutput: "duration",
 		},
 	}
 
 	for _, testCase := range testCases {
 		t.Run(testCase.Name, func(t *testing.T) {
-			input := filters.NewArrayValue(testCase.Input.Items)
-			output, err := filters.Length(input)
+			output, err := filters.Type(testCase.Input)
 			require.NoError(t, err)
 			assert.Equal(t, testCase.ExpectedOutput, output.String())
 		})

--- a/server/expression/filters/type_test.go
+++ b/server/expression/filters/type_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/kubeshop/tracetest/server/expression/filters"
 	"github.com/kubeshop/tracetest/server/expression/types"
+	"github.com/kubeshop/tracetest/server/expression/value"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -12,17 +13,17 @@ import (
 func TestType(t *testing.T) {
 	testCases := []struct {
 		Name           string
-		Input          filters.Value
+		Input          value.Value
 		ExpectedOutput string
 	}{
 		{
 			Name:           "should_return_array_for_empty_array",
-			Input:          filters.NewArrayValue([]types.TypedValue{}),
+			Input:          value.NewArray([]types.TypedValue{}),
 			ExpectedOutput: "array",
 		},
 		{
 			Name: "should_return_array_for_an_array",
-			Input: filters.NewArrayValue([]types.TypedValue{
+			Input: value.NewArray([]types.TypedValue{
 				types.GetTypedValue("1"),
 				types.GetTypedValue("2"),
 			}),
@@ -30,12 +31,12 @@ func TestType(t *testing.T) {
 		},
 		{
 			Name:           "should_return_number_for_number",
-			Input:          filters.NewValue(types.GetTypedValue("1")),
+			Input:          value.New(types.GetTypedValue("1")),
 			ExpectedOutput: "number",
 		},
 		{
 			Name:           "should_return_duration_for_duration",
-			Input:          filters.NewValue(types.GetTypedValue("25ms")),
+			Input:          value.New(types.GetTypedValue("25ms")),
 			ExpectedOutput: "duration",
 		},
 	}

--- a/server/expression/filters/utils.go
+++ b/server/expression/filters/utils.go
@@ -2,27 +2,7 @@ package filters
 
 import (
 	"fmt"
-	"reflect"
-	"regexp"
-	"strings"
 )
-
-var arrayRegex = regexp.MustCompile(`^\[[^\]]*\]$`) // anything wrapped with []
-
-func formatOutput(in interface{}) string {
-	inType := reflect.TypeOf(in)
-	switch inType.Kind() {
-	case reflect.Array:
-	case reflect.Slice:
-		return "array"
-	}
-
-	return fmt.Sprintf("%v", in)
-}
-
-func formatArray(in []string) string {
-	return fmt.Sprintf("[%s]", strings.Join(in, ","))
-}
 
 func toStringSlice(in []interface{}) []string {
 	out := make([]string, 0, len(in))
@@ -31,8 +11,4 @@ func toStringSlice(in []interface{}) []string {
 	}
 
 	return out
-}
-
-func isArray(in string) bool {
-	return arrayRegex.Match([]byte(in))
 }

--- a/server/expression/parser_rules.go
+++ b/server/expression/parser_rules.go
@@ -21,6 +21,7 @@ type OpTerm struct {
 
 type Term struct {
 	FunctionCall *FunctionCall `( @@`
+	Array        *Array        `| @@`
 	Duration     *string       `| @Duration `
 	Number       *string       `| @Number `
 	Attribute    *Attribute    `| @Attribute `
@@ -38,10 +39,14 @@ type FunctionCall struct {
 	Args []*Term `"(" ( @@ ("," @@ )* )? ")"`
 }
 
+type Array struct {
+	Items []*Term `"[" ( @@ ("," @@ )* )? "]"`
+}
+
 var languageLexer = lexer.MustStateful(lexer.Rules{
 	"Root": {
 		{Name: "whitespace", Pattern: `\s+`, Action: nil},
-		{Name: "Punc", Pattern: `[(),|]`, Action: nil},
+		{Name: "Punc", Pattern: `[(),|\[\]]`, Action: nil},
 
 		{Name: "Comparator", Pattern: `!=|<=|>=|=|<|>|contains|not-contains`},
 		{Name: "Operator", Pattern: `(\+|\-|\*|\/)`, Action: nil},

--- a/server/expression/parser_test.go
+++ b/server/expression/parser_test.go
@@ -484,6 +484,84 @@ func TestFunctions(t *testing.T) {
 	runTestCases(t, testCases)
 }
 
+func TestArrays(t *testing.T) {
+	testCases := []parserTestCase{
+		{
+			Name:  "should_parse_empty_array",
+			Query: `[] = []`,
+			ExpectedOutput: expression.Statement{
+				Left: expression.Expr{
+					Left: &expression.Term{
+						Array: &expression.Array{},
+					},
+				},
+				Comparator: "=",
+				Right: expression.Expr{
+					Left: &expression.Term{
+						Array: &expression.Array{},
+					},
+				},
+			},
+		},
+		{
+			Name:  "should_parse_single_item_arrays",
+			Query: `[2] = [3]`,
+			ExpectedOutput: expression.Statement{
+				Left: expression.Expr{
+					Left: &expression.Term{
+						Array: &expression.Array{
+							Items: []*expression.Term{
+								{Number: strp("2")},
+							},
+						},
+					},
+				},
+				Comparator: "=",
+				Right: expression.Expr{
+					Left: &expression.Term{
+						Array: &expression.Array{
+							Items: []*expression.Term{
+								{Number: strp("3")},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			Name:  "should_parse_multiple_items_arrays",
+			Query: `[1, 2s, "3"] = ["3", 2s, 1]`,
+			ExpectedOutput: expression.Statement{
+				Left: expression.Expr{
+					Left: &expression.Term{
+						Array: &expression.Array{
+							Items: []*expression.Term{
+								{Number: strp("1")},
+								{Duration: strp("2s")},
+								{Str: &expression.Str{Text: "3", Args: []expression.Expr{}}},
+							},
+						},
+					},
+				},
+				Comparator: "=",
+				Right: expression.Expr{
+					Left: &expression.Term{
+						Array: &expression.Array{
+							Items: []*expression.Term{
+								{Str: &expression.Str{Text: "3", Args: []expression.Expr{}}},
+								{Duration: strp("2s")},
+								{Number: strp("1")},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	runTestCases(t, testCases)
+}
+
 func runTestCases(t *testing.T, testCases []parserTestCase) {
 	for _, testCase := range testCases {
 		t.Run(testCase.Name, func(t *testing.T) {

--- a/server/expression/types/types.go
+++ b/server/expression/types/types.go
@@ -11,6 +11,7 @@ const (
 	TypeAttribute
 	TypeDuration
 	TypeVariable
+	TypeArray
 )
 
 var typeNames = map[Type]string{
@@ -20,11 +21,13 @@ var typeNames = map[Type]string{
 	TypeAttribute: "attribute",
 	TypeDuration:  "duration",
 	TypeVariable:  "variable",
+	TypeArray:     "array",
 }
 
 func GetType(value string) Type {
 	numberRegex := regexp.MustCompile(`^([0-9]+(\.[0-9]+)?)$`)
 	durationRegex := regexp.MustCompile(`^([0-9]+(\.[0-9]+)?)(ns|us|ms|s|m|h)$`)
+	arrayRegex := regexp.MustCompile(`\[[^\,]*(,[^\],]+)*\]`)
 
 	if numberRegex.Match([]byte(value)) {
 		return TypeNumber
@@ -32,6 +35,10 @@ func GetType(value string) Type {
 
 	if durationRegex.Match([]byte(value)) {
 		return TypeDuration
+	}
+
+	if arrayRegex.Match([]byte(value)) {
+		return TypeArray
 	}
 
 	return TypeString

--- a/server/expression/value/value.go
+++ b/server/expression/value/value.go
@@ -10,9 +10,12 @@ import (
 type valueType int
 
 const (
-	SingleItem valueType = iota
-	Array
+	TypeSingle valueType = iota
+	TypeArray
+	TypeNil
 )
+
+var Nil = Value{Type: TypeNil}
 
 type Value struct {
 	Items []types.TypedValue
@@ -20,12 +23,11 @@ type Value struct {
 }
 
 func NewFromString(input string) Value {
-	typedValue := types.TypedValue{Value: input, Type: types.GetType(input)}
-	return New(typedValue)
+	return New(types.GetTypedValue(input))
 }
 
 func New(value types.TypedValue) Value {
-	return Value{Items: []types.TypedValue{value}, Type: SingleItem}
+	return Value{Items: []types.TypedValue{value}, Type: TypeSingle}
 }
 
 func NewArrayFromStrings(inputs []string) Value {
@@ -38,7 +40,7 @@ func NewArrayFromStrings(inputs []string) Value {
 }
 
 func NewArray(values []types.TypedValue) Value {
-	return Value{Items: values, Type: Array}
+	return Value{Items: values, Type: TypeArray}
 }
 
 func (v Value) Len() int {
@@ -46,7 +48,7 @@ func (v Value) Len() int {
 }
 
 func (v Value) IsArray() bool {
-	return v.Type == Array
+	return v.Type == TypeArray
 }
 
 func (v Value) Value() types.TypedValue {

--- a/server/expression/value/value.go
+++ b/server/expression/value/value.go
@@ -10,16 +10,16 @@ import (
 type valueType int
 
 const (
-	TypeSingle valueType = iota
+	TypeNil valueType = iota
+	TypeSingle
 	TypeArray
-	TypeNil
 )
 
-var Nil = Value{Type: TypeNil}
+var Nil = Value{vType: TypeNil}
 
 type Value struct {
 	Items []types.TypedValue
-	Type  valueType
+	vType valueType
 }
 
 func NewFromString(input string) Value {
@@ -27,7 +27,7 @@ func NewFromString(input string) Value {
 }
 
 func New(value types.TypedValue) Value {
-	return Value{Items: []types.TypedValue{value}, Type: TypeSingle}
+	return Value{Items: []types.TypedValue{value}, vType: TypeSingle}
 }
 
 func NewArrayFromStrings(inputs []string) Value {
@@ -40,7 +40,7 @@ func NewArrayFromStrings(inputs []string) Value {
 }
 
 func NewArray(values []types.TypedValue) Value {
-	return Value{Items: values, Type: TypeArray}
+	return Value{Items: values, vType: TypeArray}
 }
 
 func (v Value) Len() int {
@@ -48,7 +48,7 @@ func (v Value) Len() int {
 }
 
 func (v Value) IsArray() bool {
-	return v.Type == TypeArray
+	return v.vType == TypeArray
 }
 
 func (v Value) Value() types.TypedValue {
@@ -57,6 +57,14 @@ func (v Value) Value() types.TypedValue {
 	}
 
 	return types.TypedValue{}
+}
+
+func (v Value) Type() types.Type {
+	if v.IsArray() {
+		return types.TypeArray
+	}
+
+	return v.Value().Type
 }
 
 func (v Value) ValueAt(index int) types.TypedValue {

--- a/server/expression/value/value.go
+++ b/server/expression/value/value.go
@@ -1,4 +1,4 @@
-package filters
+package value
 
 import (
 	"fmt"
@@ -19,25 +19,25 @@ type Value struct {
 	Type  valueType
 }
 
-func NewValueFromString(input string) Value {
+func NewFromString(input string) Value {
 	typedValue := types.TypedValue{Value: input, Type: types.GetType(input)}
-	return NewValue(typedValue)
+	return New(typedValue)
 }
 
-func NewValue(value types.TypedValue) Value {
+func New(value types.TypedValue) Value {
 	return Value{Items: []types.TypedValue{value}, Type: SingleItem}
 }
 
-func NewArrayValueFromStrings(inputs []string) Value {
+func NewArrayFromStrings(inputs []string) Value {
 	typedValues := make([]types.TypedValue, 0, len(inputs))
 	for _, str := range inputs {
 		typedValues = append(typedValues, types.TypedValue{Value: str, Type: types.GetType(str)})
 	}
 
-	return NewArrayValue(typedValues)
+	return NewArray(typedValues)
 }
 
-func NewArrayValue(values []types.TypedValue) Value {
+func NewArray(values []types.TypedValue) Value {
 	return Value{Items: values, Type: Array}
 }
 


### PR DESCRIPTION
This PR adds a new `type` filter and allows users to declare arrays to run comparisons.

This was based on #950. It is useful for checking if some field is a number or a string

### Motivation

1. Imagine a field can be either a `string` or a `number`. We don't have a way of writing an assertion like that. So instead, we could work with arrays to overcome this issue:

```yaml
# check if id is either a number or a string
["string", "number"] contains attr:my_json | json_path '.id' | type
```

2. Imagine you want to compare multiple values from a json_path query at once:

```yaml
# check if ids are 35 and 38 in this exact order
# in the future we can override the equal operator to make the order of the array irrelevant. But 
# I'm not adding this to this PR
attr:my_json | json_path '$.array[*].id' = [35, 38]
```

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [x] updated the docs
- [x] added a test
