### PR TITLE
fix(frontend): deleting the last remaining test when creating a transaction has issues

### DIFF
--- a/web/src/components/TransactionPlugin/steps/TestsSelection/TestsSelectionInput/TestItem.tsx
+++ b/web/src/components/TransactionPlugin/steps/TestsSelection/TestsSelectionInput/TestItem.tsx
@@ -6,7 +6,7 @@ import * as S from './TestsSelectionInput.styled';
 interface IProps {
   test: TTest;
   sortableId: string;
-  onDelete(testId: string): void;
+  onDelete(sortableId: string): void;
 }
 
 const TestItem = ({test, onDelete, sortableId}: IProps) => {
@@ -21,7 +21,7 @@ const TestItem = ({test, onDelete, sortableId}: IProps) => {
     <S.TestItemContainer ref={setNodeRef} style={style} {...attributes}>
       <S.DragHandle {...listeners} />
       <span>{test.name}</span>
-      <S.DeleteIcon onClick={() => onDelete(test.id)} />
+      <S.DeleteIcon onClick={() => onDelete(sortableId)} />
     </S.TestItemContainer>
   );
 };

--- a/web/src/components/TransactionPlugin/steps/TestsSelection/TestsSelectionInput/TestItemList.tsx
+++ b/web/src/components/TransactionPlugin/steps/TestsSelection/TestsSelectionInput/TestItemList.tsx
@@ -5,7 +5,7 @@ import * as S from './TestsSelectionInput.styled';
 
 interface IProps {
   items: ISortableTest[];
-  onDelete(testId: string): void;
+  onDelete(sortableId: string): void;
 }
 
 const TestItemList = ({items, onDelete}: IProps) => {

--- a/web/src/components/TransactionPlugin/steps/TestsSelection/TestsSelectionInput/TestsSelectionInput.tsx
+++ b/web/src/components/TransactionPlugin/steps/TestsSelection/TestsSelectionInput/TestsSelectionInput.tsx
@@ -65,7 +65,7 @@ const TestsSelectionInput = ({value = [], onChange = noop, testList}: IProps) =>
   const onDelete = useCallback(
     (testId: string) => {
       onChange(value.filter(id => id !== testId));
-      setSelectedTestList(selectedTestList.filter(test => test.id !== testId));
+      setSelectedTestList(selectedTestList.filter(({test}) => test.id !== testId));
     },
     [onChange, selectedTestList, value]
   );

--- a/web/src/components/TransactionPlugin/steps/TestsSelection/TestsSelectionInput/TestsSelectionInput.tsx
+++ b/web/src/components/TransactionPlugin/steps/TestsSelection/TestsSelectionInput/TestsSelectionInput.tsx
@@ -63,9 +63,9 @@ const TestsSelectionInput = ({value = [], onChange = noop, testList}: IProps) =>
   );
 
   const onDelete = useCallback(
-    (testId: string) => {
-      onChange(value.filter(id => id !== testId));
-      setSelectedTestList(selectedTestList.filter(({test}) => test.id !== testId));
+    (sortableId: string) => {
+      onChange(value.filter((id, index) => `${id}-${index}` !== sortableId));
+      setSelectedTestList(selectedTestList.filter(test => test.id !== sortableId));
     },
     [onChange, selectedTestList, value]
   );


### PR DESCRIPTION
This PR fixes an issue when trying to delete a test from the item list.

## Changes

- Uses the sortable id to delete the test from the value array, matching the id + index.

## Fixes

- 1604

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
