### PR TITLE
fix(frontend): remove tabs in settings page

### DIFF
--- a/web/src/components/Settings/DataStore/DataStore.styled.ts
+++ b/web/src/components/Settings/DataStore/DataStore.styled.ts
@@ -18,7 +18,7 @@ export const Description = styled(Typography.Text)`
 export const Wrapper = styled.div`
   display: flex;
   flex-direction: column;
-  margin-top: 24px;
+  margin-bottom: 24px;
   background: ${({theme}) => theme.color.white};
 `;
 

--- a/web/src/pages/Settings/Content.tsx
+++ b/web/src/pages/Settings/Content.tsx
@@ -1,11 +1,11 @@
-import {Tabs} from 'antd';
+// import {Tabs} from 'antd';
 import DataStore from 'components/Settings/DataStore';
 import {useDataStoreConfig} from 'providers/DataStoreConfig/DataStoreConfig.provider';
 import * as S from './Settings.styled';
 
-const TabsKeys = {
+/* const TabsKeys = {
   DataStore: 'dataStore',
-};
+}; */
 
 const Content = () => {
   const {dataStoreConfig} = useDataStoreConfig();
@@ -13,16 +13,16 @@ const Content = () => {
   return (
     <S.Container>
       <S.Header>
-        <S.Title>Settings</S.Title>
+        <S.Title>Configure Data Store</S.Title>
       </S.Header>
 
-      <S.TabsContainer>
+      {/* <S.TabsContainer>
         <Tabs size="small">
-          <Tabs.TabPane key={TabsKeys.DataStore} tab="Configure Data Store">
-            <DataStore dataStoreConfig={dataStoreConfig} />
-          </Tabs.TabPane>
+          <Tabs.TabPane key={TabsKeys.DataStore} tab="Configure Data Store"> */}
+      <DataStore dataStoreConfig={dataStoreConfig} />
+      {/* </Tabs.TabPane>
         </Tabs>
-      </S.TabsContainer>
+      </S.TabsContainer> */}
     </S.Container>
   );
 };

--- a/web/src/pages/Settings/Settings.styled.ts
+++ b/web/src/pages/Settings/Settings.styled.ts
@@ -19,6 +19,10 @@ export const TabsContainer = styled.div`
   .ant-tabs-nav {
     padding: 0;
   }
+
+  .ant-tabs-content {
+    margin-top: 24px;
+  }
 `;
 
 export const Title = styled(Typography.Title)`


### PR DESCRIPTION
This PR removes the tabs in the settings page because right now we only support Data Store configuration.

## Changes

- Remove tabs in settings page

## Fixes

-

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Screenshots

<img width="1624" alt="Screenshot 2022-12-13 at 16 04 53" src="https://user-images.githubusercontent.com/3879892/207443403-4b20dd1b-2749-4790-9cbf-c28f73ce023e.png">