### PR TITLE
chore: merge openapi generation into main makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,41 @@
+PROJECT_ROOT=${shell dirname $${PWD}}
+
+OPENAPI_GENERATOR_VER=v5.4.0
+OPENAPI_GENERATOR_IMAGE=openapitools/openapi-generator-cli:$(OPENAPI_GENERATOR_VER)
+OPENAPI_TARGET_DIR=./openapi/
+
+
+generate: generate-cli generate-server
+
+generate-cli:
+	rm -rf $(OPENAPI_TARGET_DIR)
+	mkdir -p ./tmp
+	mkdir -p $(OPENAPI_TARGET_DIR)
+
+	docker run --rm -u ${shell id -u}  -v "$(PROJECT_ROOT)/cli:/local" -w "/local" ${OPENAPI_GENERATOR_IMAGE} \
+		generate \
+		-i api/openapi.yaml \
+		-g go \
+		-o ./cli/tmp \
+		--generate-alias-as-model
+	cp ./tmp/*.go $(OPENAPI_TARGET_DIR)
+	rm -rf ./tmp
+
+	go fmt ./...; cd ..
+
+
+generate-server:
+	rm -rf $(OPENAPI_SERVER_TARGET_DIR)
+	mkdir -p ./tmp
+
+	docker run --rm -u ${shell id -u}  -v "$(PROJECT_ROOT)/server:/local" -w "/local" ${OPENAPI_GENERATOR_IMAGE} \
+		generate \
+		-i api/openapi.yaml \
+		-g go-server \
+		-o ./tmp \
+		--generate-alias-as-model
+	mv ./tmp/go $(OPENAPI_SERVER_TARGET_DIR)
+	rm -f $(OPENAPI_SERVER_TARGET_DIR)/api_api_service.go
+	rm -rf ./tmp
+
+	go fmt ./...

--- a/cli/Makefile
+++ b/cli/Makefile
@@ -2,29 +2,6 @@ VERSION ?= "dev"
 TRACETEST_ENV ?= "dev"
 ANALYTICS_BE_KEY ?= ""
 
-
-PROJECT_ROOT=${shell dirname $${PWD}}
-
-OPENAPI_GENERATOR_VER=v5.4.0
-OPENAPI_GENERATOR_IMAGE=openapitools/openapi-generator-cli:$(OPENAPI_GENERATOR_VER)
-OPENAPI_GENERATOR_CLI=docker run --rm -u ${shell id -u}  -v "$(PROJECT_ROOT):/local" -w "/local" ${OPENAPI_GENERATOR_IMAGE}
-OPENAPI_TARGET_DIR=./openapi/
-
-generate-client:
-	rm -rf $(OPENAPI_TARGET_DIR)
-	mkdir -p ./tmp
-	mkdir -p $(OPENAPI_TARGET_DIR)
-
-	$(OPENAPI_GENERATOR_CLI)  generate \
-		-i api/openapi.yaml \
-		-g go \
-		-o ./cli/tmp \
-		--generate-alias-as-model
-	cp ./tmp/*.go $(OPENAPI_TARGET_DIR)
-	rm -rf ./tmp
-
-	go fmt ./...; cd ..
-
 build:
 ifeq (, $(shell which goreleaser))
 	go install github.com/goreleaser/goreleaser@latest

--- a/cli/openapi/api_api.go
+++ b/cli/openapi/api_api.go
@@ -2910,6 +2910,20 @@ type ApiGetTransactionRunsRequest struct {
 	ctx           context.Context
 	ApiService    *ApiApiService
 	transactionId string
+	take          *int32
+	skip          *int32
+}
+
+// indicates how many results can be returned by each page
+func (r ApiGetTransactionRunsRequest) Take(take int32) ApiGetTransactionRunsRequest {
+	r.take = &take
+	return r
+}
+
+// indicates how many results will be skipped when paginating
+func (r ApiGetTransactionRunsRequest) Skip(skip int32) ApiGetTransactionRunsRequest {
+	r.skip = &skip
+	return r
 }
 
 func (r ApiGetTransactionRunsRequest) Execute() ([]TransactionRun, *http.Response, error) {
@@ -2956,6 +2970,12 @@ func (a *ApiApiService) GetTransactionRunsExecute(r ApiGetTransactionRunsRequest
 	localVarQueryParams := url.Values{}
 	localVarFormParams := url.Values{}
 
+	if r.take != nil {
+		localVarQueryParams.Add("take", parameterToString(*r.take, ""))
+	}
+	if r.skip != nil {
+		localVarQueryParams.Add("skip", parameterToString(*r.skip, ""))
+	}
 	// to determine the Content-Type header
 	localVarHTTPContentTypes := []string{}
 

--- a/server/Makefile
+++ b/server/Makefile
@@ -27,25 +27,6 @@ run:
 build:
 	go build -o tracetest-server -ldflags="$(GO_LDFLAGS)" .
 
-OPENAPI_GENERATOR_VER=v5.4.0
-OPENAPI_GENERATOR_IMAGE=openapitools/openapi-generator-cli:$(OPENAPI_GENERATOR_VER)
-OPENAPI_GENERATOR_CLI=docker run --rm -u ${shell id -u}  -v "${PWD}:/app" -v "${PWD}/../api:/app/api" -w "/app" ${OPENAPI_GENERATOR_IMAGE}
-OPENAPI_SERVER_TARGET_DIR=./openapi
-generate:
-	rm -rf $(OPENAPI_SERVER_TARGET_DIR)
-	mkdir -p ./tmp
-
-	$(OPENAPI_GENERATOR_CLI)  generate \
-		-i api/openapi.yaml \
-		-g go-server \
-		-o ./tmp \
-		--generate-alias-as-model
-	mv ./tmp/go $(OPENAPI_SERVER_TARGET_DIR)
-	rm -f $(OPENAPI_SERVER_TARGET_DIR)/api_api_service.go
-	rm -rf ./tmp
-
-	go fmt ./...
-
 PROTOC_VER=0.3.1
 UNAME_P := $(shell uname -p)
 ifeq ($(UNAME_P),x86_64)

--- a/web/src/types/Generated.types.ts
+++ b/web/src/types/Generated.types.ts
@@ -5,6 +5,8 @@
 
 export interface paths {
   "/definition.yaml": {
+    /** Upsert a definition */
+    put: operations["upsertDefinition"];
     /** Execute a definition */
     post: operations["executeDefinition"];
   };
