### PR TITLE
feat: allow tests to reference outputs declared in them

### DIFF
--- a/server/model/run.go
+++ b/server/model/run.go
@@ -101,8 +101,14 @@ func (r Run) SuccessfullyPolledTraces(t *traces.Trace) Run {
 	return r
 }
 
-func (r Run) SuccessfullyAsserted(outputs OrderedMap[string, string], res OrderedMap[SpanQuery, []AssertionResult], allPassed bool) Run {
+func (r Run) SuccessfullyAsserted(
+	outputs OrderedMap[string, string],
+	environment Environment,
+	res OrderedMap[SpanQuery, []AssertionResult],
+	allPassed bool,
+) Run {
 	r.Outputs = outputs
+	r.Environment = environment
 	r.Results = &RunResults{
 		AllPassed: allPassed,
 		Results:   res,

--- a/server/testdb/tests.go
+++ b/server/testdb/tests.go
@@ -104,6 +104,11 @@ func (td *postgresDB) UpdateTest(ctx context.Context, test model.Test) (model.Te
 	// keep the same creation date to keep sort order
 	test.CreatedAt = oldTest.CreatedAt
 
+	// keep outputs if new test doesn't have any
+	if test.Outputs.Len() == 0 {
+		test.Outputs = oldTest.Outputs
+	}
+
 	testToUpdate, err := model.BumpTestVersionIfNeeded(oldTest, test)
 	if err != nil {
 		return model.Test{}, fmt.Errorf("could not bump test version: %w", err)

--- a/tracetesting/definitions/test_create.yml
+++ b/tracetesting/definitions/test_create.yml
@@ -65,7 +65,12 @@ spec:
     assertions:
     - attr:sql.query contains "INSERT INTO tests"
 
-  # outputs:
-  # - name: TEST_ID
-  #   selector: span[name = "Tracetest trigger"]
-  #   value: attr:tracetest.response.body | json_path '$.id'
+  # ensure we can reference outputs declared in the same test
+  - selector: span[name = "Tracetest trigger"]
+    assertions:
+    - attr:tracetest.response.body | json_path '$.id' = env:TEST_ID
+
+  outputs:
+  - name: TEST_ID
+    selector: span[name = "Tracetest trigger"]
+    value: attr:tracetest.response.body | json_path '$.id'


### PR DESCRIPTION
This PR fixes two problems with outputs:

1. Right now it's not possible to export output and use it within the same test. This fixes this limitation by injecting the outputs into the environment before running the test assertions;
2. When updating a test that contains outputs, the new version of the test doesn't contain those outputs. 

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
