### PR TITLE
chore(backend): updating the open API contract to support datastore test connection changes

### DIFF
--- a/api/config.yaml
+++ b/api/config.yaml
@@ -105,14 +105,25 @@ components:
           type: string
         maxVersion:
           type: string
-    TestConnectionRequest:
+    DataStoreTestConnectionRequest:
       $ref: "#/components/schemas/DataStore"
-    TestConnectionResponse:
+    DataStoreTestConnectionResponse:
       type: object
       properties:
-        successful:
+        allPassed:
           type: boolean
-        errorMessage:
+        checks:
+          type: array
+          items:
+            $ref: "#/components/schemas/DataStoreTestConnectionCheck"
+    DataStoreTestConnectionCheck:
+      type: object
+      properties:
+        passed:
+          type: boolean
+        check:
+          type: string
+        result:
           type: string
     SupportedDataStores:
       type: string

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -1100,11 +1100,11 @@ paths:
         content:
           text/json:
             schema:
-              $ref: "./config.yaml#/components/schemas/TestConnectionRequest"
+              $ref: "./config.yaml#/components/schemas/DataStoreTestConnectionRequest"
       responses:
         201:
           description: Test connection Result
           content:
             application/json:
               schema:
-                $ref: "./config.yaml#/components/schemas/TestConnectionResponse"
+                $ref: "./config.yaml#/components/schemas/DataStoreTestConnectionResponse"

--- a/web/src/providers/DataStore/DataStore.provider.tsx
+++ b/web/src/providers/DataStore/DataStore.provider.tsx
@@ -79,9 +79,10 @@ const DataStoreProvider = ({children}: IProps) => {
   const onTestConnection = useCallback(
     async (draft: TDraftDataStore) => {
       const {dataStores: [dataStore] = []} = await DataStoreService.getRequest(draft);
-      const {successful, errorMessage = ''} = await testConnection(dataStore!).unwrap();
+      const errorMessage = '';
+      const {allPassed} = await testConnection(dataStore!).unwrap();
 
-      if (successful)
+      if (allPassed)
         return api.success({
           message: 'Connection is setup',
           description: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor',

--- a/web/src/redux/apis/endpoints/Config.endpoint.ts
+++ b/web/src/redux/apis/endpoints/Config.endpoint.ts
@@ -39,8 +39,8 @@ const ConfigEndpoint = (builder: TTestApiEndpointBuilder) => ({
       // body: connectionTest,
     }),
     transformResponse: () => ({
-      successful: true,
-      // errorMessage: 'Error connecting to Data Store',
+      allPassed: true,
+      checks: [],
     }),
   }),
 });

--- a/web/src/types/Config.types.ts
+++ b/web/src/types/Config.types.ts
@@ -26,8 +26,8 @@ export type TRawDataStore = TConfigSchemas['DataStore'];
 export type TDataStore = Model<TRawDataStore, {}>;
 export type TRawGRPCClientSettings = TConfigSchemas['GRPCClientSettings'];
 
-export type TTestConnectionRequest = TConfigSchemas['TestConnectionRequest'];
-export type TTestConnectionResponse = TConfigSchemas['TestConnectionResponse'];
+export type TTestConnectionRequest = TConfigSchemas['DataStoreTestConnectionRequest'];
+export type TTestConnectionResponse = TConfigSchemas['DataStoreTestConnectionResponse'];
 
 export interface IGRPCClientSettings extends TRawGRPCClientSettings {
   fileCA: File;

--- a/web/src/types/Generated.types.ts
+++ b/web/src/types/Generated.types.ts
@@ -928,13 +928,13 @@ export interface operations {
       /** Test connection Result */
       201: {
         content: {
-          "application/json": external["config.yaml"]["components"]["schemas"]["TestConnectionResponse"];
+          "application/json": external["config.yaml"]["components"]["schemas"]["DataStoreTestConnectionResponse"];
         };
       };
     };
     requestBody: {
       content: {
-        "text/json": external["config.yaml"]["components"]["schemas"]["TestConnectionRequest"];
+        "text/json": external["config.yaml"]["components"]["schemas"]["DataStoreTestConnectionRequest"];
       };
     };
   };
@@ -1002,10 +1002,15 @@ export interface external {
           minVersion?: string;
           maxVersion?: string;
         };
-        TestConnectionRequest: external["config.yaml"]["components"]["schemas"]["DataStore"];
-        TestConnectionResponse: {
-          successful?: boolean;
-          errorMessage?: string;
+        DataStoreTestConnectionRequest: external["config.yaml"]["components"]["schemas"]["DataStore"];
+        DataStoreTestConnectionResponse: {
+          allPassed?: boolean;
+          checks?: external["config.yaml"]["components"]["schemas"]["DataStoreTestConnectionCheck"][];
+        };
+        DataStoreTestConnectionCheck: {
+          passed?: boolean;
+          check?: string;
+          result?: string;
         };
         /** @enum {string} */
         SupportedDataStores: "jaeger" | "openSearch" | "tempo" | "signalFx";


### PR DESCRIPTION
This PR adds the OpenAPI contract for the test connection service response

## Changes

- Adds the DataStoreTestConnectionChecks

## Fixes

- #1679 

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
