### PR TITLE
fix(server): map transactions createdAt sort field to correct db field

### DIFF
--- a/server/testdb/environments.go
+++ b/server/testdb/environments.go
@@ -54,11 +54,6 @@ INSERT INTO environments (
 	`
 )
 
-var environmentSortingFields = map[string]string{
-	"created": "e.created_at",
-	"name":    "e.name",
-}
-
 func (td *postgresDB) CreateEnvironment(ctx context.Context, environment model.Environment) (model.Environment, error) {
 	environment.ID = environment.Slug()
 	environment.CreatedAt = time.Now()
@@ -113,7 +108,12 @@ func (td *postgresDB) GetEnvironments(ctx context.Context, take, skip int32, que
 		sql += condition
 	}
 
-	sql = sortQuery(sql, sortBy, sortDirection, environmentSortingFields)
+	sortFields := map[string]string{
+		"created": "e.created_at",
+		"name":    "e.name",
+	}
+
+	sql = sortQuery(sql, sortBy, sortDirection, sortFields)
 	sql += ` LIMIT $1 OFFSET $2 `
 
 	stmt, err := td.db.Prepare(sql)

--- a/server/testdb/environments.go
+++ b/server/testdb/environments.go
@@ -108,12 +108,12 @@ func (td *postgresDB) GetEnvironments(ctx context.Context, take, skip int32, que
 		sql += condition
 	}
 
-	sortFields := map[string]string{
+	sortingFields := map[string]string{
 		"created": "e.created_at",
 		"name":    "e.name",
 	}
 
-	sql = sortQuery(sql, sortBy, sortDirection, sortFields)
+	sql = sortQuery(sql, sortBy, sortDirection, sortingFields)
 	sql += ` LIMIT $1 OFFSET $2 `
 
 	stmt, err := td.db.Prepare(sql)

--- a/server/testdb/tests.go
+++ b/server/testdb/tests.go
@@ -184,12 +184,6 @@ const (
 	`
 )
 
-var sortingFields = map[string]string{
-	"created":  "t.created_at",
-	"name":     "t.name",
-	"last_run": "last_test_run_time",
-}
-
 func sortQuery(sql, sortBy, sortDirection string, sortingFields map[string]string) string {
 	sortField, ok := sortingFields[sortBy]
 
@@ -246,6 +240,12 @@ func (td *postgresDB) GetTests(ctx context.Context, take, skip int32, query, sor
 	if hasSearchQuery {
 		params = append(params, cleanSearchQuery)
 		sql += condition
+	}
+
+	sortingFields := map[string]string{
+		"created":  "t.created_at",
+		"name":     "t.name",
+		"last_run": "last_test_run_time",
 	}
 
 	sql = sortQuery(sql, sortBy, sortDirection, sortingFields)

--- a/server/testdb/transactions.go
+++ b/server/testdb/transactions.go
@@ -239,6 +239,12 @@ func (td *postgresDB) GetTransactions(ctx context.Context, take, skip int32, que
 		sql += condition
 	}
 
+	sortingFields := map[string]string{
+		"created":  "t.created_at",
+		"name":     "t.name",
+		"last_run": "t.created_at",
+	}
+
 	sql = sortQuery(sql, sortBy, sortDirection, sortingFields)
 	sql += ` LIMIT $1 OFFSET $2 `
 


### PR DESCRIPTION
This PR fixes the mapping used to sort transactions by `createdAt` field.

## Fixes

- #1598 

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
