### PR TITLE
Add Flame Graph as a Trace view

### DIFF
--- a/k8s/tracetest.beta.yaml
+++ b/k8s/tracetest.beta.yaml
@@ -17,7 +17,7 @@ demo:
     otelCart: http://otel-cartservice.otel-demo:7070
     otelCheckout: http://otel-checkoutservice.otel-demo:5050
 
-experimentalFeatures: []
+experimentalFeatures: ["flamegraph"]
 
 telemetry:
   dataStores:

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -18,6 +18,8 @@
         "@emotion/react": "11.9.0",
         "@lezer/highlight": "1.0.0",
         "@opentelemetry/semantic-conventions": "1.3.0",
+        "@pyroscope/flamegraph": "0.25.2-1679-ab8cd3f.0",
+        "@pyroscope/models": "0.4.5",
         "@reduxjs/toolkit": "1.8.4",
         "@sentry/react": "6.19.7",
         "@sentry/tracing": "6.19.7",
@@ -65,7 +67,8 @@
         "react-use": "17.4.0",
         "redux-first-history": "5.0.12",
         "styled-components": "5.3.3",
-        "typescript": "~4.1.5"
+        "typescript": "~4.1.5",
+        "zod": "3.19.1"
       },
       "devDependencies": {
         "@craco/craco": "6.4.3",
@@ -4526,6 +4529,24 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
       "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="
+    },
+    "node_modules/@pyroscope/flamegraph": {
+      "version": "0.25.2-1679-ab8cd3f.0",
+      "resolved": "https://registry.npmjs.org/@pyroscope/flamegraph/-/flamegraph-0.25.2-1679-ab8cd3f.0.tgz",
+      "integrity": "sha512-FQJlphSWo/+JSI5xjr5xGTqAFYx2oA6yTWYAIzxmM38dx0GFVM//m9gN509KBWM8n7YJR7YoeqI7sPzPazLM3Q==",
+      "peerDependencies": {
+        "react": ">=16.14.0",
+        "react-dom": ">=16.14.0",
+        "true-myth": "^5.1.2"
+      }
+    },
+    "node_modules/@pyroscope/models": {
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/@pyroscope/models/-/models-0.4.5.tgz",
+      "integrity": "sha512-00h8CZbzjG/9eI08swcRJ/KgiA8B0OBXvnPzmcn6F1etV1Dytdun2yuDuJ+vNQ+9Hohd7kzI5/fHlpeS+7EUpw==",
+      "peerDependencies": {
+        "zod": "^3.11.6"
+      }
     },
     "node_modules/@reduxjs/toolkit": {
       "version": "1.8.4",
@@ -38068,6 +38089,14 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/zod": {
+      "version": "3.19.1",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.19.1.tgz",
+      "integrity": "sha512-LYjZsEDhCdYET9ikFu6dVPGp2YH9DegXjdJToSzD9rO6fy4qiRYFoyEYwps88OseJlPyl2NOe2iJuhEhL7IpEA==",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
     "node_modules/zustand": {
       "version": "3.7.2",
       "resolved": "https://registry.npmjs.org/zustand/-/zustand-3.7.2.tgz",
@@ -41369,6 +41398,16 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
       "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="
+    },
+    "@pyroscope/flamegraph": {
+      "version": "0.25.2-1679-ab8cd3f.0",
+      "resolved": "https://registry.npmjs.org/@pyroscope/flamegraph/-/flamegraph-0.25.2-1679-ab8cd3f.0.tgz",
+      "integrity": "sha512-FQJlphSWo/+JSI5xjr5xGTqAFYx2oA6yTWYAIzxmM38dx0GFVM//m9gN509KBWM8n7YJR7YoeqI7sPzPazLM3Q=="
+    },
+    "@pyroscope/models": {
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/@pyroscope/models/-/models-0.4.5.tgz",
+      "integrity": "sha512-00h8CZbzjG/9eI08swcRJ/KgiA8B0OBXvnPzmcn6F1etV1Dytdun2yuDuJ+vNQ+9Hohd7kzI5/fHlpeS+7EUpw=="
     },
     "@reduxjs/toolkit": {
       "version": "1.8.4",
@@ -67078,6 +67117,11 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
       "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="
+    },
+    "zod": {
+      "version": "3.19.1",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.19.1.tgz",
+      "integrity": "sha512-LYjZsEDhCdYET9ikFu6dVPGp2YH9DegXjdJToSzD9rO6fy4qiRYFoyEYwps88OseJlPyl2NOe2iJuhEhL7IpEA=="
     },
     "zustand": {
       "version": "3.7.2",

--- a/web/package.json
+++ b/web/package.json
@@ -14,6 +14,8 @@
     "@emotion/react": "11.9.0",
     "@lezer/highlight": "1.0.0",
     "@opentelemetry/semantic-conventions": "1.3.0",
+    "@pyroscope/flamegraph": "0.25.2-1679-ab8cd3f.0",
+    "@pyroscope/models": "0.4.5",
     "@reduxjs/toolkit": "1.8.4",
     "@sentry/react": "6.19.7",
     "@sentry/tracing": "6.19.7",
@@ -61,7 +63,8 @@
     "react-use": "17.4.0",
     "redux-first-history": "5.0.12",
     "styled-components": "5.3.3",
-    "typescript": "~4.1.5"
+    "typescript": "~4.1.5",
+    "zod": "3.19.1"
   },
   "scripts": {
     "start": "craco start",

--- a/web/src/components/RunDetailTest/Visualization.tsx
+++ b/web/src/components/RunDetailTest/Visualization.tsx
@@ -1,6 +1,3 @@
-import {useCallback, useEffect} from 'react';
-import {Node, NodeChange} from 'react-flow-renderer';
-
 import {VisualizationType} from 'components/RunDetailTrace/RunDetailTrace';
 import SkeletonDiagram from 'components/SkeletonDiagram';
 import {useTestSpecForm} from 'components/TestSpecForm/TestSpecForm.provider';
@@ -8,6 +5,8 @@ import DAG from 'components/Visualization/components/DAG';
 import Timeline from 'components/Visualization/components/Timeline';
 import {TestState} from 'constants/TestRun.constants';
 import {useSpan} from 'providers/Span/Span.provider';
+import {useCallback, useEffect} from 'react';
+import {Node, NodeChange} from 'react-flow-renderer';
 import {useAppDispatch, useAppSelector} from 'redux/hooks';
 import {initNodes, onNodesChange as onNodesChangeAction} from 'redux/slices/DAG.slice';
 import DAGSelectors from 'selectors/DAG.selectors';
@@ -15,6 +14,7 @@ import TraceAnalyticsService from 'services/Analytics/TestRunAnalytics.service';
 import TraceDiagramAnalyticsService from 'services/Analytics/TraceDiagramAnalytics.service';
 import {TSpan} from 'types/Span.types';
 import {TTestRunState} from 'types/TestRun.types';
+import {Flame} from '../Visualization/components/Flame/Flame';
 
 export interface IProps {
   runState: TTestRunState;
@@ -69,27 +69,43 @@ const Visualization = ({runState, spans, type}: IProps) => {
   if (runState !== TestState.FINISHED) {
     return <SkeletonDiagram />;
   }
+  return (
+    <>
+      {type === VisualizationType.Dag && (
+        <DAG
+          edges={edges}
+          isMatchedMode={matchedSpans.length > 0 || isOpen}
+          matchedSpans={matchedSpans}
+          nodes={nodes}
+          onNavigateToSpan={onNavigateToSpan}
+          onNodesChange={onNodesChange}
+          onNodeClick={onNodeClick}
+          selectedSpan={focusedSpan}
+        />
+      )}
 
-  return type === VisualizationType.Dag ? (
-    <DAG
-      edges={edges}
-      isMatchedMode={matchedSpans.length > 0 || isOpen}
-      matchedSpans={matchedSpans}
-      nodes={nodes}
-      onNavigateToSpan={onNavigateToSpan}
-      onNodesChange={onNodesChange}
-      onNodeClick={onNodeClick}
-      selectedSpan={focusedSpan}
-    />
-  ) : (
-    <Timeline
-      isMatchedMode={matchedSpans.length > 0 || isOpen}
-      matchedSpans={matchedSpans}
-      onNavigateToSpan={onNavigateToSpan}
-      onNodeClick={onNodeClickTimeline}
-      selectedSpan={selectedSpan?.id ?? ''}
-      spans={spans}
-    />
+      {type === VisualizationType.Timeline && (
+        <Timeline
+          isMatchedMode={matchedSpans.length > 0 || isOpen}
+          matchedSpans={matchedSpans}
+          onNavigateToSpan={onNavigateToSpan}
+          onNodeClick={onNodeClickTimeline}
+          selectedSpan={selectedSpan?.id ?? ''}
+          spans={spans}
+        />
+      )}
+
+      {type === VisualizationType.Flame && (
+        <Flame
+          isMatchedMode={matchedSpans.length > 0 || isOpen}
+          matchedSpans={matchedSpans}
+          onNavigateToSpan={onNavigateToSpan}
+          onNodeClick={onNodeClickTimeline}
+          selectedSpan={selectedSpan?.id ?? ''}
+          spans={spans}
+        />
+      )}
+    </>
   );
 };
 

--- a/web/src/components/RunDetailTrace/RunDetailTrace.tsx
+++ b/web/src/components/RunDetailTrace/RunDetailTrace.tsx
@@ -1,10 +1,9 @@
-import {useCallback, useState} from 'react';
-import {useNavigate} from 'react-router-dom';
-
 import Drawer from 'components/Drawer';
 import SpanDetail from 'components/SpanDetail';
 import Switch from 'components/Visualization/components/Switch';
 import {TestState} from 'constants/TestRun.constants';
+import {useCallback, useState} from 'react';
+import {useNavigate} from 'react-router-dom';
 import {useAppSelector} from 'redux/hooks';
 import SpanSelectors from 'selectors/Span.selectors';
 import TraceSelectors from 'selectors/Trace.selectors';
@@ -22,6 +21,7 @@ interface IProps {
 export enum VisualizationType {
   Dag,
   Timeline,
+  Flame,
 }
 
 const RunDetailTrace = ({run, testId}: IProps) => {
@@ -41,9 +41,11 @@ const RunDetailTrace = ({run, testId}: IProps) => {
         leftPanel={<SpanDetail onCreateTestSpec={handleOnCreateSpec} searchText={searchText} span={span} />}
         rightPanel={
           <S.Section>
-            <S.SearchContainer>
-              <Search runId={run.id} testId={testId} />
-            </S.SearchContainer>
+            {visualizationType !== VisualizationType.Flame && (
+              <S.SearchContainer>
+                <Search runId={run.id} testId={testId} />
+              </S.SearchContainer>
+            )}
 
             <S.VisualizationContainer>
               <S.SwitchContainer>

--- a/web/src/components/RunDetailTrace/Visualization.tsx
+++ b/web/src/components/RunDetailTrace/Visualization.tsx
@@ -1,6 +1,4 @@
 import SkeletonDiagram from 'components/SkeletonDiagram';
-import DAG from 'components/Visualization/components/DAG';
-import Timeline from 'components/Visualization/components/Timeline';
 import {TestState} from 'constants/TestRun.constants';
 import {useCallback, useEffect} from 'react';
 import {Node, NodeChange} from 'react-flow-renderer';
@@ -12,6 +10,9 @@ import TraceDiagramAnalyticsService from 'services/Analytics/TraceDiagramAnalyti
 import {TSpan} from 'types/Span.types';
 import {TTestRunState} from 'types/TestRun.types';
 import {useDrawer} from '../Drawer/Drawer';
+import DAG from '../Visualization/components/DAG';
+import {Flame} from '../Visualization/components/Flame/Flame';
+import Timeline from '../Visualization/components/Timeline';
 import {VisualizationType} from './RunDetailTrace';
 
 interface IProps {
@@ -70,26 +71,41 @@ const Visualization = ({runState, spans, type}: IProps) => {
     return <SkeletonDiagram />;
   }
 
-  return type === VisualizationType.Dag ? (
-    <DAG
-      edges={edges}
-      isMatchedMode={isMatchedMode}
-      matchedSpans={matchedSpans}
-      nodes={nodes}
-      onNavigateToSpan={onNavigateToSpan}
-      onNodesChange={onNodesChange}
-      onNodeClick={onNodeClick}
-      selectedSpan={selectedSpan}
-    />
-  ) : (
-    <Timeline
-      isMatchedMode={isMatchedMode}
-      matchedSpans={matchedSpans}
-      onNavigateToSpan={onNavigateToSpan}
-      onNodeClick={onNodeClickTimeline}
-      selectedSpan={selectedSpan}
-      spans={spans}
-    />
+  return (
+    <>
+      {type === VisualizationType.Dag && (
+        <DAG
+          edges={edges}
+          isMatchedMode={isMatchedMode}
+          matchedSpans={matchedSpans}
+          nodes={nodes}
+          onNavigateToSpan={onNavigateToSpan}
+          onNodesChange={onNodesChange}
+          onNodeClick={onNodeClick}
+          selectedSpan={selectedSpan}
+        />
+      )}
+      {type === VisualizationType.Timeline && (
+        <Timeline
+          isMatchedMode={isMatchedMode}
+          matchedSpans={matchedSpans}
+          onNavigateToSpan={onNavigateToSpan}
+          onNodeClick={onNodeClickTimeline}
+          selectedSpan={selectedSpan}
+          spans={spans}
+        />
+      )}
+      {type === VisualizationType.Flame && (
+        <Flame
+          isMatchedMode={isMatchedMode}
+          matchedSpans={matchedSpans}
+          onNavigateToSpan={onNavigateToSpan}
+          onNodeClick={onNodeClickTimeline}
+          selectedSpan={selectedSpan}
+          spans={spans}
+        />
+      )}
+    </>
   );
 };
 

--- a/web/src/components/Visualization/components/Flame/Flame.styled.tsx
+++ b/web/src/components/Visualization/components/Flame/Flame.styled.tsx
@@ -1,0 +1,5 @@
+import styled from 'styled-components';
+
+export const Container = styled.div`
+  padding: 24px;
+`;

--- a/web/src/components/Visualization/components/Flame/Flame.tsx
+++ b/web/src/components/Visualization/components/Flame/Flame.tsx
@@ -1,0 +1,30 @@
+import {convertJaegerTraceToProfile, FlamegraphRenderer} from '@pyroscope/flamegraph';
+import '@pyroscope/flamegraph/dist/index.css';
+import {useMemo} from 'react';
+import FlameGraphService from 'services/Flamegraph.service';
+import {TSpan} from 'types/Span.types';
+import {useTestRun} from '../../../../providers/TestRun/TestRun.provider';
+import * as S from './Flame.styled';
+
+interface IProps {
+  isMatchedMode: boolean;
+  matchedSpans: string[];
+  selectedSpan: string;
+  spans: TSpan[];
+  width?: number;
+  onNavigateToSpan(spanId: string): void;
+  onNodeClick(spanId: string): void;
+}
+
+export const Flame: React.FC<IProps> = ({spans}) => {
+  const {run} = useTestRun();
+  const profile = useMemo(
+    () => convertJaegerTraceToProfile(FlameGraphService.convertTracetestSpanToJaeger(run.trace?.traceId || '', spans)),
+    [spans, run.trace?.traceId]
+  );
+  return (
+    <S.Container>
+      <FlamegraphRenderer profile={profile} colorMode="light" showToolbar />
+    </S.Container>
+  );
+};

--- a/web/src/components/Visualization/components/Flame/__tests__/FlameView.test.tsx
+++ b/web/src/components/Visualization/components/Flame/__tests__/FlameView.test.tsx
@@ -1,0 +1,36 @@
+import FlamegraphService from 'services/Flamegraph.service';
+import {TSpan} from 'types/Span.types';
+
+describe('Flame View Test', () => {
+  const traceId = '1';
+  const s1 = {id: '1', parentId: '', name: 'one'} as TSpan;
+  const s2 = {id: '2', parentId: '1', name: 'two'} as TSpan;
+  const s3 = {id: '3', parentId: '2', name: 'three'} as TSpan;
+  const spans = [s1, s2, s3];
+
+  test('parentReferences', () => {
+    expect(FlamegraphService.parentReferences(traceId, spans, s2)).toStrictEqual([
+      {
+        refType: 'CHILD_OF',
+        spanID: s1.id,
+        traceID: traceId,
+      },
+    ]);
+  });
+
+  test('tracetestSpanToJagerSpan', () => {
+    expect(FlamegraphService.tracetestSpanToJagerSpan(traceId, spans, s1)).toStrictEqual({
+      operationName: s1.name,
+      duration: 0,
+      processID: '',
+      references: FlamegraphService.parentReferences(traceId, spans, s1),
+      spanID: s1.id,
+      startTime: 0,
+      tags: [],
+      traceID: traceId,
+      warnings: [],
+      flags: '',
+      logs: {fields: [], timestamp: 0},
+    });
+  });
+});

--- a/web/src/components/Visualization/components/Switch/Switch.styled.ts
+++ b/web/src/components/Visualization/components/Switch/Switch.styled.ts
@@ -1,4 +1,4 @@
-import {BarsOutlined, ClusterOutlined} from '@ant-design/icons';
+import {BarsOutlined, ClusterOutlined, PicCenterOutlined} from '@ant-design/icons';
 import styled from 'styled-components';
 
 export const Container = styled.div`
@@ -18,6 +18,12 @@ export const DAGIcon = styled(ClusterOutlined)<{$isSelected?: boolean}>`
 `;
 
 export const TimelineIcon = styled(BarsOutlined)<{$isSelected?: boolean}>`
+  color: ${({$isSelected = false, theme}) => ($isSelected ? theme.color.primary : theme.color.textSecondary)};
+  cursor: pointer;
+  font-size: ${({theme}) => theme.size.xl};
+`;
+
+export const FlameIcon = styled(PicCenterOutlined)<{$isSelected?: boolean}>`
   color: ${({$isSelected = false, theme}) => ($isSelected ? theme.color.primary : theme.color.textSecondary)};
   cursor: pointer;
   font-size: ${({theme}) => theme.size.xl};

--- a/web/src/components/Visualization/components/Switch/Switch.tsx
+++ b/web/src/components/Visualization/components/Switch/Switch.tsx
@@ -1,11 +1,12 @@
 import {Tooltip} from 'antd';
 
 import {VisualizationType} from 'components/RunDetailTrace/RunDetailTrace';
+import ExperimentalFeature from '../../../../utils/ExperimentalFeature';
 import * as S from './Switch.styled';
 
 interface IProps {
-  onChange(type: VisualizationType): void;
   type: VisualizationType;
+  onChange(type: VisualizationType): void;
 }
 
 const Switch = ({onChange, type}: IProps) => (
@@ -19,6 +20,11 @@ const Switch = ({onChange, type}: IProps) => (
         onClick={() => onChange(VisualizationType.Timeline)}
       />
     </Tooltip>
+    {ExperimentalFeature.isEnabled('flamegraph') && (
+      <Tooltip title="Flame view" placement="right">
+        <S.FlameIcon $isSelected={type === VisualizationType.Flame} onClick={() => onChange(VisualizationType.Flame)} />
+      </Tooltip>
+    )}
   </S.Container>
 );
 

--- a/web/src/services/Flamegraph.service.ts
+++ b/web/src/services/Flamegraph.service.ts
@@ -1,0 +1,43 @@
+import {Trace} from '@pyroscope/models';
+import {TSpan} from '../types/Span.types';
+
+type Span = Trace['spans'][number];
+
+const FlameGraphService = () => ({
+  parentReferences(traceId: string, spans: TSpan[], current: TSpan): Span['references'] {
+    const parent = spans.find(s => s.id === current.parentId);
+    if (!parent) return [];
+    return [
+      {
+        refType: 'CHILD_OF',
+        spanID: parent.id,
+        traceID: traceId,
+      },
+    ];
+  },
+  tracetestSpanToJagerSpan(id: string, spans: TSpan[], s: TSpan): Span {
+    const milliseconds = 1000;
+    return {
+      operationName: s.name,
+      duration: ((s.endTime || 0) - (s.startTime || 0)) * milliseconds,
+      processID: '',
+      references: this.parentReferences(id, spans, s),
+      spanID: s.id,
+      startTime: (s.startTime || 0) * milliseconds,
+      tags: [],
+      traceID: id,
+      warnings: [],
+      flags: '',
+      logs: {fields: [], timestamp: 0},
+    };
+  },
+  convertTracetestSpanToJaeger(traceID: string, spans: TSpan[]): Trace {
+    return {
+      traceID,
+      spans: spans.map(s => this.tracetestSpanToJagerSpan(traceID, spans, s)),
+      processes: {p1: {serviceName: '', tags: []}, p2: {serviceName: '', tags: []}},
+    };
+  },
+});
+
+export default FlameGraphService();


### PR DESCRIPTION
This PR add a new trace view called Flame view.
We use the same library jager is using called @pyroscope/flamegraph
So we can benefit from future development for the specific trace visualization goal like this [one](https://github.com/pyroscope-io/pyroscope/pull/1679) 

<img width="858" alt="Screen Shot 2022-11-14 at 23 59 43" src="https://user-images.githubusercontent.com/6259987/201815920-8e85156a-7182-44b2-8c7f-a586b818c497.png">

<img width="965" alt="Screen Shot 2022-11-14 at 23 57 36" src="https://user-images.githubusercontent.com/6259987/201815913-88301c4a-d631-4754-a969-b3c1b8d5a9e8.png">




## Changes

- Add new Trace view


## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [x] added a test
