### PR TITLE
fix(frontend): fix no-tracing mode while loading from api

### DIFF
--- a/web/src/components/Layout/Layout.tsx
+++ b/web/src/components/Layout/Layout.tsx
@@ -44,7 +44,7 @@ const footerMenuItems = [
 
 const Layout = ({children, hasMenu = false}: IProps) => {
   useRouterSync();
-  const {dataStoreConfig} = useDataStoreConfig();
+  const {dataStoreConfig, isLoading} = useDataStoreConfig();
   const pathname = useLocation().pathname;
   const isNoTracingMode = dataStoreConfig.mode === ConfigMode.NO_TRACING_MODE;
 
@@ -86,7 +86,7 @@ const Layout = ({children, hasMenu = false}: IProps) => {
             )}
 
             <S.Layout>
-              <Header hasEnvironments hasLogo={!hasMenu} isNoTracingMode={isNoTracingMode} />
+              <Header hasEnvironments hasLogo={!hasMenu} isNoTracingMode={isNoTracingMode && !isLoading} />
               <S.Content $hasMenu={hasMenu}>{children}</S.Content>
             </S.Layout>
           </S.Layout>

--- a/web/src/pages/Home/Content.tsx
+++ b/web/src/pages/Home/Content.tsx
@@ -1,104 +1,16 @@
-import CreateTestModal from 'components/CreateTestModal/CreateTestModal';
-import CreateTransactionModal from 'components/CreateTransactionModal/CreateTransactionModal';
-import Empty from 'components/Empty';
-import Pagination from 'components/Pagination';
-import TestCard from 'components/ResourceCard/TestCard';
-import TransactionCard from 'components/ResourceCard/TransactionCard';
-import {SortBy, SortDirection, sortOptions} from 'constants/Test.constants';
-import useDeleteResource from 'hooks/useDeleteResource';
-import usePagination from 'hooks/usePagination';
-import useTestCrud from 'providers/Test/hooks/useTestCrud';
-import {useCallback, useState} from 'react';
-import {useGetResourcesQuery} from 'redux/apis/TraceTest.api';
-import HomeAnalyticsService from 'services/Analytics/HomeAnalytics.service';
-import {ResourceType, TResource} from 'types/Resource.type';
-import {TTest} from 'types/Test.types';
-import {TTransaction} from 'types/Transaction.types';
-import useTransactionCrud from 'providers/Transaction/hooks/useTransactionCrud';
-import * as S from './Home.styled';
-import HomeActions from './HomeActions';
-import HomeFilters from './HomeFilters';
-import Loading from './Loading';
+import ConfigCTA from './ConfigCTA';
+import Resources from './Resources';
 
-const {onTestClick} = HomeAnalyticsService;
-type TParameters = {sortBy: SortBy; sortDirection: SortDirection};
-const [{params: defaultSort}] = sortOptions;
+interface IProps {
+  isLoading: boolean;
+  shouldDisplayConfigSetup: boolean;
+  skipConfigSetup(): void;
+}
 
-const Content = () => {
-  const [isCreateTransactionOpen, setIsCreateTransactionOpen] = useState(false);
-  const [isCreateTestOpen, setIsCreateTestOpen] = useState(false);
-  const [parameters, setParameters] = useState<TParameters>(defaultSort);
+const Content = ({isLoading, shouldDisplayConfigSetup, skipConfigSetup}: IProps) => {
+  if (isLoading) return null;
 
-  const pagination = usePagination<TResource, TParameters>(useGetResourcesQuery, parameters);
-  const onDeleteResource = useDeleteResource();
-  const {runTest} = useTestCrud();
-  const {runTransaction} = useTransactionCrud();
-
-  const handleOnRun = useCallback(
-    (id: string, type: ResourceType) => {
-      if (type === ResourceType.Test) runTest(id);
-      else if (type === ResourceType.Transaction) runTransaction(id);
-    },
-    [runTest, runTransaction]
-  );
-
-  const handleOnViewAll = useCallback((id: string) => {
-    onTestClick(id);
-  }, []);
-
-  return (
-    <>
-      <S.Wrapper>
-        <S.HeaderContainer>
-          <S.TitleText>All Tests</S.TitleText>
-        </S.HeaderContainer>
-
-        <S.ActionsContainer>
-          <HomeFilters
-            onSearch={pagination.search}
-            onSortBy={(sortBy, sortDirection) => setParameters({sortBy, sortDirection})}
-          />
-          <HomeActions
-            onCreateTransaction={() => setIsCreateTransactionOpen(true)}
-            onCreateTest={() => setIsCreateTestOpen(true)}
-          />
-        </S.ActionsContainer>
-
-        <Pagination<TResource>
-          emptyComponent={
-            <Empty message="You have not created any tests yet. Use the Create button to create your first test" />
-          }
-          loadingComponent={<Loading />}
-          {...pagination}
-        >
-          <S.TestListContainer data-cy="test-list">
-            {pagination.list?.map(resource =>
-              resource.type === ResourceType.Test ? (
-                <TestCard
-                  key={resource.item.id}
-                  onDelete={onDeleteResource}
-                  onRun={handleOnRun}
-                  onViewAll={handleOnViewAll}
-                  test={resource.item as TTest}
-                />
-              ) : (
-                <TransactionCard
-                  key={resource.item.id}
-                  onDelete={onDeleteResource}
-                  onRun={handleOnRun}
-                  onViewAll={handleOnViewAll}
-                  transaction={resource.item as TTransaction}
-                />
-              )
-            )}
-          </S.TestListContainer>
-        </Pagination>
-      </S.Wrapper>
-
-      <CreateTestModal isOpen={isCreateTestOpen} onClose={() => setIsCreateTestOpen(false)} />
-      <CreateTransactionModal isOpen={isCreateTransactionOpen} onClose={() => setIsCreateTransactionOpen(false)} />
-    </>
-  );
+  return shouldDisplayConfigSetup ? <ConfigCTA onSkip={skipConfigSetup} /> : <Resources />;
 };
 
 export default Content;

--- a/web/src/pages/Home/Home.tsx
+++ b/web/src/pages/Home/Home.tsx
@@ -3,17 +3,20 @@ import withAnalytics from 'components/WithAnalytics/WithAnalytics';
 import {useDataStoreConfig} from 'providers/DataStoreConfig/DataStoreConfig.provider';
 import CreateTransactionProvider from 'providers/CreateTransaction';
 import CreateTestProvider from 'providers/CreateTest';
-import ConfigCTA from './ConfigCTA';
 import Content from './Content';
 
 const Home = () => {
-  const {shouldDisplayConfigSetup, skipConfigSetup} = useDataStoreConfig();
+  const {isLoading, shouldDisplayConfigSetup, skipConfigSetup} = useDataStoreConfig();
 
   return (
     <Layout hasMenu>
       <CreateTransactionProvider>
         <CreateTestProvider>
-          {shouldDisplayConfigSetup ? <ConfigCTA onSkip={skipConfigSetup} /> : <Content />}
+          <Content
+            isLoading={isLoading}
+            shouldDisplayConfigSetup={shouldDisplayConfigSetup}
+            skipConfigSetup={skipConfigSetup}
+          />
         </CreateTestProvider>
       </CreateTransactionProvider>
     </Layout>

--- a/web/src/pages/Home/Resources.tsx
+++ b/web/src/pages/Home/Resources.tsx
@@ -1,0 +1,104 @@
+import CreateTestModal from 'components/CreateTestModal/CreateTestModal';
+import CreateTransactionModal from 'components/CreateTransactionModal/CreateTransactionModal';
+import Empty from 'components/Empty';
+import Pagination from 'components/Pagination';
+import TestCard from 'components/ResourceCard/TestCard';
+import TransactionCard from 'components/ResourceCard/TransactionCard';
+import {SortBy, SortDirection, sortOptions} from 'constants/Test.constants';
+import useDeleteResource from 'hooks/useDeleteResource';
+import usePagination from 'hooks/usePagination';
+import useTestCrud from 'providers/Test/hooks/useTestCrud';
+import {useCallback, useState} from 'react';
+import {useGetResourcesQuery} from 'redux/apis/TraceTest.api';
+import HomeAnalyticsService from 'services/Analytics/HomeAnalytics.service';
+import {ResourceType, TResource} from 'types/Resource.type';
+import {TTest} from 'types/Test.types';
+import {TTransaction} from 'types/Transaction.types';
+import useTransactionCrud from 'providers/Transaction/hooks/useTransactionCrud';
+import * as S from './Home.styled';
+import HomeActions from './HomeActions';
+import HomeFilters from './HomeFilters';
+import Loading from './Loading';
+
+const {onTestClick} = HomeAnalyticsService;
+type TParameters = {sortBy: SortBy; sortDirection: SortDirection};
+const [{params: defaultSort}] = sortOptions;
+
+const Resources = () => {
+  const [isCreateTransactionOpen, setIsCreateTransactionOpen] = useState(false);
+  const [isCreateTestOpen, setIsCreateTestOpen] = useState(false);
+  const [parameters, setParameters] = useState<TParameters>(defaultSort);
+
+  const pagination = usePagination<TResource, TParameters>(useGetResourcesQuery, parameters);
+  const onDeleteResource = useDeleteResource();
+  const {runTest} = useTestCrud();
+  const {runTransaction} = useTransactionCrud();
+
+  const handleOnRun = useCallback(
+    (id: string, type: ResourceType) => {
+      if (type === ResourceType.Test) runTest(id);
+      else if (type === ResourceType.Transaction) runTransaction(id);
+    },
+    [runTest, runTransaction]
+  );
+
+  const handleOnViewAll = useCallback((id: string) => {
+    onTestClick(id);
+  }, []);
+
+  return (
+    <>
+      <S.Wrapper>
+        <S.HeaderContainer>
+          <S.TitleText>All Tests</S.TitleText>
+        </S.HeaderContainer>
+
+        <S.ActionsContainer>
+          <HomeFilters
+            onSearch={pagination.search}
+            onSortBy={(sortBy, sortDirection) => setParameters({sortBy, sortDirection})}
+          />
+          <HomeActions
+            onCreateTransaction={() => setIsCreateTransactionOpen(true)}
+            onCreateTest={() => setIsCreateTestOpen(true)}
+          />
+        </S.ActionsContainer>
+
+        <Pagination<TResource>
+          emptyComponent={
+            <Empty message="You have not created any tests yet. Use the Create button to create your first test" />
+          }
+          loadingComponent={<Loading />}
+          {...pagination}
+        >
+          <S.TestListContainer data-cy="test-list">
+            {pagination.list?.map(resource =>
+              resource.type === ResourceType.Test ? (
+                <TestCard
+                  key={resource.item.id}
+                  onDelete={onDeleteResource}
+                  onRun={handleOnRun}
+                  onViewAll={handleOnViewAll}
+                  test={resource.item as TTest}
+                />
+              ) : (
+                <TransactionCard
+                  key={resource.item.id}
+                  onDelete={onDeleteResource}
+                  onRun={handleOnRun}
+                  onViewAll={handleOnViewAll}
+                  transaction={resource.item as TTransaction}
+                />
+              )
+            )}
+          </S.TestListContainer>
+        </Pagination>
+      </S.Wrapper>
+
+      <CreateTestModal isOpen={isCreateTestOpen} onClose={() => setIsCreateTestOpen(false)} />
+      <CreateTransactionModal isOpen={isCreateTransactionOpen} onClose={() => setIsCreateTransactionOpen(false)} />
+    </>
+  );
+};
+
+export default Resources;


### PR DESCRIPTION
This PR fixes an issue with the no-tracing mode state while the app is still loading the config from the API.

## Changes

- fix no-tracing mode state

## Fixes

- fixes #1674 

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Screenshots

Now the `no-tracing mode banner` and the `config cta` are visible only if we received the response from the config api.

<img width="1624" alt="Screenshot 2022-12-14 at 11 16 17" src="https://user-images.githubusercontent.com/3879892/207649738-3ecb378d-00a3-4f81-aa90-475122799a91.png">

