### PR TITLE
feat(frontend): add initial settings page

### DIFF
--- a/web/src/components/Layout/Layout.styled.ts
+++ b/web/src/components/Layout/Layout.styled.ts
@@ -36,9 +36,21 @@ export const MenuContainer = styled.div`
 `;
 
 export const Sider = styled(LayoutAntd.Sider)`
+  .ant-layout-sider-children {
+    display: flex;
+    flex-direction: column;
+  }
+
   .ant-layout-sider-trigger {
     background: #2c1a54;
   }
 
   background: linear-gradient(180deg, #2f1e61 0%, #8b2c53 111.31%, rgba(49, 38, 132, 0) 180.18%, #df4f80 180.18%);
+`;
+
+export const SiderContent = styled.div`
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  justify-content: space-between;
 `;

--- a/web/src/components/Layout/Layout.tsx
+++ b/web/src/components/Layout/Layout.tsx
@@ -1,4 +1,4 @@
-import {ClusterOutlined, GlobalOutlined} from '@ant-design/icons';
+import {ClusterOutlined, GlobalOutlined, SettingOutlined} from '@ant-design/icons';
 import {Menu} from 'antd';
 
 import logoAsset from 'assets/logo-white.svg';
@@ -31,6 +31,15 @@ const menuItems = [
   },
 ];
 
+const footerMenuItems = [
+  {
+    key: '0',
+    icon: <SettingOutlined />,
+    label: <Link to="/settings">Settings</Link>,
+    path: '/settings',
+  },
+];
+
 const Layout = ({children, hasMenu = false}: IProps) => {
   useRouterSync();
 
@@ -48,14 +57,27 @@ const Layout = ({children, hasMenu = false}: IProps) => {
                   </Link>
                 </S.LogoContainer>
 
-                <S.MenuContainer>
-                  <Menu
-                    defaultSelectedKeys={[menuItems.findIndex(value => value.path === pathname).toString() || '0']}
-                    items={menuItems}
-                    mode="inline"
-                    theme="dark"
-                  />
-                </S.MenuContainer>
+                <S.SiderContent>
+                  <S.MenuContainer>
+                    <Menu
+                      defaultSelectedKeys={[menuItems.findIndex(value => value.path === pathname).toString() || '0']}
+                      items={menuItems}
+                      mode="inline"
+                      theme="dark"
+                    />
+                  </S.MenuContainer>
+
+                  <S.MenuContainer>
+                    <Menu
+                      defaultSelectedKeys={[
+                        footerMenuItems.findIndex(value => value.path === pathname).toString() || '0',
+                      ]}
+                      items={footerMenuItems}
+                      mode="inline"
+                      theme="dark"
+                    />
+                  </S.MenuContainer>
+                </S.SiderContent>
               </S.Sider>
             )}
 

--- a/web/src/components/Router/Router.tsx
+++ b/web/src/components/Router/Router.tsx
@@ -5,6 +5,7 @@ import {history} from 'redux/store';
 import Envs from 'pages/Environments';
 import Home from 'pages/Home';
 import RunDetail from 'pages/RunDetail';
+import Settings from 'pages/Settings';
 import Test from 'pages/Test';
 import Transaction from 'pages/Transaction';
 import TransactionRunDetail from 'pages/TransactionRunDetail';
@@ -18,6 +19,8 @@ const Router = () => (
       <Route path="/" element={<Home />} />
 
       <Route path="/environments" element={<Envs />} />
+
+      <Route path="/settings" element={<Settings />} />
 
       <Route path="/test/:testId" element={<Test />} />
 

--- a/web/src/components/Settings/DataStore/DataStore.tsx
+++ b/web/src/components/Settings/DataStore/DataStore.tsx
@@ -1,0 +1,3 @@
+const DataStore = () => <div>Data Store</div>;
+
+export default DataStore;

--- a/web/src/components/Settings/DataStore/index.ts
+++ b/web/src/components/Settings/DataStore/index.ts
@@ -1,0 +1,2 @@
+// eslint-disable-next-line no-restricted-exports
+export {default} from './DataStore';

--- a/web/src/pages/Settings/Content.tsx
+++ b/web/src/pages/Settings/Content.tsx
@@ -1,0 +1,26 @@
+import {Tabs} from 'antd';
+
+import DataStore from 'components/Settings/DataStore';
+import * as S from './Settings.styled';
+
+const TabsKeys = {
+  DataStore: 'dataStore',
+};
+
+const Content = () => (
+  <S.Container>
+    <S.Header>
+      <S.Title>Settings</S.Title>
+    </S.Header>
+
+    <S.TabsContainer>
+      <Tabs size="small">
+        <Tabs.TabPane key={TabsKeys.DataStore} tab="Configure Data Store">
+          <DataStore />
+        </Tabs.TabPane>
+      </Tabs>
+    </S.TabsContainer>
+  </S.Container>
+);
+
+export default Content;

--- a/web/src/pages/Settings/Settings.styled.ts
+++ b/web/src/pages/Settings/Settings.styled.ts
@@ -1,0 +1,32 @@
+import styled from 'styled-components';
+import {Typography} from 'antd';
+
+export const Container = styled.div`
+  padding: 0 24px;
+`;
+
+export const Header = styled.div`
+  padding: 23px 0;
+  width: 100%;
+`;
+
+export const TabsContainer = styled.div`
+  .ant-tabs-nav {
+    padding: 0 12px;
+    margin-bottom: 0;
+  }
+
+  .ant-tabs-nav {
+    padding: 0;
+  }
+
+  .ant-tabs-content {
+    margin-top: 24px;
+  }
+`;
+
+export const Title = styled(Typography.Title)`
+  && {
+    margin: 0;
+  }
+`;

--- a/web/src/pages/Settings/Settings.tsx
+++ b/web/src/pages/Settings/Settings.tsx
@@ -1,0 +1,11 @@
+import Layout from 'components/Layout';
+import withAnalytics from 'components/WithAnalytics/WithAnalytics';
+import Content from './Content';
+
+const Settings = () => (
+  <Layout hasMenu>
+    <Content />
+  </Layout>
+);
+
+export default withAnalytics(Settings, 'settings');

--- a/web/src/pages/Settings/index.ts
+++ b/web/src/pages/Settings/index.ts
@@ -1,0 +1,2 @@
+// eslint-disable-next-line no-restricted-exports
+export {default} from './Settings';


### PR DESCRIPTION
This PR adds the initial settings page structure with tabs support for different groups of settings.

## Changes

- New settings page

## Fixes

- fixes #1625 

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Screenshot

<img width="1624" alt="Screenshot 2022-12-07 at 11 49 16" src="https://user-images.githubusercontent.com/3879892/206240410-15944a87-6160-4989-830d-6973da683404.png">