### PR TITLE
feat(cli): add `--environment` flag

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,3 @@
 Dockerfile
 web/node_modules
+cli/dist

--- a/cli/cmd/test_run_cmd.go
+++ b/cli/cmd/test_run_cmd.go
@@ -10,9 +10,12 @@ import (
 	"go.uber.org/zap"
 )
 
-var runTestFileDefinition string
-var runTestWaitForResult bool
-var runTestJUnit string
+var (
+	runTestFileDefinition,
+	runTestEnvID,
+	runTestJUnit string
+	runTestWaitForResult bool
+)
 
 var testRunCmd = &cobra.Command{
 	Use:    "run",
@@ -28,6 +31,7 @@ var testRunCmd = &cobra.Command{
 		runTestAction := actions.NewRunTestAction(cliConfig, cliLogger, client)
 		actionArgs := actions.RunTestConfig{
 			DefinitionFile: runTestFileDefinition,
+			EnvID:          runTestEnvID,
 			WaitForResult:  runTestWaitForResult,
 			JUnit:          runTestJUnit,
 		}
@@ -43,6 +47,7 @@ var testRunCmd = &cobra.Command{
 }
 
 func init() {
+	testRunCmd.PersistentFlags().StringVarP(&runTestEnvID, "environment", "e", "", "--environment <id>")
 	testRunCmd.PersistentFlags().StringVarP(&runTestFileDefinition, "definition", "d", "", "--definition <definition-file.yml>")
 	testRunCmd.PersistentFlags().BoolVarP(&runTestWaitForResult, "wait-for-result", "w", false, "")
 	testRunCmd.PersistentFlags().StringVarP(&runTestJUnit, "junit", "j", "", "--junit <junit-output.xml>")

--- a/cli/go.mod
+++ b/cli/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/compose-spec/compose-go v1.5.1
 	github.com/cucumber/ci-environment/go v0.0.0-20220915001957-711b1c82415f
 	github.com/denisbrodbeck/machineid v1.0.1
+	github.com/joho/godotenv v1.3.0
 	github.com/kubeshop/tracetest/server v0.0.0
 	github.com/pterm/pterm v0.12.46
 	github.com/segmentio/analytics-go/v3 v3.2.1

--- a/server/http/controller.go
+++ b/server/http/controller.go
@@ -652,7 +652,6 @@ func (c *controller) CreateEnvironment(ctx context.Context, in openapi.Environme
 
 	if environment.ID != "" {
 		exists, err := c.testDB.EnvironmentIDExists(ctx, environment.ID)
-
 		if err != nil {
 			return handleDBError(err), err
 		}

--- a/tracetesting/transactions/envs/localhost.env
+++ b/tracetesting/transactions/envs/localhost.env
@@ -1,1 +1,3 @@
-HOST=http://localhost:11633
+EXAMPLE_TEST_ID=w2ON-RVVg
+TARGET_URL=http://localhost:11633
+DEMO_APP_URL=http://demo-api:8081

--- a/tracetesting/transactions/test-ids.yaml
+++ b/tracetesting/transactions/test-ids.yaml
@@ -2,13 +2,11 @@ type: Transaction
 spec:
   id: TmAKdfV4g
   name: Test IDs
-  env:
-    EXAMPLE_TEST_ID: "w2ON-RVVg"
   steps:
   # ensure test doesn not exists
   - ./tests/delete-example-test.yaml
 
-  # tests
+  #
   - ./tests/create-nonexisting-id.yaml
   - ./tests/create-existing-id.yaml
 

--- a/tracetesting/transactions/tests/create-existing-id.yaml
+++ b/tracetesting/transactions/tests/create-existing-id.yaml
@@ -1,7 +1,7 @@
 type: Test
 spec:
   id: zwWc1RV4R
-  name: Create with non-existing ID
+  name: Create with existing ID
   trigger:
     type: http
     httpRequest:

--- a/tracetesting/transactions/tests/create-nonexisting-id.yaml
+++ b/tracetesting/transactions/tests/create-nonexisting-id.yaml
@@ -1,6 +1,6 @@
 type: Test
 spec:
-  id: zwWc1RV4R
+  id: v4QKJR4Vg
   name: Create with non-existing ID
   trigger:
     type: http
@@ -36,8 +36,7 @@ spec:
     assertions:
       - attr:tracetest.selected_spans.count = 1
       - attr:tracetest.response.status = 200
-      - ${attr:tracetest.response.body | json_path '.id' } != ""
-      - ${attr:tracetest.response.body | json_path '.id' } = "${env:EXAMPLE_TEST_ID}" #
+      - attr:tracetest.response.body | json_path '.id' = env:EXAMPLE_TEST_ID
   - selector: span[name="POST /api/tests" tracetest.span.type="http"]
     assertions:
     - attr:tracetest.selected_spans.count = 1


### PR DESCRIPTION
This PR adds the `--environment` or `-e` flag. This allows to pass an environment ID to be used when running the test/transaction.

## Example using ID: 
![Screenshot 2022-11-18 at 12 47 51](https://user-images.githubusercontent.com/314548/202745013-ce2b01f4-f1ac-45f1-9bb9-3a80c708fc16.png)

This will use the environment with ID `localhost`

## Example using file path:
![Screenshot 2022-11-18 at 14 04 26](https://user-images.githubusercontent.com/314548/202761100-5d0930d3-09cb-482a-85ed-bca76f61b60c.png)


This will create (or update) an env with name/id of `localhost.env` (base path) and run the test/transaction using that id

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
