### PR TITLE
1505 1475 [Transactions] Display test spec summary results for transaction test runs

### DIFF
--- a/web/src/components/ResourceCard/ResourceCardSummary.tsx
+++ b/web/src/components/ResourceCard/ResourceCardSummary.tsx
@@ -1,5 +1,4 @@
 import {Tooltip} from 'antd';
-
 import {TSummary} from 'types/Test.types';
 import Date from 'utils/Date';
 import * as S from './ResourceCard.styled';

--- a/web/src/components/RunDetailLayout/RunDetailLayout.tsx
+++ b/web/src/components/RunDetailLayout/RunDetailLayout.tsx
@@ -1,4 +1,6 @@
 import {Tabs, TabsProps} from 'antd';
+import {useMemo} from 'react';
+import {useNavigate, useParams} from 'react-router-dom';
 
 import RunDetailTest from 'components/RunDetailTest';
 import RunDetailTrace from 'components/RunDetailTrace';
@@ -6,8 +8,7 @@ import RunDetailTrigger from 'components/RunDetailTrigger';
 import {RunDetailModes} from 'constants/TestRun.constants';
 import TestRunAnalyticsService from 'services/Analytics/TestRunAnalytics.service';
 import {useTestRun} from 'providers/TestRun/TestRun.provider';
-import {useMemo} from 'react';
-import {useNavigate, useParams} from 'react-router-dom';
+import useDocumentTitle from 'hooks/useDocumentTitle';
 import GuidedTourService, {GuidedTours} from 'services/GuidedTour.service';
 import {TTest} from 'types/Test.types';
 import {Steps} from '../GuidedTour/traceStepList';
@@ -32,6 +33,7 @@ const RunDetailLayout = ({test: {id, name, trigger, version = 1}, test}: IProps)
   const navigate = useNavigate();
   const {mode = RunDetailModes.TRIGGER} = useParams();
   const {isError, run} = useTestRun();
