### PR TITLE
🐛 1401 1 of X goes away when cycling through spans

### DIFF
--- a/web/src/components/Header/HeaderMenu.tsx
+++ b/web/src/components/Header/HeaderMenu.tsx
@@ -2,7 +2,7 @@ import {Popover, Typography} from 'antd';
 
 import {DOCUMENTATION_URL, GITHUB_URL} from 'constants/Common.constants';
 import {useGuidedTour} from 'providers/GuidedTour/GuidedTour.provider';
-import {useMemo} from 'react';
+import {useCallback, useMemo} from 'react';
 import {useLocation, useParams} from 'react-router-dom';
 import HomeAnalyticsService from 'services/Analytics/HomeAnalytics.service';
 import {switchTraceMode} from '../GuidedTour/traceStepList';
@@ -16,17 +16,19 @@ const HeaderMenu = () => {
   const params = useParams();
   const {setState, state} = useGuidedTour();
 
+  const onStartOnboarding = useCallback(() => {
+    switchTraceMode(0);
+    setState(st => ({...st, tourActive: true, run: true}));
+  }, [setState]);
+
   const content = useMemo(
     () =>
       ShowOnboardingContent(
         onGuidedTourClick,
-        () => {
-          switchTraceMode(0);
-          setState(st => ({...st, tourActive: true, run: true}));
-        },
+        () => onStartOnboarding(),
         () => setState(st => ({...st, dialog: false}))
       ),
-    [setState]
+    [onStartOnboarding, setState]
   );
 
   return (
@@ -64,7 +66,7 @@ const HeaderMenu = () => {
                 key: 'Onboarding',
                 disabled: !params.runId,
                 label: (
-                  <a key="guidedTour" onClick={() => setState(st => ({...st, dialog: !st.dialog}))}>
+                  <a key="guidedTour" onClick={onStartOnboarding}>
                     Show Onboarding
                   </a>
                 ),

--- a/web/src/redux/actions/Router.actions.ts
+++ b/web/src/redux/actions/Router.actions.ts
@@ -20,16 +20,17 @@ const RouterActions = () => ({
     'router/addAssertionResult',
     async ({search}, {getState, dispatch}) => {
       const {[RouterSearchFields.SelectedAssertion]: positionIndex} = search;
+      const selectedSpec = TestSpecsSelectors.selectSelectedSpec(getState() as RootState);
 
-      if (typeof positionIndex === 'undefined') {
+      if (typeof positionIndex === 'undefined' && selectedSpec) {
         dispatch(setSelectedSpec());
         return;
       }
+
       const assertionResult = TestSpecsSelectors.selectAssertionByPositionIndex(
         getState() as RootState,
         Number(positionIndex)
       );
-      const selectedSpec = TestSpecsSelectors.selectSelectedSpec(getState() as RootState);
       const isDagReady = DAGSelectors.selectNodes(getState() as RootState).length > 0;
 
       if (selectedSpec === assertionResult?.selector) return;


### PR DESCRIPTION
This PR fixes a couple of small issues on the app, primarily the error where the 1 of X component was disappearing when clicking on the arrows from the test mode.
The second one was a wrong flow when clicking show onboarding as it would display the alert instead of starting the onboarding right away.

## Fixes

- #1401 
- #1418 

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
