### PR TITLE
fix(frontend): fixes summary checks not opening the proper test spec

### DIFF
--- a/web/src/components/AssertionResultChecks/AssertionResultChecks.styled.ts
+++ b/web/src/components/AssertionResultChecks/AssertionResultChecks.styled.ts
@@ -1,0 +1,57 @@
+import {Badge} from 'antd';
+import styled, {css} from 'styled-components';
+
+export const Container = styled.div`
+  display: flex;
+  gap: 2px;
+`;
+
+export const CustomBadge = styled(Badge)<{$styleType: 'node' | 'summary' | 'default'}>`
+  border: ${({theme}) => `1px solid ${theme.color.textSecondary}`};
+  border-radius: 9999px;
+  cursor: pointer;
+  line-height: 19px;
+  padding: 0 8px;
+  white-space: nowrap;
+
+  .ant-badge-status-text {
+    color: ${({theme}) => theme.color.textSecondary};
+    font-size: ${({theme}) => theme.size.sm};
+    margin-left: 3px;
+  }
+
+  ${({$styleType}) =>
+    $styleType === 'node' &&
+    css`
+      border: none;
+      font-size: ${({theme}) => theme.size.xs};
+      line-height: 10px;
+      padding: 0 2px;
+      vertical-align: bottom;
+      margin: 0;
+
+      .ant-badge-status-dot {
+        height: 8px;
+        top: 0;
+        width: 8px;
+      }
+
+      .ant-badge-status-text {
+        font-size: ${({theme}) => theme.size.xs};
+        margin-left: 2px;
+      }
+    `}
+
+  ${({$styleType}) =>
+    $styleType === 'summary' &&
+    css`
+      border: none;
+      padding: 0 2px;
+      vertical-align: bottom;
+
+      .ant-badge-status-dot {
+        height: 10px;
+        width: 10px;
+      }
+    `}
+`;

--- a/web/src/components/AssertionResultChecks/AssertionResultChecks.tsx
+++ b/web/src/components/AssertionResultChecks/AssertionResultChecks.tsx
@@ -1,0 +1,18 @@
+import {IResult} from 'types/Assertion.types';
+import AttributeCheck from './ResultCheck';
+import * as S from './AssertionResultChecks.styled';
+
+interface IProps {
+  failed: IResult[];
+  passed: IResult[];
+  styleType?: 'node' | 'summary' | 'default';
+}
+
+const AssertionResultChecks = ({passed, failed, styleType}: IProps) => (
+  <S.Container>
+    {Boolean(passed.length) && <AttributeCheck items={passed} type="success" styleType={styleType} />}
+    {Boolean(failed.length) && <AttributeCheck items={failed} type="error" styleType={styleType} />}
+  </S.Container>
+);
+
+export default AssertionResultChecks;

--- a/web/src/components/AssertionResultChecks/ResultCheck.tsx
+++ b/web/src/components/AssertionResultChecks/ResultCheck.tsx
@@ -3,14 +3,15 @@ import {Dropdown, Menu} from 'antd';
 import {useTestSpecs} from 'providers/TestSpecs/TestSpecs.provider';
 import TraceAnalyticsService from 'services/Analytics/TestRunAnalytics.service';
 import {IResult} from 'types/Assertion.types';
-import * as S from './AttributeRow.styled';
+import * as S from './AssertionResultChecks.styled';
 
 interface IProps {
   items: IResult[];
   type: 'error' | 'success';
+  styleType?: 'node' | 'summary' | 'default';
 }
 
