### PR TITLE
Add search in span detail

### DIFF
--- a/web/cypress/e2e/TestRunDetail/TestRunDetail.spec.ts
+++ b/web/cypress/e2e/TestRunDetail/TestRunDetail.spec.ts
@@ -12,12 +12,11 @@ describe('Test Run Detail Views', () => {
     cy.get('[data-cy=attribute-row-http-method]').should('be.visible');
   });
 
-  it('Trace view -> attribute list -> switch between tabs', () => {
+  it('Trace view -> attribute list', () => {
     cy.selectRunDetailMode(2);
     cy.get('[data-cy=trace-node-http]').click();
 
     cy.get('[data-cy=attribute-list]').should('be.visible');
-    cy.get('[data-cy=attribute-tabs-response]').should('be.visible').click();
   });
 
   it('Test view -> create assertion with empty selector', () => {

--- a/web/src/components/AttributeList/AttributeList.tsx
+++ b/web/src/components/AttributeList/AttributeList.tsx
@@ -1,4 +1,5 @@
 import AttributeRow from 'components/AttributeRow';
+import {OtelReference} from 'components/TestSpecForm/hooks/useGetOTELSemanticConventionAttributesInfo';
 import {TResultAssertions} from 'types/Assertion.types';
 import {TSpanFlatAttribute} from 'types/Span.types';
 import TraceAnalyticsService from 'services/Analytics/TestRunAnalytics.service';
@@ -10,9 +11,10 @@ interface IProps {
   attributeList: TSpanFlatAttribute[];
   onCreateTestSpec(attribute: TSpanFlatAttribute): void;
   searchText?: string;
+  semanticConventions: OtelReference;
 }
 
-const AttributeList = ({assertions, attributeList, onCreateTestSpec, searchText}: IProps) => {
+const AttributeList = ({assertions, attributeList, onCreateTestSpec, searchText, semanticConventions}: IProps) => {
   const onCopy = (value: string) => {
     TraceAnalyticsService.onAttributeCopy();
     navigator.clipboard.writeText(value);
@@ -29,6 +31,7 @@ const AttributeList = ({assertions, attributeList, onCreateTestSpec, searchText}
           key={attribute.key}
           onCopy={onCopy}
           onCreateTestSpec={onCreateTestSpec}
+          semanticConventions={semanticConventions}
         />
       ))}
     </S.AttributeList>

--- a/web/src/components/AttributeList/__tests__/AttributeList.test.tsx
+++ b/web/src/components/AttributeList/__tests__/AttributeList.test.tsx
@@ -12,13 +12,17 @@ describe('AttributeList', () => {
       },
     ];
 
-    const {getByTestId} = render(<AttributeList attributeList={attributeList} onCreateTestSpec={onCreateTestSpec} />);
+    const {getByTestId} = render(
+      <AttributeList attributeList={attributeList} onCreateTestSpec={onCreateTestSpec} semanticConventions={{}} />
+    );
 
     expect(getByTestId('attribute-list')).toBeInTheDocument();
   });
 
   it('should render the empty list', () => {
-    const {getByTestId} = render(<AttributeList attributeList={[]} onCreateTestSpec={onCreateTestSpec} />);
+    const {getByTestId} = render(
+      <AttributeList attributeList={[]} onCreateTestSpec={onCreateTestSpec} semanticConventions={{}} />
+    );
 
     expect(getByTestId('empty-attribute-list')).toBeInTheDocument();
   });

--- a/web/src/components/AttributeRow/AttributeRow.styled.ts
+++ b/web/src/components/AttributeRow/AttributeRow.styled.ts
@@ -1,4 +1,4 @@
-import {Badge, Typography} from 'antd';
+import {Badge, Tag as AntdTag, Typography} from 'antd';
 import styled from 'styled-components';
 
 export {default as AttributeTitle} from './AttributeTitle';
@@ -17,6 +17,7 @@ export const Container = styled.div`
 `;
 
 export const Header = styled.div`
+  cursor: pointer;
   flex: 1;
 `;
 
@@ -49,4 +50,22 @@ export const CustomBadge = styled(Badge)`
     font-size: ${({theme}) => theme.size.sm};
     margin-left: 3px;
   }
+`;
+
+export const Title = styled(Typography.Title)`
+  && {
+    margin-bottom: 0;
+  }
+`;
+
+export const DetailContainer = styled.div`
+  width: 270px;
+`;
+
+export const TagsContainer = styled.div`
+  margin-top: 8px;
+`;
+
+export const Tag = styled(AntdTag)`
+  background: #e7e8eb;
 `;

--- a/web/src/components/AttributeRow/AttributeRow.tsx
+++ b/web/src/components/AttributeRow/AttributeRow.tsx
@@ -1,9 +1,14 @@
 import {MoreOutlined} from '@ant-design/icons';
-import {Dropdown, Menu, message} from 'antd';
+import {Dropdown, Menu, message, Popover} from 'antd';
+import parse from 'html-react-parser';
+import MarkdownIt from 'markdown-it';
+import React, {useMemo} from 'react';
 
+import AttributeValue from 'components/AttributeValue';
+import {OtelReference} from 'components/TestSpecForm/hooks/useGetOTELSemanticConventionAttributesInfo';
+import SpanAttributeService from 'services/SpanAttribute.service';
 import {IResult} from 'types/Assertion.types';
 import {TSpanFlatAttribute} from 'types/Span.types';
-import AttributeValue from '../AttributeValue';
 import AttributeCheck from './AttributeCheck';
 import * as S from './AttributeRow.styled';
 
@@ -14,6 +19,7 @@ interface IProps {
   searchText?: string;
   onCopy(value: string): void;
   onCreateTestSpec(attribute: TSpanFlatAttribute): void;
+  semanticConventions: OtelReference;
 }
 
 enum Action {
@@ -29,9 +35,12 @@ const AttributeRow = ({
   onCopy,
   onCreateTestSpec,
   searchText,
+  semanticConventions,
 }: IProps) => {
   const passedCount = assertionsPassed?.length ?? 0;
   const failedCount = assertionsFailed?.length ?? 0;
+  const semanticConvention = SpanAttributeService.getReferencePicker(semanticConventions, key);
+  const description = useMemo(() => parse(MarkdownIt().render(semanticConvention.description)), [semanticConvention]);
 
   const handleOnClick = ({key: option}: {key: string}) => {
     if (option === Action.Copy) {
@@ -43,7 +52,9 @@ const AttributeRow = ({
       return onCreateTestSpec(attribute);
     }
   };
+
   const cypressKey = key.toLowerCase().replace('.', '-');
+
   const menu = (
     <Menu
       items={[
@@ -59,16 +70,31 @@ const AttributeRow = ({
       onClick={handleOnClick}
     />
   );
+
+  const content = (
+    <S.DetailContainer>
+      {semanticConvention.description !== '' ? description : 'We have not found a description for this attribute'}
+      <S.TagsContainer>
+        {semanticConvention.tags.map(tag => (
+          <S.Tag key={tag}>{tag}</S.Tag>
+        ))}
+      </S.TagsContainer>
+    </S.DetailContainer>
+  );
+
   return (
     <S.Container data-cy={`attribute-row-${cypressKey}`}>
-      <S.Header>
-        <S.AttributeTitle title={key} searchText={searchText} />
-        <S.AttributeValueRow>
-          <AttributeValue value={value} searchText={searchText} />
-        </S.AttributeValueRow>
-        {passedCount > 0 && <AttributeCheck items={assertionsPassed!} type="success" />}
-        {failedCount > 0 && <AttributeCheck items={assertionsFailed!} type="error" />}
-      </S.Header>
+      <Popover content={content} placement="right" title={<S.Title level={3}>{key}</S.Title>} trigger="click">
+        <S.Header>
+          <S.AttributeTitle title={key} searchText={searchText} />
+
+          <S.AttributeValueRow>
+            <AttributeValue value={value} searchText={searchText} />
+          </S.AttributeValueRow>
+          {passedCount > 0 && <AttributeCheck items={assertionsPassed!} type="success" />}
+          {failedCount > 0 && <AttributeCheck items={assertionsFailed!} type="error" />}
+        </S.Header>
+      </Popover>
 
       <Dropdown overlay={menu}>
         <a onClick={e => e.preventDefault()}>

--- a/web/src/components/AttributeRow/__tests__/AttributeRow.test.tsx
+++ b/web/src/components/AttributeRow/__tests__/AttributeRow.test.tsx
@@ -13,7 +13,13 @@ const onCopy = jest.fn();
 describe('AttributeRow', () => {
   it('should render correctly', () => {
     const {getByText} = render(
-      <AttributeRow searchText="" attribute={attribute} onCreateTestSpec={onCreateTestSpec} onCopy={onCopy} />
+      <AttributeRow
+        searchText=""
+        attribute={attribute}
+        onCreateTestSpec={onCreateTestSpec}
+        onCopy={onCopy}
+        semanticConventions={{}}
+      />
     );
 
     expect(getByText(attribute.key)).toBeInTheDocument();

--- a/web/src/components/SearchInput/SearchInput.tsx
+++ b/web/src/components/SearchInput/SearchInput.tsx
@@ -2,7 +2,7 @@ import {debounce} from 'lodash';
 import {useMemo} from 'react';
 import * as S from './SearchInput.styled';
 
-interface ISearchInputProps {
+interface IProps {
   height?: string;
   width?: string;
   placeholder: string;
@@ -10,13 +10,7 @@ interface ISearchInputProps {
   delay?: number;
 }
 
-const SearchInput: React.FC<ISearchInputProps> = ({
-  height = '32px',
-  width = '270px',
-  placeholder,
-  onSearch,
-  delay = 500,
-}) => {
+const SearchInput = ({height = '32px', width = '270px', placeholder, onSearch, delay = 500}: IProps) => {
   const handleSearch = useMemo(
     () =>
       debounce(event => {

--- a/web/src/components/SpanDetail/Attributes.tsx
+++ b/web/src/components/SpanDetail/Attributes.tsx
@@ -1,62 +1,34 @@
-import {Tabs} from 'antd';
+import {useEffect, useRef, useState} from 'react';
 
 import AttributeList from 'components/AttributeList';
-import {SemanticGroupNames} from 'constants/SemanticGroupNames.constants';
-import {capitalize} from 'lodash';
-import {useEffect, useMemo, useRef, useState} from 'react';
-import TraceAnalyticsService from 'services/Analytics/TestRunAnalytics.service';
-import SpanAttributeService from 'services/SpanAttribute.service';
 import {TResultAssertions} from 'types/Assertion.types';
 import {TSpanFlatAttribute} from 'types/Span.types';
-import {getObjectIncludesText} from 'utils/Common';
 import * as S from './SpanDetail.styled';
 
 interface IProps {
   assertions?: TResultAssertions;
   attributeList: TSpanFlatAttribute[];
   searchText?: string;
-  type: SemanticGroupNames;
   onCreateTestSpec(attribute: TSpanFlatAttribute): void;
 }
 
-const Attributes = ({assertions, attributeList, onCreateTestSpec, searchText, type}: IProps) => {
+const Attributes = ({assertions, attributeList, onCreateTestSpec, searchText}: IProps) => {
   const containerRef = useRef<HTMLDivElement>(null);
   const [topPosition, setTopPosition] = useState(0);
-  const sectionList = useMemo(
-    () => SpanAttributeService.getSpanAttributeSectionsList(attributeList, type!),
-    [attributeList, type]
-  );
 
   useEffect(() => {
     setTopPosition(containerRef?.current?.offsetTop ?? 0);
   }, [attributeList]);
 
   return (
-    <S.TabContainer $top={topPosition} ref={containerRef}>
-      <Tabs
-        data-cy="span-details-attributes"
-        onChange={tabName => TraceAnalyticsService.onChangeTab(tabName)}
-        size="small"
-      >
-        {sectionList.map(({section, attributeList: attrList}) => (
-          <Tabs.TabPane
-            tab={
-              <span data-cy={`attribute-tabs-${section.toLowerCase()}`}>
-                {capitalize(section)} {getObjectIncludesText(attrList, searchText) && <S.Dot />}
-              </span>
-            }
-            key={section}
-          >
-            <AttributeList
-              assertions={assertions}
-              attributeList={attrList}
-              onCreateTestSpec={onCreateTestSpec}
-              searchText={searchText}
-            />
-          </Tabs.TabPane>
-        ))}
-      </Tabs>
-    </S.TabContainer>
+    <S.AttributesContainer $top={topPosition} ref={containerRef}>
+      <AttributeList
+        assertions={assertions}
+        attributeList={attributeList}
+        onCreateTestSpec={onCreateTestSpec}
+        searchText={searchText}
+      />
+    </S.AttributesContainer>
   );
 };
 

--- a/web/src/components/SpanDetail/Attributes.tsx
+++ b/web/src/components/SpanDetail/Attributes.tsx
@@ -1,6 +1,7 @@
 import {useEffect, useRef, useState} from 'react';
 
 import AttributeList from 'components/AttributeList';
+import {OtelReference} from 'components/TestSpecForm/hooks/useGetOTELSemanticConventionAttributesInfo';
 import {TResultAssertions} from 'types/Assertion.types';
 import {TSpanFlatAttribute} from 'types/Span.types';
 import * as S from './SpanDetail.styled';
@@ -10,9 +11,10 @@ interface IProps {
   attributeList: TSpanFlatAttribute[];
   searchText?: string;
   onCreateTestSpec(attribute: TSpanFlatAttribute): void;
+  semanticConventions: OtelReference;
 }
 
-const Attributes = ({assertions, attributeList, onCreateTestSpec, searchText}: IProps) => {
+const Attributes = ({assertions, attributeList, onCreateTestSpec, searchText, semanticConventions}: IProps) => {
   const containerRef = useRef<HTMLDivElement>(null);
   const [topPosition, setTopPosition] = useState(0);
 
@@ -27,6 +29,7 @@ const Attributes = ({assertions, attributeList, onCreateTestSpec, searchText}: I
         attributeList={attributeList}
         onCreateTestSpec={onCreateTestSpec}
         searchText={searchText}
+        semanticConventions={semanticConventions}
       />
     </S.AttributesContainer>
   );

--- a/web/src/components/SpanDetail/SpanDetail.styled.ts
+++ b/web/src/components/SpanDetail/SpanDetail.styled.ts
@@ -59,25 +59,11 @@ export const Row = styled.div`
   margin-bottom: 4px;
 `;
 
-export const Dot = styled.div`
-  background-color: ${({theme}) => theme.color.textHighlight};
-  border-radius: 50%;
-  display: inline-block;
-  height: 10px;
-  margin-left: 5px;
-  width: 10px;
+export const AttributesContainer = styled.div<{$top: number}>`
+  height: calc(100% - ${({$top}) => `${$top}px`});
+  overflow-y: scroll;
 `;
 
-export const TabContainer = styled.div<{$top: number}>`
-  height: calc(100% - ${({$top}) => `${$top}px`});
-
-  .ant-tabs-nav {
-    padding: 0 12px;
-    margin-bottom: 0;
-  }
-
-  .ant-tabs-content-holder {
-    height: calc(100% - 38px);
-    overflow-y: scroll;
-  }
+export const SearchContainer = styled.div`
+  padding: 0 12px;
 `;

--- a/web/src/components/SpanDetail/SpanDetail.tsx
+++ b/web/src/components/SpanDetail/SpanDetail.tsx
@@ -81,6 +81,7 @@ const SpanDetail = ({onCreateTestSpec = noop, searchText, span}: IProps) => {
         attributeList={filteredAttributes}
         onCreateTestSpec={handleCreateTestSpec}
         searchText={searchText}
+        semanticConventions={semanticConventions}
       />
     </>
   );

--- a/web/src/components/SpanDetail/__tests__/SpanDetail.test.tsx
+++ b/web/src/components/SpanDetail/__tests__/SpanDetail.test.tsx
@@ -1,9 +1,0 @@
-import {render} from 'test-utils';
-import SpanMock from '../../../models/__mocks__/Span.mock';
-import SpanDetail from '../SpanDetail';
-
-test('Layout', () => {
-  const {getByText} = render(<SpanDetail span={SpanMock.model()} />);
-
-  expect(getByText('All')).toBeTruthy();
-});

--- a/web/src/components/TestSpecForm/Fields/AttributeField.tsx
+++ b/web/src/components/TestSpecForm/Fields/AttributeField.tsx
@@ -1,6 +1,6 @@
 import {FormItemProps, Select, Form} from 'antd';
 import {uniqBy} from 'lodash';
-import {ReactElement, useMemo, useState} from 'react';
+import {useMemo, useState} from 'react';
 import SpanAttributeService from 'services/SpanAttribute.service';
 import {TSpanFlatAttribute} from 'types/Span.types';
 import {OtelReference} from '../hooks/useGetOTELSemanticConventionAttributesInfo';
@@ -12,7 +12,7 @@ interface IProps extends FormItemProps {
   reference: OtelReference;
 }
 
-export const AttributeField = ({reference, attributeList, ...props}: IProps): ReactElement => {
+const AttributeField = ({reference, attributeList, ...props}: IProps) => {
   const [hoveredKey, setHoveredKey] = useState<string | undefined>(undefined);
   const [newAttribute, setNewAttribute] = useState<string | undefined>(undefined);
 
@@ -29,12 +29,10 @@ export const AttributeField = ({reference, attributeList, ...props}: IProps): Re
         showSearch
         dropdownRender={useDropDownRenderComponent(reference, hoveredKey)}
         dropdownStyle={hoveredKey ? {minWidth: 550, maxWidth: 550} : undefined}
-        filterOption={(search, option) => {
-          const itMatches = SpanAttributeService.getItMatchesAttributeByKey(reference, option?.key || '', search);
-
-          return itMatches;
-        }}
-        onSearch={sarchValue => setNewAttribute(sarchValue)}
+        filterOption={(search, option) =>
+          SpanAttributeService.getItMatchesAttributeByKey(reference, option?.key || '', search)
+        }
+        onSearch={searchValue => setNewAttribute(searchValue)}
       >
         {filteredAttributedList.map(({key}) => (
           <Select.Option key={key} value={key}>
@@ -47,3 +45,5 @@ export const AttributeField = ({reference, attributeList, ...props}: IProps): Re
     </Form.Item>
   );
 };
+
+export default AttributeField;

--- a/web/src/components/TestSpecForm/hooks/useGetOTELSemanticConventionAttributesInfo.tsx
+++ b/web/src/components/TestSpecForm/hooks/useGetOTELSemanticConventionAttributesInfo.tsx
@@ -1,3 +1,4 @@
+import AttributesTags from 'constants/AttributesTags.json';
 import {useGetConventionsQuery} from 'redux/apis/OtelRepo.api';
 
 export type OtelReference = Record<string, OtelReferenceModel>;
@@ -7,16 +8,19 @@ export interface OtelReferenceModel {
   tags: string[];
 }
 
+const attributesTags: OtelReference = AttributesTags;
+
 export const useGetOTELSemanticConventionAttributesInfo = (): OtelReference => {
   return {
     ...useGetConventionsQuery({kind: 'http'})?.data,
     ...useGetConventionsQuery({kind: 'database'})?.data,
     ...useGetConventionsQuery({kind: 'cloudevents'})?.data,
     ...useGetConventionsQuery({kind: 'compatibility'})?.data,
-    ...useGetConventionsQuery({kind: 'exception'})?.data,
+    ...useGetConventionsQuery({kind: 'trace-exception'})?.data,
     ...useGetConventionsQuery({kind: 'faas'})?.data,
     ...useGetConventionsQuery({kind: 'general'})?.data,
     ...useGetConventionsQuery({kind: 'messaging'})?.data,
     ...useGetConventionsQuery({kind: 'rpc'})?.data,
+    ...attributesTags,
   };
 };

--- a/web/src/redux/apis/OtelRepo.api.ts
+++ b/web/src/redux/apis/OtelRepo.api.ts
@@ -41,7 +41,7 @@ const OtelRepoAPI = createApi({
         const message: OTELYaml = jsyaml.load(rawSpanList);
         return (
           (message?.groups || [])
-            .flatMap<CompleteAttribute>(s => (s.attributes || []).map(d => ({...d, group: s.id})))
+            .flatMap<CompleteAttribute>(s => (s.attributes || []).map(d => ({...d, group: s.prefix})))
             .reduce((acc: OtelReference, d: CompleteAttribute) => {
               let id = `${d.group}.${d?.ref || d?.id || ''}`;
               acc[id] = {description: d?.brief || '', tags: normalizeThis(d?.examples)};

--- a/web/src/services/__tests__/SpanAttribute.service.test.ts
+++ b/web/src/services/__tests__/SpanAttribute.service.test.ts
@@ -1,84 +1,8 @@
 import SpanAttributeService from '../SpanAttribute.service';
-import {SemanticGroupNames} from '../../constants/SemanticGroupNames.constants';
-import {SectionNames} from '../../constants/Span.constants';
 import {Attributes} from '../../constants/SpanAttribute.constants';
 import {TSpanFlatAttribute} from '../../types/Span.types';
 
 describe('SpanAttributeService', () => {
-  describe('getFilteredSpanAttributeList', () => {
-    it('should return the sections for http type', () => {
-      expect(SpanAttributeService.getSpanAttributeSectionsList([], SemanticGroupNames.Http)).toEqual([
-        {
-          section: SectionNames.request,
-          attributeList: [],
-        },
-        {
-          section: SectionNames.response,
-          attributeList: [],
-        },
-        {
-          section: SectionNames.custom,
-          attributeList: [],
-        },
-        {
-          section: SectionNames.all,
-          attributeList: [],
-        },
-      ]);
-    });
-
-    it('should return the sections for database type with values', () => {
-      const attribute = {
-        key: Attributes.DB_SYSTEM,
-        value: 'mysql',
-      };
-
-      expect(SpanAttributeService.getSpanAttributeSectionsList([attribute], SemanticGroupNames.Database)).toEqual([
-        {
-          section: SectionNames.metadata,
-          attributeList: [attribute],
-        },
-        {
-          section: SectionNames.custom,
-          attributeList: [],
-        },
-        {
-          section: SectionNames.all,
-          attributeList: [attribute],
-        },
-      ]);
-    });
-
-    it('should return the sections for messaging type with values', () => {
-      const attribute = {
-        key: Attributes.MESSAGING_SYSTEM,
-        value: 'kafka',
-      };
-
-      const customAttribute = {
-        key: 'messaging.payload',
-        value: '{}',
-      };
-
-      expect(
-        SpanAttributeService.getSpanAttributeSectionsList([attribute, customAttribute], SemanticGroupNames.Messaging)
-      ).toEqual([
-        {
-          section: SectionNames.metadata,
-          attributeList: [attribute],
-        },
-        {
-          section: SectionNames.custom,
-          attributeList: [customAttribute],
-        },
-        {
-          section: SectionNames.all,
-          attributeList: [attribute, customAttribute],
-        },
-      ]);
-    });
-  });
-
   describe('getFilteredSelectorAttributeList', () => {
     it('should return the filtered list of attributes', () => {
       const attributeList: TSpanFlatAttribute[] = [


### PR DESCRIPTION
This PR removes the tabs in the search detail view and adds search capabilities to the list of attributes.

## Changes

- Remove tabs
- Search attributes

## Fixes

- fixes #1449

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Loom

https://www.loom.com/share/5264974020dc457ca8bac663af5dda29