### PR TITLE
feature(frontend): data store save confirmation logic

### DIFF
--- a/web/cypress/e2e/Environments/Environments.spec.ts
+++ b/web/cypress/e2e/Environments/Environments.spec.ts
@@ -31,7 +31,7 @@ function deleteEnvironment() {
   cy.intercept({method: 'DELETE', url: '/api/environments/*'}).as('deleteEnvironment');
   cy.intercept({method: 'GET', url: '/api/environments?take=20&skip=0*'}).as('getEnvironments');
 
-  cy.get('[data-cy=delete-confirmation-modal] .ant-btn-primary').click();
+  cy.get('[data-cy=confirmation-modal] .ant-btn-primary').click();
   cy.wait('@deleteEnvironment');
   cy.wait('@getEnvironments');
 }

--- a/web/cypress/e2e/TestRunDetail/Outputs.spec.ts
+++ b/web/cypress/e2e/TestRunDetail/Outputs.spec.ts
@@ -66,7 +66,7 @@ describe('Outputs', () => {
     // Delete output
     cy.get('[data-cy="output-actions-button-db.name"]').click();
     cy.get('[data-cy=output-item-actions-delete]').click();
-    cy.get('[data-cy=delete-confirmation-modal] .ant-btn-primary').click();
+    cy.get('[data-cy=confirmation-modal] .ant-btn-primary').click();
 
     // Publish and run
     cy.get('[data-cy=output-publish-button]').click();

--- a/web/cypress/support/commands.ts
+++ b/web/cypress/support/commands.ts
@@ -38,7 +38,7 @@ Cypress.Commands.add('deleteTest', (shouldIntercept = false) => {
     cy.get(`[data-cy=test-actions-button-${localTestId}]`, {timeout: 10000}).should('be.visible');
     cy.get(`[data-cy=test-actions-button-${localTestId}]`).click({force: true});
     cy.get('[data-cy=test-card-delete]').click();
-    cy.get('[data-cy=delete-confirmation-modal] .ant-btn-primary').click();
+    cy.get('[data-cy=confirmation-modal] .ant-btn-primary').click();
     cy.wait('@testDelete');
     cy.get(`[data-cy=test-actions-button-${localTestId}]`).should('not.exist');
     cy.wait('@testList');
@@ -244,7 +244,7 @@ Cypress.Commands.add('deleteTransaction', () => {
     cy.get(`[data-cy=test-actions-button-${localTestId}]`, {timeout: 10000}).should('be.visible');
     cy.get(`[data-cy=test-actions-button-${localTestId}]`).click({force: true});
     cy.get('[data-cy=test-card-delete]').click();
-    cy.get('[data-cy=delete-confirmation-modal] .ant-btn-primary').click();
+    cy.get('[data-cy=confirmation-modal] .ant-btn-primary').click();
     cy.wait('@transactionDelete');
     cy.get(`[data-cy=test-actions-button-${localTestId}]`).should('not.exist');
     cy.wait('@testList');

--- a/web/src/components/ConfirmationModal/ConfirmationModal.tsx
+++ b/web/src/components/ConfirmationModal/ConfirmationModal.tsx
@@ -6,18 +6,28 @@ interface IProps {
   onConfirm(): void;
   title: string;
   heading?: string;
+  okText?: string;
+  cancelText?: string;
 }
 
-const ConfirmationModal = ({isOpen, title, heading = 'Delete Confirmation', onClose, onConfirm}: IProps) => {
+const ConfirmationModal = ({
+  isOpen,
+  title,
+  heading = 'Delete Confirmation',
+  onClose,
+  onConfirm,
+  okText = 'Delete',
+  cancelText = 'Cancel',
+}: IProps) => {
   return (
     <Modal
-      cancelText="Cancel"
-      okText="Delete"
+      cancelText={cancelText}
+      okText={okText}
       onCancel={onClose}
       onOk={onConfirm}
       title={heading}
       visible={isOpen}
-      data-cy="delete-confirmation-modal"
+      data-cy="confirmation-modal"
     >
       <p>{title}</p>
     </Modal>

--- a/web/src/hooks/useDeleteResource.tsx
+++ b/web/src/hooks/useDeleteResource.tsx
@@ -27,7 +27,12 @@ const useDeleteResource = () => {
 
   return useCallback(
     (id: string, name: string, type: ResourceType) => {
-      onOpen(`Are you sure you want to delete “${name}”?`, () => onConfirmDelete(id, type));
+      onOpen({
+        title: `Are you sure you want to delete “${name}”?`,
+        onConfirm() {
+          onConfirmDelete(id, type);
+        },
+      });
     },
     [onConfirmDelete, onOpen]
   );

--- a/web/src/hooks/useDeleteResourceRun.tsx
+++ b/web/src/hooks/useDeleteResourceRun.tsx
@@ -34,7 +34,10 @@ const useDeleteResourceRun = ({id, isRunView = false, type}: IProps) => {
 
   return useCallback(
     (runId: string) => {
-      onOpen(`Are you sure you want to delete the Run?`, () => onConfirmDelete(runId));
+      onOpen({
+        title: `Are you sure you want to delete the Run?`,
+        onConfirm: () => onConfirmDelete(runId),
+      });
     },
     [onConfirmDelete, onOpen]
   );

--- a/web/src/pages/Environments/EnvironmentContent.tsx
+++ b/web/src/pages/Environments/EnvironmentContent.tsx
@@ -35,7 +35,10 @@ const EnvironmentContent = () => {
   };
 
   const handleOnDelete = (id: string) => {
-    onOpen(`Are you sure you want to delete the environment?`, () => deleteEnvironment({environmentId: id}));
+    onOpen({
+      title: `Are you sure you want to delete the environment?`,
+      onConfirm: () => deleteEnvironment({environmentId: id}),
+    });
   };
 
   return (

--- a/web/src/providers/ConfirmationModal/ConfirmationModal.provider.tsx
+++ b/web/src/providers/ConfirmationModal/ConfirmationModal.provider.tsx
@@ -3,9 +3,16 @@ import {createContext, useCallback, useContext, useMemo, useState} from 'react';
 import ConfirmationModal from 'components/ConfirmationModal';
 
 type TOnConfirm = typeof noop;
+type TOnOPenProps = {
+  title: string;
+  heading?: string;
+  okText?: string;
+  cancelText?: string;
+  onConfirm: TOnConfirm;
+};
 
 interface IContext {
-  onOpen(title: string, onConfirm: TOnConfirm, heading?: string): void;
+  onOpen(props: TOnOPenProps): void;
 }
 
 export const Context = createContext<IContext>({
@@ -19,16 +26,18 @@ interface IProps {
 export const useConfirmationModal = () => useContext(Context);
 
 const ConfirmationModalProvider = ({children}: IProps) => {
-  const [title, setTitle] = useState<string>('');
-  const [heading, setHeading] = useState<string>('');
-  const [onConfirm, setOnConfirm] = useState<TOnConfirm>(() => noop);
+  const [{title, heading, okText, cancelText, onConfirm}, setProps] = useState<TOnOPenProps>({
+    title: '',
+    heading: '',
+    okText: '',
+    cancelText: '',
+    onConfirm: noop,
+  });
   const [isOpen, setIsOpen] = useState(false);
 
-  const onOpen = useCallback((newTitle: string, onConfirmFn: TOnConfirm, newHeading = 'Delete Confirmation') => {
-    setTitle(newTitle);
-    setOnConfirm(() => onConfirmFn);
+  const onOpen = useCallback((newProps: TOnOPenProps) => {
+    setProps(newProps);
     setIsOpen(true);
-    setHeading(newHeading);
   }, []);
 
   const triggerConfirm = useCallback(() => {
@@ -47,6 +56,8 @@ const ConfirmationModalProvider = ({children}: IProps) => {
         isOpen={isOpen}
         title={title}
         heading={heading}
+        okText={okText}
+        cancelText={cancelText}
       />
     </Context.Provider>
   );

--- a/web/src/providers/DataStore/DataStore.provider.tsx
+++ b/web/src/providers/DataStore/DataStore.provider.tsx
@@ -3,6 +3,7 @@ import {createContext, useCallback, useContext, useMemo, useState} from 'react';
 import {useUpdateDatastoreConfigMutation} from 'redux/apis/TraceTest.api';
 import {TDraftDataStore} from 'types/Config.types';
 import DataStoreService from 'services/DataStore.service';
+import {useConfirmationModal} from '../ConfirmationModal/ConfirmationModal.provider';
 
 interface IContext {
   isFormValid: boolean;
@@ -27,12 +28,23 @@ export const useSetupConfig = () => useContext(Context);
 const SetupConfigProvider = ({children}: IProps) => {
   const [updateConfig, {isLoading}] = useUpdateDatastoreConfigMutation();
   const [isFormValid, setIsFormValid] = useState(false);
+  const {onOpen} = useConfirmationModal();
 
-  const onSaveConfig = useCallback(async (draft: TDraftDataStore) => {
-    const configRequest = await DataStoreService.getRequest(draft);
-    console.log('@@saving draft', draft, configRequest);
-    // const config = await updateConfig(configRequest).unwrap();
-  }, []);
+  const onSaveConfig = useCallback(
+    async (draft: TDraftDataStore) => {
+      onOpen({
+        title: 'Tracetest is about to be restarted and there will be some downtime. Please confirm to continue.',
+        heading: 'Save Confirmation',
+        okText: 'Confirm',
+        onConfirm: async () => {
+          const configRequest = await DataStoreService.getRequest(draft);
+          console.log('@@saving draft', draft, configRequest);
+          // const config = await updateConfig(configRequest).unwrap();
+        },
+      });
+    },
+    [onOpen]
+  );
 
   const onIsFormValid = useCallback((isValid: boolean) => {
     setIsFormValid(isValid);

--- a/web/src/providers/TestOutput/TestOutput.provider.tsx
+++ b/web/src/providers/TestOutput/TestOutput.provider.tsx
@@ -81,8 +81,11 @@ const TestOutputProvider = ({children, testId, runId}: IProps) => {
 
   const onDelete = useCallback(
     (index: number) => {
-      onOpen(`Are you sure you want to delete the output?`, () => {
-        dispatch(outputDeleted(index));
+      onOpen({
+        title: `Are you sure you want to delete the output?`,
+        onConfirm: () => {
+          dispatch(outputDeleted(index));
+        },
       });
     },
     [dispatch, onOpen]

--- a/web/src/providers/TestSpecs/hooks/useTestSpecsCrud.ts
+++ b/web/src/providers/TestSpecs/hooks/useTestSpecsCrud.ts
@@ -100,7 +100,10 @@ const useTestSpecsCrud = ({runId, testId, test, isDraftMode, assertionResults}: 
   );
   const remove = useCallback(
     (selector: string) => {
-      onOpen('Are you sure you want to remove this test spec?', () => onConfirmRemove(selector));
+      onOpen({
+        title: 'Are you sure you want to remove this test spec?',
+        onConfirm: () => onConfirmRemove(selector),
+      });
     },
     [onConfirmRemove, onOpen]
   );

--- a/web/src/providers/Transaction/Transaction.provider.tsx
+++ b/web/src/providers/Transaction/Transaction.provider.tsx
@@ -83,7 +83,10 @@ const TransactionProvider = ({children, transactionId, version = 0}: IProps) => 
         navigate('/');
       }
 
-      onOpen(`Are you sure you want to delete “${name}”?`, onConfirmation);
+      onOpen({
+        title: `Are you sure you want to delete “${name}”?`,
+        onConfirm: onConfirmation,
+      });
     },
     [deleteTransaction, navigate, onOpen]
   );


### PR DESCRIPTION
This PR adds the save logic for the data store config form letting the users know that saving the config will cause some server downtime.

## Changes

- Updates the confirmation modal
- Adds the confirmation modal after clicking save

## Fixes

- [[In-App Config] Setup Wizard#1622](https://github.com/kubeshop/tracetest/issues/1622)

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
