### PR TITLE
Fix flamegraph alignment

### DIFF
--- a/web/src/components/RunDetailTrace/RunDetailTrace.styled.ts
+++ b/web/src/components/RunDetailTrace/RunDetailTrace.styled.ts
@@ -1,5 +1,6 @@
 import {CloseCircleFilled} from '@ant-design/icons';
 import styled from 'styled-components';
+import {VisualizationType} from './RunDetailTrace';
 
 export const Container = styled.div`
   display: flex;
@@ -19,8 +20,8 @@ export const Section = styled.div`
   z-index: 1;
 `;
 
-export const VisualizationContainer = styled.div`
-  height: calc(100% - 52px);
+export const VisualizationContainer = styled.div<{$visualizationType?: VisualizationType}>`
+  height: calc(100% - ${({$visualizationType}) => ($visualizationType === VisualizationType.Flame ? 0 : 52)}px);
   position: relative;
 `;
 

--- a/web/src/components/RunDetailTrace/RunDetailTrace.tsx
+++ b/web/src/components/RunDetailTrace/RunDetailTrace.tsx
@@ -47,7 +47,7 @@ const RunDetailTrace = ({run, testId}: IProps) => {
               </S.SearchContainer>
             )}
 
-            <S.VisualizationContainer>
+            <S.VisualizationContainer $visualizationType={visualizationType}>
               <S.SwitchContainer>
                 {run.state === TestState.FINISHED && (
                   <Switch

--- a/web/src/components/RunDetailTrace/Visualization.tsx
+++ b/web/src/components/RunDetailTrace/Visualization.tsx
@@ -97,6 +97,7 @@ const Visualization = ({runState, spans, type}: IProps) => {
       )}
       {type === VisualizationType.Flame && (
         <Flame
+          isTrace
           isMatchedMode={isMatchedMode}
           matchedSpans={matchedSpans}
           onNavigateToSpan={onNavigateToSpan}

--- a/web/src/components/Visualization/components/Flame/Flame.styled.tsx
+++ b/web/src/components/Visualization/components/Flame/Flame.styled.tsx
@@ -1,5 +1,6 @@
 import styled from 'styled-components';
 
-export const Container = styled.div`
+export const Container = styled.div<{$isTrace: boolean}>`
   padding: 24px;
+  max-width: ${({$isTrace}) => ($isTrace ? 'unset' : '60vw')};
 `;

--- a/web/src/components/Visualization/components/Flame/Flame.tsx
+++ b/web/src/components/Visualization/components/Flame/Flame.tsx
@@ -8,6 +8,7 @@ import * as S from './Flame.styled';
 
 interface IProps {
   isMatchedMode: boolean;
+  isTrace?: boolean;
   matchedSpans: string[];
   selectedSpan: string;
   spans: TSpan[];
@@ -16,14 +17,14 @@ interface IProps {
   onNodeClick(spanId: string): void;
 }
 
-export const Flame: React.FC<IProps> = ({spans}) => {
+export const Flame: React.FC<IProps> = ({spans, isTrace = false}) => {
   const {run} = useTestRun();
   const profile = useMemo(
     () => convertJaegerTraceToProfile(FlameGraphService.convertTracetestSpanToJaeger(run.trace?.traceId || '', spans)),
     [spans, run.trace?.traceId]
   );
   return (
-    <S.Container>
+    <S.Container $isTrace={isTrace}>
       <FlamegraphRenderer profile={profile} colorMode="light" showToolbar />
     </S.Container>
   );


### PR DESCRIPTION
This PR fix flamegraph alignment reported on #1544

- Flame graph container was not accounting to the fact that the default search bar is not present on the flame trace view
- Fix max-width issue on test view

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
