### PR TITLE
fix: disable trigger span from being generated

### DIFF
--- a/k8s/tracetest.beta.yaml
+++ b/k8s/tracetest.beta.yaml
@@ -40,5 +40,4 @@ telemetry:
 server:
   telemetry:
     exporter: collector
-    applicationExporter: collector
     dataStore: jaeger

--- a/k8s/tracetest.integration.yaml
+++ b/k8s/tracetest.integration.yaml
@@ -40,5 +40,4 @@ telemetry:
 server:
   telemetry:
     exporter: collector
-    applicationExporter: collector
     dataStore: jaeger


### PR DESCRIPTION
This PR disables instances to generate the trigger span as it is already generated when the trace is received.

## Checklist

- [ ] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
