### PR TITLE
fix(server): make last run time optional in openapi

### DIFF
--- a/api/tests.yaml
+++ b/api/tests.yaml
@@ -62,6 +62,7 @@ components:
             time:
               type: string
               format: date-time
+              nullable: true
             passes:
               type: integer
               readOnly: true

--- a/cli/openapi/api_api.go
+++ b/cli/openapi/api_api.go
@@ -2910,6 +2910,20 @@ type ApiGetTransactionRunsRequest struct {
 	ctx           context.Context
 	ApiService    *ApiApiService
 	transactionId string
+	take          *int32
+	skip          *int32
+}
+
+// indicates how many results can be returned by each page
+func (r ApiGetTransactionRunsRequest) Take(take int32) ApiGetTransactionRunsRequest {
+	r.take = &take
+	return r
+}
+
+// indicates how many results will be skipped when paginating
+func (r ApiGetTransactionRunsRequest) Skip(skip int32) ApiGetTransactionRunsRequest {
+	r.skip = &skip
+	return r
 }
 
 func (r ApiGetTransactionRunsRequest) Execute() ([]TransactionRun, *http.Response, error) {
@@ -2956,6 +2970,12 @@ func (a *ApiApiService) GetTransactionRunsExecute(r ApiGetTransactionRunsRequest
 	localVarQueryParams := url.Values{}
 	localVarFormParams := url.Values{}
 
+	if r.take != nil {
+		localVarQueryParams.Add("take", parameterToString(*r.take, ""))
+	}
+	if r.skip != nil {
+		localVarQueryParams.Add("skip", parameterToString(*r.skip, ""))
+	}
 	// to determine the Content-Type header
 	localVarHTTPContentTypes := []string{}
 

--- a/cli/openapi/model_test_summary_last_run.go
+++ b/cli/openapi/model_test_summary_last_run.go
@@ -17,9 +17,9 @@ import (
 
 // TestSummaryLastRun struct for TestSummaryLastRun
 type TestSummaryLastRun struct {
-	Time   *time.Time `json:"time,omitempty"`
-	Passes *int32     `json:"passes,omitempty"`
-	Fails  *int32     `json:"fails,omitempty"`
+	Time   NullableTime `json:"time,omitempty"`
+	Passes *int32       `json:"passes,omitempty"`
+	Fails  *int32       `json:"fails,omitempty"`
 }
 
 // NewTestSummaryLastRun instantiates a new TestSummaryLastRun object
@@ -39,36 +39,47 @@ func NewTestSummaryLastRunWithDefaults() *TestSummaryLastRun {
 	return &this
 }
 
-// GetTime returns the Time field value if set, zero value otherwise.
+// GetTime returns the Time field value if set, zero value otherwise (both if not set or set to explicit null).
 func (o *TestSummaryLastRun) GetTime() time.Time {
-	if o == nil || o.Time == nil {
+	if o == nil || o.Time.Get() == nil {
 		var ret time.Time
 		return ret
 	}
-	return *o.Time
+	return *o.Time.Get()
 }
 
 // GetTimeOk returns a tuple with the Time field value if set, nil otherwise
 // and a boolean to check if the value has been set.
+// NOTE: If the value is an explicit nil, `nil, true` will be returned
 func (o *TestSummaryLastRun) GetTimeOk() (*time.Time, bool) {
-	if o == nil || o.Time == nil {
+	if o == nil {
 		return nil, false
 	}
-	return o.Time, true
+	return o.Time.Get(), o.Time.IsSet()
 }
 
 // HasTime returns a boolean if a field has been set.
 func (o *TestSummaryLastRun) HasTime() bool {
-	if o != nil && o.Time != nil {
+	if o != nil && o.Time.IsSet() {
 		return true
 	}
 
 	return false
 }
 
-// SetTime gets a reference to the given time.Time and assigns it to the Time field.
+// SetTime gets a reference to the given NullableTime and assigns it to the Time field.
 func (o *TestSummaryLastRun) SetTime(v time.Time) {
-	o.Time = &v
+	o.Time.Set(&v)
+}
+
+// SetTimeNil sets the value for Time to be an explicit nil
+func (o *TestSummaryLastRun) SetTimeNil() {
+	o.Time.Set(nil)
+}
+
+// UnsetTime ensures that no value is present for Time, not even an explicit nil
+func (o *TestSummaryLastRun) UnsetTime() {
+	o.Time.Unset()
 }
 
 // GetPasses returns the Passes field value if set, zero value otherwise.
@@ -137,8 +148,8 @@ func (o *TestSummaryLastRun) SetFails(v int32) {
 
 func (o TestSummaryLastRun) MarshalJSON() ([]byte, error) {
 	toSerialize := map[string]interface{}{}
-	if o.Time != nil {
-		toSerialize["time"] = o.Time
+	if o.Time.IsSet() {
+		toSerialize["time"] = o.Time.Get()
 	}
 	if o.Passes != nil {
 		toSerialize["passes"] = o.Passes

--- a/server/http/mappings/tests.go
+++ b/server/http/mappings/tests.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"strconv"
+	"time"
 
 	"github.com/kubeshop/tracetest/server/assertions/comparator"
 	"github.com/kubeshop/tracetest/server/assertions/selectors"
@@ -18,6 +19,14 @@ import (
 
 type OpenAPI struct {
 	traceConversionConfig traces.ConversionConfig
+}
+
+func optionalTime(in time.Time) *time.Time {
+	if in.IsZero() {
+		return nil
+	}
+
+	return &in
 }
 
 func (m OpenAPI) Transaction(in model.Transaction) openapi.Transaction {
@@ -36,7 +45,7 @@ func (m OpenAPI) Transaction(in model.Transaction) openapi.Transaction {
 		Summary: openapi.TestSummary{
 			Runs: int32(in.Summary.Runs),
 			LastRun: openapi.TestSummaryLastRun{
-				Time:   in.Summary.LastRun.Time,
+				Time:   optionalTime(in.Summary.LastRun.Time),
 				Passes: 0,
 				Fails:  0,
 			},
@@ -82,7 +91,7 @@ func (m OpenAPI) Test(in model.Test) openapi.Test {
 		Summary: openapi.TestSummary{
 			Runs: int32(in.Summary.Runs),
 			LastRun: openapi.TestSummaryLastRun{
-				Time:   in.Summary.LastRun.Time,
+				Time:   optionalTime(in.Summary.LastRun.Time),
 				Passes: int32(in.Summary.LastRun.Passes),
 				Fails:  int32(in.Summary.LastRun.Fails),
 			},

--- a/server/openapi/model_test_summary_last_run.go
+++ b/server/openapi/model_test_summary_last_run.go
@@ -14,7 +14,7 @@ import (
 )
 
 type TestSummaryLastRun struct {
-	Time time.Time `json:"time,omitempty"`
+	Time *time.Time `json:"time,omitempty"`
 
 	Passes int32 `json:"passes,omitempty"`
 


### PR DESCRIPTION
This PR fixes the bug when a test has no runs, the backend would return the last run date as `0001-01-01`, making the UI show `run 2022 years ago`. Now the last run time is optional, so the UI looks like this now:

![Screenshot 2022-11-21 at 11 04 52](https://user-images.githubusercontent.com/314548/203074670-2089b4e9-c096-4c20-a607-f33a543f1052.png)

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
