### PR TITLE
feature(frontend): adding docs banner to data store config forms

### DIFF
--- a/web/src/components/Settings/DataStoreDocsBanner/DataStoreDocsBanner.styled.ts
+++ b/web/src/components/Settings/DataStoreDocsBanner/DataStoreDocsBanner.styled.ts
@@ -1,0 +1,18 @@
+import { Typography } from 'antd';
+import styled from 'styled-components';
+
+export const DataStoreDocsBannerContainer = styled.div`
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  padding: 12px 18px;
+  border-radius: 2px;
+  width: max-content;
+  background: ${({ theme }) => theme.color.backgroundInteractive};
+`;
+
+export const Text = styled(Typography.Text)`
+  a {
+    font-weight: 700;
+  }
+`;

--- a/web/src/components/Settings/DataStoreDocsBanner/DataStoreDocsBanner.tsx
+++ b/web/src/components/Settings/DataStoreDocsBanner/DataStoreDocsBanner.tsx
@@ -1,0 +1,24 @@
+import {ReadOutlined} from '@ant-design/icons';
+import {SupportedDataStoresToDocsLink, SupportedDataStoresToName} from 'constants/DataStore.constants';
+import {SupportedDataStores} from 'types/Config.types';
+import * as S from './DataStoreDocsBanner.styled';
+
+interface IProps {
+  dataStoreType: SupportedDataStores;
+}
+
+const DataStoreDocsBanner = ({dataStoreType}: IProps) => {
+  return (
+    <S.DataStoreDocsBannerContainer>
+      <ReadOutlined />
+      <S.Text>
+        Need more information about setting up {SupportedDataStoresToName[dataStoreType]}?{' '}
+        <a href={SupportedDataStoresToDocsLink[dataStoreType]} target="_blank">
+          Go to our docs
+        </a>
+      </S.Text>
+    </S.DataStoreDocsBannerContainer>
+  );
+};
+
+export default DataStoreDocsBanner;

--- a/web/src/components/Settings/DataStoreDocsBanner/index.ts
+++ b/web/src/components/Settings/DataStoreDocsBanner/index.ts
@@ -1,0 +1,2 @@
+// eslint-disable-next-line no-restricted-exports
+export {default} from './DataStoreDocsBanner';

--- a/web/src/components/Settings/DataStoreForm/DataStoreForm.tsx
+++ b/web/src/components/Settings/DataStoreForm/DataStoreForm.tsx
@@ -2,6 +2,7 @@ import {Form} from 'antd';
 import {useCallback, useMemo} from 'react';
 import SetupConfigService from 'services/DataStore.service';
 import {TDraftDataStore, TDataStoreForm, TDataStoreConfig} from 'types/Config.types';
+import DataStoreDocsBanner from '../DataStoreDocsBanner/DataStoreDocsBanner';
 import DataStoreComponentFactory from '../DataStorePlugin/DataStoreComponentFactory';
 import * as S from './DataStoreForm.styled';
 import DataStoreSelectionInput from './DataStoreSelectionInput';
@@ -46,6 +47,7 @@ const DataStoreForm = ({form, onSubmit, dataStoreConfig, onIsFormValid}: IProps)
         <Form.Item name="dataStoreType">
           <DataStoreSelectionInput />
         </Form.Item>
+        <DataStoreDocsBanner dataStoreType={dataStoreType!} />
         <S.Title>Provide connection info</S.Title>
         <DataStoreComponentFactory dataStoreType={dataStoreType} />
       </S.FormContainer>

--- a/web/src/constants/DataStore.constants.ts
+++ b/web/src/constants/DataStore.constants.ts
@@ -1,0 +1,15 @@
+import {SupportedDataStores} from '../types/Config.types';
+
+export const SupportedDataStoresToName = {
+  [SupportedDataStores.JAEGER]: 'Jaeger',
+  [SupportedDataStores.OpenSearch]: 'OpenSearch',
+  [SupportedDataStores.SignalFX]: 'SignalFX',
+  [SupportedDataStores.TEMPO]: 'Tempo',
+} as const;
+
+export const SupportedDataStoresToDocsLink = {
+  [SupportedDataStores.JAEGER]: 'https://docs.tracetest.io/run-locally/#installing-jaeger',
+  [SupportedDataStores.OpenSearch]: 'https://docs.tracetest.io/run-locally/#installing-jaeger',
+  [SupportedDataStores.SignalFX]: 'https://docs.tracetest.io/run-locally/#installing-jaeger',
+  [SupportedDataStores.TEMPO]: 'https://docs.tracetest.io/run-locally/#installing-jaeger',
+} as const;

--- a/web/src/services/DataStore.service.ts
+++ b/web/src/services/DataStore.service.ts
@@ -30,14 +30,11 @@ const DataStoreService = (): IDataStoreService => ({
   },
 
   getInitialValues(config) {
-    const {
-      defaultDataStore = '',
-      dataStores = []
-    } = config;
+    const {defaultDataStore = '', dataStores = []} = config;
     const dataStoreType = dataStores.find(({name}) => name === defaultDataStore)?.type;
     const type = (dataStoreType || SupportedDataStores.JAEGER) as SupportedDataStores;
 
-    return dataStoreServiceMap[type].getInitialValues(config);
+    return {...dataStoreServiceMap[type].getInitialValues(config), dataStoreType: type};
   },
 
   validateDraft(draft) {


### PR DESCRIPTION
This PR adds the documentation banner for each data store form.

## Changes

- Adds documentation banner for each data store form

## Fixes

- [[In-App Config] Add documentation link to each trace data store screen#1657](https://github.com/kubeshop/tracetest/issues/1657)

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test


https://www.loom.com/share/37b74450e69140e8a07cfcd49fdcfdad