### PR TITLE
test:  adding e2e tests for transactions and transactions runs

### DIFF
--- a/web/cypress/e2e/Home/CreateTest.spec.ts
+++ b/web/cypress/e2e/Home/CreateTest.spec.ts
@@ -14,7 +14,7 @@ describe('Create test', () => {
     cy.openTestCreationModal();
     cy.fillCreateFormBasicStep(name);
     cy.setCreateFormUrl('GET', 'http://demo-pokemon-api.demo.svc.cluster.local/pokemon');
-    cy.submitCreateTestForm();
+    cy.submitCreateForm();
     cy.makeSureUserIsOnTracePage();
     cy.get('[data-cy=test-details-name]').should('have.text', `${name} (v1)`);
   });
@@ -33,7 +33,7 @@ describe('Create test', () => {
           parseSpecialCharSequences: false,
         }
       );
-    cy.submitCreateTestForm();
+    cy.submitCreateForm();
     cy.makeSureUserIsOnTracePage();
     cy.get('[data-cy=test-details-name]').should('have.text', `${name} (v1)`);
   });

--- a/web/cypress/e2e/Home/CreateTestFromCurl.spec.ts
+++ b/web/cypress/e2e/Home/CreateTestFromCurl.spec.ts
@@ -19,9 +19,9 @@ describe('Create test from CURL Command', () => {
    `,
         {parseSpecialCharSequences: false}
       );
-    cy.get('[data-cy=create-test-next-button]').last().click();
+    cy.get('[data-cy=CreateTestFactory-create-next-button]').last().click();
 
-    cy.submitCreateTestForm();
+    cy.submitCreateForm();
     cy.matchTestRunPageUrl();
     cy.cancelOnBoarding();
     cy.get('[data-cy=test-details-name]').should('have.text', `${name} (v1)`);

--- a/web/cypress/e2e/Home/CreateTestFromPostman.spec.ts
+++ b/web/cypress/e2e/Home/CreateTestFromPostman.spec.ts
@@ -10,7 +10,7 @@ describe('Create test from Postman Collection', () => {
     cy.get('[data-cy="collectionFile"]').attachFile('collection.json');
     cy.get('[data-cy=collectionTest-select]').click();
     cy.get('[data-cy=collectionTest-1]').click({force: true});
-    cy.submitCreateTestForm();
+    cy.submitCreateForm();
     cy.matchTestRunPageUrl();
     cy.cancelOnBoarding();
     cy.get('[data-cy=test-details-name]').should('have.text', `${name} (v1)`);

--- a/web/cypress/e2e/Transactions/Transactions.spec.ts
+++ b/web/cypress/e2e/Transactions/Transactions.spec.ts
@@ -1,0 +1,41 @@
+import TransactionUtils from '../utils/Transactions';
+
+const transactionUtils = TransactionUtils();
+
+describe('Transactions', () => {
+  beforeEach(() => {
+    cy.visit('/');
+    cy.wrap(transactionUtils.createTests());
+  });
+
+  afterEach(() => {
+    cy.wrap(transactionUtils.deleteTests()).then(() => {
+      cy.deleteTransaction();
+    });
+  });
+
+  it('should create a transaction with multiple tests', () => {
+    const name = `Transaction - #${String(Date.now()).slice(-4)}`;
+    cy.openTransactionCreationModal();
+    cy.inteceptHomeApiCall();
+    cy.fillCreateFormBasicStep(name, name, 'CreateTransactionFactory');
+
+    transactionUtils.testList.forEach(test => {
+      cy.get('[data-cy=transaction-test-selection]').click();
+      cy.get(`[data-cy="${test.name}"]`).first().click();
+    });
+
+    cy.submitCreateForm('CreateTransactionFactory');
+    cy.get('[data-cy=transaction-details-name').should('have.text', `${name} (v1)`);
+  });
+
+  it('should create a transaction with no tests', () => {
+    const name = `Transaction - #${String(Date.now()).slice(-4)}`;
+    cy.openTransactionCreationModal();
+    cy.inteceptHomeApiCall();
+    cy.fillCreateFormBasicStep(name, name, 'CreateTransactionFactory');
+
+    cy.submitCreateForm('CreateTransactionFactory');
+    cy.get('[data-cy=transaction-details-name').should('have.text', `${name} (v1)`);
+  });
+});