+  useDocumentTitle(`${name} - ${run.state}`);
 
   const tabBarExtraContent = useMemo(
     () => ({

--- a/web/src/components/TransactionRunLayout/TransactionRunLayout.tsx
+++ b/web/src/components/TransactionRunLayout/TransactionRunLayout.tsx
@@ -2,6 +2,7 @@ import {useNavigate} from 'react-router-dom';
 import TransactionHeader from 'components/TransactionHeader';
 import {TTransaction} from 'types/Transaction.types';
 import {TTransactionRun} from 'types/TransactionRun.types';
+import useDocumentTitle from 'hooks/useDocumentTitle';
 import * as S from './TransactionRunLayout.styled';
 import EditTransaction from '../EditTransaction';
 import TransactionRunResult from '../TransactionRunResult/TransactionRunResult';
@@ -13,6 +14,7 @@ interface IProps {
 
 const TransactionRunDetailLayout = ({transaction, transaction: {id: transactionId}, transactionRun}: IProps) => {
   const navigate = useNavigate();
+  useDocumentTitle(`${transaction.name} - ${transactionRun.state}`);
 
   return (
     <>

--- a/web/src/components/TransactionRunResult/ExecutionStep.tsx
+++ b/web/src/components/TransactionRunResult/ExecutionStep.tsx
@@ -1,4 +1,5 @@
 import {capitalize} from 'lodash';
+import {Tooltip} from 'antd';
 import {LinkOutlined} from '@ant-design/icons';
 import {TestState} from 'constants/TestRun.constants';
 import {TTest} from 'types/Test.types';
@@ -26,7 +27,7 @@ interface IProps {
 const ExecutionStep = ({
   index,
   test: {name, trigger, id: testId},
-  testRun: {id: runId, state, testVersion} = TestRun({}),
+  testRun: {id: runId, state, testVersion, passedAssertionCount, failedAssertionCount} = TestRun({}),
 }: IProps) => {
   return (
     <S.Container data-cy={`run-card-${name}`} key={`${testId}-${runId}`}>
@@ -39,10 +40,32 @@ const ExecutionStep = ({
           <S.TextTag>{capitalize(state)}</S.TextTag>
         </S.TagContainer>
       </S.Info>
+      <S.AssertionResultContainer>
+        {runId && (
+          <>
+            <Tooltip title="Passed assertions">
+              <S.HeaderDetail>
+                <S.HeaderDot $passed />
+                {passedAssertionCount}
+              </S.HeaderDetail>
+            </Tooltip>
+            <Tooltip title="Failed assertions">
+              <S.HeaderDetail>
+                <S.HeaderDot $passed={false} />
+                {failedAssertionCount}
+              </S.HeaderDetail>
+            </Tooltip>
+          </>
+        )}
+      </S.AssertionResultContainer>
       <S.ExecutionStepStatus>
-        <S.ExecutionStepRunLink to={`/test/${testId}/run/${runId}`} target="_blank">
-          <LinkOutlined />
-        </S.ExecutionStepRunLink>
+        {runId && (
+          <Tooltip title="Go to Run">
+            <S.ExecutionStepRunLink to={`/test/${testId}/run/${runId}`} target="_blank">
+              <LinkOutlined />
+            </S.ExecutionStepRunLink>
+          </Tooltip>
+        )}
       </S.ExecutionStepStatus>
     </S.Container>
   );

--- a/web/src/components/TransactionRunResult/TransactionRunResult.styled.ts
+++ b/web/src/components/TransactionRunResult/TransactionRunResult.styled.ts
@@ -9,7 +9,7 @@ export const Container = styled.div`
   border-radius: 2px;
   background: ${({theme}) => theme.color.background};
   display: grid;
-  grid-template-columns: auto 1fr auto;
+  grid-template-columns: auto 1fr auto auto;
   gap: 16px;
   padding: 7px 16px;
   margin-bottom: 8px;
@@ -100,4 +100,28 @@ export const ResultContainer = styled.div`
   display: flex;
   flex-direction: column;
   gap: 24px;
+`;
+
+export const HeaderDetail = styled(Typography.Text)`
+  display: flex;
+  align-items: center;
+  color: ${({theme}) => theme.color.textSecondary};
+  font-size: ${({theme}) => theme.size.sm};
+  margin-right: 8px;
+`;
+
+export const HeaderDot = styled.span<{$passed: boolean}>`
+  background-color: ${({$passed, theme}) => ($passed ? theme.color.success : theme.color.error)};
+  border-radius: 50%;
+  display: inline-block;
+  height: 10px;
+  line-height: 0;
+  margin-right: 4px;
+  vertical-align: -0.1em;
+  width: 10px;
+`;
+
+export const AssertionResultContainer = styled.div`
+  display: flex;
+  align-items: center;
 `;

--- a/web/src/constants/Common.constants.ts
+++ b/web/src/constants/Common.constants.ts
@@ -1,6 +1,7 @@
 export const SENTRY_DNS = 'https://8411cbb3b7d84c879f711f0e642a28e3@o1229268.ingest.sentry.io/6375361';
-
 export const SENTRY_ALLOWED_URLS = [/.*?localhost:3000/, /.*?tracetest.io/];
+
+export const DOCUMENT_TITLE = 'Tracetest';
 
 export const DOCUMENTATION_URL = 'https://kubeshop.github.io/tracetest/';
 export const GITHUB_URL = 'https://github.com/kubeshop/tracetest';

--- a/web/src/hooks/useDocumentTitle.ts
+++ b/web/src/hooks/useDocumentTitle.ts
@@ -1,0 +1,14 @@
+import {useEffect} from 'react';
+import {DOCUMENT_TITLE} from '../constants/Common.constants';
+
+const useDocumentTitle = (title: string) => {
+  useEffect(() => {
+    document.title = `${DOCUMENT_TITLE} - ${title}`;
+
+    return () => {
+      document.title = DOCUMENT_TITLE;
+    };
+  }, [title]);
+};
+
+export default useDocumentTitle;

--- a/web/src/pages/Test/Content.tsx
+++ b/web/src/pages/Test/Content.tsx
@@ -15,6 +15,7 @@ import {ResourceType} from 'types/Resource.type';
 import {TTestRun} from 'types/TestRun.types';
 import ExperimentalFeature from 'utils/ExperimentalFeature';
 import * as S from './Test.styled';
+import useDocumentTitle from '../../hooks/useDocumentTitle';
 
 const Content = () => {
   const navigate = useNavigate();
@@ -22,6 +23,7 @@ const Content = () => {
   const onDeleteResource = useDeleteResource();
   const {runTest, isLoadingRunTest} = useTestCrud();
   const params = useMemo(() => ({testId: test.id}), [test.id]);
+  useDocumentTitle(`${test.name}`);
 
   const handleRunTest = useCallback(async () => {
     if (test.id) runTest(test.id);

--- a/web/src/pages/Transaction/Content.tsx
+++ b/web/src/pages/Transaction/Content.tsx
@@ -10,6 +10,7 @@ import {useGetTransactionRunsQuery} from 'redux/apis/TraceTest.api';
 import {TTransactionRun} from 'types/TransactionRun.types';
 import ExperimentalFeature from 'utils/ExperimentalFeature';
 import useTransactionCrud from 'providers/Transaction/hooks/useTransactionCrud';
+import useDocumentTitle from 'hooks/useDocumentTitle';
 import * as S from './Transaction.styled';
 
 const Content = () => {
@@ -17,6 +18,8 @@ const Content = () => {
   const {onDelete, transaction} = useTransaction();
   const {runTransaction, isEditLoading} = useTransactionCrud();
   const params = useMemo(() => ({transactionId: transaction.id}), [transaction.id]);
+
+  useDocumentTitle(`${transaction.name}`);
 
   const handleRunTest = useCallback(async () => {
     if (transaction.id) runTransaction(transaction.id);

--- a/web/src/pages/TransactionRunDetail/Content.tsx
+++ b/web/src/pages/TransactionRunDetail/Content.tsx
@@ -1,6 +1,6 @@
 import TransactionRunLayout from 'components/TransactionRunLayout';
 import {useTransaction} from 'providers/Transaction/Transaction.provider';
-import {useTransactionRun} from 'providers/TransactionRun/TransactionRunProvider';
+import {useTransactionRun} from 'providers/TransactionRun/TransactionRun.provider';
 
 const Content = () => {
   const {transaction} = useTransaction();

--- a/web/src/providers/TransactionRun/TransactionRun.provider.tsx
+++ b/web/src/providers/TransactionRun/TransactionRun.provider.tsx
@@ -21,7 +21,6 @@ export const useTransactionRun = () => useContext(Context);
 
 const TransactionRunProvider = ({children, transactionId, runId}: IProps) => {
   const {data: transactionRun} = useGetTransactionRunByIdQuery({transactionId, runId});
-
   const value = useMemo<IContext>(() => ({transactionRun}), [transactionRun]);
 
   return transactionRun ? (

--- a/web/src/providers/TransactionRun/index.ts
+++ b/web/src/providers/TransactionRun/index.ts
@@ -1,2 +1,2 @@
 // eslint-disable-next-line no-restricted-exports
-export {default} from './TransactionRunProvider';
+export {default} from './TransactionRun.provider';


### PR DESCRIPTION
This PR has the changes to display the results summary for each of the execution steps on the transaction run page.
It allows users to see the passed and failed assertions.

## Changes

- Adds the assertions summary to execution steps
- Adds logic to update the document title for tests and transactions

## Fixes

- #1505 
- #1475 

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

https://www.loom.com/share/812f1b3cb17d414f8b48ae55efca65bf