### PR TITLE
feat: allow span[] as a valid selector

### DIFF
--- a/server/assertions/selectors/parser.go
+++ b/server/assertions/selectors/parser.go
@@ -11,7 +11,7 @@ type ParserSelector struct {
 }
 
 type parserSpanSelector struct {
-	Filters       []parserFilter      `"span""["( @@* ( "," @@)*)"]"`
+	Filters       []parserFilter      `"span""["( @@* ( "," @@)*)*"]"`
 	PseudoClass   parserPseudoClass   `@@*`
 	ChildSelector *parserSpanSelector ` @@*`
 }

--- a/server/assertions/selectors/selector_test.go
+++ b/server/assertions/selectors/selector_test.go
@@ -109,6 +109,11 @@ func TestSelector(t *testing.T) {
 			ExpectedSpanIds: []trace.SpanID{updatePokemonDatabaseSpanID},
 		},
 		{
+			Name:            "Selector_to_select_all_children_spans",
+			Expression:      `span[service.name="Pokeshop" tracetest.span.type="http"] span[]`,
+			ExpectedSpanIds: []trace.SpanID{insertPokemonDatabaseSpanID, getPokemonFromExternalAPISpanID, updatePokemonDatabaseSpanID},
+		},
+		{
 			Name:            "Selector_with_first_pseudo_class",
 			Expression:      `span[tracetest.span.type="db"]:first`,
 			ExpectedSpanIds: []trace.SpanID{insertPokemonDatabaseSpanID},

--- a/server/assertions/selectors/selector_test.go
+++ b/server/assertions/selectors/selector_test.go
@@ -69,57 +69,62 @@ func TestSelector(t *testing.T) {
 		ExpectedSpanIds []trace.SpanID
 	}{
 		{
-			Name:            "Empty selector should select all spans",
+			Name:            "Empty_selector_should_select_all_spans",
 			Expression:      ``,
 			ExpectedSpanIds: []trace.SpanID{postImportSpanID, insertPokemonDatabaseSpanID, getPokemonFromExternalAPISpanID, updatePokemonDatabaseSpanID},
 		},
 		{
-			Name:            "Selector with span name",
+			Name:            "Selector_without_parameters_should_select_all_spans",
+			Expression:      `span[]`,
+			ExpectedSpanIds: []trace.SpanID{postImportSpanID, insertPokemonDatabaseSpanID, getPokemonFromExternalAPISpanID, updatePokemonDatabaseSpanID},
+		},
+		{
+			Name:            "Selector_with_span_name",
 			Expression:      `span[name="Get pokemon from external API"]`,
 			ExpectedSpanIds: []trace.SpanID{getPokemonFromExternalAPISpanID},
 		},
 		{
-			Name:            "Selector with simple single attribute querying",
+			Name:            "Selector_with_simple_single_attribute_querying",
 			Expression:      `span[service.name="Pokeshop"]`,
 			ExpectedSpanIds: []trace.SpanID{postImportSpanID, insertPokemonDatabaseSpanID},
 		},
 		{
-			Name:            "Multiple span selectors",
+			Name:            "Multiple_span_selectors",
 			Expression:      `span[service.name="Pokeshop"], span[service.name="Pokeshop-worker"]`,
 			ExpectedSpanIds: []trace.SpanID{postImportSpanID, insertPokemonDatabaseSpanID, getPokemonFromExternalAPISpanID, updatePokemonDatabaseSpanID},
 		},
 		{
-			Name:            "Multiple spans using contains",
+			Name:            "Multiple_spans_using_contains",
 			Expression:      `span[service.name contains "Pokeshop"]`,
 			ExpectedSpanIds: []trace.SpanID{postImportSpanID, insertPokemonDatabaseSpanID, getPokemonFromExternalAPISpanID, updatePokemonDatabaseSpanID},
 		},
 		{
-			Name:            "Selector with multiple attributes",
+			Name:            "Selector_with_multiple_attributes",
 			Expression:      `span[service.name="Pokeshop" tracetest.span.type="db"]`,
 			ExpectedSpanIds: []trace.SpanID{insertPokemonDatabaseSpanID},
 		},
 		{
-			Name:            "Selector with child selector",
+			Name:            "Selector_with_child_selector",
 			Expression:      `span[service.name="Pokeshop-worker"] span[tracetest.span.type="db"]`,
 			ExpectedSpanIds: []trace.SpanID{updatePokemonDatabaseSpanID},
 		},
 		{
-			Name:            "Selector with first pseudo class",
+			Name:            "Selector_with_first_pseudo_class",
 			Expression:      `span[tracetest.span.type="db"]:first`,
 			ExpectedSpanIds: []trace.SpanID{insertPokemonDatabaseSpanID},
 		},
 		{
-			Name:            "Selector with first pseudo class",
+			Name:            "Selector_with_first_pseudo_class",
 			Expression:      `span[tracetest.span.type="db"]:last`,
 			ExpectedSpanIds: []trace.SpanID{updatePokemonDatabaseSpanID},
 		},
 		{
-			Name:            "Selector with nth_child pseudo class",
+			Name:            "Selector_with_nth_child_pseudo_class",
 			Expression:      `span[tracetest.span.type="db"]:nth_child(2)`,
 			ExpectedSpanIds: []trace.SpanID{updatePokemonDatabaseSpanID},
 		},
 		{
-			Name:            "Selector should not match parent when children are specified",
+			Name:            "Selector_should_not_match_parent_when_children_are_specified",
 			Expression:      `span[service.name = "Pokeshop-worker"] span[service.name = "Pokeshop-worker"]`,
 			ExpectedSpanIds: []trace.SpanID{updatePokemonDatabaseSpanID},
 		},
@@ -137,7 +142,7 @@ func TestSelector(t *testing.T) {
 }
 
 func ensureExpectedSpansWereReturned(t *testing.T, spanIDs []trace.SpanID, spans []traces.Span) {
-	assert.Len(t, spans, len(spanIDs), "Should return the same number of spans as we expected")
+	assert.Len(t, spans, len(spanIDs), "Should_return_the_same_number_of_spans_as_we_expected")
 	for _, span := range spans {
 		assert.Contains(t, spanIDs, span.ID, "span ID was returned but wasn't expected")
 	}

--- a/server/assertions/selectors/selector_test.go
+++ b/server/assertions/selectors/selector_test.go
@@ -125,7 +125,7 @@ func TestSelector(t *testing.T) {
 		},
 		{
 			Name:            "SelectorWithNthChildPseudoClass",
-			Expression:      `span[tracetest.span.type="db"]:nthChild(2)`,
+			Expression:      `span[tracetest.span.type="db"]:nth_child(2)`,
 			ExpectedSpanIds: []trace.SpanID{updatePokemonDatabaseSpanID},
 		},
 		{

--- a/server/assertions/selectors/selector_test.go
+++ b/server/assertions/selectors/selector_test.go
@@ -69,67 +69,67 @@ func TestSelector(t *testing.T) {
 		ExpectedSpanIds []trace.SpanID
 	}{
 		{
-			Name:            "Empty_selector_should_select_all_spans",
+			Name:            "EmptySelectorShouldSelectAllSpans",
 			Expression:      ``,
 			ExpectedSpanIds: []trace.SpanID{postImportSpanID, insertPokemonDatabaseSpanID, getPokemonFromExternalAPISpanID, updatePokemonDatabaseSpanID},
 		},
 		{
-			Name:            "Selector_without_parameters_should_select_all_spans",
+			Name:            "SelectorWithoutParametersShouldSelectAllSpans",
 			Expression:      `span[]`,
 			ExpectedSpanIds: []trace.SpanID{postImportSpanID, insertPokemonDatabaseSpanID, getPokemonFromExternalAPISpanID, updatePokemonDatabaseSpanID},
 		},
 		{
-			Name:            "Selector_with_span_name",
+			Name:            "SelectorWithSpanName",
 			Expression:      `span[name="Get pokemon from external API"]`,
 			ExpectedSpanIds: []trace.SpanID{getPokemonFromExternalAPISpanID},
 		},
 		{
-			Name:            "Selector_with_simple_single_attribute_querying",
+			Name:            "SelectorWithSimpleSingleAttributeQuerying",
 			Expression:      `span[service.name="Pokeshop"]`,
 			ExpectedSpanIds: []trace.SpanID{postImportSpanID, insertPokemonDatabaseSpanID},
 		},
 		{
-			Name:            "Multiple_span_selectors",
+			Name:            "MultipleSpanSelectors",
 			Expression:      `span[service.name="Pokeshop"], span[service.name="Pokeshop-worker"]`,
 			ExpectedSpanIds: []trace.SpanID{postImportSpanID, insertPokemonDatabaseSpanID, getPokemonFromExternalAPISpanID, updatePokemonDatabaseSpanID},
 		},
 		{
-			Name:            "Multiple_spans_using_contains",
+			Name:            "MultipleSpansUsingContains",
 			Expression:      `span[service.name contains "Pokeshop"]`,
 			ExpectedSpanIds: []trace.SpanID{postImportSpanID, insertPokemonDatabaseSpanID, getPokemonFromExternalAPISpanID, updatePokemonDatabaseSpanID},
 		},
 		{
-			Name:            "Selector_with_multiple_attributes",
+			Name:            "SelectorWithMultipleAttributes",
 			Expression:      `span[service.name="Pokeshop" tracetest.span.type="db"]`,
 			ExpectedSpanIds: []trace.SpanID{insertPokemonDatabaseSpanID},
 		},
 		{
-			Name:            "Selector_with_child_selector",
+			Name:            "SelectorWithChildSelector",
 			Expression:      `span[service.name="Pokeshop-worker"] span[tracetest.span.type="db"]`,
 			ExpectedSpanIds: []trace.SpanID{updatePokemonDatabaseSpanID},
 		},
 		{
-			Name:            "Selector_to_select_all_children_spans",
+			Name:            "SelectorToSelectAllChildrenSpans",
 			Expression:      `span[service.name="Pokeshop" tracetest.span.type="http"] span[]`,
 			ExpectedSpanIds: []trace.SpanID{insertPokemonDatabaseSpanID, getPokemonFromExternalAPISpanID, updatePokemonDatabaseSpanID},
 		},
 		{
-			Name:            "Selector_with_first_pseudo_class",
+			Name:            "SelectorWithFirstPseudoClass",
 			Expression:      `span[tracetest.span.type="db"]:first`,
 			ExpectedSpanIds: []trace.SpanID{insertPokemonDatabaseSpanID},
 		},
 		{
-			Name:            "Selector_with_first_pseudo_class",
+			Name:            "SelectorWithFirstPseudoClass",
 			Expression:      `span[tracetest.span.type="db"]:last`,
 			ExpectedSpanIds: []trace.SpanID{updatePokemonDatabaseSpanID},
 		},
 		{
-			Name:            "Selector_with_nth_child_pseudo_class",
-			Expression:      `span[tracetest.span.type="db"]:nth_child(2)`,
+			Name:            "SelectorWithNthChildPseudoClass",
+			Expression:      `span[tracetest.span.type="db"]:nthChild(2)`,
 			ExpectedSpanIds: []trace.SpanID{updatePokemonDatabaseSpanID},
 		},
 		{
-			Name:            "Selector_should_not_match_parent_when_children_are_specified",
+			Name:            "SelectorShouldNotMatchParentWhenChildrenAreSpecified",
 			Expression:      `span[service.name = "Pokeshop-worker"] span[service.name = "Pokeshop-worker"]`,
 			ExpectedSpanIds: []trace.SpanID{updatePokemonDatabaseSpanID},
 		},


### PR DESCRIPTION
This PR enables users to define `span[]` as a valid selector to select all spans.

### Motivation

Without this, there's no way of selecting all spans that are descendent of a parent span. With this change, you can define it as `span[parent-attrs] span[]`

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [x] added a test