--- a/web/cypress/e2e/Transactions/TransactionsRun.spec.ts
+++ b/web/cypress/e2e/Transactions/TransactionsRun.spec.ts
@@ -1,0 +1,81 @@
+import TransactionUtils from '../utils/Transactions';
+
+const transactionUtils = TransactionUtils();
+
+describe('Transactions', () => {
+  beforeEach(() => {
+    cy.visit('/');
+    cy.wrap(transactionUtils.createTests());
+  });
+
+  afterEach(() => {
+    cy.wrap(transactionUtils.deleteTests()).then(() => {
+      cy.deleteTransaction();
+    });
+  });
+
+  it('should create and run a transaction with multiple tests', () => {
+    const name = `Transaction - #${String(Date.now()).slice(-4)}`;
+    cy.openTransactionCreationModal();
+    cy.inteceptHomeApiCall();
+    cy.fillCreateFormBasicStep(name, name, 'CreateTransactionFactory');
+
+    transactionUtils.testList.forEach(test => {
+      cy.get('[data-cy=transaction-test-selection]').click();
+      cy.get(`[data-cy="${test.name}"]`).first().click();
+    });
+
+    cy.submitCreateForm('CreateTransactionFactory');
+    cy.get('[data-cy=transaction-details-name').should('have.text', `${name} (v1)`);
+    cy.get('[data-cy=transaction-run-button]', {timeout: 30000}).should('be.visible');
+  });
+
+  it('should rerun a transaction after creation', () => {
+    const name = `Transaction - #${String(Date.now()).slice(-4)}`;
+    cy.openTransactionCreationModal();
+    cy.inteceptHomeApiCall();
+    cy.fillCreateFormBasicStep(name, name, 'CreateTransactionFactory');
+
+    transactionUtils.testList.forEach(test => {
+      cy.get('[data-cy=transaction-test-selection]').click();
+      cy.get(`[data-cy="${test.name}"]`).first().click();
+    });
+
+    cy.submitCreateForm('CreateTransactionFactory');
+    cy.get('[data-cy=transaction-details-name').should('have.text', `${name} (v1)`);
+    cy.get('[data-cy=transaction-run-button]', {timeout: 30000}).should('be.visible').click();
+
+    cy.get('[data-cy=transaction-details-name').should('have.text', `${name} (v1)`);
+    cy.get('[data-cy=transaction-run-button]', {timeout: 30000}).should('be.visible').click();
+  });
+
+  it('should update a transaction and rerun', () => {
+    const name = `Transaction - #${String(Date.now()).slice(-4)}`;
+    cy.openTransactionCreationModal();
+    cy.inteceptHomeApiCall();
+    cy.fillCreateFormBasicStep(name, name, 'CreateTransactionFactory');
+
+    transactionUtils.testList.forEach(test => {
+      cy.get('[data-cy=transaction-test-selection]').click();
+      cy.get(`[data-cy="${test.name}"]`).first().click();
+    });
+
+    cy.submitCreateForm('CreateTransactionFactory');
+    cy.get('[data-cy=transaction-details-name').should('have.text', `${name} (v1)`);
+    cy.get('[data-cy=transaction-run-button]', {timeout: 30000}).should('be.visible');
+    cy.get('[data-cy^=transaction-execution-step-]').should('have.length', 2);
+
+    const updateName = `${name} - updated`;
+
+    cy.get('[data-cy=create-test-name-input]').type(' - updated');
+    transactionUtils.testList.forEach(test => {
+      cy.get('[data-cy=transaction-test-selection]').click();
+      cy.get(`[data-cy="${test.name}"]`).first().click();
+    });
+
+    cy.get('[data-cy=edit-transaction-submit]').click();
+    cy.get('[data-cy=transaction-details-name').should('have.text', `${updateName} (v2)`);
+    cy.get('[data-cy=transaction-run-button]', {timeout: 30000}).should('be.visible');
+    cy.get('[data-cy^=transaction-execution-step-]').should('have.length', 4);
+  });
+});

