### PR TITLE
fix: fail transaction when step fail to trigger operation

### DIFF
--- a/server/executor/runner.go
+++ b/server/executor/runner.go
@@ -160,6 +160,9 @@ func (r persistentRunner) processExecQueue(job execReq) {
 
 	response, err := triggerer.Trigger(job.ctx, resolvedTest, triggerOptions)
 	run = r.handleExecutionResult(run, response, err)
+	if err != nil {
+		job.channel <- RunResult{Run: run, Err: err}
+	}
 
 	run.SpanID = response.SpanID
 


### PR DESCRIPTION
This PR makes the transaction runner mark the transaction as FAILED if any of the steps fail.

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
