### PR TITLE
fix execution time calc

### DIFF
--- a/server/model/run.go
+++ b/server/model/run.go
@@ -45,7 +45,7 @@ func (r Run) Copy() Run {
 
 func (r Run) ExecutionTime() int {
 	var endDate time.Time
-	if !r.CompletedAt.IsZero() {
+	if !dateIsZero(r.CompletedAt) {
 		endDate = r.CompletedAt
 	} else {
 		endDate = Now()
@@ -54,6 +54,10 @@ func (r Run) ExecutionTime() int {
 	et := math.Ceil(endDate.Sub(r.CreatedAt).Seconds())
 
 	return int(et)
+}
+
+func dateIsZero(in time.Time) bool {
+	return in.IsZero() || in.Unix() == 0
 }
 
 func (r Run) Start() Run {

--- a/server/model/run_test.go
+++ b/server/model/run_test.go
@@ -39,6 +39,15 @@ func TestRunExecutionTime(t *testing.T) {
 			now:      time.Date(2022, 01, 25, 12, 45, 34, 300, time.UTC),
 			expected: 2,
 		},
+		{
+			name: "ZeroedDate",
+			run: model.Run{
+				CreatedAt:   time.Date(2022, 01, 25, 12, 45, 33, 100, time.UTC),
+				CompletedAt: time.Unix(0, 0),
+			},
+			now:      time.Date(2022, 01, 25, 12, 45, 34, 300, time.UTC),
+			expected: 2,
+		},
 	}
 
 	for _, c := range cases {


### PR DESCRIPTION
This PR fixes the execution time calculation when test is running

## Changes

-

## Fixes

-

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [x] added a test
