### PR TITLE
feature(backend): adding outputs to the test definition file

### DIFF
--- a/server/model/yaml/test.go
+++ b/server/model/yaml/test.go
@@ -137,6 +137,7 @@ func GetTestFromOpenapiObject(test openapi.Test) (Test, error) {
 		Description: test.Description,
 		Trigger:     convertServiceUnderTestIntoTrigger(test.ServiceUnderTest),
 		Specs:       convertOpenAPITestSpecIntoSpecArray(test.Specs),
+		Outputs:     convertOpenAPITestOutputsIntoOutputsArray(test.Outputs),
 	}, nil
 }
 
@@ -233,4 +234,20 @@ func convertOpenAPITestSpecIntoSpecArray(testSpec openapi.TestSpecs) []TestSpec 
 	}
 
 	return definitionArray
+}
+
+func convertOpenAPITestOutputsIntoOutputsArray(outputs []openapi.TestOutput) Outputs {
+	outputArray := make(Outputs, 0, len(outputs))
+
+	for _, output := range outputs {
+		newOutput := Output{
+			Name:     output.Name,
+			Selector: output.Selector.Query,
+			Value:    output.Value,
+		}
+
+		outputArray = append(outputArray, newOutput)
+	}
+
+	return outputArray
 }


### PR DESCRIPTION
This PR adds the outputs to be part of the test definition file response

## Changes

- Adds outputs to the response object

## Fixes

- https://github.com/kubeshop/tracetest/issues/1576

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

![Screenshot 2022-11-24 at 9 26 16](https://user-images.githubusercontent.com/11051031/203824149-613317ab-a2b0-46be-b91a-32ee49833a49.png)