### PR TITLE
feat(frontend): add initial config architecture with types and service

### DIFF
--- a/web/src/constants/Config.constants.ts
+++ b/web/src/constants/Config.constants.ts
@@ -1,0 +1,5 @@
+export enum DataStores {
+  GRPC = 'GRPC',
+  OPEN_SEARCH = 'OPEN_SEARCH',
+  SIGNAL_FX = 'SIGNAL_FX',
+}

--- a/web/src/services/Config.service.ts
+++ b/web/src/services/Config.service.ts
@@ -1,0 +1,20 @@
+import {DataStores} from 'constants/Config.constants';
+import {TConfig} from 'types/Config.types';
+import GRPCService from './DataStores/GRPC.service';
+
+const DataStoreServices = {
+  [DataStores.GRPC]: GRPCService,
+  [DataStores.OPEN_SEARCH]: GRPCService, // TODO
+  [DataStores.SIGNAL_FX]: GRPCService, // TODO
+} as const;
+
+const ConfigService = {
+  getYamlConfig(values: TConfig) {
+    // TODO
+  },
+  validate(values: TConfig) {
+    // TODO
+  },
+};
+
+export default ConfigService;

--- a/web/src/services/DataStores/GRPC.service.ts
+++ b/web/src/services/DataStores/GRPC.service.ts
@@ -1,0 +1,13 @@
+import {IDataStoreService, TConfig} from 'types/Config.types';
+
+const GRPCService: IDataStoreService = {
+  getYamlConfig(values: TConfig) {
+    // TODO
+  },
+  validate(values: TConfig): boolean {
+    // TODO
+    return true;
+  },
+};
+
+export default GRPCService;

--- a/web/src/types/Config.types.ts
+++ b/web/src/types/Config.types.ts
@@ -1,0 +1,28 @@
+interface IConfigCommon {
+  dataStoreName: string;
+  dataStoreType: string;
+  poolingMaxWaitTimeForTrace: string;
+  poolingRetryDelay: string;
+}
+
+interface IDataStoreGRPC {
+  // TODO
+}
+
+interface IDataStoreOpenSearch {
+  // TODO
+}
+
+interface IDataStoreSignalFx {
+  // TODO
+}
+
+type TDataStoreUnion = IDataStoreGRPC | IDataStoreOpenSearch | IDataStoreSignalFx;
+
+export type TConfig<T = TDataStoreUnion> = Partial<IConfigCommon & T>;
+
+// DataStore service interface
+export interface IDataStoreService {
+  getYamlConfig(values: TConfig): void; // TODO: define return type
+  validate(values: TConfig): boolean;
+}


### PR DESCRIPTION
This PR adds a proposal for the initial `config` architecture including basic types and data services.

![config-services](https://user-images.githubusercontent.com/3879892/205938569-d9c90fba-c1fb-48b2-8429-305f6edb376a.png)

## Changes

-

## Fixes

-

## Checklist

- [ ] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
