### PR TITLE
fix: env merging and output processing

### DIFF
--- a/server/executor/outputs_processor.go
+++ b/server/executor/outputs_processor.go
@@ -66,7 +66,7 @@ func outputProcessor(ctx context.Context, outputs model.OrderedMap[string, model
 		value := ""
 		spans.
 			ForEach(func(_ int, span traces.Span) bool {
-				value = extractAttr(traces.Span{}, stores, out.expr)
+				value = extractAttr(span, stores, out.expr)
 				// take only the first value
 				return false
 			}).

--- a/server/model/environments_test.go
+++ b/server/model/environments_test.go
@@ -42,3 +42,24 @@ func TestEnvironmentMerge(t *testing.T) {
 	assert.Contains(t, newEnv.Values, model.EnvironmentValue{Key: "apiKey", Value: "abcdef"})
 	assert.Contains(t, newEnv.Values, model.EnvironmentValue{Key: "apiKeyLocation", Value: "header"})
 }
+
+func TestEnvironmentMergeWithEmptyEnvironment(t *testing.T) {
+	env1 := model.Environment{
+		ID:          "my-env",
+		Name:        "my environment",
+		Description: "my description",
+		CreatedAt:   time.Now(),
+		Values: []model.EnvironmentValue{
+			{Key: "URL", Value: "http://localhost"},
+			{Key: "PORT", Value: "8085"},
+		},
+	}
+
+	env2 := model.Environment{
+		Values: []model.EnvironmentValue{},
+	}
+
+	newEnv := env1.Merge(env2)
+	require.Len(t, newEnv.Values, 2)
+
+}

--- a/server/model/transactions.go
+++ b/server/model/transactions.go
@@ -89,3 +89,25 @@ func NewTransactionRun(transaction Transaction) TransactionRun {
 		CurrentTest:        0,
 	}
 }
+
+func (run TransactionRun) InjectOutputsIntoEnvironment(env Environment) Environment {
+	if run.CurrentTest == 0 {
+		return env
+	}
+
+	lastExecutedTest := run.StepRuns[run.CurrentTest-1]
+	lastEnvironment := lastExecutedTest.Environment
+	newEnvVariables := make([]EnvironmentValue, 0)
+	lastExecutedTest.Outputs.ForEach(func(key, val string) error {
+		newEnvVariables = append(newEnvVariables, EnvironmentValue{
+			Key:   key,
+			Value: val,
+		})
+
+		return nil
+	})
+
+	newEnvironment := Environment{Values: newEnvVariables}
+
+	return lastEnvironment.Merge(newEnvironment)
+}

--- a/server/model/transactions_test.go
+++ b/server/model/transactions_test.go
@@ -1,0 +1,38 @@
+package model_test
+
+import (
+	"testing"
+
+	"github.com/kubeshop/tracetest/server/model"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEnvironmentOutputInjection(t *testing.T) {
+	environment := model.Environment{
+		ID:   "env-id",
+		Name: "my environment",
+		Values: []model.EnvironmentValue{
+			{Key: "HOST", Value: "http://my-api.com"},
+			{Key: "PORT", Value: "8081"},
+		},
+	}
+
+	run := model.TransactionRun{
+		CurrentTest: 1,
+		StepRuns: []model.TransactionStepRun{
+			{
+				Environment: environment,
+				Outputs: (model.OrderedMap[string, string]{}).
+					MustAdd("TEST_ID", "123456").
+					MustAdd("RUN_ID", "2"),
+			},
+		},
+	}
+
+	newEnvironment := run.InjectOutputsIntoEnvironment(environment)
+
+	assert.Contains(t, newEnvironment.Values, model.EnvironmentValue{Key: "HOST", Value: "http://my-api.com"})
+	assert.Contains(t, newEnvironment.Values, model.EnvironmentValue{Key: "PORT", Value: "8081"})
+	assert.Contains(t, newEnvironment.Values, model.EnvironmentValue{Key: "TEST_ID", Value: "123456"})
+	assert.Contains(t, newEnvironment.Values, model.EnvironmentValue{Key: "RUN_ID", Value: "2"})
+}


### PR DESCRIPTION
This PR fixes the output processor and environment merging when running transactions.

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
