### PR TITLE
feat: add startTime and endTime span attributes

### DIFF
--- a/server/traces/traces.go
+++ b/server/traces/traces.go
@@ -54,6 +54,8 @@ func augmentSpanData(span *Span) {
 	span.Attributes["name"] = span.Name
 	span.Attributes["tracetest.span.type"] = spanType(span.Attributes)
 	span.Attributes["tracetest.span.duration"] = spanDuration(*span)
+	span.Attributes["tracetest.span.startTime"] = fmt.Sprintf("%d", span.StartTime.UnixNano())
+	span.Attributes["tracetest.span.endTime"] = fmt.Sprintf("%d", span.EndTime.UnixNano())
 }
 
 func spanType(attrs Attributes) string {

--- a/tracetesting/definitions/test_run.yml
+++ b/tracetesting/definitions/test_run.yml
@@ -17,6 +17,9 @@ spec:
     assertions:
     - attr:tracetest.selected_spans.count = 1
     - attr:tracetest.response.status = 200
+    # Ensure startTime and endTime are present in span
+    - attr:tracetest.span.startTime > 0
+    - attr:tracetest.span.endTime > 0
   - selector: span[name = "POST /api/tests/{testId}/run" tracetest.span.type = "http"]
     assertions:
     - attr:tracetest.selected_spans.count = 1


### PR DESCRIPTION
This PR adds `tracetest.span.startTime` and `tracetest.span.endTime` to the span attributes. This allows users to check if an operation happened within X seconds since another operation by using test outputs.

## Checklist

- [ ] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
