### PR TITLE
fix step duplication in transactions

### DIFF
--- a/server/testdb/tests.go
+++ b/server/testdb/tests.go
@@ -173,9 +173,8 @@ const (
 	testMaxVersionQuery = `
 	INNER JOIN (
 		SELECT id as idx, max(version) as latest_version FROM tests GROUP BY idx
-		) as latest_tests ON latest_tests.idx = t.id
-
-		WHERE t.version = latest_tests.latest_version `
+		) as latest_tests ON latest_tests.idx = t.id AND t.version = latest_tests.latest_version
+	`
 )
 
 var sortingFields = map[string]string{

--- a/server/testdb/transactions.go
+++ b/server/testdb/transactions.go
@@ -322,7 +322,7 @@ func (td *postgresDB) readTransactionRow(ctx context.Context, row scanner) (mode
 }
 
 func (td *postgresDB) getTransactionSteps(ctx context.Context, transaction model.Transaction) ([]model.Test, error) {
-	stmt, err := td.db.Prepare(getTestSQL + `INNER JOIN transaction_steps ts ON t.id = ts.test_id
+	stmt, err := td.db.Prepare(getTestSQL + testMaxVersionQuery + ` INNER JOIN transaction_steps ts ON t.id = ts.test_id
 	 WHERE ts.transaction_id = $1 AND ts.transaction_version = $2 ORDER BY ts.step_number ASC`)
 	if err != nil {
 		return []model.Test{}, fmt.Errorf("prepare: %w", err)


### PR DESCRIPTION
This PR fixes the bug where transactions would have duplicated steps when a new test version was created.

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [x] added a test
