### PR TITLE
fix: ignore extra slash at end of cli endpoint

### DIFF
--- a/cli/actions/configure_action.go
+++ b/cli/actions/configure_action.go
@@ -49,11 +49,7 @@ func (a configureAction) Run(ctx context.Context, args ConfigureConfig) error {
 	if args.SetValues.Endpoint != nil {
 		serverURL = *args.SetValues.Endpoint
 	} else {
-		existingURL := ""
-		if existingConfig.Scheme != "" && existingConfig.Endpoint != "" {
-			existingURL = fmt.Sprintf("%s://%s", existingConfig.Scheme, existingConfig.Endpoint)
-		}
-		serverURL = ui.TextInput("Enter your Tracetest server URL", existingURL)
+		serverURL = ui.TextInput("Enter your Tracetest server URL", existingConfig.URL())
 	}
 
 	if !strings.HasPrefix(serverURL, "http://") && !strings.HasPrefix(serverURL, "https://") {
@@ -74,7 +70,7 @@ func (a configureAction) Run(ctx context.Context, args ConfigureConfig) error {
 	}
 
 	scheme := urlParts[0]
-	endpoint := urlParts[1]
+	endpoint := strings.TrimSuffix(urlParts[1], "/")
 
 	config := config.Config{
 		Scheme:           scheme,

--- a/cli/cmd/config.go
+++ b/cli/cmd/config.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/kubeshop/tracetest/cli/analytics"
 	"github.com/kubeshop/tracetest/cli/config"
@@ -67,7 +68,7 @@ func getAPIClient() *openapi.APIClient {
 	config := openapi.NewConfiguration()
 	config.AddDefaultHeader("x-client-id", analytics.ClientID())
 	config.Scheme = cliConfig.Scheme
-	config.Host = cliConfig.Endpoint
+	config.Host = strings.TrimSuffix(cliConfig.Endpoint, "/")
 	if cliConfig.ServerPath != nil {
 		config.Servers = []openapi.ServerConfiguration{
 			{

--- a/cli/config/config.go
+++ b/cli/config/config.go
@@ -22,6 +22,14 @@ type Config struct {
 	AnalyticsEnabled bool    `yaml:"analyticsEnabled"`
 }
 
+func (c Config) URL() string {
+	if c.Scheme == "" || c.Endpoint == "" {
+		return ""
+	}
+
+	return fmt.Sprintf("%s://%s", c.Scheme, strings.TrimSuffix(c.Endpoint, "/"))
+}
+
 func (c Config) IsEmpty() bool {
 	thisConfigJson, _ := json.Marshal(c)
 	emptyConfigJson, _ := json.Marshal(Config{})


### PR DESCRIPTION
This PR makes the CLI ignore the slash at the end of the endpoint and prevent that from making the API calls from failing.

`http://localhost:1234/` becomes `http://localhost:1234`

This PR also considers that the configuration can be edited by hand and still removes the slash from other places when configuring the CLI HTTP client.

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