-const AttributeCheck = ({items, type}: IProps) => {
+const ResultCheck = ({items, type, styleType = 'default'}: IProps) => {
   const {setSelectedSpec} = useTestSpecs();
 
   const handleOnClick = (id: string) => {
@@ -32,7 +33,7 @@ const AttributeCheck = ({items, type}: IProps) => {
   if (items.length === 1) {
     return (
       <div onClick={() => handleOnClick(items[0].id)}>
-        <S.CustomBadge status={type} text={items.length} />
+        <S.CustomBadge status={type} text={items.length} $styleType={styleType} />
       </div>
     );
   }
@@ -40,12 +41,10 @@ const AttributeCheck = ({items, type}: IProps) => {
   return (
     <div>
       <Dropdown overlay={menuLayout} placement="bottomLeft" trigger={['click']}>
-        <div>
-          <S.CustomBadge status={type} text={items.length} />
-        </div>
+        <S.CustomBadge status={type} text={items.length} $styleType={styleType} />
       </Dropdown>
     </div>
   );
 };
 
-export default AttributeCheck;
+export default ResultCheck;

--- a/web/src/components/AssertionResultChecks/ResultCheck.tsx
+++ b/web/src/components/AssertionResultChecks/ResultCheck.tsx
@@ -1,4 +1,5 @@
 import {Dropdown, Menu} from 'antd';
+import {uniqBy} from 'lodash';
 
 import {useTestSpecs} from 'providers/TestSpecs/TestSpecs.provider';
 import TraceAnalyticsService from 'services/Analytics/TestRunAnalytics.service';
@@ -22,7 +23,7 @@ const ResultCheck = ({items, type, styleType = 'default'}: IProps) => {
 
   const menuLayout = (
     <Menu
-      items={items.map(item => ({
+      items={uniqBy(items, 'id').map(item => ({
         key: item.id,
         label: item.label,
       }))}

--- a/web/src/components/AttributeList/AttributeList.tsx
+++ b/web/src/components/AttributeList/AttributeList.tsx
@@ -26,8 +26,7 @@ const AttributeList = ({assertions, attributeList, onCreateTestSpec, onCreateOut
       {attributeList.map(attribute => (
         <AttributeRow
           searchText={searchText}
-          assertionsFailed={assertions?.[attribute.key]?.failed}
-          assertionsPassed={assertions?.[attribute.key]?.passed}
+          assertions={assertions}
           attribute={attribute}
           key={attribute.key}
           onCopy={onCopy}

--- a/web/src/components/AttributeRow/AttributeRow.styled.ts
+++ b/web/src/components/AttributeRow/AttributeRow.styled.ts
@@ -1,5 +1,5 @@
 import {InfoCircleOutlined} from '@ant-design/icons';
-import {Badge, Tag as AntdTag, Typography} from 'antd';
+import {Tag as AntdTag, Typography} from 'antd';
 import styled from 'styled-components';
 
 export {default as AttributeTitle} from './AttributeTitle';
@@ -34,22 +34,6 @@ export const TextContainer = styled.div`
 
 export const Text = styled(Typography.Text)`
   font-size: ${({theme}) => theme.size.sm};
-`;
-
-export const CustomBadge = styled(Badge)`
-  border: ${({theme}) => `1px solid ${theme.color.textSecondary}`};
-  border-radius: 9999px;
-  cursor: pointer;
-  line-height: 19px;
-  margin-left: 8px;
-  padding: 0 8px;
-  white-space: nowrap;
-
-  .ant-badge-status-text {
-    color: ${({theme}) => theme.color.textSecondary};
-    font-size: ${({theme}) => theme.size.sm};
-    margin-left: 3px;
-  }
 `;
 
 export const Title = styled(Typography.Title)`

--- a/web/src/components/SpanDetail/Header.tsx
+++ b/web/src/components/SpanDetail/Header.tsx
@@ -1,19 +1,22 @@
 import {SettingOutlined, ToolOutlined} from '@ant-design/icons';
+import {useMemo} from 'react';
 import * as SSpanNode from 'components/Visualization/components/DAG/SpanNode.styled';
 import {SemanticGroupNamesToText} from 'constants/SemanticGroupNames.constants';
 import {SpanKindToText} from 'constants/Span.constants';
 import SpanService from 'services/Span.service';
 import {TSpan} from 'types/Span.types';
+import {TResultAssertions} from 'types/Assertion.types';
 import * as S from './SpanDetail.styled';
+import AssertionResultChecks from '../AssertionResultChecks/AssertionResultChecks';
 
 interface IProps {
   span?: TSpan;
-  totalFailedChecks?: number;
-  totalPassedChecks?: number;
+  assertions?: TResultAssertions;
 }
 
-const Header = ({span, totalFailedChecks, totalPassedChecks}: IProps) => {
+const Header = ({span, assertions = {}}: IProps) => {
   const {kind, name, service, system, type} = SpanService.getSpanInfo(span);
+  const {failed, passed} = useMemo(() => SpanService.getAssertionResultSummary(assertions), [assertions]);
 
   return (
     <S.Header>
@@ -34,18 +37,7 @@ const Header = ({span, totalFailedChecks, totalPassedChecks}: IProps) => {
         )}
       </S.Column>
       <S.Row>
-        {Boolean(totalPassedChecks) && (
-          <S.HeaderCheck>
-            <S.HeaderDot $passed />
-            {totalPassedChecks}
-          </S.HeaderCheck>
-        )}
-        {Boolean(totalFailedChecks) && (
-          <S.HeaderCheck>
-            <S.HeaderDot $passed={false} />
-            {totalFailedChecks}
-          </S.HeaderCheck>
-        )}
+        <AssertionResultChecks failed={failed} passed={passed} styleType="summary" />
       </S.Row>
     </S.Header>
   );

--- a/web/src/components/SpanDetail/SpanDetail.tsx
+++ b/web/src/components/SpanDetail/SpanDetail.tsx
@@ -27,7 +27,6 @@ interface IProps {
 const SpanDetail = ({onCreateTestSpec = noop, searchText, span}: IProps) => {
   const {open} = useTestSpecForm();
   const {onNavigateAndOpenModal} = useTestOutput();
-  const spansResult = useAppSelector(TestSpecsSelectors.selectSpansResult);
   const assertions = useAppSelector(state => TestSpecsSelectors.selectAssertionResultsBySpan(state, span?.id || ''));
   const [search, setSearch] = useState('');
   const semanticConventions = useGetOTELSemanticConventionAttributesInfo();
@@ -84,11 +83,7 @@ const SpanDetail = ({onCreateTestSpec = noop, searchText, span}: IProps) => {
 
   return (
     <>
-      <Header
-        span={span}
-        totalFailedChecks={span?.id ? spansResult[span.id]?.failed : 0}
-        totalPassedChecks={span?.id ? spansResult[span?.id]?.passed : 0}
-      />
+      <Header span={span} assertions={assertions} />
       <S.HeaderDivider />
 
       <S.SearchContainer data-cy="attributes-search-container">

--- a/web/src/components/Visualization/components/DAG/SpanNode.styled.ts
+++ b/web/src/components/Visualization/components/DAG/SpanNode.styled.ts
@@ -82,6 +82,7 @@ export const Footer = styled.div`
   bottom: 12px;
   position: absolute;
   right: 10px;
+  display: flex;
 `;
 
 export const Header = styled.div`

--- a/web/src/components/Visualization/components/DAG/SpanNode.tsx
+++ b/web/src/components/Visualization/components/DAG/SpanNode.tsx
@@ -1,19 +1,22 @@
 import {ClockCircleOutlined, SettingOutlined, ToolOutlined} from '@ant-design/icons';
+import {useMemo} from 'react';
 import {Handle, NodeProps, Position} from 'react-flow-renderer';
 
 import {SemanticGroupNamesToText} from 'constants/SemanticGroupNames.constants';
 import {SpanKindToText} from 'constants/Span.constants';
 import {useAppSelector} from 'redux/hooks';
+import SpanService from 'services/Span.service';
 import TestSpecsSelectors from 'selectors/TestSpecs.selectors';
 import {INodeDataSpan} from 'types/DAG.types';
 import * as S from './SpanNode.styled';
+import AssertionResultChecks from '../../../AssertionResultChecks/AssertionResultChecks';
 
 interface IProps extends NodeProps<INodeDataSpan> {}
 
 const SpanNode = ({data, id, selected}: IProps) => {
-  const spansResult = useAppSelector(TestSpecsSelectors.selectSpansResult);
-  const passedChecks = spansResult[data.id]?.passed;
-  const failedChecks = spansResult[data.id]?.failed;
+  const assertions = useAppSelector(state => TestSpecsSelectors.selectAssertionResultsBySpan(state, data?.id || ''));
+  const {failed, passed} = useMemo(() => SpanService.getAssertionResultSummary(assertions), [assertions]);
+
   const className = data.isMatched ? 'matched' : '';
 
   return (
@@ -54,8 +57,7 @@ const SpanNode = ({data, id, selected}: IProps) => {
       </S.Body>
 
       <S.Footer>
-        {Boolean(passedChecks) && <S.BadgeCheck status="success" text={passedChecks} />}
-        {Boolean(failedChecks) && <S.BadgeCheck status="error" text={failedChecks} />}
+        <AssertionResultChecks failed={failed} passed={passed} styleType="node" />
       </S.Footer>
 
       <Handle id={id} position={Position.Bottom} style={{bottom: 0, visibility: 'hidden'}} type="source" />

--- a/web/src/redux/testOutputs/slice.ts
+++ b/web/src/redux/testOutputs/slice.ts
@@ -21,7 +21,7 @@ const testOutputsSlice = createSlice({
       state.outputs = action.payload;
     },
     outputAdded(state, action: PayloadAction<TTestOutput>) {
-      state.outputs.push({...action.payload, isDeleted: false, isDraft: true, id: state.outputs.length + 1});
+      state.outputs.push({...action.payload, isDeleted: false, isDraft: true, id: state.outputs.length});
     },
     outputUpdated(state, action: PayloadAction<{output: TTestOutput}>) {
       state.outputs.splice(action.payload.output.id, 1, {...action.payload.output, isDeleted: false, isDraft: true});

--- a/web/src/selectors/TestSpecs.selectors.ts
+++ b/web/src/selectors/TestSpecs.selectors.ts
@@ -25,10 +25,10 @@ const selectAssertionResultsBySpan = createSelector(
       assertionResults.resultList
         .flatMap(assertionResult =>
           assertionResult.resultList.map(assertion => ({
-            id: assertionResult.selector,
+            id: assertionResult.selector  || 'All Spans',
             attribute: assertion.assertion,
             assertionResult,
-            label: assertionResult.selector,
+            label: assertionResult.selector || 'All Spans',
             result: assertion.spanResults.find(spanResult => spanResult.spanId === spanId),
           }))
         )

--- a/web/src/services/Span.service.ts
+++ b/web/src/services/Span.service.ts
@@ -5,6 +5,7 @@ import {SpanKind} from 'constants/Span.constants';
 import {TSpan, TSpanFlatAttribute} from 'types/Span.types';
 import {getObjectIncludesText} from 'utils/Common';
 import OperatorService from './Operator.service';
+import {TResultAssertions, TResultAssertionsSummary} from '../types/Assertion.types';
 
 const itemSelectorKeys = SELECTOR_DEFAULT_ATTRIBUTES.flatMap(el => el.attributes);
 
@@ -51,6 +52,21 @@ const SpanService = () => ({
       (matchList, span) => (getObjectIncludesText(span.attributes, searchText) ? [...matchList, span.id] : matchList),
       []
     );
+  },
+
+  getAssertionResultSummary(assertions: TResultAssertions): TResultAssertionsSummary {
+    const resultSummary = Object.values(assertions).reduce<TResultAssertionsSummary>(
+      ({failed: prevFailed, passed: prevPassed}, {failed, passed}) => ({
+        failed: prevFailed.concat(failed),
+        passed: prevPassed.concat(passed),
+      }),
+      {
+        failed: [],
+        passed: [],
+      }
+    );
+
+    return resultSummary;
   },
 });
 

--- a/web/src/services/SpanAttribute.service.ts
+++ b/web/src/services/SpanAttribute.service.ts
@@ -7,6 +7,7 @@ import {Attributes, TraceTestAttributes} from 'constants/SpanAttribute.constants
 import {isEmpty, remove} from 'lodash';
 import {TSpanFlatAttribute} from 'types/Span.types';
 import {getObjectIncludesText, isJson} from 'utils/Common';
+import {TResultAssertions, TResultAssertionsSummary} from 'types/Assertion.types';
 
 const flatAttributes = Object.values(Attributes);
 const flatTraceTestAttributes = Object.values(TraceTestAttributes);
@@ -81,6 +82,27 @@ const SpanAttributeService = () => ({
         getObjectIncludesText(tags, searchTextLowerCase)
       );
     });
+  },
+
+  getAttributeAssertionResults(attrName: string, assertions: TResultAssertions): TResultAssertionsSummary {
+    const resultList = Object.entries(assertions).reduce<TResultAssertionsSummary>(
+      ({failed: prevFailed, passed: prevPassed}, [assertionString, {failed, passed}]) => {
+        const itMatches = assertionString.toLowerCase().includes(attrName.toLowerCase());
+
+        return itMatches
+          ? {
+              failed: prevFailed.concat(failed),
+              passed: prevPassed.concat(passed),
+            }
+          : {failed: prevFailed, passed: prevPassed};
+      },
+      {
+        failed: [],
+        passed: [],
+      }
+    );
+
+    return resultList;
   },
 });
 

--- a/web/src/types/Assertion.types.ts
+++ b/web/src/types/Assertion.types.ts
@@ -57,13 +57,12 @@ export interface IResult {
   assertionResult: TAssertionResultEntry;
 }
 
-export type TResultAssertions = Record<
-  string,
-  {
-    failed: IResult[];
-    passed: IResult[];
-  }
->;
+export type TResultAssertionsSummary = {
+  failed: IResult[];
+  passed: IResult[];
+};
+
+export type TResultAssertions = Record<string, TResultAssertionsSummary>;
 
 export interface ICheckResult {
   result: TAssertionSpanResult;


### PR DESCRIPTION
This PR fixes an issue caused by the expression changes introduced with Transactions. Before showing the results checks for each attribute span we would match the attribute string, as that changed it broke the logic.

## Changes

- Now we are looking at the assertion string to see if the attribute exists as part of the operation.

## Fixes

- https://github.com/kubeshop/tracetest/issues/1498

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