--- a/web/cypress/e2e/constants/Transactions.ts
+++ b/web/cypress/e2e/constants/Transactions.ts
@@ -1,0 +1,31 @@
+import {TRawTest} from '../../../src/types/Test.types';
+
+export const transactionTestList: TRawTest[] = [
+  {
+    name: 'POST test',
+    description: 'transaction',
+    serviceUnderTest: {
+      triggerType: 'http',
+      triggerSettings: {
+        http: {
+          url: 'http://demo-pokemon-api.demo.svc.cluster.local/pokemon/import',
+          method: 'POST',
+          body: '{"id": 6}',
+        },
+      },
+    },
+  },
+  {
+    name: 'GET test',
+    description: 'transaction',
+    serviceUnderTest: {
+      triggerType: 'http',
+      triggerSettings: {
+        http: {
+          url: 'http://demo-pokemon-api.demo.svc.cluster.local/pokemon',
+          method: 'GET',
+        },
+      },
+    },
+  },
+];

--- a/web/cypress/e2e/utils/Common.ts
+++ b/web/cypress/e2e/utils/Common.ts
@@ -1,6 +1,7 @@
 Cypress.on('uncaught:exception', err => !err.message.includes('ResizeObserver loop limit exceeded'));
 
 const testIdRegex = /\/test\/([\w-]+)/;
