### PR TITLE
fix(frontend): fixing output selector input

### DIFF
--- a/web/public/index.html
+++ b/web/public/index.html
@@ -68,7 +68,7 @@
           env: getTemplateValue('{{ .Env }}', '', parser.toString),
           demoEnabled: getTemplateValue('{{ .DemoEnabled }}', '["pokeshop", "otel"]', parser.toArray),
           demoEndpoints: getTemplateValue('{{ .DemoEndpoints }}', '{"PokeshopHttp": "http://demo-api:8081", "PokeshopGrpc": "demo-api:8082", "OtelFrontend": "http://otel-frontend:8084" }', parser.toObject),
-          experimentalFeatures: getTemplateValue('{{ .ExperimentalFeatures }}', '[]', parser.toArray),
+          experimentalFeatures: getTemplateValue('{{ .ExperimentalFeatures }}', '["flamegraph"]', parser.toArray),
         };
 
         var base = document.createElement('base');

--- a/web/src/components/OutputModal/OutputModalForm.tsx
+++ b/web/src/components/OutputModal/OutputModalForm.tsx
@@ -57,7 +57,7 @@ const OutputModalForm = ({form, runId, spanIdList, testId}: IProps) => {
         ]}
         style={{marginBottom: 0}}
       >
-        <Editor basicSetup={{lineNumbers: true}} type={SupportedEditors.Selector} />
+        <Editor basicSetup={{lineNumbers: true}} type={SupportedEditors.Selector} placeholder="" />
       </Form.Item>
 
       <Form.Item

--- a/web/src/pages/RunDetail/RunDetail.tsx
+++ b/web/src/pages/RunDetail/RunDetail.tsx
@@ -19,11 +19,11 @@ const RunDetail = () => {
         <TestRunProvider testId={testId} runId={runId}>
           <TestSpecsProvider testId={testId} runId={runId}>
             <TestSpecFormProvider testId={testId}>
-              <TestOutputProvider testId={testId} runId={runId}>
-                <SpanProvider>
+              <SpanProvider>
+                <TestOutputProvider testId={testId} runId={runId}>
                   <Content />
-                </SpanProvider>
-              </TestOutputProvider>
+                </TestOutputProvider>
+              </SpanProvider>
             </TestSpecFormProvider>
           </TestSpecsProvider>
         </TestRunProvider>


### PR DESCRIPTION
This PR fixes an issue we have with the creative output modal where the selector field doesn't work as expected.

## Changes

- Moving span provider to wrap the output modal provider.

## Fixes

- [Fix adding otput flow#1534](https://github.com/kubeshop/tracetest/issues/1534)

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
