### PR TITLE
feature(frontend): test connection data store logic

### DIFF
--- a/api/config.yaml
+++ b/api/config.yaml
@@ -106,26 +106,7 @@ components:
         maxVersion:
           type: string
     TestConnectionRequest:
-      type: object
-      properties:
-        type:
-          type: string
-          enum:
-            - datastore
-            - exporter
-        info:
-          type: object
-          properties:
-            jaeger:
-              $ref: "#/components/schemas/GRPCClientSettings"
-            tempo:
-              $ref: "#/components/schemas/GRPCClientSettings"
-            openSearch:
-              $ref: "#/components/schemas/OpenSearch"
-            signalFx:
-              $ref: "#/components/schemas/SignalFX"
-            collector:
-              $ref: "#/components/schemas/CollectorConfig"
+      $ref: "#/components/schemas/DataStore"
     TestConnectionResponse:
       type: object
       properties:

--- a/web/src/components/Settings/DataStore/DataStore.tsx
+++ b/web/src/components/Settings/DataStore/DataStore.tsx
@@ -10,7 +10,8 @@ interface IProps {
 }
 
 const DataStore = ({dataStoreConfig}: IProps) => {
-  const {isLoading, isFormValid, onIsFormValid, onSaveConfig} = useSetupConfig();
+  const {isLoading, isFormValid, onIsFormValid, onSaveConfig, isTestConnectionLoading, onTestConnection} =
+    useSetupConfig();
 
   const [form] = Form.useForm<TDraftDataStore>();
 
@@ -21,6 +22,11 @@ const DataStore = ({dataStoreConfig}: IProps) => {
     [onSaveConfig]
   );
 
+  const handleTestConnection = useCallback(async () => {
+    const draft = form.getFieldsValue();
+    onTestConnection(draft);
+  }, [form, onTestConnection]);
+
   return (
     <S.Wrapper data-cy="config-datastore-form">
       <S.FormContainer>
@@ -30,7 +36,12 @@ const DataStore = ({dataStoreConfig}: IProps) => {
             solution. Select your tracing data store and enter the configuration info.
           </S.Description>
           <S.Title>Choose OpenTelemetry data store</S.Title>
-          <DataStoreForm form={form} dataStoreConfig={dataStoreConfig} onSubmit={handleOnSubmit} onIsFormValid={onIsFormValid} />
+          <DataStoreForm
+            form={form}
+            dataStoreConfig={dataStoreConfig}
+            onSubmit={handleOnSubmit}
+            onIsFormValid={onIsFormValid}
+          />
         </div>
         <S.ButtonsContainer>
           <Button
@@ -44,10 +55,10 @@ const DataStore = ({dataStoreConfig}: IProps) => {
           </Button>
           <Button
             data-cy="config-datastore-submit"
-            loading={isLoading}
+            loading={isTestConnectionLoading}
             disabled={!isFormValid}
             type="primary"
-            onClick={() => console.log('@@test connection')}
+            onClick={handleTestConnection}
           >
             Test Connection
           </Button>

--- a/web/src/constants/Theme.constants.ts
+++ b/web/src/constants/Theme.constants.ts
@@ -27,4 +27,18 @@ export const theme: DefaultTheme = {
   font: {
     family: 'SFPro',
   },
+  notification: {
+    success: {
+      style: {
+        border: '1px solid #52C41A',
+        background: '#F6FFED',
+      },
+    },
+    error: {
+      style: {
+        border: '1px solid #F5222D',
+        background: '#FFF1F0',
+      },
+    },
+  },
 };

--- a/web/src/redux/apis/endpoints/Config.endpoint.ts
+++ b/web/src/redux/apis/endpoints/Config.endpoint.ts
@@ -31,10 +31,16 @@ const ConfigEndpoint = (builder: TTestApiEndpointBuilder) => ({
     invalidatesTags: [{type: TracetestApiTags.CONFIG, id: 'datastore'}],
   }),
   testConnection: builder.mutation<TTestConnectionResponse, TTestConnectionRequest>({
+    // remove comments once the real service is ready
     query: connectionTest => ({
-      url: `/config/connection`,
-      method: HTTP_METHOD.PUT,
-      body: connectionTest,
+      url: `/tests`,
+      // url: `/config/connection`,
+      method: HTTP_METHOD.GET,
+      // body: connectionTest,
+    }),
+    transformResponse: () => ({
+      successful: true,
+      // errorMessage: 'Error connecting to Data Store',
     }),
   }),
 });

--- a/web/src/styled.d.ts
+++ b/web/src/styled.d.ts
@@ -33,5 +33,20 @@ declare module 'styled-components' {
     font: {
       family: string;
     };
+
+    notification: {
+      success: {
+        style: {
+          border: string;
+          background: string;
+        };
+      };
+      error: {
+        style: {
+          border: string;
+          background: string;
+        };
+      };
+    };
   }
 }

--- a/web/src/types/Config.types.ts
+++ b/web/src/types/Config.types.ts
@@ -41,3 +41,5 @@ export type TDataStoreService = {
 export interface IDataStorePluginProps {}
 export interface IDataStorePluginMap
   extends Record<SupportedDataStores, (props: IDataStorePluginProps) => React.ReactElement> {}
+
+

--- a/web/src/types/Generated.types.ts
+++ b/web/src/types/Generated.types.ts
@@ -1002,17 +1002,7 @@ export interface external {
           minVersion?: string;
           maxVersion?: string;
         };
-        TestConnectionRequest: {
-          /** @enum {string} */
-          type?: "datastore" | "exporter";
-          info?: {
-            jaeger?: external["config.yaml"]["components"]["schemas"]["GRPCClientSettings"];
-            tempo?: external["config.yaml"]["components"]["schemas"]["GRPCClientSettings"];
-            openSearch?: external["config.yaml"]["components"]["schemas"]["OpenSearch"];
-            signalFx?: external["config.yaml"]["components"]["schemas"]["SignalFX"];
-            collector?: external["config.yaml"]["components"]["schemas"]["CollectorConfig"];
-          };
-        };
+        TestConnectionRequest: external["config.yaml"]["components"]["schemas"]["DataStore"];
         TestConnectionResponse: {
           successful?: boolean;
           errorMessage?: string;


### PR DESCRIPTION
This PR adds the FE logic to support the test connection service.

## Changes

- Adds mock config API to test
- Includes triggering the service from the form
- Adds notification theme styling

## Fixes

- [[In-App Config] Setup Wizard#1622](https://github.com/kubeshop/tracetest/issues/1622)

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test


https://www.loom.com/share/cd6ba23ae4a742b98bd5195925112570