### PR TITLE
feature(frontend): adding no tracing mode warning

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -3,7 +3,7 @@ import * as Sentry from '@sentry/react';
 import ErrorBoundary from 'components/ErrorBoundary';
 import Router from 'components/Router';
 import {theme} from 'constants/Theme.constants';
-import ConfigProvider from 'providers/DataStoreConfig';
+import DataStoreConfigProvider from 'providers/DataStoreConfig';
 import {ReduxWrapperProvider} from 'redux/ReduxWrapperProvider';
 import {ThemeProvider} from 'styled-components';
 import './App.less';
@@ -13,9 +13,9 @@ const App = () => {
     <ThemeProvider theme={theme}>
       <Sentry.ErrorBoundary fallback={({error}) => <ErrorBoundary error={error} />}>
         <ReduxWrapperProvider>
-          <ConfigProvider>
+          <DataStoreConfigProvider>
             <Router />
-          </ConfigProvider>
+          </DataStoreConfigProvider>
         </ReduxWrapperProvider>
       </Sentry.ErrorBoundary>
     </ThemeProvider>

--- a/web/src/components/Header/Header.styled.tsx
+++ b/web/src/components/Header/Header.styled.tsx
@@ -28,6 +28,7 @@ export const Header = styled(Layout.Header)`
 
 export const Logo = styled.img`
   height: 24px;
+  margin-right: 24px;
 `;
 
 export const NavMenu = styled(Menu).attrs({

--- a/web/src/components/Header/Header.tsx
+++ b/web/src/components/Header/Header.tsx
@@ -4,13 +4,15 @@ import Logo from 'assets/Logo.svg';
 import * as S from './Header.styled';
 import HeaderMenu from './HeaderMenu';
 import EnvironmentSelector from '../EnvironmentSelector';
+import NoTracingPopover from '../NoTracingPopover/NoTracingPopover';
 
 interface IProps {
   hasEnvironments?: boolean;
   hasLogo?: boolean;
+  isNoTracingMode: boolean;
 }
 
-const Header = ({hasEnvironments = false, hasLogo = false}: IProps) => (
+const Header = ({hasEnvironments = false, hasLogo = false, isNoTracingMode}: IProps) => (
   <S.Header>
     <div>
       {hasLogo && (
@@ -21,6 +23,7 @@ const Header = ({hasEnvironments = false, hasLogo = false}: IProps) => (
     </div>
 
     <Space>
+      {isNoTracingMode && <NoTracingPopover />}
       {hasEnvironments && <EnvironmentSelector />}
 
       <HeaderMenu />

--- a/web/src/components/Layout/Layout.tsx
+++ b/web/src/components/Layout/Layout.tsx
@@ -1,5 +1,7 @@
 import {ClusterOutlined, GlobalOutlined, SettingOutlined} from '@ant-design/icons';
 import {Menu} from 'antd';
+import React from 'react';
+import {Link, useLocation} from 'react-router-dom';
 
 import logoAsset from 'assets/logo-white.svg';
 import FileViewerModalProvider from 'components/FileViewerModal/FileViewerModal.provider';
@@ -7,8 +9,8 @@ import Header from 'components/Header';
 import useRouterSync from 'hooks/useRouterSync';
 import ConfirmationModalProvider from 'providers/ConfirmationModal';
 import EnvironmentProvider from 'providers/Environment';
-import React from 'react';
-import {Link, useLocation} from 'react-router-dom';
+import {useDataStoreConfig} from 'providers/DataStoreConfig/DataStoreConfig.provider';
+import {ConfigMode} from 'types/Config.types';
 import * as S from './Layout.styled';
 
 interface IProps {
@@ -42,8 +44,10 @@ const footerMenuItems = [
 
 const Layout = ({children, hasMenu = false}: IProps) => {
   useRouterSync();
-
+  const {dataStoreConfig} = useDataStoreConfig();
   const pathname = useLocation().pathname;
+  const isNoTracingMode = dataStoreConfig.mode === ConfigMode.NO_TRACING_MODE;
+
   return (
     <FileViewerModalProvider>
       <ConfirmationModalProvider>
@@ -82,7 +86,7 @@ const Layout = ({children, hasMenu = false}: IProps) => {
             )}
 
             <S.Layout>
-              <Header hasEnvironments hasLogo={!hasMenu} />
+              <Header hasEnvironments hasLogo={!hasMenu} isNoTracingMode={isNoTracingMode} />
               <S.Content $hasMenu={hasMenu}>{children}</S.Content>
             </S.Layout>
           </S.Layout>

--- a/web/src/components/NoTracingPopover/NoTracingPopover.styled.ts
+++ b/web/src/components/NoTracingPopover/NoTracingPopover.styled.ts
@@ -1,0 +1,74 @@
+import {DisconnectOutlined,} from '@ant-design/icons';
+import {Button, Typography} from 'antd';
+import styled, {createGlobalStyle} from 'styled-components';
+
+export const CustomPopoverGlobalStyles = createGlobalStyle`
+  .no-tracing-popover {
+    .ant-popover-inner-content {
+      background: ${({theme}) => theme.color.alertYellow};
+    }
+
+    .ant-popover-arrow-content::before {
+      background: ${({theme}) => theme.color.alertYellow};
+    }
+  }
+`;
+
+export const Icon = styled(DisconnectOutlined)`
+  && {
+    color: ${({theme}) => theme.color.warningYellow};
+    cursor: pointer;
+    font-size: ${({theme}) => theme.size.lg};
+`;
+
+export const WarningButton = styled(Button)`
+  background: ${({theme}) => theme.color.warningYellow};
+  width: 57px;
+  height: 24px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 0 !important;
+  border: none;
+  font-weight: 600;
+
+  &:hover,
+  &:focus {
+    background: ${({theme}) => theme.color.warningYellow};
+  }
+`;
+
+export const Title = styled(Typography.Title)`
+  && {
+    font-size: ${({theme}) => theme.size.lg};
+    margin: 0;
+  }
+`;
+
+export const Text = styled(Typography.Text)`
+  && {
+    font-size: ${({theme}) => theme.size.md};
+    margin: 0;
+  }
+`;
+
+export const MessageContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+`;
+
+export const ButtonContainer = styled.div`
+  justify-content: flex-end;
+  display: flex;
+  margin-top: 6px;
+`;
+
+export const Trigger = styled.div`
+  display: flex;
+  gap: 6px;
+  align-items: center;
+  cursor: pointer;
+  margin-right: 24px;
+`;

--- a/web/src/components/NoTracingPopover/NoTracingPopover.styled.ts
+++ b/web/src/components/NoTracingPopover/NoTracingPopover.styled.ts
@@ -1,22 +1,9 @@
-import {DisconnectOutlined,} from '@ant-design/icons';
+import {SettingOutlined} from '@ant-design/icons';
 import {Button, Typography} from 'antd';
-import styled, {createGlobalStyle} from 'styled-components';
+import styled from 'styled-components';
 
-export const CustomPopoverGlobalStyles = createGlobalStyle`
-  .no-tracing-popover {
-    .ant-popover-inner-content {
-      background: ${({theme}) => theme.color.alertYellow};
-    }
-
-    .ant-popover-arrow-content::before {
-      background: ${({theme}) => theme.color.alertYellow};
-    }
-  }
-`;
-
-export const Icon = styled(DisconnectOutlined)`
+export const Icon = styled(SettingOutlined)`
   && {
-    color: ${({theme}) => theme.color.warningYellow};
     cursor: pointer;
     font-size: ${({theme}) => theme.size.lg};
 `;
@@ -57,6 +44,7 @@ export const MessageContainer = styled.div`
   display: flex;
   flex-direction: column;
   gap: 8px;
+  max-width: 340px;
 `;
 
 export const ButtonContainer = styled.div`
@@ -71,4 +59,8 @@ export const Trigger = styled.div`
   align-items: center;
   cursor: pointer;
   margin-right: 24px;
+  border-radius: 12px;
+  padding: 4px 7px;
+  background: ${({theme}) => theme.color.backgroundDark};
+  height: 24px;
 `;

--- a/web/src/components/NoTracingPopover/NoTracingPopover.tsx
+++ b/web/src/components/NoTracingPopover/NoTracingPopover.tsx
@@ -1,0 +1,36 @@
+import {Popover} from 'antd';
+import {useMemo} from 'react';
+import {Link} from 'react-router-dom';
+import * as S from './NoTracingPopover.styled';
+
+const NoTracingPopover = () => {
+  const content = useMemo(
+    () => (
+      <S.MessageContainer>
+        <S.Title>
+          <S.Icon /> No-Tracing Mode
+        </S.Title>
+        <S.Text>Tracetest is not configured to work with traces. Go to the settings page to set it up.</S.Text>
+        <S.ButtonContainer>
+          <Link to="/settings">
+            <S.WarningButton>Setup</S.WarningButton>
+          </Link>
+        </S.ButtonContainer>
+      </S.MessageContainer>
+    ),
+    []
+  );
+
+  return (
+    <>
+      <S.CustomPopoverGlobalStyles />
+      <Popover content={content} overlayClassName="no-tracing-popover" placement="bottomLeft">
+        <S.Trigger>
+          <S.Icon /> No-Tracing Mode
+        </S.Trigger>
+      </Popover>
+    </>
+  );
+};
+
+export default NoTracingPopover;

--- a/web/src/components/NoTracingPopover/NoTracingPopover.tsx
+++ b/web/src/components/NoTracingPopover/NoTracingPopover.tsx
@@ -1,4 +1,4 @@
-import {Popover} from 'antd';
+import {Button, Popover} from 'antd';
 import {useMemo} from 'react';
 import {Link} from 'react-router-dom';
 import * as S from './NoTracingPopover.styled';
@@ -7,13 +7,16 @@ const NoTracingPopover = () => {
   const content = useMemo(
     () => (
       <S.MessageContainer>
-        <S.Title>
-          <S.Icon /> No-Tracing Mode
-        </S.Title>
-        <S.Text>Tracetest is not configured to work with traces. Go to the settings page to set it up.</S.Text>
+        <div>
+          <S.Title>Tracing is not configured.</S.Title>
+          <S.Text>
+            Tracetest needs configuration information about your backend trace data store so it can collect the trace
+            after a test run. Please configure your data store now.
+          </S.Text>
+        </div>
         <S.ButtonContainer>
           <Link to="/settings">
-            <S.WarningButton>Setup</S.WarningButton>
+            <Button type="primary">Configure</Button>
           </Link>
         </S.ButtonContainer>
       </S.MessageContainer>
@@ -22,14 +25,11 @@ const NoTracingPopover = () => {
   );
 
   return (
-    <>
-      <S.CustomPopoverGlobalStyles />
-      <Popover content={content} overlayClassName="no-tracing-popover" placement="bottomLeft">
-        <S.Trigger>
-          <S.Icon /> No-Tracing Mode
-        </S.Trigger>
-      </Popover>
-    </>
+    <Popover content={content} overlayClassName="no-tracing-popover" placement="bottom">
+      <S.Trigger>
+        <S.Icon /> No-Tracing Mode
+      </S.Trigger>
+    </Popover>
   );
 };
 

--- a/web/src/components/SetupAlert/SetupAlert.tsx
+++ b/web/src/components/SetupAlert/SetupAlert.tsx
@@ -1,10 +1,15 @@
+import {Button} from 'antd';
 import {useDataStoreConfig} from 'providers/DataStoreConfig/DataStoreConfig.provider';
+import {Link} from 'react-router-dom';
 import {ConfigMode} from 'types/Config.types';
+import {useAppSelector} from '../../redux/hooks';
+import UserSelectors from '../../selectors/User.selectors';
 import * as S from './SetupAlert.styled';
 
 const SetupAlert = () => {
-  const {dataStoreConfig} = useDataStoreConfig();
-  const shouldDisplay = dataStoreConfig.mode === ConfigMode.NO_TRACING_MODE;
+  const {dataStoreConfig, skipConfigSetup} = useDataStoreConfig();
+  const initConfigSetup = useAppSelector(state => UserSelectors.selectUserPreference(state, 'initConfigSetup'));
+  const shouldDisplay = Boolean(initConfigSetup) && dataStoreConfig.mode === ConfigMode.NO_TRACING_MODE;
 
   return shouldDisplay ? (
     <S.Container
@@ -12,7 +17,12 @@ const SetupAlert = () => {
         <S.Message>
           <S.TextBold>No trace data store configured.</S.TextBold>
           <S.Text>Let us know the details of your existing tracing solution so we can gather the trace.</S.Text>
-          <S.WarningButton href="/settings">Setup</S.WarningButton>
+          <Link to="/settings">
+            <S.WarningButton>Setup</S.WarningButton>
+          </Link>
+          <Button color="primary" onClick={skipConfigSetup}>
+            Later
+          </Button>
         </S.Message>
       }
       type="warning"

--- a/web/src/constants/Theme.constants.ts
+++ b/web/src/constants/Theme.constants.ts
@@ -4,6 +4,7 @@ export const theme: DefaultTheme = {
   color: {
     background: '#FBFBFF',
     backgroundInteractive: 'rgba(56, 101, 246, 0.05)',
+    backgroundDark: '#E2E4ED',
     border: '#CDD1DB',
     borderLight: 'rgba(3, 24, 73, 0.1)',
     error: '#FF4D4F',

--- a/web/src/constants/Theme.constants.ts
+++ b/web/src/constants/Theme.constants.ts
@@ -16,6 +16,7 @@ export const theme: DefaultTheme = {
     textSecondary: '#687492',
     white: '#FFFFFF',
     warningYellow: '#FAAD14',
+    alertYellow: '#fffbe6',
   },
   size: {
     xs: '10px',

--- a/web/src/redux/apis/endpoints/Config.endpoint.ts
+++ b/web/src/redux/apis/endpoints/Config.endpoint.ts
@@ -19,7 +19,7 @@ const ConfigEndpoint = (builder: TTestApiEndpointBuilder) => ({
     transformResponse: () =>
       DataStoreConfigMock.model({
         dataStores: [{name: 'jaeger', type: SupportedDataStores.JAEGER}],
-        defaultDataStore: 'jaeger',
+        defaultDataStore: 'jaeger1',
       }),
   }),
   updateDatastoreConfig: builder.mutation<undefined, TRawDataStoreConfig>({

--- a/web/src/redux/apis/endpoints/Config.endpoint.ts
+++ b/web/src/redux/apis/endpoints/Config.endpoint.ts
@@ -19,7 +19,7 @@ const ConfigEndpoint = (builder: TTestApiEndpointBuilder) => ({
     transformResponse: () =>
       DataStoreConfigMock.model({
         dataStores: [{name: 'jaeger', type: SupportedDataStores.JAEGER}],
-        defaultDataStore: 'jaeger1',
+        defaultDataStore: 'jaeger',
       }),
   }),
   updateDatastoreConfig: builder.mutation<undefined, TRawDataStoreConfig>({

--- a/web/src/styled.d.ts
+++ b/web/src/styled.d.ts
@@ -20,6 +20,7 @@ declare module 'styled-components' {
       textSecondary: string;
       white: string;
       warningYellow: string;
+      alertYellow: string;
     };
     /** Font size */
     size: {

--- a/web/src/styled.d.ts
+++ b/web/src/styled.d.ts
@@ -8,6 +8,7 @@ declare module 'styled-components' {
     color: {
       background: string;
       backgroundInteractive: string;
+      backgroundDark: string;
       border: string;
       borderLight: string;
       error: string;


### PR DESCRIPTION
This PR adds the no tracing mode global warning to let users know that a part of the Tracetest setup is missing.

## Changes

- Adds new popover at the header component level

## Fixes

- #1628 

## Checklist

- [X] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test


https://www.loom.com/share/89be91d5bc714cb49e667c980491d6c6