### PR TITLE
1434 [Transactions] Environment definition execution

### DIFF
--- a/server/http/controller.go
+++ b/server/http/controller.go
@@ -484,7 +484,36 @@ func (c *controller) ExecuteDefinition(ctx context.Context, testDefinition opena
 		return c.executeTest(ctx, test.Model(), testDefinition.RunInformation)
 	}
 
+	if environment, err := def.Environment(); err == nil {
+		return c.createEnvFromDefinition(ctx, environment)
+	}
+
 	return openapi.Response(http.StatusUnprocessableEntity, nil), nil
+}
+
+func (c *controller) createEnvFromDefinition(ctx context.Context, def yaml.Environment) (openapi.ImplResponse, error) {
+	environment := def.Model()
+
+	if environment.ID != "" {
+		_, err := c.testDB.UpdateEnvironment(ctx, environment)
+
+		if err != nil {
+			return handleDBError(err), err
+		}
+	} else {
+		env, err := c.testDB.CreateEnvironment(ctx, environment)
+		environment.ID = env.ID
+
+		if err != nil {
+			return handleDBError(err), err
+		}
+	}
+
+	res := openapi.ExecuteDefinitionResponse{
+		Id: environment.ID,
+	}
+
+	return openapi.Response(200, res), nil
 }
 
 func metadata(in *map[string]string) model.RunMetadata {

--- a/server/model/yaml/encoding.go
+++ b/server/model/yaml/encoding.go
@@ -45,6 +45,13 @@ func Decode(contents []byte) (File, error) {
 			return File{}, fmt.Errorf("cannot decode transaction: %w", err)
 		}
 		f.Spec = transaction
+	case FileTypeEnvironment:
+		var environment Environment
+		err := mapstructure.Decode(f.Spec, &environment)
+		if err != nil {
+			return File{}, fmt.Errorf("cannot decode environment: %w", err)
+		}
+		f.Spec = environment
 	default:
 		return File{}, fmt.Errorf("invalid file type %s", f.Type)
 	}

--- a/server/model/yaml/environment.go
+++ b/server/model/yaml/environment.go
@@ -1,0 +1,52 @@
+package yaml
+
+import (
+	"fmt"
+
+	"github.com/kubeshop/tracetest/server/model"
+)
+
+type Environment struct {
+	ID          string            `mapstructure:"id"`
+	Name        string            `mapstructure:"name"`
+	Description string            `mapstructure:"description" yaml:",omitempty"`
+	Values      EnvironmentValues `mapstructure:"values"`
+}
+
+type EnvironmentValue struct {
+	Key   string `mapstructure:"key"`
+	Value string `mapstructure:"value"`
+}
+
+type EnvironmentValues []EnvironmentValue
+
+func (evs EnvironmentValues) Model() []model.EnvironmentValue {
+	mevs := make([]model.EnvironmentValue, 0, len(evs))
+	for _, ev := range evs {
+		mevs = append(mevs, model.EnvironmentValue{
+			Key:   ev.Key,
+			Value: ev.Value,
+		})
+	}
+
+	return mevs
+}
+
+func (e Environment) Validate() error {
+	if e.Name == "" {
+		return fmt.Errorf("transaction name cannot be empty")
+	}
+
+	return nil
+}
+
+func (e Environment) Model() model.Environment {
+	me := model.Environment{
+		ID:          e.ID,
+		Name:        e.Name,
+		Description: e.Description,
+		Values:      e.Values.Model(),
+	}
+
+	return me
+}

--- a/server/model/yaml/environment.go
+++ b/server/model/yaml/environment.go
@@ -34,7 +34,13 @@ func (evs EnvironmentValues) Model() []model.EnvironmentValue {
 
 func (e Environment) Validate() error {
 	if e.Name == "" {
-		return fmt.Errorf("transaction name cannot be empty")
+		return fmt.Errorf("environment name cannot be empty")
+	}
+
+	for _, v := range e.Values {
+		if v.Key == "" {
+			return fmt.Errorf("environment value name cannot be empty")
+		}
 	}
 
 	return nil

--- a/server/model/yaml/file.go
+++ b/server/model/yaml/file.go
@@ -11,6 +11,7 @@ type FileType string
 const (
 	FileTypeTest        FileType = "Test"
 	FileTypeTransaction FileType = "Transaction"
+	FileTypeEnvironment FileType = "Environment"
 )
 
 type File struct {
@@ -65,4 +66,17 @@ func (f File) Transaction() (Transaction, error) {
 	}
 
 	return transaction, nil
+}
+
+func (f File) Environment() (Environment, error) {
+	if f.Type != FileTypeEnvironment {
+		return Environment{}, fmt.Errorf("file is not an environment")
+	}
+
+	environment, ok := f.Spec.(Environment)
+	if !ok {
+		return Environment{}, fmt.Errorf("file spec cannot be casted to an environment")
+	}
+
+	return environment, nil
 }

--- a/web/public/index.html
+++ b/web/public/index.html
@@ -67,7 +67,7 @@
           appVersion: getTemplateValue('{{ .AppVersion }}', '', parser.toString),
           env: getTemplateValue('{{ .Env }}', '', parser.toString),
           demoEnabled: getTemplateValue('{{ .DemoEnabled }}', '["pokeshop", "otel"]', parser.toArray),
-          demoEndpoints: getTemplateValue('{{ .DemoEndpoints }}', '{"PokeshopHttp": "http://demo-api:8081", "PokeshopGrpc": "demo-pokemon-api.demo.svc.cluster.local:8082", "OtelFrontend": "http://otel-frontend:8084" }', parser.toObject),
+          demoEndpoints: getTemplateValue('{{ .DemoEndpoints }}', '{"PokeshopHttp": "http://demo-pokemon-api.demo.svc.cluster.local", "PokeshopGrpc": "demo-pokemon-api.demo.svc.cluster.local:8082", "OtelFrontend": "http://otel-frontend:8084" }', parser.toObject),
           experimentalFeatures: getTemplateValue('{{ .ExperimentalFeatures }}', '["transactions"]', parser.toArray),
         };
 

--- a/web/public/index.html
+++ b/web/public/index.html
@@ -67,7 +67,7 @@
           appVersion: getTemplateValue('{{ .AppVersion }}', '', parser.toString),
           env: getTemplateValue('{{ .Env }}', '', parser.toString),
           demoEnabled: getTemplateValue('{{ .DemoEnabled }}', '["pokeshop", "otel"]', parser.toArray),
-          demoEndpoints: getTemplateValue('{{ .DemoEndpoints }}', '{"PokeshopHttp": "http://demo-pokemon-api.demo.svc.cluster.local", "PokeshopGrpc": "demo-pokemon-api.demo.svc.cluster.local:8082", "OtelFrontend": "http://otel-frontend:8084" }', parser.toObject),
+          demoEndpoints: getTemplateValue('{{ .DemoEndpoints }}', '{"PokeshopHttp": "http://demo-api:8081", "PokeshopGrpc": "demo-pokemon-api.demo.svc.cluster.local:8082", "OtelFrontend": "http://otel-frontend:8084" }', parser.toObject),
           experimentalFeatures: getTemplateValue('{{ .ExperimentalFeatures }}', '["transactions"]', parser.toArray),
         };
 


### PR DESCRIPTION
This PR adds the definition yaml execution support for environment files, same logic as for tests, if the id exits we update, if not we create a new brand entry to the DB.

## Changes

- Adds execution support for environment definition files

## Fixes

- #1434 

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test


https://www.loom.com/share/78716627311d45209f14214d6cb0c961 [NO SOUND]