@@ -133,6 +135,28 @@ export interface paths {
 export interface components {}
 
 export interface operations {
+  /** Upsert a definition */
+  upsertDefinition: {
+    responses: {
+      /** Definition updated */
+      200: {
+        content: {
+          "application/json": external["definition.yaml"]["components"]["schemas"]["UpsertDefinitionResponse"];
+        };
+      };
+      /** Definition created */
+      201: {
+        content: {
+          "application/json": external["definition.yaml"]["components"]["schemas"]["UpsertDefinitionResponse"];
+        };
+      };
+    };
+    requestBody: {
+      content: {
+        "text/json": external["definition.yaml"]["components"]["schemas"]["TextDefinition"];
+      };
+    };
+  };
   /** Execute a definition */
   executeDefinition: {
     responses: {
@@ -148,8 +172,6 @@ export interface operations {
           "application/json": external["definition.yaml"]["components"]["schemas"]["ExecuteDefinitionResponse"];
         };
       };
-      /** trying to create a test with an already existing ID */
-      422: unknown;
     };
     requestBody: {
       content: {
@@ -279,6 +301,12 @@ export interface operations {
     parameters: {
       path: {
         transactionId: string;
+      };
+      query: {
+        /** indicates how many results can be returned by each page */
+        take?: number;
+        /** indicates how many results will be skipped when paginating */
+        skip?: number;
       };
     };
     responses: {
@@ -865,6 +893,12 @@ export interface external {
     paths: {};
     components: {
       schemas: {
+        UpsertDefinitionResponse: {
+          /** @description resource ID */
+          id?: string;
+          /** @description resource type */
+          type?: string;
+        };
         ExecuteDefinitionResponse: {
           /** @description resource ID */
           id?: string;
@@ -1083,9 +1117,9 @@ export interface external {
             | "FAILED";
           /** @description Details of the cause for the last `FAILED` state */
           lastErrorState?: string;
-          /** @description time it took for the test to complete, either success or fail. If the test is still running, it will show the time up to the time of the request */
+          /** @description time in seconds it took for the test to complete, either success or fail. If the test is still running, it will show the time up to the time of the request */
           executionTime?: number;
-          /** @description time it took for the triggering transaction to complete, either success or fail. If the test is still running, it will show the time up to the time of the request */
+          /** @description time in milliseconds it took for the triggering transaction to complete, either success or fail. If the test is still running, it will show the time up to the time of the request */
           triggerTime?: number;
           /** Format: date-time */
           createdAt?: string;


### PR DESCRIPTION
This PR creates a centralized makefile in the proejct root, so we can regenerate openapi code for all modules with a single command. This will prevent desyncronization between web, cli and server openapi code.

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
