### PR TITLE
fix(e2e): change cypress selector to match autocomplete options

### DIFF
--- a/web/cypress/support/commands.ts
+++ b/web/cypress/support/commands.ts
@@ -4,7 +4,7 @@ import {PokeshopDemo} from '../../src/constants/Demo.constants';
 import {getTestId} from '../e2e/utils/Common';
 
 export const testRunPageRegex = /\/test\/(.*)\/run\/(.*)/;
-export const getAttributeListId = (number: number) => `.cm-tooltip-autocomplete [id*=${number}]`;
+export const getAttributeListId = (number: number) => `.cm-tooltip-autocomplete [id$=-${number}]`;
 export const getComparatorListId = (number: number) => `#assertion-form_assertions_${number}_comparator_list`;
 export const getValueFromList = (number: number) => `[data-cy=assertion-check-value-menu] li:nth-child(${number})`;
 
@@ -193,7 +193,7 @@ Cypress.Commands.add('createTest', () => {
   cy.waitForTracePageApiCalls();
 });
 
-Cypress.Commands.add('createAssertion', (index = 0) => {
+Cypress.Commands.add('createAssertion', () => {
   cy.selectRunDetailMode(3);
 
   cy.get(`[data-cy=trace-node-database]`, {timeout: 25000}).first().click({force: true});
@@ -203,7 +203,7 @@ Cypress.Commands.add('createAssertion', (index = 0) => {
 
   cy.get('[data-cy=expression-editor] [contenteditable]').first().type('db.name', {delay: 100});
 
-  const attributeListId = getAttributeListId(index);
+  const attributeListId = getAttributeListId(0);
   cy.get(attributeListId, {timeout: 10000}).first().click();
   cy.get(getValueFromList(1)).first().click();
 

--- a/web/cypress/support/index.d.ts
+++ b/web/cypress/support/index.d.ts
@@ -1,7 +1,7 @@
 declare namespace Cypress {
   interface Chainable {
     createMultipleTestRuns(id: string, count: number): Chainable<Element>;
-    createAssertion(index?: number): Chainable<Element>;
+    createAssertion(): Chainable<Element>;
     openTestCreationModal(): Chainable<Element>;
     interceptTracePageApiCalls(): Chainable<Element>;
     inteceptHomeApiCall(): Chainable<Element>;


### PR DESCRIPTION
This PR fixes an unstable e2e test. The Cypress selector to match autocomplete options in the Assertions form was failing when the `id` of the `<ul />` element had the number '0' in it.

## Changes

- Fix cypress selector

## Fixes

-

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
