### PR TITLE
fix(frontend): change SetupAlert to work with a unique preference key

### DIFF
--- a/web/src/components/SetupAlert/SetupAlert.styled.ts
+++ b/web/src/components/SetupAlert/SetupAlert.styled.ts
@@ -31,13 +31,10 @@ export const Message = styled.div`
 
 export const WarningButton = styled(Button)`
   background: ${({theme}) => theme.color.warningYellow};
-  width: 57px;
-  height: 24px;
   display: flex;
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  padding: 0 !important;
   border: none;
   font-weight: 600;
 

--- a/web/src/components/SetupAlert/SetupAlert.tsx
+++ b/web/src/components/SetupAlert/SetupAlert.tsx
@@ -1,17 +1,12 @@
 import {Button} from 'antd';
 import {useDataStoreConfig} from 'providers/DataStoreConfig/DataStoreConfig.provider';
 import {Link} from 'react-router-dom';
-import {ConfigMode} from 'types/Config.types';
-import {useAppSelector} from '../../redux/hooks';
-import UserSelectors from '../../selectors/User.selectors';
 import * as S from './SetupAlert.styled';
 
 const SetupAlert = () => {
-  const {dataStoreConfig, skipConfigSetup} = useDataStoreConfig();
-  const initConfigSetup = useAppSelector(state => UserSelectors.selectUserPreference(state, 'initConfigSetup'));
-  const shouldDisplay = Boolean(initConfigSetup) && dataStoreConfig.mode === ConfigMode.NO_TRACING_MODE;
+  const {shouldDisplayConfigSetupFromTest, skipConfigSetupFromTest} = useDataStoreConfig();
 
-  return shouldDisplay ? (
+  return shouldDisplayConfigSetupFromTest ? (
     <S.Container
       message={
         <S.Message>
@@ -20,7 +15,7 @@ const SetupAlert = () => {
           <Link to="/settings">
             <S.WarningButton>Setup</S.WarningButton>
           </Link>
-          <Button color="primary" onClick={skipConfigSetup}>
+          <Button color="primary" onClick={skipConfigSetupFromTest}>
             Later
           </Button>
         </S.Message>

--- a/web/src/providers/DataStoreConfig/DataStoreConfig.provider.tsx
+++ b/web/src/providers/DataStoreConfig/DataStoreConfig.provider.tsx
@@ -13,15 +13,19 @@ interface IContext {
   isLoading: boolean;
   isError: boolean;
   skipConfigSetup(): void;
+  skipConfigSetupFromTest(): void;
   shouldDisplayConfigSetup: boolean;
+  shouldDisplayConfigSetupFromTest: boolean;
 }
 
 const Context = createContext<IContext>({
   dataStoreConfig: DataStoreConfig({}),
   skipConfigSetup: noop,
+  skipConfigSetupFromTest: noop,
   isLoading: false,
   isError: false,
   shouldDisplayConfigSetup: false,
+  shouldDisplayConfigSetupFromTest: false,
 });
 
 interface IProps {
@@ -34,13 +38,27 @@ const DataStoreConfigProvider = ({children}: IProps) => {
   const dispatch = useAppDispatch();
   const {data: dataStoreConfig = DataStoreConfig({}), isLoading, isError} = useGetDataStoreConfigQuery({});
   const initConfigSetup = useAppSelector(state => UserSelectors.selectUserPreference(state, 'initConfigSetup'));
+  const initConfigSetupFromTest = useAppSelector(state =>
+    UserSelectors.selectUserPreference(state, 'initConfigSetupFromTest')
+  );
 
-  const shouldDisplayConfigSetup = Boolean(initConfigSetup) && dataStoreConfig.mode === ConfigMode.NO_TRACING_MODE;
+  const shouldDisplayConfigSetup = !!initConfigSetup && dataStoreConfig.mode === ConfigMode.NO_TRACING_MODE;
+  const shouldDisplayConfigSetupFromTest =
+    !!initConfigSetupFromTest && dataStoreConfig.mode === ConfigMode.NO_TRACING_MODE;
 
   const skipConfigSetup = useCallback(() => {
     dispatch(
       setUserPreference({
         key: 'initConfigSetup',
+        value: false,
+      })
+    );
+  }, [dispatch]);
+
+  const skipConfigSetupFromTest = useCallback(() => {
+    dispatch(
+      setUserPreference({
+        key: 'initConfigSetupFromTest',
         value: false,
       })
     );
@@ -52,9 +70,19 @@ const DataStoreConfigProvider = ({children}: IProps) => {
       isLoading,
       isError,
       skipConfigSetup,
+      skipConfigSetupFromTest,
       shouldDisplayConfigSetup,
+      shouldDisplayConfigSetupFromTest,
     }),
-    [dataStoreConfig, isError, isLoading, shouldDisplayConfigSetup, skipConfigSetup]
+    [
+      dataStoreConfig,
+      isError,
+      isLoading,
+      shouldDisplayConfigSetup,
+      shouldDisplayConfigSetupFromTest,
+      skipConfigSetup,
+      skipConfigSetupFromTest,
+    ]
   );
 
   return <Context.Provider value={value}>{children}</Context.Provider>;

--- a/web/src/services/UserPreferences.service.ts
+++ b/web/src/services/UserPreferences.service.ts
@@ -9,6 +9,7 @@ const initialUserPreferences: IUserPreferences = {
   lang: 'en',
   environmentId: '',
   initConfigSetup: true,
+  initConfigSetupFromTest: true,
   isOnboardingComplete: false,
 };
 

--- a/web/src/types/User.types.ts
+++ b/web/src/types/User.types.ts
@@ -2,6 +2,7 @@ export interface IUserPreferences {
   lang: string;
   environmentId: string;
   initConfigSetup: boolean;
+  initConfigSetupFromTest: boolean;
   isOnboardingComplete: boolean;
 }
 


### PR DESCRIPTION
This PR updates the `SetupAlert` to work with a unique preference key. Otherwise, you won't be able to see the alert message in a test.

## Changes

- Fix `SetupAlert` component logic

## Fixes

-

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
