### PR TITLE
1517 [Transactions] Enable Transaction Runs Service Pagination

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -230,6 +230,18 @@ paths:
           schema:
             type: string
           required: true
+        - in: query
+          name: take
+          description: "indicates how many results can be returned by each page"
+          schema:
+            type: integer
+            default: 20
+        - in: query
+          name: skip
+          description: "indicates how many results will be skipped when paginating"
+          schema:
+            type: integer
+            default: 0
       summary: "Get all runs from a particular transaction"
       description: "Get all runs from a particular transaction"
       operationId: getTransactionRuns

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -40,6 +40,8 @@ services:
 
   otel-collector:
     image: otel/opentelemetry-collector-contrib:0.59.0
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     ports:
         - "55679:55679"
         - "4317:4317"

--- a/server/http/controller.go
+++ b/server/http/controller.go
@@ -914,8 +914,8 @@ func (c *controller) GetTransactionRun(ctx context.Context, transactionId string
 	return openapi.Response(http.StatusOK, openapiRun), nil
 }
 
-func (c *controller) GetTransactionRuns(ctx context.Context, transactionId string) (openapi.ImplResponse, error) {
-	runs, err := c.testDB.GetTransactionsRuns(ctx, transactionId)
+func (c *controller) GetTransactionRuns(ctx context.Context, transactionId string, take, skip int32) (openapi.ImplResponse, error) {
+	runs, err := c.testDB.GetTransactionsRuns(ctx, transactionId, take, skip)
 	if err != nil {
 		return handleDBError(err), err
 	}

--- a/server/model/repository.go
+++ b/server/model/repository.go
@@ -54,7 +54,7 @@ type TransactionRunRepository interface {
 	UpdateTransactionRun(context.Context, TransactionRun) error
 	DeleteTransactionRun(context.Context, TransactionRun) error
 	GetTransactionRun(context.Context, string, int) (TransactionRun, error)
-	GetTransactionsRuns(context.Context, string) ([]TransactionRun, error)
+	GetTransactionsRuns(context.Context, string, int32, int32) ([]TransactionRun, error)
 }
 
 type Repository interface {

--- a/server/openapi/api.go
+++ b/server/openapi/api.go
@@ -89,7 +89,7 @@ type ApiApiServicer interface {
 	GetTests(context.Context, int32, int32, string, string, string) (ImplResponse, error)
 	GetTransaction(context.Context, string) (ImplResponse, error)
 	GetTransactionRun(context.Context, string, int32) (ImplResponse, error)
-	GetTransactionRuns(context.Context, string) (ImplResponse, error)
+	GetTransactionRuns(context.Context, string, int32, int32) (ImplResponse, error)
 	GetTransactionVersion(context.Context, string, int32) (ImplResponse, error)
 	GetTransactions(context.Context, int32, int32, string, string, string) (ImplResponse, error)
 	ImportTestRun(context.Context, ExportedTestInformation) (ImplResponse, error)

--- a/server/openapi/api_api.go
+++ b/server/openapi/api_api.go
@@ -833,9 +833,20 @@ func (c *ApiApiController) GetTransactionRun(w http.ResponseWriter, r *http.Requ
 // GetTransactionRuns - Get all runs from a particular transaction
 func (c *ApiApiController) GetTransactionRuns(w http.ResponseWriter, r *http.Request) {
 	params := mux.Vars(r)
+	query := r.URL.Query()
 	transactionIdParam := params["transactionId"]
 
-	result, err := c.service.GetTransactionRuns(r.Context(), transactionIdParam)
+	takeParam, err := parseInt32Parameter(query.Get("take"), false)
+	if err != nil {
+		c.errorHandler(w, r, &ParsingError{Err: err}, nil)
+		return
+	}
+	skipParam, err := parseInt32Parameter(query.Get("skip"), false)
+	if err != nil {
+		c.errorHandler(w, r, &ParsingError{Err: err}, nil)
+		return
+	}
+	result, err := c.service.GetTransactionRuns(r.Context(), transactionIdParam, takeParam, skipParam)
 	// If an error occurred, encode the error with the status code
 	if err != nil {
 		c.errorHandler(w, r, err, &result)

--- a/server/testdb/mock.go
+++ b/server/testdb/mock.go
@@ -207,8 +207,8 @@ func (m *MockRepository) GetTransactionRun(ctx context.Context, transactionID st
 }
 
 // GetTransactionsRuns implements model.Repository
-func (m *MockRepository) GetTransactionsRuns(ctx context.Context, transactionID string) ([]model.TransactionRun, error) {
-	args := m.Called(ctx, transactionID)
+func (m *MockRepository) GetTransactionsRuns(ctx context.Context, transactionID string, take, skip int32) ([]model.TransactionRun, error) {
+	args := m.Called(ctx, transactionID, take, skip)
 	return args.Get(0).([]model.TransactionRun), args.Error(1)
 }
 

--- a/server/testdb/transaction_runs.go
+++ b/server/testdb/transaction_runs.go
@@ -243,13 +243,13 @@ func (td *postgresDB) GetTransactionRun(ctx context.Context, transactionId strin
 	return run, nil
 }
 
-func (td *postgresDB) GetTransactionsRuns(ctx context.Context, transactionId string) ([]model.TransactionRun, error) {
-	stmt, err := td.db.Prepare(selectTransactionRunQuery + " WHERE transaction_id = $1")
+func (td *postgresDB) GetTransactionsRuns(ctx context.Context, transactionId string, take, skip int32) ([]model.TransactionRun, error) {
+	stmt, err := td.db.Prepare(selectTransactionRunQuery + " WHERE transaction_id = $1 ORDER BY created_at DESC LIMIT $2 OFFSET $3")
 	if err != nil {
 		return []model.TransactionRun{}, fmt.Errorf("prepare: %w", err)
 	}
 
-	rows, err := stmt.QueryContext(ctx, transactionId)
+	rows, err := stmt.QueryContext(ctx, transactionId, take, skip)
 	if err != nil {
 		return []model.TransactionRun{}, fmt.Errorf("query: %w", err)
 	}

--- a/server/testdb/transactions_runs_test.go
+++ b/server/testdb/transactions_runs_test.go
@@ -131,7 +131,7 @@ func TestListTransactionRun(t *testing.T) {
 	newRun3, err := db.CreateTransactionRun(context.TODO(), run3)
 	require.NoError(t, err)
 
-	runs, err := db.GetTransactionsRuns(context.TODO(), transaction.ID.String())
+	runs, err := db.GetTransactionsRuns(context.TODO(), transaction.ID.String(), 20, 0)
 	require.NoError(t, err)
 
 	assert.Len(t, runs, 2)
@@ -166,7 +166,7 @@ func TestBug(t *testing.T) {
 	run2, err = db.CreateTransactionRun(ctx, run2)
 	require.NoError(t, err)
 
-	runs, err := db.GetTransactionsRuns(ctx, transaction.ID.String())
+	runs, err := db.GetTransactionsRuns(ctx, transaction.ID.String(), 20, 0)
 	require.NoError(t, err)
 	assert.Contains(t, runs, run1)
 	assert.Contains(t, runs, run2)
@@ -179,7 +179,7 @@ func TestBug(t *testing.T) {
 	run3, err = db.CreateTransactionRun(ctx, run3)
 	require.NoError(t, err)
 
-	runs, err = db.GetTransactionsRuns(ctx, newTransaction.ID.String())
+	runs, err = db.GetTransactionsRuns(ctx, newTransaction.ID.String(), 20, 0)
 	require.NoError(t, err)
 	assert.Len(t, runs, 3)
 	assert.Contains(t, runs, run1)

--- a/web/src/components/ResourceCard/TransactionCard.tsx
+++ b/web/src/components/ResourceCard/TransactionCard.tsx
@@ -69,7 +69,7 @@ const TransactionCard = ({
         hasRuns={Boolean(list.length)}
         isCollapsed={isCollapsed}
         isLoading={isLoading}
-        onViewAll={() => onViewAll(transactionId, ResourceType.Test)}
+        onViewAll={() => onViewAll(transactionId, ResourceType.Transaction)}
       >
         <S.RunsListContainer>
           {list.map(run => (


### PR DESCRIPTION
This PR enables pagination for the transaction-run service

## Changes

- Open API and transaction run controller update

## Fixes

- https://github.com/kubeshop/tracetest/issues/1517

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
