### PR TITLE
feat: add summary to transaction listing endpoint and return version in transaction run

### DIFF
--- a/api/transactions.yaml
+++ b/api/transactions.yaml
@@ -34,6 +34,9 @@ components:
         id:
           type: string
           readOnly: true
+        version:
+          type: integer
+          readOnly: true
         createdAt:
           type: string
           format: date-time

--- a/api/transactions.yaml
+++ b/api/transactions.yaml
@@ -22,6 +22,11 @@ components:
         createdAt:
           type: string
           format: date-time
+        summary:
+          $ref: "./tests.yaml#/components/schemas/TestSummary"
+          description: summary of transaction
+          readOnly: true
+
 
     TransactionRun:
       type: object

--- a/server/http/mappings/tests.go
+++ b/server/http/mappings/tests.go
@@ -33,6 +33,14 @@ func (m OpenAPI) Transaction(in model.Transaction) openapi.Transaction {
 		Version:     int32(in.Version),
 		Steps:       testIds,
 		CreatedAt:   in.CreatedAt,
+		Summary: openapi.TestSummary{
+			Runs: int32(in.Summary.Runs),
+			LastRun: openapi.TestSummaryLastRun{
+				Time:   in.Summary.LastRun.Time,
+				Passes: 0,
+				Fails:  0,
+			},
+		},
 	}
 }
 

--- a/server/http/mappings/tests.go
+++ b/server/http/mappings/tests.go
@@ -58,6 +58,7 @@ func (m OpenAPI) TransactionRun(in model.TransactionRun) openapi.TransactionRun 
 
 	return openapi.TransactionRun{
 		Id:          fmt.Sprintf("%d", in.ID),
+		Version:     int32(in.TransactionVersion),
 		CreatedAt:   in.CreatedAt,
 		CompletedAt: in.CompletedAt,
 		State:       string(in.State),

--- a/server/openapi/impl.go
+++ b/server/openapi/impl.go
@@ -9,7 +9,7 @@
 
 package openapi
 
-// Implementation response defines an error code with the associated body
+//Implementation response defines an error code with the associated body
 type ImplResponse struct {
 	Code int
 	Body interface{}

--- a/server/openapi/model_transaction.go
+++ b/server/openapi/model_transaction.go
@@ -26,10 +26,15 @@ type Transaction struct {
 	Steps []string `json:"steps,omitempty"`
 
 	CreatedAt time.Time `json:"createdAt,omitempty"`
+
+	Summary TestSummary `json:"summary,omitempty"`
 }
 
 // AssertTransactionRequired checks if the required fields are not zero-ed
 func AssertTransactionRequired(obj Transaction) error {
+	if err := AssertTestSummaryRequired(obj.Summary); err != nil {
+		return err
+	}
 	return nil
 }
 

--- a/server/openapi/model_transaction_run.go
+++ b/server/openapi/model_transaction_run.go
@@ -16,6 +16,8 @@ import (
 type TransactionRun struct {
 	Id string `json:"id,omitempty"`
 
+	Version int32 `json:"version,omitempty"`
+
 	CreatedAt time.Time `json:"createdAt,omitempty"`
 
 	CompletedAt time.Time `json:"completedAt,omitempty"`

--- a/server/testdb/transactions.go
+++ b/server/testdb/transactions.go
@@ -135,8 +135,16 @@ const getTransactionSQL = `
 		t.version,
 		t.name,
 		t.description,
-		t.created_at
+		t.created_at,
+		(SELECT COUNT(*) FROM transaction_runs tr WHERE tr.transaction_id = t.id) as total_runs,
+		last_transaction_run.created_at as last_transaction_run_time
 	FROM transactions t
+	LEFT OUTER JOIN (
+		SELECT MAX(id) as id, transaction_id FROM transaction_runs GROUP BY transaction_id
+	) as ltr ON ltr.transaction_id = t.id
+	LEFT OUTER JOIN
+		transaction_runs last_transaction_run
+	ON last_transaction_run.transaction_id = ltr.transaction_id AND last_transaction_run.id = ltr.id
 `
 
 const transactionMaxVersionQuery = `
@@ -264,16 +272,23 @@ func (td *postgresDB) readTransactionRows(ctx context.Context, rows *sql.Rows) (
 func (td *postgresDB) readTransactionRow(ctx context.Context, row scanner) (model.Transaction, error) {
 	transaction := model.Transaction{}
 
+	var lastRunTime *time.Time
+
 	err := row.Scan(
 		&transaction.ID,
 		&transaction.Version,
 		&transaction.Name,
 		&transaction.Description,
 		&transaction.CreatedAt,
+		&transaction.Summary.Runs,
+		&lastRunTime,
 	)
 
 	switch err {
 	case nil:
+		if lastRunTime != nil {
+			transaction.Summary.LastRun.Time = *lastRunTime
+		}
 		return transaction, nil
 	case sql.ErrNoRows:
 		return model.Transaction{}, ErrNotFound


### PR DESCRIPTION
This PR adds the summary to the transaction endpoints and returns the transaction version in the transaction run object.

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
