### PR TITLE
feature(frontend): moving navigation logic to use anchor tags when possible

### DIFF
--- a/web/src/components/Layout/Layout.tsx
+++ b/web/src/components/Layout/Layout.tsx
@@ -7,9 +7,8 @@ import Header from 'components/Header';
 import useRouterSync from 'hooks/useRouterSync';
 import ConfirmationModalProvider from 'providers/ConfirmationModal';
 import EnvironmentProvider from 'providers/Environment';
-import {MenuInfo} from 'rc-menu/es/interface';
 import React from 'react';
-import {Link, useLocation, useNavigate} from 'react-router-dom';
+import {Link, useLocation} from 'react-router-dom';
 import * as S from './Layout.styled';
 
 interface IProps {
@@ -21,25 +20,20 @@ const menuItems = [
   {
     key: '0',
     icon: <ClusterOutlined />,
-    label: 'Tests',
+    label: <Link to="/">Tests</Link>,
     path: '/',
   },
   {
     key: '1',
     icon: <GlobalOutlined />,
-    label: 'Environments',
+    label: <Link to="/environments">Environments</Link>,
     path: '/environments',
   },
 ];
 
 const Layout = ({children, hasMenu = false}: IProps) => {
-  const navigate = useNavigate();
   useRouterSync();
 
-  const handleOnClickMenu = (menuInfo: MenuInfo) => {
-    const item = menuItems.find(menuItem => menuItem.key === menuInfo.key);
-    navigate(item?.path ?? '/');
-  };
   const pathname = useLocation().pathname;
   return (
     <FileViewerModalProvider>
@@ -59,7 +53,6 @@ const Layout = ({children, hasMenu = false}: IProps) => {
                     defaultSelectedKeys={[menuItems.findIndex(value => value.path === pathname).toString() || '0']}
                     items={menuItems}
                     mode="inline"
-                    onClick={handleOnClickMenu}
                     theme="dark"
                   />
                 </S.MenuContainer>

--- a/web/src/components/ResourceCard/ResourceCardRuns.tsx
+++ b/web/src/components/ResourceCard/ResourceCardRuns.tsx
@@ -8,10 +8,10 @@ interface IProps {
   isCollapsed: boolean;
   isLoading: boolean;
   onViewAll(): void;
-  resourceId: string;
+  resourcePath: string;
 }
 
-const ResourceCardRuns = ({children, hasMoreRuns, hasRuns, isCollapsed, isLoading, onViewAll, resourceId}: IProps) => {
+const ResourceCardRuns = ({children, hasMoreRuns, hasRuns, isCollapsed, isLoading, onViewAll, resourcePath}: IProps) => {
   if (isCollapsed) return null;
 
   return (
@@ -28,7 +28,7 @@ const ResourceCardRuns = ({children, hasMoreRuns, hasRuns, isCollapsed, isLoadin
 
       {hasMoreRuns && (
         <S.FooterContainer>
-          <S.Link data-cy="test-details-link" onClick={onViewAll} href={`/test/${resourceId}`}>
+          <S.Link data-cy="test-details-link" onClick={onViewAll} href={resourcePath}>
             View all runs
           </S.Link>
         </S.FooterContainer>

--- a/web/src/components/ResourceCard/ResourceCardRuns.tsx
+++ b/web/src/components/ResourceCard/ResourceCardRuns.tsx
@@ -8,9 +8,10 @@ interface IProps {
   isCollapsed: boolean;
   isLoading: boolean;
   onViewAll(): void;
+  resourceId: string;
 }
 
-const ResourceCardRuns = ({children, hasMoreRuns, hasRuns, isCollapsed, isLoading, onViewAll}: IProps) => {
+const ResourceCardRuns = ({children, hasMoreRuns, hasRuns, isCollapsed, isLoading, onViewAll, resourceId}: IProps) => {
   if (isCollapsed) return null;
 
   return (
@@ -27,7 +28,7 @@ const ResourceCardRuns = ({children, hasMoreRuns, hasRuns, isCollapsed, isLoadin
 
       {hasMoreRuns && (
         <S.FooterContainer>
-          <S.Link data-cy="test-details-link" onClick={onViewAll}>
+          <S.Link data-cy="test-details-link" onClick={onViewAll} href={`/test/${resourceId}`}>
             View all runs
           </S.Link>
         </S.FooterContainer>

--- a/web/src/components/ResourceCard/TestCard.tsx
+++ b/web/src/components/ResourceCard/TestCard.tsx
@@ -64,6 +64,7 @@ const TestCard = ({onDelete, onRun, onViewAll, test}: IProps) => {
         isCollapsed={isCollapsed}
         isLoading={isLoading}
         onViewAll={() => onViewAll(test.id, ResourceType.Test)}
+        resourceId={test.id}
       >
         <S.RunsListContainer data-cy="run-card-list">
           {list.map(run => (

--- a/web/src/components/ResourceCard/TestCard.tsx
+++ b/web/src/components/ResourceCard/TestCard.tsx
@@ -64,7 +64,7 @@ const TestCard = ({onDelete, onRun, onViewAll, test}: IProps) => {
         isCollapsed={isCollapsed}
         isLoading={isLoading}
         onViewAll={() => onViewAll(test.id, ResourceType.Test)}
-        resourceId={test.id}
+        resourcePath={`/test/${test.id}`}
       >
         <S.RunsListContainer data-cy="run-card-list">
           {list.map(run => (

--- a/web/src/components/ResourceCard/TransactionCard.tsx
+++ b/web/src/components/ResourceCard/TransactionCard.tsx
@@ -69,7 +69,7 @@ const TransactionCard = ({
         hasRuns={Boolean(list.length)}
         isCollapsed={isCollapsed}
         isLoading={isLoading}
-        resourceId={transactionId}
+        resourcePath={`/transaction/${transactionId}`}
         onViewAll={() => onViewAll(transactionId, ResourceType.Transaction)}
       >
         <S.RunsListContainer>

--- a/web/src/components/ResourceCard/TransactionCard.tsx
+++ b/web/src/components/ResourceCard/TransactionCard.tsx
@@ -69,6 +69,7 @@ const TransactionCard = ({
         hasRuns={Boolean(list.length)}
         isCollapsed={isCollapsed}
         isLoading={isLoading}
+        resourceId={transactionId}
         onViewAll={() => onViewAll(transactionId, ResourceType.Transaction)}
       >
         <S.RunsListContainer>

--- a/web/src/components/RunDetailLayout/HeaderLeft.tsx
+++ b/web/src/components/RunDetailLayout/HeaderLeft.tsx
@@ -1,4 +1,4 @@
-import {useNavigate} from 'react-router-dom';
+import {Link} from 'react-router-dom';
 
 import {useTestRun} from 'providers/TestRun/TestRun.provider';
 import Date from 'utils/Date';
@@ -14,13 +14,14 @@ interface IProps {
 }
 
 const HeaderLeft = ({name, testId, triggerType}: IProps) => {
-  const navigate = useNavigate();
   const {run} = useTestRun();
   const createdTimeAgo = Date.getTimeAgo(run?.createdAt ?? '');
 
   return (
     <S.Section $justifyContent="flex-start">
-      <S.BackIcon data-cy="test-header-back-button" onClick={() => navigate(`/test/${testId}`)} />
+      <Link data-cy="test-header-back-button" to={`/test/${testId}`}>
+        <S.BackIcon />
+      </Link>
       <S.InfoContainer data-tour={GuidedTourService.getStep(GuidedTours.Trace, Steps.MetaDetails)}>
         <S.Row>
           <S.Title data-cy="test-details-name">

--- a/web/src/components/RunDetailLayout/RunDetailLayout.styled.ts
+++ b/web/src/components/RunDetailLayout/RunDetailLayout.styled.ts
@@ -1,6 +1,7 @@
 import styled from 'styled-components';
 import {Typography} from 'antd';
 import {LeftOutlined} from '@ant-design/icons';
+import {Link} from 'react-router-dom';
 
 export const BackIcon = styled(LeftOutlined)`
   cursor: pointer;
@@ -109,5 +110,17 @@ export const Title = styled(Typography.Title).attrs({ellipsis: true, level: 2})`
   && {
     margin: 0;
     max-width: calc((100vw / 2) - 150px - 54px);
+  }
+`;
+
+export const TabLink = styled(Link)<{$isActive: boolean}>`
+  && {
+    color: ${({theme, $isActive}) => $isActive && theme.color.white};
+
+    &:hover,
+    &:visited,
+    &:focused {
+      color: ${({theme, $isActive}) => $isActive && theme.color.white};
+    }
   }
 `;

--- a/web/src/components/RunDetailLayout/RunDetailLayout.tsx
+++ b/web/src/components/RunDetailLayout/RunDetailLayout.tsx
@@ -1,6 +1,6 @@
 import {Tabs, TabsProps} from 'antd';
 import {useMemo} from 'react';
-import {useNavigate, useParams} from 'react-router-dom';
+import {useParams} from 'react-router-dom';
 import RunDetailTest from 'components/RunDetailTest';
 import RunDetailTrace from 'components/RunDetailTrace';
 import RunDetailTrigger from 'components/RunDetailTrigger';
@@ -28,8 +28,13 @@ const renderTabBar: TabsProps['renderTabBar'] = (props, DefaultTabBar) => (
   </S.ContainerHeader>
 );
 
+const renderTab = (title: string, testId: string, runId: string, mode: string) => (
+  <S.TabLink $isActive={mode === title.toLowerCase()} to={`/test/${testId}/run/${runId}/${title.toLowerCase()}`}>
+    {title}
+  </S.TabLink>
+);
+
 const RunDetailLayout = ({test: {id, name, trigger, version = 1}, test}: IProps) => {
-  const navigate = useNavigate();
   const {mode = RunDetailModes.TRIGGER} = useParams();
   const {isError, run} = useTestRun();
   useDocumentTitle(`${name} - ${run.state}`);
@@ -49,19 +54,18 @@ const RunDetailLayout = ({test: {id, name, trigger, version = 1}, test}: IProps)
         centered
         onChange={activeKey => {
           TestRunAnalyticsService.onChangeMode(activeKey as RunDetailModes);
-          navigate(`/test/${id}/run/${run.id}/${activeKey}`);
         }}
         renderTabBar={renderTabBar}
         tabBarExtraContent={tabBarExtraContent}
         destroyInactiveTabPane
       >
-        <Tabs.TabPane tab="Trigger" key={RunDetailModes.TRIGGER}>
+        <Tabs.TabPane tab={renderTab('Trigger', id, run.id, mode)} key={RunDetailModes.TRIGGER}>
           <RunDetailTrigger test={test} run={run} isError={isError} />
         </Tabs.TabPane>
-        <Tabs.TabPane tab="Trace" key={RunDetailModes.TRACE}>
+        <Tabs.TabPane tab={renderTab('Trace', id, run.id, mode)} key={RunDetailModes.TRACE}>
           <RunDetailTrace run={run} testId={id} />
         </Tabs.TabPane>
-        <Tabs.TabPane tab="Test" key={RunDetailModes.TEST}>
+        <Tabs.TabPane tab={renderTab('Test', id, run.id, mode)} key={RunDetailModes.TEST}>
           <RunDetailTest run={run} testId={id} />
         </Tabs.TabPane>
       </Tabs>

--- a/web/src/components/TestHeader/TestHeader.tsx
+++ b/web/src/components/TestHeader/TestHeader.tsx
@@ -1,19 +1,21 @@
 import ResourceCardActions from 'components/ResourceCard/ResourceCardActions';
+import {Link} from 'react-router-dom';
 import * as S from './TestHeader.styled';
 
 interface IProps {
   description: string;
   id: string;
-  onBack(): void;
   onDelete(): void;
   title: string;
   runButton: React.ReactElement;
 }
 
-const TestHeader = ({description, id, onBack, onDelete, title, runButton}: IProps) => (
+const TestHeader = ({description, id, onDelete, title, runButton}: IProps) => (
   <S.Container $isWhite>
     <S.Section>
-      <S.BackIcon data-cy="test-header-back-button" onClick={onBack} />
+      <Link to="/" data-cy="test-header-back-button">
+        <S.BackIcon />
+      </Link>
       <div>
         <S.Title data-cy="test-details-name">{title}</S.Title>
         <S.Text>{description}</S.Text>

--- a/web/src/components/TransactionHeader/TransactionHeader.tsx
+++ b/web/src/components/TransactionHeader/TransactionHeader.tsx
@@ -1,4 +1,5 @@
 import {Button} from 'antd';
+import {Link} from 'react-router-dom';
 import {useTransaction} from 'providers/Transaction/Transaction.provider';
 import {TestState as TestStateEnum} from 'constants/TestRun.constants';
 import TestState from '../TestState';
@@ -8,13 +9,11 @@ import {TTransaction} from '../../types/Transaction.types';
 import {TTransactionRun} from '../../types/TransactionRun.types';
 
 interface IProps {
-  onBack(): void;
   transaction: TTransaction;
   transactionRun: TTransactionRun;
 }
 
 const TransactionHeader = ({
-  onBack,
   transaction: {id: transactionId, name, version, description},
   transactionRun: {state, id: runId},
 }: IProps) => {
@@ -23,7 +22,9 @@ const TransactionHeader = ({
   return (
     <S.Container>
       <S.Section>
-        <S.BackIcon data-cy="transaction-header-back-button" onClick={onBack} />
+        <Link to={`/transaction/${transactionId}`} data-cy="transaction-header-back-button">
+          <S.BackIcon />
+        </Link>
         <div>
           <S.Title data-cy="transaction-details-name">
             {name} (v{version})

--- a/web/src/components/TransactionPlugin/steps/TestsSelection/TestsSelectionInput/TestItem.tsx
+++ b/web/src/components/TransactionPlugin/steps/TestsSelection/TestsSelectionInput/TestItem.tsx
@@ -20,7 +20,9 @@ const TestItem = ({test, onDelete, sortableId}: IProps) => {
   return (
     <S.TestItemContainer ref={setNodeRef} style={style} {...attributes}>
       <S.DragHandle {...listeners} />
-      <span>{test.name}</span>
+      <S.TestLink to={`/test/${test.id}`} target="_blank">
+        <span>{test.name}</span>
+      </S.TestLink>
       <S.DeleteIcon onClick={() => onDelete(test.id)} />
     </S.TestItemContainer>
   );

--- a/web/src/components/TransactionPlugin/steps/TestsSelection/TestsSelectionInput/TestsSelectionInput.styled.ts
+++ b/web/src/components/TransactionPlugin/steps/TestsSelection/TestsSelectionInput/TestsSelectionInput.styled.ts
@@ -1,4 +1,5 @@
 import {HolderOutlined, DeleteOutlined} from '@ant-design/icons';
+import {Link} from 'react-router-dom';
 import styled from 'styled-components';
 
 export const TestItemContainer = styled.li`
@@ -34,4 +35,16 @@ export const ItemListContainer = styled.ul`
   padding: 0;
   margin: 0;
   margin-bottom: 12px;
+`;
+
+export const TestLink = styled(Link)`
+  && {
+    color: ${({theme}) => theme.color.text};
+
+    &:hover,
+    &:visited,
+    &:focused {
+      color: ${({theme}) => theme.color.text};
+    }
+  }
 `;

--- a/web/src/components/TransactionRunLayout/TransactionRunLayout.tsx
+++ b/web/src/components/TransactionRunLayout/TransactionRunLayout.tsx
@@ -1,5 +1,4 @@
 import {useMemo} from 'react';
-import {useNavigate} from 'react-router-dom';
 import TransactionHeader from 'components/TransactionHeader';
 import {TTransaction} from 'types/Transaction.types';
 import {TTransactionRun} from 'types/TransactionRun.types';
@@ -14,15 +13,13 @@ interface IProps {
   transactionRun: TTransactionRun;
 }
 
-const TransactionRunDetailLayout = ({transaction, transaction: {id: transactionId}, transactionRun}: IProps) => {
-  const navigate = useNavigate();
+const TransactionRunDetailLayout = ({transaction, transactionRun}: IProps) => {
   useDocumentTitle(`${transaction.name} - ${transactionRun.state}`);
   const draftTransaction = useMemo(() => TransactionService.getInitialValues(transaction), [transaction]);
 
   return (
     <>
       <TransactionHeader
-        onBack={() => navigate(`/transaction/${transactionId}`)}
         transactionRun={transactionRun}
         transaction={transaction}
       />

--- a/web/src/components/TransactionRunResult/ExecutionStep.tsx
+++ b/web/src/components/TransactionRunResult/ExecutionStep.tsx
@@ -1,6 +1,7 @@
 import {capitalize} from 'lodash';
 import {Tooltip} from 'antd';
 import {LinkOutlined} from '@ant-design/icons';
+import {Link} from 'react-router-dom';
 import {TestState} from 'constants/TestRun.constants';
 import {TTest} from 'types/Test.types';
 import {TTestRun, TTestRunState} from 'types/TestRun.types';
@@ -34,18 +35,21 @@ const ExecutionStep = ({
   }),
 }: IProps) => {
   const stateIsFinished = ([TestState.FINISHED, TestState.FAILED] as string[]).includes(state);
+  const toLink = runId ? `/test/${testId}/run/${runId}` : `/test/${testId}`;
 
   return (
     <S.Container data-cy={`transaction-execution-step-${name}`}>
       <S.ExecutionStepStatus>{iconBasedOnResult(state, index)}</S.ExecutionStepStatus>
-      <S.Info>
-        <S.ExecutionStepName>{`${name} v${testVersion}`}</S.ExecutionStepName>
-        <S.TagContainer>
-          <S.TextTag>{trigger.method}</S.TextTag>
-          <S.TextTag $isLight>{trigger.entryPoint}</S.TextTag>
-          {!stateIsFinished && <S.TextTag>{capitalize(state)}</S.TextTag>}
-        </S.TagContainer>
-      </S.Info>
+      <Link to={toLink} target="_blank">
+        <S.Info>
+          <S.ExecutionStepName>{`${name} v${testVersion}`}</S.ExecutionStepName>
+          <S.TagContainer>
+            <S.TextTag>{trigger.method}</S.TextTag>
+            <S.TextTag $isLight>{trigger.entryPoint}</S.TextTag>
+            {!stateIsFinished && <S.TextTag>{capitalize(state)}</S.TextTag>}
+          </S.TagContainer>
+        </S.Info>
+      </Link>
       <S.AssertionResultContainer>
         {runId && (
           <>
@@ -65,13 +69,11 @@ const ExecutionStep = ({
         )}
       </S.AssertionResultContainer>
       <S.ExecutionStepStatus>
-        {runId && (
-          <Tooltip title="Go to Run">
-            <S.ExecutionStepRunLink to={`/test/${testId}/run/${runId}`} target="_blank" data-cy="execution-step-run-link">
-              <LinkOutlined />
-            </S.ExecutionStepRunLink>
-          </Tooltip>
-        )}
+        <Tooltip title="Go to Run">
+          <S.ExecutionStepRunLink to={toLink} target="_blank" data-cy="execution-step-run-link">
+            <LinkOutlined />
+          </S.ExecutionStepRunLink>
+        </Tooltip>
       </S.ExecutionStepStatus>
     </S.Container>
   );

--- a/web/src/pages/Home/Content.tsx
+++ b/web/src/pages/Home/Content.tsx
@@ -8,7 +8,6 @@ import useDeleteResource from 'hooks/useDeleteResource';
 import usePagination from 'hooks/usePagination';
 import useTestCrud from 'providers/Test/hooks/useTestCrud';
 import {useCallback, useState} from 'react';
-import {useNavigate} from 'react-router-dom';
 import {useGetResourcesQuery} from 'redux/apis/TraceTest.api';
 import HomeAnalyticsService from 'services/Analytics/HomeAnalytics.service';
 import {ResourceType, TResource} from 'types/Resource.type';
@@ -30,7 +29,6 @@ const Content = () => {
   const [isCreateTestOpen, setIsCreateTestOpen] = useState(false);
   const [parameters, setParameters] = useState<TParameters>(defaultSort);
 
-  const navigate = useNavigate();
   const pagination = usePagination<TResource, TParameters>(useGetResourcesQuery, parameters);
   const onDeleteResource = useDeleteResource();
   const {runTest} = useTestCrud();
@@ -44,13 +42,9 @@ const Content = () => {
     [runTest, runTransaction]
   );
 
-  const handleOnViewAll = useCallback(
-    (id: string, type: ResourceType) => {
-      onTestClick(id);
-      navigate(`/${type}/${id}`);
-    },
-    [navigate]
-  );
+  const handleOnViewAll = useCallback((id: string) => {
+    onTestClick(id);
+  }, []);
 
   return (
     <>

--- a/web/src/pages/Test/Content.tsx
+++ b/web/src/pages/Test/Content.tsx
@@ -1,6 +1,5 @@
 import {useMemo} from 'react';
 import {Button} from 'antd';
-import {useNavigate} from 'react-router-dom';
 import PaginatedList from 'components/PaginatedList';
 import TestRunCard from 'components/RunCard/TestRunCard';
 import TestHeader from 'components/TestHeader';
@@ -16,7 +15,6 @@ import {Steps} from 'components/GuidedTour/testDetailsStepList';
 import * as S from './Test.styled';
 
 const Content = () => {
-  const navigate = useNavigate();
   const {test} = useTest();
   const onDeleteResource = useDeleteResource();
   const {runTest, isLoadingRunTest} = useTestCrud();
@@ -30,7 +28,6 @@ const Content = () => {
           test.trigger.entryPoint
         }`}
         id={test.id}
-        onBack={() => navigate('/')}
         onDelete={() => onDeleteResource(test.id, test.name, ResourceType.Test)}
         title={`${test.name} (v${test.version})`}
         runButton={

--- a/web/src/pages/Transaction/Content.tsx
+++ b/web/src/pages/Transaction/Content.tsx
@@ -1,6 +1,5 @@
 import {Button} from 'antd';
 import {useCallback, useMemo} from 'react';
-import {useNavigate} from 'react-router-dom';
 
 import PaginatedList from 'components/PaginatedList';
 import TransactionRunCard from 'components/RunCard/TransactionRunCard';
@@ -13,7 +12,6 @@ import useDocumentTitle from 'hooks/useDocumentTitle';
 import * as S from './Transaction.styled';
 
 const Content = () => {
-  const navigate = useNavigate();
   const {onDelete, transaction} = useTransaction();
   const {runTransaction, isEditLoading} = useTransactionCrud();
   const params = useMemo(() => ({transactionId: transaction.id}), [transaction.id]);
@@ -29,7 +27,6 @@ const Content = () => {
       <TestHeader
         description={transaction.description}
         id={transaction.id}
-        onBack={() => navigate('/')}
         onDelete={() => onDelete(transaction.id, transaction.name)}
         title={`${transaction.name} (v${transaction.version})`}
         runButton={

--- a/web/src/providers/Test/hooks/useTestCrud.ts
+++ b/web/src/providers/Test/hooks/useTestCrud.ts
@@ -29,7 +29,7 @@ const useTestCrud = () => {
 
       const mode = match?.params.mode || 'trigger';
 
-      navigate(`/test/${testId}/run/${run.id}/${mode}`);
+      navigate(`/test/${testId}/run/${run.id}/${mode}`, {});
     },
     [dispatch, match?.params.mode, navigate, runTestAction, selectedEnvironment?.id]
   );

--- a/web/src/providers/Test/hooks/useTestCrud.ts
+++ b/web/src/providers/Test/hooks/useTestCrud.ts
@@ -29,7 +29,7 @@ const useTestCrud = () => {
 
       const mode = match?.params.mode || 'trigger';
 
-      navigate(`/test/${testId}/run/${run.id}/${mode}`, {});
+      navigate(`/test/${testId}/run/${run.id}/${mode}`);
     },
     [dispatch, match?.params.mode, navigate, runTestAction, selectedEnvironment?.id]
   );


### PR DESCRIPTION
This PR updates the navigation logic to use anchor tags instead of programmatically redirect the user so it can decide to open the target URL in a separate tab.

## Fixes

- [Show links to tests from transaction run page](https://github.com/kubeshop/tracetest/issues/1597)
- [Most links should support 'right click' to open a new window](https://github.com/kubeshop/tracetest/issues/1601) (Partially)

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
