### PR TITLE
Fix style issue with the Authorization Type in the create test form

### DIFF
--- a/web/src/components/CreateTestPlugins/Rest/steps/RequestDetails/RequestDetailsAuthInput/apiKeyFields.tsx
+++ b/web/src/components/CreateTestPlugins/Rest/steps/RequestDetails/RequestDetailsAuthInput/apiKeyFields.tsx
@@ -10,7 +10,7 @@ export const apiKeyFields: React.ReactElement = (
       <R.FlexContainer>
         <Form.Item
           data-cy="apiKey-key"
-          style={{flexBasis: '50%'}}
+          style={{flexBasis: '50%', marginTop: '26px'}}
           name={['auth', 'apiKey', 'key']}
           label="Key"
           rules={[{required: true}]}
@@ -19,7 +19,7 @@ export const apiKeyFields: React.ReactElement = (
         </Form.Item>
         <Form.Item
           data-cy="apiKey-value"
-          style={{flexBasis: '50%'}}
+          style={{flexBasis: '50%', marginTop: '26px'}}
           name={['auth', 'apiKey', 'value']}
           label="Value"
           rules={[{required: true}]}

--- a/web/src/components/CreateTestPlugins/Rest/steps/RequestDetails/RequestDetailsAuthInput/basicFields.tsx
+++ b/web/src/components/CreateTestPlugins/Rest/steps/RequestDetails/RequestDetailsAuthInput/basicFields.tsx
@@ -9,7 +9,7 @@ export const basicFields: React.ReactElement = (
   <S.Row>
     <R.FlexContainer>
       <Form.Item
-        style={{flexBasis: '50%'}}
+        style={{flexBasis: '50%', marginTop: '26px'}}
         name={['auth', 'basic', 'username']}
         data-cy="basic-username"
         label="Username"
@@ -18,7 +18,7 @@ export const basicFields: React.ReactElement = (
         <Editor type={SupportedEditors.Interpolation} />
       </Form.Item>
       <Form.Item
-        style={{flexBasis: '50%'}}
+        style={{flexBasis: '50%', marginTop: '26px'}}
         name={['auth', 'basic', 'password']}
         label="Password"
         data-cy="basic-password"

--- a/web/src/components/CreateTestPlugins/Rest/steps/RequestDetails/RequestDetailsAuthInput/bearerFields.tsx
+++ b/web/src/components/CreateTestPlugins/Rest/steps/RequestDetails/RequestDetailsAuthInput/bearerFields.tsx
@@ -3,7 +3,13 @@ import Editor from 'components/Editor';
 import {SupportedEditors} from 'constants/Editor.constants';
 
 export const bearerFields: React.ReactElement = (
-  <Form.Item data-cy="bearer-token" name={['auth', 'bearer', 'token']} label="Token" rules={[{required: true}]}>
+  <Form.Item
+    data-cy="bearer-token"
+    name={['auth', 'bearer', 'token']}
+    label="Token"
+    rules={[{required: true}]}
+    style={{marginTop: '26px'}}
+  >
     <Editor type={SupportedEditors.Interpolation} />
   </Form.Item>
 );


### PR DESCRIPTION
This PR fixes a style issue with the `Authorization Type` in the create test form.

## Changes

- Style issue

## Fixes

- fixes #1439 

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Screenshot

![2022-10-31 16 53 00](https://user-images.githubusercontent.com/3879892/199118146-26f07d78-700f-400e-950e-f9e4560288e7.gif)