### PR TITLE
docs(edit-link): fixed broken link

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -41,7 +41,7 @@ const config = {
           sidebarPath: require.resolve("./sidebars.js"),
           // Please change this to your repo.
           // Remove this to remove the "edit this page" links.
-          editUrl: "https://github.com/kubeshop/tracetest",
+          editUrl: "https://github.com/kubeshop/tracetest/blob/main/docs/",
           routeBasePath: "/",
         },
         theme: {


### PR DESCRIPTION
This PR fixes the broken `edit this page` link.

## Changes

-

## Fixes

-

## Checklist

- [ ] tested locally
- [ ] added new dependencies
- [x] updated the docs
- [ ] added a test
