### PR TITLE
feat: implement option for waiting for result when running transactions

### DIFF
--- a/cli/actions/run_test_action.go
+++ b/cli/actions/run_test_action.go
@@ -362,9 +362,18 @@ func (a runTestAction) transactionRun(ctx context.Context, transaction openapi.T
 	formattedOutput := formatter.Format(tro)
 	fmt.Print(formattedOutput)
 
-	if params.WaitForResult && tro.Run.GetState() == "FAILED" {
-		// It failed, so we have to return an error status
-		os.Exit(1)
+	if params.WaitForResult {
+		if tro.Run.GetState() == "FAILED" {
+			// It failed, so we have to return an error status
+			os.Exit(1)
+		}
+
+		for _, step := range tro.Run.Steps {
+			if !step.Result.GetAllPassed() {
+				// if any test doesn't pass, fail the transaction execution
+				os.Exit(1)
+			}
+		}
 	}
 
 	return nil

--- a/cli/formatters/test_run_test.go
+++ b/cli/formatters/test_run_test.go
@@ -164,3 +164,87 @@ func TestFailingTestOutput(t *testing.T) {
 `
 	assert.Equal(t, expectedOutput, output)
 }
+
+func TestFailingTestOutputWithPadding(t *testing.T) {
+	in := formatters.TestRunOutput{
+		HasResults: true,
+		Test: openapi.Test{
+			Id:   openapi.PtrString("9876543"),
+			Name: openapi.PtrString("Testcase 2"),
+		},
+		Run: openapi.TestRun{
+			Id: openapi.PtrString("1"),
+			Result: &openapi.AssertionResults{
+				AllPassed: openapi.PtrBool(false),
+				Results: []openapi.AssertionResultsResults{
+					{
+						Selector: &openapi.Selector{
+							Query: openapi.PtrString(`span[name = "my span"]`),
+						},
+						Results: []openapi.AssertionResult{
+							{
+								Assertion: openapi.PtrString(`attr:tracetest.span.duration <= 200ms`),
+								AllPassed: openapi.PtrBool(true),
+								SpanResults: []openapi.AssertionSpanResult{
+									{
+										SpanId:        openapi.PtrString("123456"),
+										ObservedValue: openapi.PtrString("157ms"),
+										Passed:        openapi.PtrBool(true),
+										Error:         nil,
+									},
+								},
+							},
+						},
+					},
+					{
+						Selector: &openapi.Selector{
+							Query: openapi.PtrString(`span[name = "my other span"]`),
+						},
+						Results: []openapi.AssertionResult{
+							{
+								Assertion: openapi.PtrString(`attr:http.status = 200`),
+								AllPassed: openapi.PtrBool(true),
+								SpanResults: []openapi.AssertionSpanResult{
+									{
+										SpanId:        openapi.PtrString("456789"),
+										ObservedValue: openapi.PtrString("404"),
+										Passed:        openapi.PtrBool(false),
+										Error:         nil,
+									},
+								},
+							},
+							{
+								Assertion: openapi.PtrString(`attr:tracetest.span.duration <= 200ms`),
+								AllPassed: openapi.PtrBool(true),
+								SpanResults: []openapi.AssertionSpanResult{
+									{
+										SpanId:        openapi.PtrString("456789"),
+										ObservedValue: openapi.PtrString("68ms"),
+										Passed:        openapi.PtrBool(true),
+										Error:         nil,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	formatter := formatters.TestRun(config.Config{
+		Scheme:   "http",
+		Endpoint: "localhost:11633",
+	}, false, formatters.WithPadding(1))
+	output := formatter.Format(in)
+	expectedOutput := `	✘ Testcase 2 (http://localhost:11633/test/9876543/run/1/test)
+		✔ span[name = "my span"]
+			✔ #123456
+				✔ attr:tracetest.span.duration <= 200ms (157ms)
+		✘ span[name = "my other span"]
+			✘ #456789
+				✘ attr:http.status = 200 (404) (http://localhost:11633/test/9876543/run/1/test?selectedAssertion=1&selectedSpan=456789)
+				✔ attr:tracetest.span.duration <= 200ms (68ms)
+`
+	assert.Equal(t, expectedOutput, output)
+}

--- a/cli/formatters/transaction_run.go
+++ b/cli/formatters/transaction_run.go
@@ -62,15 +62,16 @@ func (f transactionRun) pretty(output TransactionRunOutput) string {
 	}
 
 	link := output.RunWebURL
-	if f.allTransactionStepsPassed(output) {
-		message := fmt.Sprintf("%s %s (%s)\n", PASSED_TEST_ICON, output.Transaction.GetName(), link)
-		return f.getColoredText(true, message)
+	allStepsPassed := f.allTransactionStepsPassed(output)
+	message := fmt.Sprintf("%s %s (%s)\n", PASSED_TEST_ICON, output.Transaction.GetName(), link)
+
+	if !allStepsPassed {
+		message = fmt.Sprintf("%s %s (%s)\n", FAILED_TEST_ICON, output.Transaction.GetName(), link)
 	}
 
-	message := fmt.Sprintf("%s %s (%s)\n", FAILED_TEST_ICON, output.Transaction.GetName(), link)
 	// the transaction name + all steps
 	formattedMessages := make([]string, 0, len(output.Run.Steps)+1)
-	formattedMessages = append(formattedMessages, f.getColoredText(false, message))
+	formattedMessages = append(formattedMessages, f.getColoredText(allStepsPassed, message))
 
 	for i, testRun := range output.Run.Steps {
 		test := output.Transaction.Steps[i]

--- a/cli/formatters/transaction_run.go
+++ b/cli/formatters/transaction_run.go
@@ -90,7 +90,7 @@ func (f transactionRun) pretty(output TransactionRunOutput) string {
 
 func (f transactionRun) allTransactionStepsPassed(output TransactionRunOutput) bool {
 	for _, step := range output.Run.Steps {
-		if step.Result.AllPassed == nil || !*step.Result.AllPassed {
+		if !step.Result.GetAllPassed() {
 			return false
 		}
 	}

--- a/cli/formatters/transaction_run.go
+++ b/cli/formatters/transaction_run.go
@@ -51,10 +51,11 @@ func (f transactionRun) json(output TransactionRunOutput) string {
 
 func (f transactionRun) pretty(output TransactionRunOutput) string {
 	if output.Run.GetState() == "FAILED" {
+		fmt.Println(output.Run)
 		return f.getColoredText(false, "Failed to execute transaction")
 	}
 
-	if !output.HasResults {
+	if output.HasResults {
 		link := output.RunWebURL
 		message := fmt.Sprintf("%s %s (%s)\n", PASSED_TEST_ICON, output.Transaction.GetName(), link)
 		return f.getColoredText(true, message)

--- a/cli/formatters/transaction_run.go
+++ b/cli/formatters/transaction_run.go
@@ -51,7 +51,6 @@ func (f transactionRun) json(output TransactionRunOutput) string {
 
 func (f transactionRun) pretty(output TransactionRunOutput) string {
 	if output.Run.GetState() == "FAILED" {
-		fmt.Println(output.Run)
 		return f.getColoredText(false, "Failed to execute transaction")
 	}
 


### PR DESCRIPTION
This PR implements `--wait-for-result` for transaction runs and improve the result output.

### Successful transaction
![Screenshot from 2022-12-01 16-15-27](https://user-images.githubusercontent.com/2704737/205140038-824fc6f3-c5cd-42b5-ad4a-861f3a437c9a.png)

### Failed transaction
![Screenshot from 2022-12-01 16-16-26](https://user-images.githubusercontent.com/2704737/205140240-c1d8d169-61aa-4c79-b885-5fa9c0c88d6f.png)



## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
