### PR TITLE
send step run updates using the transaction subscription

### DIFF
--- a/server/app/app.go
+++ b/server/app/app.go
@@ -131,10 +131,6 @@ func (a *App) Start() error {
 		Add(executor.NewDBUpdater(a.db)).
 		Add(executor.NewSubscriptionUpdater(subscriptionManager))
 
-	execTransactionUpdater := (executor.CompositeTransactionUpdater{}).
-		Add(executor.NewDBTranasctionUpdater(a.db)).
-		Add(executor.NewSubscriptionTransactionUpdater(subscriptionManager))
-
 	assertionExecutor := executor.NewAssertionExecutor(a.tracer)
 	outputProcesser := executor.InstrumentedOutputProcessor(a.tracer)
 	assertionRunner := executor.NewAssertionRunner(execTestUpdater, assertionExecutor, outputProcesser)
@@ -157,7 +153,7 @@ func (a *App) Start() error {
 	runner.Start(5) // worker count. should be configurable
 	defer runner.Stop()
 
-	transactionRunner := executor.NewTransactionRunner(runner, a.db, execTransactionUpdater, a.config)
+	transactionRunner := executor.NewTransactionRunner(runner, a.db, subscriptionManager, a.config)
 	transactionRunner.Start(5)
 	defer transactionRunner.Stop()
 

--- a/server/executor/transaction_runner.go
+++ b/server/executor/transaction_runner.go
@@ -7,17 +7,28 @@ import (
 
 	"github.com/kubeshop/tracetest/server/config"
 	"github.com/kubeshop/tracetest/server/model"
+	"github.com/kubeshop/tracetest/server/subscription"
 )
 
 type TransactionRunner interface {
 	Run(context.Context, model.Transaction, model.RunMetadata, model.Environment) model.TransactionRun
 }
 
-func NewTransactionRunner(runner Runner, db model.Repository, updater TransactionRunUpdater, config config.Config) persistentTransactionRunner {
+func NewTransactionRunner(
+	runner Runner,
+	db model.Repository,
+	subscriptionManager *subscription.Manager,
+	config config.Config,
+) persistentTransactionRunner {
+	updater := (CompositeTransactionUpdater{}).
+		Add(NewDBTranasctionUpdater(db)).
+		Add(NewSubscriptionTransactionUpdater(subscriptionManager))
+
 	return persistentTransactionRunner{
 		testRunner:          runner,
 		db:                  db,
 		updater:             updater,
+		subscriptionManager: subscriptionManager,
 		executionChannel:    make(chan transactionRunJob, 1),
 		exit:                make(chan bool),
 		checkTestStateDelay: config.PoolingRetryDelay() / 2,
@@ -33,6 +44,7 @@ type persistentTransactionRunner struct {
 	testRunner          Runner
 	db                  model.Repository
 	updater             TransactionRunUpdater
+	subscriptionManager *subscription.Manager
 	checkTestStateDelay time.Duration
 	executionChannel    chan transactionRunJob
 	exit                chan bool
@@ -119,6 +131,28 @@ func (r persistentTransactionRunner) runTransactionStep(ctx context.Context, tra
 	stepRun := createStepRun(testRun)
 	transactionRun.StepRuns = append(transactionRun.StepRuns, stepRun)
 
+	// listen for updates and propagate them as if they were transaction updates
+	r.subscriptionManager.Subscribe(testRun.ResourceID(), subscription.NewSubscriberFunction(
+		func(m subscription.Message) error {
+			updatedRun := m.Content.(model.Run)
+
+			for i, run := range transactionRun.StepRuns {
+				if run.ID == updatedRun.ID && run.TestID == updatedRun.TestID {
+					transactionRun.StepRuns[i] = createStepRun(updatedRun)
+					break
+				}
+			}
+
+			r.subscriptionManager.PublishUpdate(subscription.Message{
+				ResourceID: transactionRun.ResourceID(),
+				Type:       "result_update",
+				Content:    transactionRun,
+			})
+
+			return nil
+		}),
+	)
+
 	err = r.updater.Update(ctx, transactionRun)
 	if err != nil {
 		return model.TransactionRun{}, fmt.Errorf("could not update transaction run: %w", err)
@@ -160,26 +194,4 @@ func createStepRun(testRun model.Run) model.TransactionStepRun {
 		Environment: testRun.Environment,
 		Outputs:     testRun.Outputs,
 	}
-}
-
-func (r persistentTransactionRunner) patchEnvironment(baseEnvironment model.Environment, run model.TransactionRun) model.Environment {
-	if run.CurrentTest == 0 {
-		return baseEnvironment
-	}
-
-	lastExecutedTest := run.StepRuns[run.CurrentTest-1]
-	lastEnvironment := lastExecutedTest.Environment
-	newEnvVariables := make([]model.EnvironmentValue, 0)
-	lastExecutedTest.Outputs.ForEach(func(key, val string) error {
-		newEnvVariables = append(newEnvVariables, model.EnvironmentValue{
-			Key:   key,
-			Value: val,
-		})
-
-		return nil
-	})
-
-	newEnvironment := model.Environment{Values: newEnvVariables}
-
-	return lastEnvironment.Merge(newEnvironment)
 }

--- a/server/executor/transaction_runner_test.go
+++ b/server/executor/transaction_runner_test.go
@@ -96,11 +96,7 @@ func TestTransactionRunner(t *testing.T) {
 
 	subscriptionManager := subscription.NewManager()
 
-	transactionUpdater := (executor.CompositeTransactionUpdater{}).
-		Add(executor.NewDBTranasctionUpdater(db)).
-		Add(executor.NewSubscriptionTransactionUpdater(subscriptionManager))
-
-	runner := executor.NewTransactionRunner(testRunner, db, transactionUpdater, config)
+	runner := executor.NewTransactionRunner(testRunner, db, subscriptionManager, config)
 	runner.Start(5)
 
 	ctxWithTimeout, cancel := context.WithTimeout(ctx, 30*time.Second)
@@ -217,11 +213,7 @@ func TestTransactionRunnerWhenTestFails(t *testing.T) {
 
 	subscriptionManager := subscription.NewManager()
 
-	transactionUpdater := (executor.CompositeTransactionUpdater{}).
-		Add(executor.NewDBTranasctionUpdater(db)).
-		Add(executor.NewSubscriptionTransactionUpdater(subscriptionManager))
-
-	runner := executor.NewTransactionRunner(testRunner, db, transactionUpdater, config)
+	runner := executor.NewTransactionRunner(testRunner, db, subscriptionManager, config)
 	runner.Start(5)
 
 	ctxWithTimeout, cancel := context.WithTimeout(ctx, 30*time.Second)

--- a/server/subscription/manager.go
+++ b/server/subscription/manager.go
@@ -48,9 +48,6 @@ func (m *Manager) Unsubscribe(resourceID string, subscriptionID string) {
 }
 
 func (m *Manager) PublishUpdate(message Message) {
-	m.mutex.Lock()
-	defer m.mutex.Unlock()
-
 	if subscribers, ok := m.subscriptions[message.ResourceID]; ok {
 		for _, subscriber := range subscribers {
 			subscriber.Notify(message)


### PR DESCRIPTION
This PR makes the transaction runner send step updates using the subscription manager.

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
