### PR TITLE
[Transactions] Integrate transactions create flow

### DIFF
--- a/web/src/components/TransactionPlugin/steps/TestsSelection/TestsSelection.tsx
+++ b/web/src/components/TransactionPlugin/steps/TestsSelection/TestsSelection.tsx
@@ -11,8 +11,8 @@ const TestsSelection = () => {
   const {onNext} = useCreateTransaction();
 
   const handleSubmit = useCallback(
-    ({tests = []}: TDraftTransaction) => {
-      onNext({tests});
+    ({steps = []}: TDraftTransaction) => {
+      onNext({steps});
     },
     [onNext]
   );

--- a/web/src/components/TransactionPlugin/steps/TestsSelection/TestsSelectionForm.tsx
+++ b/web/src/components/TransactionPlugin/steps/TestsSelection/TestsSelectionForm.tsx
@@ -8,7 +8,7 @@ const TestsSelectionForm = () => {
   return (
     <Row gutter={12}>
       <Col span={18}>
-        <Form.Item name="tests">
+        <Form.Item name="steps">
           <TestsSelectionInput testList={data?.items || []} />
         </Form.Item>
       </Col>

--- a/web/src/models/Transaction.model.ts
+++ b/web/src/models/Transaction.model.ts
@@ -1,11 +1,13 @@
-import {TTransaction} from 'types/Transaction.types';
+import {TRawTransaction, TTransaction} from 'types/Transaction.types';
 
-const Transaction = ({id = '', name = '', description = '', version = 1, ...data}: TTransaction): TTransaction => ({
-  id,
-  name,
-  description,
-  version,
-  ...data,
-});
+function Transaction({id = '', name = '', description = '', version = 1, steps = []}: TRawTransaction): TTransaction {
+  return {
+    id,
+    name,
+    description,
+    version,
+    steps,
+  };
+}
 
 export default Transaction;

--- a/web/src/models/__mocks__/Transaction.mock.ts
+++ b/web/src/models/__mocks__/Transaction.mock.ts
@@ -14,11 +14,12 @@ const TransactionMock: IMockFactory<TTransaction, TTransaction> = () => ({
       name: faker.name.firstName(),
       version: faker.datatype.number(),
       description: faker.company.catchPhraseDescriptor(),
-      steps: [
+      /* steps: [
         {...test, result: 'success'},
         {...test2, result: 'fail'},
         {...test3, result: 'running'},
-      ],
+      ], */
+      steps: [test.id, test2.id, test3.id],
       env: {
         usename: 'john doe',
       },

--- a/web/src/pages/TransactionRunDetail/Content.tsx
+++ b/web/src/pages/TransactionRunDetail/Content.tsx
@@ -1,4 +1,4 @@
-import {Tag, Typography} from 'antd';
+import {/* Tag, */ Typography} from 'antd';
 import {useNavigate, useParams} from 'react-router-dom';
 import TransactionHeader from '../../components/TransactionHeader';
 import {useTransaction} from '../../providers/TransactionRunDetail/TransactionRunDetailProvider';
@@ -27,7 +27,7 @@ const Content = () => {
           <S.SectionLeft>
             <Typography style={{fontSize: 16, marginBottom: 24}}>Execution steps</Typography>
 
-            {transaction?.steps.map(({name, version, ...test}, index) => {
+            {/* {transaction?.steps.map(({name, version, ...test}, index) => {
               return (
                 <S.Containerr data-cy={`run-card-${name}`} key={test.id}>
                   <div>{iconBasedOnResult(test.result, index)}</div>
@@ -41,12 +41,12 @@ const Content = () => {
                   </S.Info>
                 </S.Containerr>
               );
-            })}
+            })} */}
           </S.SectionLeft>
           <S.SectionRight>
             <Typography style={{fontSize: 16, marginBottom: 24}}>Variables</Typography>
             {Object.keys(transaction?.env || {}).map(key => {
-              const result = transaction?.env[key];
+              const result = transaction?.env?.[key];
               return (
                 <S.Containerr data-cy={`variable-card-${key}`} key={key}>
                   <S.Infoo>

--- a/web/src/providers/CreateTransaction/CreateTransaction.provider.tsx
+++ b/web/src/providers/CreateTransaction/CreateTransaction.provider.tsx
@@ -1,5 +1,6 @@
 import {noop} from 'lodash';
 import {createContext, useCallback, useContext, useMemo} from 'react';
+import {useCreateTransactionMutation} from 'redux/apis/TraceTest.api';
 import {useAppDispatch, useAppSelector} from 'redux/hooks';
 import {
   initialState,
@@ -45,6 +46,7 @@ export const useCreateTransaction = () => useContext(Context);
 
 const CreateTransactionProvider = ({children}: IProps) => {
   const dispatch = useAppDispatch();
+  const [createTransaction, {isLoading: isLoadingCreateTransaction}] = useCreateTransactionMutation();
 
   const draftTransaction = useAppSelector(CreateTransactionSelectors.selectDraftTransaction);
   const stepNumber = useAppSelector(CreateTransactionSelectors.selectStepNumber);
@@ -53,10 +55,14 @@ const CreateTransactionProvider = ({children}: IProps) => {
   const isFinalStep = stepNumber === stepList.length - 1;
   const activeStep = stepList[stepNumber]?.id;
 
-  const onCreateTransaction = useCallback(async (draft: TDraftTransaction) => {
-    // eslint-disable-next-line no-console
-    console.log('@@ creating a new transaction!!', draft);
-  }, []);
+  const onCreateTransaction = useCallback(
+    async (draft: TDraftTransaction) => {
+      const transaction = await createTransaction(draft).unwrap();
+      // const run = await runTransaction({transactionId: transaction.id}).unwrap(); TODO: run transaction
+      // navigate(`/transaction/${transaction.id}/run/${run.id}`); TODO: navigate to transaction run detail page
+    },
+    [createTransaction]
+  );
 
   const onUpdateDraft = useCallback(
     (update: TDraftTransaction) => {
@@ -98,7 +104,7 @@ const CreateTransactionProvider = ({children}: IProps) => {
     () => ({
       draftTransaction,
       stepNumber,
-      isLoading: false,
+      isLoading: isLoadingCreateTransaction,
       isFormValid,
       onNext,
       onPrev,
@@ -112,6 +118,7 @@ const CreateTransactionProvider = ({children}: IProps) => {
     [
       draftTransaction,
       stepNumber,
+      isLoadingCreateTransaction,
       isFormValid,
       onNext,
       onPrev,

--- a/web/src/providers/CreateTransaction/CreateTransaction.provider.tsx
+++ b/web/src/providers/CreateTransaction/CreateTransaction.provider.tsx
@@ -1,5 +1,6 @@
 import {noop} from 'lodash';
 import {createContext, useCallback, useContext, useMemo} from 'react';
+import {useNavigate} from 'react-router-dom';
 import {useCreateTransactionMutation} from 'redux/apis/TraceTest.api';
 import {useAppDispatch, useAppSelector} from 'redux/hooks';
 import {
@@ -46,6 +47,7 @@ export const useCreateTransaction = () => useContext(Context);
 
 const CreateTransactionProvider = ({children}: IProps) => {
   const dispatch = useAppDispatch();
+  const navigate = useNavigate();
   const [createTransaction, {isLoading: isLoadingCreateTransaction}] = useCreateTransactionMutation();
 
   const draftTransaction = useAppSelector(CreateTransactionSelectors.selectDraftTransaction);
@@ -59,9 +61,10 @@ const CreateTransactionProvider = ({children}: IProps) => {
     async (draft: TDraftTransaction) => {
       const transaction = await createTransaction(draft).unwrap();
       // const run = await runTransaction({transactionId: transaction.id}).unwrap(); TODO: run transaction
-      // navigate(`/transaction/${transaction.id}/run/${run.id}`); TODO: navigate to transaction run detail page
+      const run = {id: 1};
+      navigate(`/transaction/${transaction.id}/run/${run.id}`);
     },
-    [createTransaction]
+    [createTransaction, navigate]
   );
 
   const onUpdateDraft = useCallback(

--- a/web/src/redux/apis/TraceTest.api.ts
+++ b/web/src/redux/apis/TraceTest.api.ts
@@ -51,6 +51,7 @@ export const {
   useCreateEnvironmentMutation,
   useUpdateEnvironmentMutation,
   useDeleteEnvironmentMutation,
+  useCreateTransactionMutation,
   useGetTransactionByIdQuery,
   useGetTransactionRunByIdQuery,
   useDeleteTransactionByIdMutation,

--- a/web/src/redux/apis/endpoints/Transaction.endpoint.ts
+++ b/web/src/redux/apis/endpoints/Transaction.endpoint.ts
@@ -1,9 +1,20 @@
-import TransactionMock from 'models/__mocks__/Transaction.mock';
-import {TTransaction} from 'types/Transaction.types';
-import {TTestApiEndpointBuilder} from 'types/Test.types';
+import {HTTP_METHOD} from 'constants/Common.constants';
 import {TracetestApiTags} from 'constants/Test.constants';
+import TransactionMock from 'models/__mocks__/Transaction.mock';
+import Transaction from 'models/Transaction.model';
+import {TTestApiEndpointBuilder} from 'types/Test.types';
+import {TDraftTransaction, TRawTransaction, TTransaction} from 'types/Transaction.types';
 
 const TransactionEndpoint = (builder: TTestApiEndpointBuilder) => ({
+  createTransaction: builder.mutation<TTransaction, TDraftTransaction>({
+    query: transaction => ({
+      url: '/transactions',
+      method: HTTP_METHOD.POST,
+      body: transaction,
+    }),
+    transformResponse: (rawTransaction: TRawTransaction) => Transaction(rawTransaction),
+    invalidatesTags: [{type: TracetestApiTags.TRANSACTION, id: 'LIST'}],
+  }),
   deleteTransactionById: builder.mutation<TTransaction, {transactionId: string}>({
     query: ({transactionId}) => ({url: `/transactions/${transactionId}`, method: 'DELETE'}),
     invalidatesTags: [{type: TracetestApiTags.TRANSACTION, id: 'LIST'}],

--- a/web/src/redux/apis/endpoints/Transaction.endpoint.ts
+++ b/web/src/redux/apis/endpoints/Transaction.endpoint.ts
@@ -25,9 +25,9 @@ const TransactionEndpoint = (builder: TTestApiEndpointBuilder) => ({
     transformResponse: () => TransactionMock.model(),
   }),
   getTransactionById: builder.query<TTransaction, {transactionId: string}>({
-    query: () => `/tests`,
+    query: ({transactionId}) => `/transactions/${transactionId}`,
     providesTags: result => [{type: TracetestApiTags.TRANSACTION, id: result?.id}],
-    transformResponse: () => TransactionMock.model(),
+    transformResponse: (rawTransaction: TRawTransaction) => Transaction(rawTransaction),
   }),
 });
 

--- a/web/src/types/Common.types.ts
+++ b/web/src/types/Common.types.ts
@@ -28,6 +28,7 @@ export type TTriggerSchemas = external['triggers.yaml']['components']['schemas']
 export type TGrpcSchemas = external['grpc.yaml']['components']['schemas'];
 export type TEnvironmentSchemas = external['environments.yaml']['components']['schemas'];
 export type TExpressionsSchemas = external['expressions.yaml']['components']['schemas'];
+export type TTransactionsSchemas = external['transactions.yaml']['components']['schemas'];
 
 export type TSelector = TTestSchemas['Selector'];
 

--- a/web/src/types/Generated.types.ts
+++ b/web/src/types/Generated.types.ts
@@ -8,6 +8,20 @@ export interface paths {
     /** Execute a definition */
     post: operations["executeDefinition"];
   };
+  "/transactions": {
+    /** get transactions */
+    get: operations["getTransactions"];
+    /** Create new transaction */
+    post: operations["createTransaction"];
+  };
+  "/transactions/{transactionId}": {
+    /** get transaction */
+    get: operations["getTransaction"];
+    /** update transaction action */
+    put: operations["updateTransaction"];
+    /** delete a transaction */
+    delete: operations["deleteTransaction"];
+  };
   "/tests": {
     /** get tests */
     get: operations["getTests"];
@@ -121,6 +135,104 @@ export interface operations {
       content: {
         "text/json": external["definition.yaml"]["components"]["schemas"]["TextDefinition"];
       };
+    };
+  };
+  /** get transactions */
+  getTransactions: {
+    parameters: {
+      query: {
+        /** indicates how many transactions can be returned by each page */
+        take?: number;
+        /** indicates how many transactions will be skipped when paginating */
+        skip?: number;
+        /** query to search transactions, based on transaction name and description */
+        query?: string;
+        /** indicates the sort field for the transactions */
+        sortBy?: "created" | "name" | "last_run";
+        /** indicates the sort direction for the transactions */
+        sortDirection?: "asc" | "desc";
+      };
+    };
+    responses: {
+      /** successful operation */
+      200: {
+        headers: {
+          /** Total records count */
+          "X-Total-Count"?: number;
+        };
+        content: {
+          "application/json": external["transactions.yaml"]["components"]["schemas"]["Transaction"][];
+        };
+      };
+      /** problem with getting transactions */
+      500: unknown;
+    };
+  };
+  /** Create new transaction */
+  createTransaction: {
+    responses: {
+      /** successful operation */
+      200: {
+        content: {
+          "application/json": external["transactions.yaml"]["components"]["schemas"]["Transaction"];
+        };
+      };
+      /** trying to create a transaction with an already existing ID */
+      400: unknown;
+    };
+    requestBody: {
+      content: {
+        "application/json": external["transactions.yaml"]["components"]["schemas"]["Transaction"];
+      };
+    };
+  };
+  /** get transaction */
+  getTransaction: {
+    parameters: {
+      path: {
+        transactionId: string;
+      };
+    };
+    responses: {
+      /** successful operation */
+      200: {
+        content: {
+          "application/json": external["transactions.yaml"]["components"]["schemas"]["Transaction"];
+        };
+      };
+      /** problem with getting a transaction */
+      500: unknown;
+    };
+  };
+  /** update transaction action */
+  updateTransaction: {
+    parameters: {
+      path: {
+        transactionId: string;
+      };
+    };
+    responses: {
+      /** successful operation */
+      204: never;
+      /** problem with updating transaction */
+      500: unknown;
+    };
+    requestBody: {
+      content: {
+        "application/json": external["transactions.yaml"]["components"]["schemas"]["Transaction"];
+      };
+    };
+  };
+  /** delete a transaction */
+  deleteTransaction: {
+    parameters: {
+      path: {
+        transactionId: string;
+      };
+    };
+    responses: {
+      /** OK */
+      204: never;
     };
   };
   /** get tests */
@@ -932,6 +1044,22 @@ export interface external {
            */
           attributes?: { [key: string]: string };
           children?: external["trace.yaml"]["components"]["schemas"]["Span"][];
+        };
+      };
+    };
+    operations: {};
+  };
+  "transactions.yaml": {
+    paths: {};
+    components: {
+      schemas: {
+        Transaction: {
+          id?: string;
+          name?: string;
+          description?: string;
+          /** @description version number of the test */
+          version?: number;
+          steps?: string[];
         };
       };
     };

--- a/web/src/types/Transaction.types.ts
+++ b/web/src/types/Transaction.types.ts
@@ -1,33 +1,31 @@
 import {CaseReducer, PayloadAction} from '@reduxjs/toolkit';
 import {FormInstance} from 'antd';
+
+import {Model, TTransactionsSchemas} from './Common.types';
 import {ICreateTestStep} from './Plugins.types';
-import {Model} from './Common.types';
 import {TTest} from './Test.types';
 
-export type TRawTransaction = {
-  id?: string;
-  name?: string;
-  description?: string;
-  version?: number;
-};
+export type TRawTransaction = TTransactionsSchemas['Transaction'];
 
-export interface TTransaction extends Model<TRawTransaction, ITransaction> {}
+export type TTransaction = Model<
+  TRawTransaction,
+  {
+    id: string;
+    name: string;
+    description: string;
+    version: number;
+    steps: string[];
+    // steps: TransactionStep[]; // TODO define if this should be part of Transaction Run
+    env?: Record<string, string>; // TODO define if this should be part of Transaction Run
+  }
+>;
 
 interface TransactionStep extends TTest {
   result: 'success' | 'fail' | 'running';
 }
 
-export interface ITransaction {
-  id: string;
-  name: string;
-  description: string;
-  version: number;
-  steps: TransactionStep[];
-  env: Record<string, string>;
-}
-
 export type TDraftTransaction = {
-  tests?: string[];
+  steps?: string[];
   name?: string;
   description?: string;
 };


### PR DESCRIPTION
This PR integrates the create transaction flow with the API.

## Changes

- Add generated types
- Connect the API call in the create transaction flow

## Fixes

- fixes #1453 

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
