### PR TITLE
fix: prevent test runner from hanging when a trigger returns an error

### DIFF
--- a/server/executor/runner.go
+++ b/server/executor/runner.go
@@ -121,7 +121,7 @@ func (r persistentRunner) Run(ctx context.Context, test model.Test, metadata mod
 
 	executor := expression.NewExecutor(ds...)
 
-	channel := make(chan RunResult, 1)
+	channel := make(chan RunResult, 2)
 
 	r.executeQueue <- execReq{
 		ctx:      ctx,


### PR DESCRIPTION
This PR set the channel buffer to 2 to prevent the test runner to hang

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
