### PR TITLE
feat(frontend): add file upload for cert files in grpc data store config

### DIFF
--- a/web/src/components/Settings/DataStorePlugin/forms/GrpcClient/GrpcClientSecure.tsx
+++ b/web/src/components/Settings/DataStorePlugin/forms/GrpcClient/GrpcClientSecure.tsx
@@ -1,4 +1,5 @@
 import {Checkbox, Col, Form, Input, Row} from 'antd';
+import RequestDetailsFileInput from 'components/CreateTestPlugins/Grpc/steps/RequestDetails/RequestDetailsFileInput';
 
 interface IProps {
   baseName: string[];
@@ -21,21 +22,21 @@ const GrpcClientSecure = ({baseName}: IProps) => (
         </Form.Item>
       </Col>
       <Col span={12}>
-        <Form.Item label="CA file" name={[...baseName, 'tls', 'settings', 'cAFile']}>
-          <Input placeholder="Enter a CA file" />
+        <Form.Item label="Upload CA file" name={[...baseName, 'fileCA']}>
+          <RequestDetailsFileInput accept="" />
         </Form.Item>
       </Col>
     </Row>
 
     <Row gutter={[16, 16]}>
       <Col span={12}>
-        <Form.Item label="Cert file" name={[...baseName, 'tls', 'settings', 'certFile']}>
-          <Input placeholder="Enter a Cert file" />
+        <Form.Item label="Upload Cert file" name={[...baseName, 'fileCert']}>
+          <RequestDetailsFileInput accept="" />
         </Form.Item>
       </Col>
       <Col span={12}>
-        <Form.Item label="Key file" name={[...baseName, 'tls', 'settings', 'keyFile']}>
-          <Input placeholder="Enter a Key file" />
+        <Form.Item label="Upload Key file" name={[...baseName, 'fileKey']}>
+          <RequestDetailsFileInput accept="" />
         </Form.Item>
       </Col>
     </Row>

--- a/web/src/services/DataStores/GrpcClient.service.ts
+++ b/web/src/services/DataStores/GrpcClient.service.ts
@@ -1,8 +1,8 @@
-import {SupportedDataStores, TDataStoreService, TRawGRPCClientSettings} from 'types/Config.types';
+import {IGRPCClientSettings, SupportedDataStores, TDataStoreService, TRawGRPCClientSettings} from 'types/Config.types';
 
 const GrpcClientService = (): TDataStoreService => ({
-  getRequest({dataStore = {}}, dataStoreType = SupportedDataStores.JAEGER) {
-    const values = dataStore[dataStoreType || SupportedDataStores.JAEGER] as TRawGRPCClientSettings;
+  async getRequest({dataStore = {}}, dataStoreType = SupportedDataStores.JAEGER) {
+    const values = dataStore[dataStoreType || SupportedDataStores.JAEGER] as IGRPCClientSettings;
     const {
       endpoint = '',
       readBufferSize,
@@ -15,10 +15,16 @@ const GrpcClientService = (): TDataStoreService => ({
         insecure = true,
         insecureSkipVerify = false,
         serverName = '',
-        settings: {cAFile = '', certFile = '', keyFile = '', minVersion = '', maxVersion = ''} = {},
+        settings: {minVersion = '', maxVersion = ''} = {},
       } = {},
       auth = {},
+      fileCA,
+      fileCert,
+      fileKey,
     } = values;
+
+    const filesToText = [fileCA, fileCert, fileKey].map(file => (file ? file.text() : Promise.resolve(undefined)));
+    const [cAFile, certFile, keyFile] = await Promise.all(filesToText);
 
     return Promise.resolve({
       type: dataStoreType,
@@ -47,7 +53,7 @@ const GrpcClientService = (): TDataStoreService => ({
     });
   },
   validateDraft({dataStore = {}, dataStoreType}) {
-    const values = dataStore[dataStoreType || SupportedDataStores.JAEGER] as TRawGRPCClientSettings;
+    const values = dataStore[dataStoreType || SupportedDataStores.JAEGER] as IGRPCClientSettings;
     const {endpoint = ''} = values;
     if (!endpoint) return Promise.resolve(false);
 
@@ -96,6 +102,9 @@ const GrpcClientService = (): TDataStoreService => ({
             },
           },
           auth,
+          fileCA: cAFile ? new File([cAFile], 'fileCA') : undefined,
+          fileCert: certFile ? new File([certFile], 'fileCert') : undefined,
+          fileKey: keyFile ? new File([keyFile], 'fileKey') : undefined,
         },
       },
       dataStoreType,

--- a/web/src/types/Config.types.ts
+++ b/web/src/types/Config.types.ts
@@ -29,8 +29,19 @@ export type TRawGRPCClientSettings = TConfigSchemas['GRPCClientSettings'];
 export type TTestConnectionRequest = TConfigSchemas['TestConnectionRequest'];
 export type TTestConnectionResponse = TConfigSchemas['TestConnectionResponse'];
 
+export interface IGRPCClientSettings extends TRawGRPCClientSettings {
+  fileCA: File;
+  fileCert: File;
+  fileKey: File;
+}
+
+interface IDataStore extends TRawDataStore {
+  jaeger?: IGRPCClientSettings;
+  tempo?: IGRPCClientSettings;
+}
+
 export type TDraftDataStore = {
-  dataStore?: TRawDataStore;
+  dataStore?: IDataStore;
   dataStoreType?: SupportedDataStores;
 };
 
@@ -45,5 +56,3 @@ export type TDataStoreService = {
 export interface IDataStorePluginProps {}
 export interface IDataStorePluginMap
   extends Record<SupportedDataStores, (props: IDataStorePluginProps) => React.ReactElement> {}
-
-


### PR DESCRIPTION
This PR adds support for file uploads for Cert files in the `GRPC Data Store` client config.

## Changes

- File upload support

## Fixes

- fixes #1627 

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Screenshots

<img width="1624" alt="Screenshot 2022-12-12 at 15 32 22" src="https://user-images.githubusercontent.com/3879892/207148415-d82df463-e05d-4c6a-92e3-51be1760439f.png">