### PR TITLE
feat: validate cli config

### DIFF
--- a/cli/cmd/config.go
+++ b/cli/cmd/config.go
@@ -20,6 +20,7 @@ func setupCommand(cmd *cobra.Command, args []string) {
 	setupOutputFormat()
 	setupLogger(cmd, args)
 	loadConfig(cmd, args)
+	validateConfig(cmd, args)
 	analytics.Init(cliConfig)
 }
 
@@ -39,6 +40,13 @@ func loadConfig(cmd *cobra.Command, args []string) {
 	}
 
 	cliConfig = config
+}
+
+func validateConfig(cmd *cobra.Command, args []string) {
+	if cliConfig.IsEmpty() {
+		cliLogger.Warn("You haven't configured your CLI, commands might fail!")
+		cliLogger.Warn("Run 'tracetest configure' to configure your CLI")
+	}
 }
 
 func setupLogger(cmd *cobra.Command, args []string) {

--- a/cli/cmd/config.go
+++ b/cli/cmd/config.go
@@ -45,12 +45,27 @@ func setupLogger(cmd *cobra.Command, args []string) {
 	atom := zap.NewAtomicLevel()
 	if verbose {
 		atom.SetLevel(zap.DebugLevel)
+	} else {
+		atom.SetLevel(zap.WarnLevel)
 	}
 
-	encoderCfg := zap.NewProductionEncoderConfig()
+	encoderCfg := zapcore.EncoderConfig{
+		TimeKey:        zapcore.OmitKey,
+		LevelKey:       "level",
+		NameKey:        zapcore.OmitKey,
+		CallerKey:      zapcore.OmitKey,
+		FunctionKey:    zapcore.OmitKey,
+		MessageKey:     "message",
+		StacktraceKey:  zapcore.OmitKey,
+		LineEnding:     zapcore.DefaultLineEnding,
+		EncodeLevel:    zapcore.CapitalColorLevelEncoder,
+		EncodeTime:     zapcore.EpochTimeEncoder,
+		EncodeDuration: zapcore.SecondsDurationEncoder,
+		EncodeCaller:   zapcore.ShortCallerEncoder,
+	}
 
 	logger := zap.New(zapcore.NewCore(
-		zapcore.NewJSONEncoder(encoderCfg),
+		zapcore.NewConsoleEncoder(encoderCfg),
 		zapcore.Lock(os.Stdout),
 		atom,
 	))

--- a/cli/cmd/config.go
+++ b/cli/cmd/config.go
@@ -44,7 +44,7 @@ func loadConfig(cmd *cobra.Command, args []string) {
 
 func validateConfig(cmd *cobra.Command, args []string) {
 	if cliConfig.IsEmpty() {
-		cliLogger.Warn("You haven't configured your CLI, commands might fail!")
+		cliLogger.Warn("You haven't configured your CLI, some commands might fail!")
 		cliLogger.Warn("Run 'tracetest configure' to configure your CLI")
 	}
 }

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -22,7 +22,7 @@ var rootCmd = &cobra.Command{
 	Use:     "tracetest",
 	Short:   "tracetest CLI is a tool to interact with a tracetest server",
 	Long:    `tracetest CLI is a tool to interact with a tracetest server`,
-	PreRun:  setupCommand,
+	PreRun:  setupCommand(),
 	PostRun: teardownCommand,
 }
 

--- a/cli/cmd/server_cmd.go
+++ b/cli/cmd/server_cmd.go
@@ -11,7 +11,7 @@ var serverCmd = &cobra.Command{
 	Use:    "server",
 	Short:  "Manage your tracetest server",
 	Long:   "Manage your tracetest server",
-	PreRun: setupCommand,
+	PreRun: setupCommand(),
 	Run: func(cmd *cobra.Command, args []string) {
 		analytics.Track("Server", "cmd", map[string]string{})
 		fmt.Println("Manage your server")

--- a/cli/cmd/server_install_cmd.go
+++ b/cli/cmd/server_install_cmd.go
@@ -14,7 +14,7 @@ var serverInstallCmd = &cobra.Command{
 	Use:    "install",
 	Short:  "install a new server",
 	Long:   "install a new server",
-	PreRun: setupCommand,
+	PreRun: setupCommand(SkipConfigValidation()),
 	Run: func(cmd *cobra.Command, args []string) {
 		installer.Force = force
 		analytics.Track("Server Install", "cmd", map[string]string{})

--- a/cli/cmd/test_cmd.go
+++ b/cli/cmd/test_cmd.go
@@ -11,7 +11,7 @@ var testCmd = &cobra.Command{
 	Use:    "test",
 	Short:  "Manage your tracetest tests",
 	Long:   "Manage your tracetest tests",
-	PreRun: setupCommand,
+	PreRun: setupCommand(),
 	Run: func(cmd *cobra.Command, args []string) {
 		analytics.Track("Test", "cmd", map[string]string{})
 

--- a/cli/cmd/test_export_cmd.go
+++ b/cli/cmd/test_export_cmd.go
@@ -19,7 +19,7 @@ var testExportCmd = &cobra.Command{
 	Use:    "export",
 	Short:  "export a test",
 	Long:   "export a test",
-	PreRun: setupCommand,
+	PreRun: setupCommand(),
 	Run: func(cmd *cobra.Command, args []string) {
 		analytics.Track("Test Export", "cmd", map[string]string{})
 

--- a/cli/cmd/test_list_cmd.go
+++ b/cli/cmd/test_list_cmd.go
@@ -13,7 +13,7 @@ var testListCmd = &cobra.Command{
 	Use:    "list",
 	Short:  "list all test",
 	Long:   "list all test",
-	PreRun: setupCommand,
+	PreRun: setupCommand(),
 	Run: func(cmd *cobra.Command, args []string) {
 		analytics.Track("Test List", "cmd", map[string]string{})
 

--- a/cli/cmd/test_run_cmd.go
+++ b/cli/cmd/test_run_cmd.go
@@ -18,7 +18,7 @@ var testRunCmd = &cobra.Command{
 	Use:    "run",
 	Short:  "run a test",
 	Long:   "run a test using a definition or an id",
-	PreRun: setupCommand,
+	PreRun: setupCommand(),
 	Run: func(cmd *cobra.Command, args []string) {
 		analytics.Track("Test Run", "cmd", map[string]string{})
 

--- a/cli/cmd/version.go
+++ b/cli/cmd/version.go
@@ -12,7 +12,7 @@ var versionCmd = &cobra.Command{
 	Use:    "version",
 	Short:  "cli versions",
 	Long:   "Display this CLI tool version",
-	PreRun: setupCommand,
+	PreRun: setupCommand(),
 	Run: func(cmd *cobra.Command, args []string) {
 		analytics.Track("Version", "cmd", map[string]string{})
 


### PR DESCRIPTION
This PR makes the CLI validate if it is configured before running any command.

It also makes the CLI logger print logs as messages and not JSON messages. This doesn't affect test outputs or other formatted outputs. Example:

![Screenshot from 2022-11-10 18-37-47](https://user-images.githubusercontent.com/2704737/201211362-4e9fea7a-1d05-4ee3-b808-800f646097f0.png)


## Checklist

- [ ] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