+const transactionIdRegex = /\/transaction\/([\w-]+)/;
 const runIdRegex = /\/run\/(\w+)/;
 
 export const getTestId = (pathname: string) => {
@@ -9,6 +10,14 @@ export const getTestId = (pathname: string) => {
   const testId = result.length > 1 ? result[1] : '';
   cy.log(testId);
   return testId;
+};
+
+export const getTransactionId = (pathname: string) => {
+  cy.log(pathname);
+  const result = pathname.match(transactionIdRegex);
+  const transactionId = result.length > 1 ? result[1] : '';
+  cy.log(transactionId);
+  return transactionId;
 };
 
 export const getResultId = (pathname: string) => {

--- a/web/cypress/e2e/utils/Transactions.ts
+++ b/web/cypress/e2e/utils/Transactions.ts
@@ -1,0 +1,42 @@
+import {TRawTest} from '../../../src/types/Test.types';
+import {transactionTestList} from '../constants/Transactions';
+
+interface ITransactionUtils {
+  testList: TRawTest[];
+  createTest(test: TRawTest): Promise<TRawTest>;
+  createTests(tests?: TRawTest[]): Promise<TRawTest[]>;
+  deleteTest(id: string): Promise<void>;
+  deleteTests(): Promise<void[]>;
+  waitForTransactionRun(): void;
+}
+
+const TransactionUtils = (): ITransactionUtils => ({
+  testList: [],
+  createTest(test) {
+    return new Promise(resolve => {
+      cy.request('POST', '/api/tests', test).then((res: Cypress.Response<TRawTest>) => {
+        resolve(res.body);
+      });
+    });
+  },
+  async createTests(tests = transactionTestList) {
+    this.testList = await Promise.all(tests.map(test => this.createTest(test)));
+
+    return this.testList;
+  },
+  deleteTest(id) {
+    return new Promise(resolve => {
+      cy.request('DELETE', `/api/tests/${id}`).then(() => {
+        resolve();
+      });
+    });
+  },
+  deleteTests() {
+    return Promise.all(this.testList.map(test => this.deleteTest(test.id)));
+  },
+  waitForTransactionRun() {
+    cy.get('[data-cy=transaction-run-result-status]').should('have.text', 'FINISHED', {timeout: 60000});
+  }
+});
+
+export default TransactionUtils;

--- a/web/cypress/support/commands.ts
+++ b/web/cypress/support/commands.ts
@@ -1,7 +1,7 @@
 import 'cypress-file-upload';
 import {camelCase} from 'lodash';
 import {PokeshopDemo} from '../../src/constants/Demo.constants';
-import {getTestId} from '../e2e/utils/Common';
+import {getTestId, getTransactionId} from '../e2e/utils/Common';
 
 export const testRunPageRegex = /\/test\/(.*)\/run\/(.*)/;
 export const getAttributeListId = (number: number) => `.cm-tooltip-autocomplete [id*=${number}]`;
@@ -49,7 +49,7 @@ Cypress.Commands.add('deleteTest', (shoudlIntercept = false) => {
 Cypress.Commands.add('openTestCreationModal', () => {
   cy.get('[data-cy=create-button]').click();
   cy.get('.ant-dropdown-menu-item').first().click();
-  cy.get('[data-cy=create-test-steps]').should('be.visible');
+  cy.get('[data-cy=create-test-steps-CreateTestFactory]').should('be.visible');
 });
 
 Cypress.Commands.add('interceptTracePageApiCalls', () => {
@@ -66,6 +66,8 @@ Cypress.Commands.add('inteceptHomeApiCall', () => {
   cy.intercept({method: 'GET', url: '/api/resources?take=20&skip=0*'}).as('testList');
   cy.intercept({method: 'DELETE', url: '/api/tests/**'}).as('testDelete');
   cy.intercept({method: 'POST', url: '/api/tests'}).as('testCreation');
+  cy.intercept({method: 'DELETE', url: '/api/transactions/**'}).as('transactionDelete');
+  cy.intercept({method: 'POST', url: '/api/transactions'}).as('transactionCreation');
 });
 
 Cypress.Commands.add('waitForTracePageApiCalls', () => {
@@ -76,7 +78,7 @@ Cypress.Commands.add('waitForTracePageApiCalls', () => {
 });
 
 Cypress.Commands.add('createTestWithAuth', (authMethod: string, keys: string[]): any => {
-  cy.get('[data-cy=create-test-next-button]').last().click();
+  cy.get('[data-cy=CreateTestFactory-create-create-button]').last().click();
   cy.selectTestFromDemoList();
   cy.get('[data-cy=auth-type-select]').click();
   cy.get(`[data-cy=auth-type-select-option-${authMethod}]`).click();
@@ -85,7 +87,7 @@ Cypress.Commands.add('createTestWithAuth', (authMethod: string, keys: string[]):
 });
 
 Cypress.Commands.add('submitAndMakeSureTestIsCreated', (name: string) => {
-  cy.submitCreateTestForm();
+  cy.submitCreateForm();
   cy.interceptTracePageApiCalls();
   cy.makeSureUserIsOnTracePage();
   cy.waitForTracePageApiCalls();
@@ -124,25 +126,26 @@ Cypress.Commands.add('cancelOnBoarding', () => {
   }
 });
 
-Cypress.Commands.add('submitCreateTestForm', () => {
-  cy.get('[data-cy=create-test-create-button]').last().click();
-  cy.wait('@testCreation');
+Cypress.Commands.add('submitCreateForm', (mode = 'CreateTestFactory') => {
+  cy.get(`[data-cy=${mode}-create-create-button]`).last().click();
+  if (mode === 'CreateTestFactory') cy.wait('@testCreation');
+  if (mode === 'CreateTransactionFactory') cy.wait('@transactionCreation');
 });
 
-Cypress.Commands.add('fillCreateFormBasicStep', (name: string, description?: string) => {
-  cy.get('[data-cy=create-test-next-button]').click();
+Cypress.Commands.add('fillCreateFormBasicStep', (name: string, description?: string, mode = 'CreateTestFactory') => {
+  if (mode === 'CreateTestFactory') cy.get(`[data-cy=${mode}-create-next-button]`).click();
   cy.get('[data-cy=create-test-name-input').type(name);
   cy.get('[data-cy=create-test-description-input').type(description || name);
-  cy.get('[data-cy=create-test-next-button]').last().click();
+  cy.get(`[data-cy=${mode}-create-next-button]`).last().click();
 });
 
 Cypress.Commands.add('createTestByName', (name: string) => {
   cy.openTestCreationModal();
-  cy.get('[data-cy=create-test-next-button]').click();
+  cy.get('[data-cy=CreateTestFactory-create-next-button]').click();
   cy.get('[data-cy=example-button]').click();
   cy.get(`[data-cy=demo-example-${camelCase(name)}]`).click();
-  cy.get('[data-cy=create-test-next-button]').last().click();
-  cy.submitCreateTestForm();
+  cy.get('[data-cy=CreateTestFactory-create-next-button]').last().click();
+  cy.submitCreateForm();
   cy.makeSureUserIsOnTracePage();
   cy.get('[data-cy=test-details-name]').should('have.text', `${name} (v1)`);
 });
@@ -172,11 +175,11 @@ Cypress.Commands.add('selectOperator', (index: number, text?: string) => {
 Cypress.Commands.add('selectTestFromDemoList', () => {
   cy.get('[data-cy=example-button]').click();
   cy.get(`[data-cy=demo-example-${camelCase(PokeshopDemo.REST[0].name)}]`).click();
-  cy.get('[data-cy=create-test-next-button]').last().click();
+  cy.get('[data-cy=CreateTestFactory-create-next-button]').last().click();
 });
 
 Cypress.Commands.add('clickNextOnCreateTestWizard', () => {
-  cy.get('[data-cy=create-test-next-button]').click();
+  cy.get('[data-cy=CreateTestFactory-create-next-button]').click();
 });
 
 Cypress.Commands.add('createTest', () => {
@@ -188,7 +191,7 @@ Cypress.Commands.add('createTest', () => {
   cy.clickNextOnCreateTestWizard();
   cy.selectTestFromDemoList();
   cy.interceptTracePageApiCalls();
-  cy.submitCreateTestForm();
+  cy.submitCreateForm();
   cy.makeSureUserIsOnTracePage();
   cy.waitForTracePageApiCalls();
 });
@@ -220,4 +223,28 @@ Cypress.Commands.add('createAssertion', (index = 0) => {
  */
 Cypress.Commands.add('selectRunDetailMode', (index: number) => {
   cy.get(`[data-cy=run-detail-header] .ant-tabs-nav-list div:nth-child(${index})`).click();
+});
+
+Cypress.Commands.add('openTransactionCreationModal', () => {
+  cy.get('[data-cy=create-button]').click();
+  cy.get('.ant-dropdown-menu-item').last().click();
+  cy.get('[data-cy=create-test-steps-CreateTransactionFactory]').should('be.visible');
+});
+
+Cypress.Commands.add('deleteTransaction', () => {
+  cy.location('pathname').then(pathname => {
+    const localTestId = getTransactionId(pathname);
+
+    cy.visit(`/`);
+    cy.wait('@testList');
+    cy.get('[data-cy=test-list]').should('exist', {timeout: 10000});
+    cy.get(`[data-cy=test-actions-button-${localTestId}]`, {timeout: 10000}).should('be.visible');
+    cy.get(`[data-cy=test-actions-button-${localTestId}]`).click({force: true});
+    cy.get('[data-cy=test-card-delete]').click();
+    cy.get('[data-cy=delete-confirmation-modal] .ant-btn-primary').click();
+    cy.wait('@transactionDelete');
+    cy.get(`[data-cy=test-actions-button-${localTestId}]`).should('not.exist');
+    cy.wait('@testList');
+    cy.clearLocalStorage();
+  });
 });

--- a/web/cypress/support/commands.ts
+++ b/web/cypress/support/commands.ts
@@ -78,7 +78,7 @@ Cypress.Commands.add('waitForTracePageApiCalls', () => {
 });
 
 Cypress.Commands.add('createTestWithAuth', (authMethod: string, keys: string[]): any => {
-  cy.get('[data-cy=CreateTestFactory-create-create-button]').last().click();
+  cy.get('[data-cy=CreateTestFactory-create-next-button]').last().click();
   cy.selectTestFromDemoList();
   cy.get('[data-cy=auth-type-select]').click();
   cy.get(`[data-cy=auth-type-select-option-${authMethod}]`).click();

--- a/web/cypress/support/index.d.ts
+++ b/web/cypress/support/index.d.ts
@@ -11,7 +11,7 @@ declare namespace Cypress {
     selectTestFromDemoList(): Chainable<Element>;
     selectOperator(index: number, text?: string): Chainable<Element>;
     editTestByTestId(testId: string): Chainable<Element>;
-    submitCreateTestForm(): Chainable<Element>;
+    submitCreateForm(mode?: string): Chainable<Element>;
     deleteTest(shouldIntercept?: boolean): Chainable<Element>;
     makeSureUserIsOnTracePage(): Chainable<Element>;
     cancelOnBoarding(): Chainable<Element>;
@@ -21,9 +21,12 @@ declare namespace Cypress {
     createTestByName(name: string): Chainable<Element>;
     submitAndMakeSureTestIsCreated(name: string): Chainable<Element>;
     createTestWithAuth(authMethod: string, keys: string[]): Chainable<string>;
-    fillCreateFormBasicStep(name: string, description?: string): Chainable<Element>;
+    fillCreateFormBasicStep(name: string, description?: string, mode?: string): Chainable<Element>;
     setCreateFormUrl(method: string, url: string): Chainable<Element>;
     selectRunDetailMode(index: number): Chainable<Element>;
     interceptEditTestCall(): Chainable<Element>;
+    deleteTransactionTests(): Chainable<Element>;
+    openTransactionCreationModal(): Chainable<Element>;
+    deleteTransaction(): Chainable<Element>;
   }
 }

--- a/web/src/components/CreateModal/CreateModal.tsx
+++ b/web/src/components/CreateModal/CreateModal.tsx
@@ -15,6 +15,7 @@ interface IProps {
   stepNumber: number;
   isLoading: boolean;
   isValid: boolean;
+  mode: string;
 }
 
 const CreateModal = ({
@@ -29,6 +30,7 @@ const CreateModal = ({
   stepNumber,
   isLoading,
   isValid,
+  mode,
 }: IProps) => {
   const isLastStep = stepNumber === stepList.length - 1;
   const step = stepList[stepNumber];
@@ -57,6 +59,7 @@ const CreateModal = ({
         stepList={stepList}
         selectedKey={activeStep}
         componentFactory={componentFactory}
+        mode={mode}
       />
     </S.Modal>
   );

--- a/web/src/components/CreateModal/CreateModal.tsx
+++ b/web/src/components/CreateModal/CreateModal.tsx
@@ -49,7 +49,7 @@ const CreateModal = ({
           isLoading={isLoading}
           stepNumber={stepNumber}
           step={step}
-          mode={componentFactory.name}
+          mode={mode}
         />
       }
     >

--- a/web/src/components/CreateModal/CreateModal.tsx
+++ b/web/src/components/CreateModal/CreateModal.tsx
@@ -47,6 +47,7 @@ const CreateModal = ({
           isLoading={isLoading}
           stepNumber={stepNumber}
           step={step}
+          mode={componentFactory.name}
         />
       }
     >

--- a/web/src/components/CreateSteps/CreateStepFooter.tsx
+++ b/web/src/components/CreateSteps/CreateStepFooter.tsx
@@ -10,9 +10,10 @@ interface IProps {
   step: ICreateTestStep;
   onPrev(): void;
   isLoading: boolean;
+  mode: string;
 }
 
-const CreateStepFooter = ({isValid, stepNumber, step, isLastStep, onPrev, isLoading}: IProps) => {
+const CreateStepFooter = ({isValid, stepNumber, step, isLastStep, onPrev, isLoading, mode}: IProps) => {
   return (
     <S.Footer>
       <span>
@@ -35,7 +36,7 @@ const CreateStepFooter = ({isValid, stepNumber, step, isLastStep, onPrev, isLoad
           <Button
             htmlType="submit"
             form={step.component}
-            data-cy="create-test-next-button"
+            data-cy={`${mode}-create-next-button`}
             disabled={!isValid}
             type="primary"
             onClick={() => CreateTestAnalyticsService.onNextClick(step.name)}
@@ -47,7 +48,7 @@ const CreateStepFooter = ({isValid, stepNumber, step, isLastStep, onPrev, isLoad
             htmlType="submit"
             form={step.component}
             onClick={() => CreateTestAnalyticsService.onCreateTestFormSubmit()}
-            data-cy="create-test-create-button"
+            data-cy={`${mode}-create-create-button`}
             disabled={!isValid}
             type="primary"
             loading={isLoading}

--- a/web/src/components/CreateSteps/CreateSteps.tsx
+++ b/web/src/components/CreateSteps/CreateSteps.tsx
@@ -10,11 +10,12 @@ interface IProps {
   selectedKey: string;
   componentFactory({step}: {step: ICreateTestStep}): React.ReactElement;
   onGoTo(stepId: string): void;
+  mode: string;
 }
 
-const CreateTestSteps = ({isLoading, stepList, selectedKey, componentFactory: ComponentFactory, onGoTo}: IProps) => {
+const CreateTestSteps = ({isLoading, stepList, selectedKey, componentFactory: ComponentFactory, onGoTo, mode}: IProps) => {
   return (
-    <S.CreateTestSteps data-cy={`create-test-steps-${ComponentFactory.name}`}>
+    <S.CreateTestSteps data-cy={`create-test-steps-${mode}`}>
       <S.ProgressLine $stepCount={stepList.length} />
       <Tabs
         type="card"

--- a/web/src/components/CreateSteps/CreateSteps.tsx
+++ b/web/src/components/CreateSteps/CreateSteps.tsx
@@ -14,7 +14,7 @@ interface IProps {
 
 const CreateTestSteps = ({isLoading, stepList, selectedKey, componentFactory: ComponentFactory, onGoTo}: IProps) => {
   return (
-    <S.CreateTestSteps data-cy="create-test-steps">
+    <S.CreateTestSteps data-cy={`create-test-steps-${ComponentFactory.name}`}>
       <S.ProgressLine $stepCount={stepList.length} />
       <Tabs
         type="card"

--- a/web/src/components/CreateTestModal/CreateTestModal.tsx
+++ b/web/src/components/CreateTestModal/CreateTestModal.tsx
@@ -33,6 +33,7 @@ const CreateTestModal = ({isOpen, onClose}: IProps) => {
       isLoading={isLoading}
       stepNumber={stepNumber}
       componentFactory={CreateTestFactory}
+      mode="CreateTestFactory"
     />
   ) : null;
 };

--- a/web/src/components/CreateTransactionModal/CreateTransactionModal.tsx
+++ b/web/src/components/CreateTransactionModal/CreateTransactionModal.tsx
@@ -33,6 +33,7 @@ const CreateTransactionModal = ({isOpen, onClose}: IProps) => {
       isLoading={false}
       stepNumber={stepNumber}
       componentFactory={CreateTransactionFactory}
+      mode="CreateTransactionFactory"
     />
   ) : null;
 };

--- a/web/src/components/TransactionHeader/TransactionHeader.tsx
+++ b/web/src/components/TransactionHeader/TransactionHeader.tsx
@@ -26,20 +26,20 @@ const TransactionHeader = ({
         <S.BackIcon data-cy="transaction-header-back-button" onClick={onBack} />
         <div>
           <S.Title data-cy="transaction-details-name">
-            {name} ({version})
+            {name} (v{version})
           </S.Title>
           <S.Text>{description}</S.Text>
         </div>
       </S.Section>
       <S.Section>
         {state && state !== TestStateEnum.FINISHED && (
-          <S.StateContainer data-cy="test-run-result-status">
+          <S.StateContainer data-cy="transaction-run-result-status">
             <S.StateText>Status:</S.StateText>
             <TestState testState={state} />
           </S.StateContainer>
         )}
         {state && state === TestStateEnum.FINISHED && (
-          <Button ghost onClick={onRun} type="primary">
+          <Button ghost onClick={onRun} type="primary" data-cy="transaction-run-button">
             Run Transaction
           </Button>
         )}

--- a/web/src/components/TransactionPlugin/steps/TestsSelection/TestsSelectionInput/TestsSelectionInput.tsx
+++ b/web/src/components/TransactionPlugin/steps/TestsSelection/TestsSelectionInput/TestsSelectionInput.tsx
@@ -83,6 +83,7 @@ const TestsSelectionInput = ({value = [], onChange = noop, testList}: IProps) =>
             <Select
               placeholder="Add a test"
               onChange={onSelectedTest}
+              data-cy="transaction-test-selection"
               value={null}
               showSearch
               filterOption={(input, option) =>
@@ -90,7 +91,7 @@ const TestsSelectionInput = ({value = [], onChange = noop, testList}: IProps) =>
               }
             >
               {testList.map(({id, name}) => (
-                <Select.Option value={id} key={id}>
+                <Select.Option value={id} key={id} data-cy={name}>
                   {name}
                 </Select.Option>
               ))}

--- a/web/src/components/TransactionRunResult/ExecutionStep.tsx
+++ b/web/src/components/TransactionRunResult/ExecutionStep.tsx
@@ -36,7 +36,7 @@ const ExecutionStep = ({
   const stateIsFinished = ([TestState.FINISHED, TestState.FAILED] as string[]).includes(state);
 
   return (
-    <S.Container data-cy={`run-card-${name}`} key={`${testId}-${runId}`}>
+    <S.Container data-cy={`transaction-execution-step-${name}`}>
       <S.ExecutionStepStatus>{iconBasedOnResult(state, index)}</S.ExecutionStepStatus>
       <S.Info>
         <S.ExecutionStepName>{`${name} v${testVersion}`}</S.ExecutionStepName>
@@ -67,7 +67,7 @@ const ExecutionStep = ({
       <S.ExecutionStepStatus>
         {runId && (
           <Tooltip title="Go to Run">
-            <S.ExecutionStepRunLink to={`/test/${testId}/run/${runId}`} target="_blank">
+            <S.ExecutionStepRunLink to={`/test/${testId}/run/${runId}`} target="_blank" data-cy="execution-step-run-link">
               <LinkOutlined />
             </S.ExecutionStepRunLink>
           </Tooltip>


### PR DESCRIPTION
This PR adds e2e tests for transactions and transaction runs.

## Changes

- Updates the different selector strings to match the tests.
- Adds transaction utils with context holding for creating and deleting tests.

## Fixes

- [[Transactions] E2E tests: Transactions#1539](https://github.com/kubeshop/tracetest/issues/1539)
- [[Transactions] E2E tests: Transactions Run#1540](https://github.com/kubeshop/tracetest/issues/1540)

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [x] added a test
