### PR TITLE
feature(cli): improve installer experience

### DIFF
--- a/cli/installer/configuration.go
+++ b/cli/installer/configuration.go
@@ -1,0 +1,56 @@
+package installer
+
+import (
+	"fmt"
+
+	cliUI "github.com/kubeshop/tracetest/cli/ui"
+)
+
+type configuration struct {
+	db map[string]interface{}
+	ui cliUI.UI
+}
+
+func newConfiguration(ui cliUI.UI) configuration {
+	return configuration{
+		db: map[string]interface{}{},
+		ui: ui,
+	}
+}
+
+func (c configuration) set(key string, value interface{}) {
+	if _, exists := c.db[key]; exists {
+		c.ui.Panic(fmt.Errorf("config key %s already exists", key))
+	}
+
+	c.db[key] = value
+}
+
+func (c configuration) get(key string) interface{} {
+	v, exists := c.db[key]
+	if !exists {
+		c.ui.Panic(fmt.Errorf("config key %s not exists", key))
+	}
+
+	return v
+}
+
+func (c configuration) Bool(key string) bool {
+	b, ok := c.get(key).(bool)
+	if !ok {
+		c.ui.Panic(fmt.Errorf("config key %s is not a bool", key))
+	}
+
+	return b
+}
+
+func (c configuration) String(key string) string {
+	s, ok := c.get(key).(string)
+	if !ok {
+		c.ui.Panic(fmt.Errorf("config key %s is not a string", key))
+	}
+
+	return s
+}
+
+type configurator func(config configuration, ui cliUI.UI) configuration

--- a/cli/installer/docker_compose.go
+++ b/cli/installer/docker_compose.go
@@ -57,29 +57,11 @@ const (
 
 func dockerComposeInstaller(config configuration, ui cliUI.UI) {
 	trackInstall("docker-compose", config, nil)
-
 	dir := config.String("output.dir")
-	force := Force
-	if fileExists(dir) && !force {
-		ui.Warning(fmt.Sprintf(`Directory "%s" already exists.`, dir))
-		force = ui.Confirm("Do you want to overwrite it?", true)
 
-		if !force {
-			ui.Exit(fmt.Sprintf(`
-Output directory "%s" already exists. Choose a diferent output dir or manually remove it.
-
-You can run this command again with the -f option to overwrite it.
-
-%s`, dir, createIssueMsg),
-			)
-		}
-	}
-
-	if force {
-		err := os.RemoveAll(dir)
-		if err != nil {
-			ui.Exit(err.Error())
-		}
+	err := os.RemoveAll(dir)
+	if err != nil {
+		ui.Exit(err.Error())
 	}
 
 	psql := "host=postgres user=postgres password=postgres port=5432 sslmode=disable"

--- a/cli/installer/docker_compose.go
+++ b/cli/installer/docker_compose.go
@@ -6,7 +6,6 @@ import (
 	"io"
 	"net/http"
 	"os"
-	"path"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -38,28 +37,14 @@ var dockerCompose = installer{
 }
 
 func configureDockerCompose(conf configuration, ui cliUI.UI) configuration {
-	dcf := ui.TextInput("Project's docker-compose file", dockerComposeFilename)
-	create := false
-	if !fileExists(dcf) {
-		ui.Error(fmt.Sprintf(`File "%s" does not exist. You need an existing docker-compose file.`, dcf))
-		create = ui.Confirm("Do you want me to create an empty docker-compose file?", true)
-		if !create {
-			ui.Exit("Cannot proceed without a docker-compose file. Please create one and re run the command. " + createIssueMsg)
-		}
-		dcf = dockerComposeFilename
-
-	}
-	conf.set("project.docker-compose.filename", dcf)
-	conf.set("project.docker-compose.create", create)
+	conf.set("project.docker-compose.filename", dockerComposeFilename)
+	conf.set("project.docker-compose.create", true)
 
 	return conf
 }
 
 func configureDockerComposeOutput(conf configuration, ui cliUI.UI) configuration {
-	conf.set(
-		"output.dir",
-		ui.TextInput("Tracetest output directory", "tracetest/"),
-	)
+	conf.set("output.dir", "tracetest/")
 
 	return conf
 }
@@ -67,7 +52,7 @@ func configureDockerComposeOutput(conf configuration, ui cliUI.UI) configuration
 const (
 	dockerComposeFilename       = "docker-compose.yaml"
 	tracetestConfigFilename     = "tracetest.yaml"
-	otelCollectorConfigFilename = "otel-collector.yaml"
+	otelCollectorConfigFilename = "collector.config.yaml"
 )
 
 func dockerComposeInstaller(config configuration, ui cliUI.UI) {
@@ -97,27 +82,25 @@ You can run this command again with the -f option to overwrite it.
 		}
 	}
 
-	cwdDockerComposeFname := config.String("project.docker-compose.filename")
-	if config.Bool("project.docker-compose.create") {
-		createEmptyDockerComposeFile(cwdDockerComposeFname, ui)
-	}
-
 	psql := "host=postgres user=postgres password=postgres port=5432 sslmode=disable"
 	tracetestConfigFile := getTracetestConfigFileContents(psql, ui, config)
-	collectorConfigFile := getCollectorConfigFileContents(ui, config)
+
 	dockerComposeFile := getDockerComposeFileContents(ui, config)
 	dockerComposeFName := filepath.Join(dir, dockerComposeFilename)
 
 	dockerCmd := fmt.Sprintf(
-		"docker compose -f %s -f %s up -d",
-		cwdDockerComposeFname,
+		"docker compose -f %s  up -d",
 		dockerComposeFName,
 	)
 
 	createDir(ui, dir)
 	saveFile(ui, dockerComposeFName, dockerComposeFile)
 	saveFile(ui, filepath.Join(dir, tracetestConfigFilename), tracetestConfigFile)
-	saveFile(ui, filepath.Join(dir, otelCollectorConfigFilename), collectorConfigFile)
+
+	if !config.Bool("installer.only_tracetest") {
+		collectorConfigFile := getCollectorConfigFileContents(ui, config)
+		saveFile(ui, filepath.Join(dir, otelCollectorConfigFilename), collectorConfigFile)
+	}
 
 	ui.Success("Install successful!")
 	ui.Println(fmt.Sprintf(`
@@ -134,45 +117,18 @@ Happy TraceTesting =)
 
 }
 
-func createEmptyDockerComposeFile(fname string, ui cliUI.UI) {
-	project := &types.Project{}
-	output, err := yaml.Marshal(project)
-	if err != nil {
-		ui.Exit(fmt.Sprintf("cannot encode docker-compose file: %s", err.Error()))
-	}
-
-	err = os.WriteFile(fname, output, 0644)
-	if err != nil {
-		ui.Exit(fmt.Sprintf("cannot write docker-compose file: %s", err.Error()))
-	}
-}
-
 func getDockerComposeFileContents(ui cliUI.UI, config configuration) []byte {
 	project := getCompleteProject(ui, config)
 	include := []string{"tracetest", "postgres"}
 
-	if config.Bool("tracetest.backend.install") {
-		include = append(include, "jaeger")
-	}
-
-	if config.Bool("tracetest.collector.install") {
-		include = append(include, "otel-collector")
-	}
-
 	if config.Bool("demo.enable.pokeshop") {
-		include = append(include, "cache", "queue", "demo-api", "demo-worker", "demo-rpc")
+		include = append(include, "cache", "queue", "demo-api", "demo-worker", "demo-rpc", "otel-collector")
 	}
 
 	filterContainers(ui, project, include)
 
 	if err := fixTracetestContainer(config, project, cliConfig.Version); err != nil {
 		ui.Exit(fmt.Sprintf("cannot configure tracetest container: %s", err.Error()))
-	}
-
-	if config.Bool("tracetest.collector.install") {
-		if err := fixOtelCollectorContainer(config, project); err != nil {
-			ui.Exit(fmt.Sprintf("cannot configure otel-collector container: %s", err.Error()))
-		}
 	}
 
 	output, err := yaml.Marshal(project)
@@ -223,8 +179,7 @@ func filterContainers(ui cliUI.UI, project *types.Project, included []string) {
 type msa = map[string]any
 
 func getCollectorConfigFileContents(ui cliUI.UI, config configuration) []byte {
-	exampleFile := config.String("tracetest.backend.type")
-	contents, err := getFileContentsForVersion("examples/tracetest-"+exampleFile+"/collector.config.yaml", cliConfig.Version)
+	contents, err := getFileContentsForVersion("examples/collector/collector.config.yaml", cliConfig.Version)
 	if err != nil {
 		ui.Exit(fmt.Errorf("cannot get collector config file: %w", err).Error())
 	}
@@ -236,48 +191,19 @@ func getCollectorConfigFileContents(ui cliUI.UI, config configuration) []byte {
 		ui.Exit(err.Error())
 	}
 
-	exporters := msa{}
-	exporter := ""
-
-	switch config.String("tracetest.backend.type") {
-	case "jaeger":
-		exporter = "jaeger"
-		exporters["jaeger"] = msa{
+	exporter := "otlp/1"
+	exporters := msa{
+		"otlp/1": msa{
 			"endpoint": config.String("tracetest.backend.endpoint.collector"),
 			"tls": msa{
 				"insecure": config.Bool("tracetest.backend.tls.insecure"),
 			},
-		}
-	case "tempo":
-		exporter = "otlp/2"
-		exporters["otlp/2"] = msa{
-			"endpoint": config.String("tracetest.backend.endpoint"),
-			"tls": msa{
-				"insecure": config.Bool("tracetest.backend.tls.insecure"),
-			},
-		}
-	case "opensearch":
-		exporter = "otlp/2"
-		exporters["otlp/2"] = msa{
-			"endpoint": config.String("tracetest.backend.data-prepper.endpoint"),
-			"tls": msa{
-				"insecure":             config.Bool("tracetest.backend.data-prepper.insecure"),
-				"insecure_skip_verify": true,
-			},
-		}
-	case "signalfx":
-		exporter = "sapm"
-		exporters["sapm"] = msa{
-			"access_token":             config.String("tracetest.backend.token"),
-			"access_token_passthrough": true,
-			"endpoint":                 fmt.Sprintf("https://ingest.%s.signalfx.com/v2/trace", config.String("tracetest.backend.realm")),
-			"max_connections":          100,
-			"num_workers":              8,
-		}
+		},
 	}
 
 	otelConfig["exporters"] = exporters
-	otelConfig["service"].(msa)["pipelines"].(msa)["traces"].(msa)["exporters"] = []string{exporter}
+
+	otelConfig["service"].(msa)["pipelines"].(msa)["traces/1"].(msa)["exporters"] = []string{exporter}
 
 	updated, err := yaml.Marshal(otelConfig)
 	if err != nil {
@@ -324,20 +250,9 @@ func fixTracetestContainer(config configuration, project *types.Project, version
 
 	tts.Image = "kubeshop/tracetest:" + version
 	tts.Build = nil
-	tts.Volumes[0].Source = path.Join(config.String("output.dir"), tracetestConfigFilename)
+	tts.Volumes[0].Source = tracetestConfigFilename
 
 	replaceService(project, serviceName, tts)
-
-	return nil
-}
-
-func fixOtelCollectorContainer(config configuration, project *types.Project) error {
-	ocs, err := project.GetService("otel-collector")
-	if err != nil {
-		return err
-	}
-
-	ocs.Volumes[0].Source = path.Join(config.String("output.dir"), otelCollectorConfigFilename)
 
 	return nil
 }
@@ -374,8 +289,7 @@ func getFileContentsForVersion(path, version string) ([]byte, error) {
 }
 
 func getCompleteProject(ui cliUI.UI, config configuration) *types.Project {
-	exampleFile := config.String("tracetest.backend.type")
-	tracetestDCContents, err := getFileContentsForVersion("examples/tracetest-"+exampleFile+"/docker-compose.yml", cliConfig.Version)
+	tracetestDCContents, err := getFileContentsForVersion("examples/collector/docker-compose.yml", cliConfig.Version)
 	if err != nil {
 		ui.Exit(fmt.Errorf("cannot get docker-compose file: %w", err).Error())
 	}
@@ -415,29 +329,9 @@ func dockerChecker(ui cliUI.UI) {
 	}
 
 	ui.Warning("I didn't find docker in your system")
-	options := []cliUI.Option{}
-	if !isWindows() {
-		options = append(options, cliUI.Option{"Install Docker Engine", installDockerEngine})
-	}
-
-	options = append(options, cliUI.Option{"Install Docker Desktop", installDockerDesktop})
-	options = append(options, cliUI.Option{"Fix manually", exitOption(
+	exitOption(
 		"Check the docker install docs on https://docs.docker.com/get-docker/",
-	)})
-	option := ui.Select("What do you want to do?", options, 0)
-
-	option.Fn(ui)
-
-	// We can't start docker programmatically on windows
-	if isWindows() {
-		ui.TextInput(`Start Docker Desktop before procceding. Press Enter`, "")
-	}
-
-	if commandExists("docker") {
-		ui.Println(ui.Green("✔ docker was successfully installed"))
-	} else {
-		ui.Exit(ui.Red("✘ docker could not be installed. Check output for errors. " + createIssueMsg))
-	}
+	)(ui)
 }
 
 func dockerReadyChecker(ui cliUI.UI) {
@@ -463,282 +357,7 @@ func dockerComposeChecker(ui cliUI.UI) {
 	}
 
 	ui.Warning("I didn't find docker compose in your system")
-	option := ui.Select("What do you want to do?", []cliUI.Option{
-		{"Install Docker Compose", installDockerCompose},
-		{"Fix manually", exitOption(
-			"Check the docker compose install docs on https://docs.docker.com/compose/install/",
-		)},
-	}, 0)
-
-	option.Fn(ui)
-
-	if commandSuccess("docker compose") {
-		ui.Println(ui.Green("✔ docker compose was successfully installed"))
-	} else {
-		ui.Exit(ui.Red("✘ docker compose could not be installed. Check output for errors. " + createIssueMsg))
-	}
-}
-
-func installDockerCompose(ui cliUI.UI) {
-	(cmd{
-		sudo:          true,
-		notConfirmMsg: "No worries. You can try installing Docker Compose manually. See https://docs.docker.com/compose/install/",
-		args: map[string]string{
-			"DockerVersion": dockerVersion(ui),
-			"Architecture":  detectArchitecture(),
-		},
-		apt: `
-			DISTRO=$(lsb_release -is | tr '[:upper:]' '[:lower:]')
-
-			# Repo install. see https://docs.docker.com/engine/install/$DISTRO/#install-using-the-repository
-			# setup repo
-			sudo apt-get -y update
-			sudo apt-get -y install \
-				ca-certificates \
-				curl \
-				gnupg \
-				lsb-release
-			sudo mkdir -p /etc/apt/keyrings
-			curl -fsSL https://download.docker.com/linux/$DISTRO/gpg | sudo gpg --batch --yes --dearmor -o /etc/apt/keyrings/docker.gpg
-
-			sudo chmod a+r /etc/apt/keyrings/docker.gpg
-
-			echo \
-				"deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/$DISTRO \
-				$(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
-
-			# install
-			sudo apt-get -y update
-			sudo apt-get -y install docker-compose-plugin
-			`,
-		dnf: `
-			# Repo install. see https://docs.docker.com/engine/install/fedora/#install-using-the-repository
-			# setup repo
-			sudo dnf -y install dnf-plugins-core
-			sudo dnf -y config-manager \
-				--add-repo \
-				https://download.docker.com/linux/fedora/docker-ce.repo
-
-			# install
-			sudo dnf -y install docker-compose-plugin
-			`,
-		yum: `
-			# Repo install. see https://docs.docker.com/engine/install/centos/#install-using-the-repository
-			# setup repo
-			sudo yum install -y yum-utils
-			sudo yum-config-manager \
-				--add-repo \
-				https://download.docker.com/linux/centos/docker-ce.repo
-
-			# install
-			sudo yum -y install docker-compose-plugin
-			`,
-		homebrew:           "brew install docker-compose",
-		macIntelChipManual: "TODO", // todo. see https://apple.stackexchange.com/a/73931
-		macAppleChipManual: "TODO", // todo. see https://apple.stackexchange.com/a/73931
-		windows:            "Check the install docs: https://docs.docker.com/compose/install/",
-		other:              "Check the install docs: https://docs.docker.com/compose/install/",
-	}).exec(ui)
-}
-
-func installDockerEngine(ui cliUI.UI) {
-	post := `
-			# post-install. not neccesary for root
-			if [ "$(id -u)" != "0" ]; then
-				sudo groupadd docker
-				sudo usermod -aG docker $USER
-				newgrp docker
-			fi
-			`
-	(cmd{
-		sudo:          true,
-		notConfirmMsg: "No worries. You can try installing Docker Engine manually. See https://docs.docker.com/engine/install/",
-		installDocs:   "https://docs.docker.com/engine/install/",
-		args: map[string]string{
-			"DockerVersion": dockerVersion(ui),
-			"Architecture":  detectArchitecture(),
-		},
-		apt: `
-			# Repo install. see https://docs.docker.com/engine/install/$DISTRO/#install-using-the-repository
-			# setup repo
-			sudo apt-get -y update
-			sudo apt-get -y install \
-				ca-certificates \
-				curl \
-				gnupg \
-				lsb-release
-
-			DISTRO=$(lsb_release -is | tr '[:upper:]' '[:lower:]')
-
-			# cleanup. see https://docs.docker.com/engine/install/$DISTRO/#uninstall-old-versions
-			sudo apt-get -y remove docker docker-engine docker.io containerd runc
-
-			sudo mkdir -p /etc/apt/keyrings
-			curl -fsSL https://download.docker.com/linux/$DISTRO/gpg | sudo gpg --batch --yes --dearmor -o /etc/apt/keyrings/docker.gpg
-
-			sudo chmod a+r /etc/apt/keyrings/docker.gpg
-
-			echo \
-				"deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/$DISTRO \
-				$(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
-
-			# install
-			sudo apt-get -y update
-			sudo apt-get -y install docker-ce docker-ce-cli containerd.io docker-compose-plugin
-			` + post,
-		dnf: `
-			# cleanup. see https://docs.docker.com/engine/install/fedora/#uninstall-old-versions
-			sudo dnf -y remove docker \
-					docker-client \
-					docker-client-latest \
-					docker-common \
-					docker-latest \
-					docker-latest-logrotate \
-					docker-logrotate \
-					docker-selinux \
-					docker-engine-selinux \
-					docker-engine
-
-
-			# Repo install. see https://docs.docker.com/engine/install/fedora/#install-using-the-repository
-			# setup repo
-			sudo dnf -y install dnf-plugins-core
-			sudo dnf -y config-manager \
-				--add-repo \
-				https://download.docker.com/linux/fedora/docker-ce.repo
-
-			# install
-			sudo dnf -y install docker-ce docker-ce-cli containerd.io docker-compose-plugin
-			sudo systemctl start docker
-			` + post,
-		yum: `
-			# cleanup. see https://docs.docker.com/engine/install/centos/#uninstall-old-versions
-			sudo yum -y remove docker \
-					docker-client \
-					docker-client-latest \
-					docker-common \
-					docker-latest \
-					docker-latest-logrotate \
-					docker-logrotate \
-					docker-engine \
-					podman \
-					runc
-
-			# Repo install. see https://docs.docker.com/engine/install/centos/#install-using-the-repository
-			# setup repo
-			sudo yum install -y yum-utils
-			sudo yum-config-manager \
-				--add-repo \
-				https://download.docker.com/linux/centos/docker-ce.repo
-
-			# install
-			sudo yum -y install docker-ce docker-ce-cli containerd.io docker-compose-plugin
-			sudo systemctl start docker
-			` + post,
-		homebrew:           "brew install docker",
-		windows:            "",
-		macIntelChipManual: "", // empty means not supported
-		macAppleChipManual: "", // empty means not supported
-		other:              "", // empty means not supported
-	}).exec(ui)
-}
-
-func installDockerDesktop(ui cliUI.UI) {
-	(cmd{
-		sudo:          true,
-		notConfirmMsg: "No worries. You can try installing Docker Desktop manually. See https://docs.docker.com/desktop/install/",
-		installDocs:   "https://docs.docker.com/desktop/",
-		args: map[string]string{
-			"DockerVersion": dockerVersion(ui),
-			"Architecture":  detectArchitecture(),
-		},
-		apt: `
-			# add docker repo. See https://docs.docker.com/engine/install/$DISTRO/#set-up-the-repository
-			sudo apt-get -y update
-			sudo apt-get -y install \
-				ca-certificates \
-				curl \
-				gnupg \
-				lsb-release
-
-			DISTRO=$(lsb_release -is | tr '[:upper:]' '[:lower:]')
-
-			# cleanup old installs. See https://docs.docker.com/desktop/install/$DISTRO/#prerequisites
-			rm -rf $HOME/.docker/desktop
-			sudo rm -f /usr/local/bin/com.docker.cli
-			sudo apt-get -y purge docker-desktop
-
-			sudo mkdir -p /etc/apt/keyrings
-			curl -fsSL https://download.docker.com/linux/$DISTRO/gpg | sudo gpg --yes --dearmor -o /etc/apt/keyrings/docker.gpg
-			echo \
-				"deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/$DISTRO \
-				$(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
-			sudo apt-get -y update
-
-			# download and install docker desktop. See https://docs.docker.com/desktop/install/$DISTRO/#install-docker-desktop
-			curl -LO https://desktop.docker.com/linux/main/{{.Architecture}}/docker-desktop-{{.DockerVersion}}-{{.Architecture}}.deb
-			sudo apt-get -y install ./docker-desktop-{{.DockerVersion}}-{{.Architecture}}.deb
-			rm ./docker-desktop-{{.DockerVersion}}-{{.Architecture}}.deb
-
-			# enable docker desktop auto start
-			systemctl --user enable docker-desktop
-			systemctl start docker-desktop
-			`,
-		dnf: `
-			# setup repo. See https://docs.docker.com/engine/install/fedora/#set-up-the-repository
-			sudo dnf -y install dnf-plugins-core
-			sudo dnf -y config-manager \
-				--add-repo \
-				https://download.docker.com/linux/fedora/docker-ce.repo
-
-			# download and install docker desktop. See https://docs.docker.com/desktop/install/$DISTRO/#install-docker-desktop
-			curl -LO https://desktop.docker.com/linux/main/{{.Architecture}}/docker-desktop-{{.DockerVersion}}-{{.Architecture}}.deb
-			sudo dnf -y install ./docker-desktop-{{.DockerVersion}}-{{.Architecture}}.deb
-
-			# enable docker desktop auto start
-			systemctl --user enable docker-desktop
-			`,
-		homebrew: "brew install --cask docker",
-		macIntelChipManual: `
-			curl -LO https://desktop.docker.com/mac/main/amd64/Docker.dmg
-			sudo hdiutil attach $(pwd)/Docker.dmg
-			sudo cp -R /Volumes/Docker/Docker.app /Applications
-			sudo hdiutil detach /Volumes/Docker
-			rm -f Docker.dmg
-			`,
-		macAppleChipManual: `
-			curl -LO https://desktop.docker.com/mac/main/arm64/Docker.dmg
-			sudo hdiutil attach $(pwd)/Docker.dmg
-			sudo cp -R /Volumes/Docker/Docker.app /Applications
-			sudo hdiutil detach /Volumes/Docker
-			rm -f Docker.dmg
-		`,
-		windows: `
-			choco install docker-desktop -y -f
-		`,
-		other: "", // empty means not supported
-	}).exec(ui)
-}
-
-func dockerVersion(ui cliUI.UI) string {
-	resp, err := http.Get("https://docs.docker.com/desktop/release-notes/")
-
-	if err != nil {
-		ui.Panic(fmt.Errorf("cannot get docker releases: %w", err))
-	}
-
-	defer resp.Body.Close()
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		ui.Panic(fmt.Errorf("cannot get docker releases: %w", err))
-	}
-
-	// matches "Docker Desktop 4.10.1", case insensitive
-	var dockerVersionRegex = regexp.MustCompile(`(?i)docker desktop (\d+\.\d+\.\d+)`)
-
-	matches := dockerVersionRegex.FindStringSubmatch(string(body))
-	if len(matches) < 2 {
-		ui.Panic(fmt.Errorf("could not find a valid docker desktop version"))
-	}
-	return matches[1]
+	exitOption(
+		"Check the docker compose install docs on https://docs.docker.com/compose/install/",
+	)(ui)
 }

--- a/cli/installer/docker_compose.go
+++ b/cli/installer/docker_compose.go
@@ -252,7 +252,7 @@ func replaceService(project *types.Project, service string, sc types.ServiceConf
 
 func getFileContentsForVersion(path, version string) ([]byte, error) {
 	if version == "dev" {
-		version = "1630-in-app-config-installer-changes"
+		version = "main"
 	}
 	url := fmt.Sprintf("https://raw.githubusercontent.com/kubeshop/tracetest/%s/%s", version, path)
 	resp, err := http.Get(url)

--- a/cli/installer/docker_compose.go
+++ b/cli/installer/docker_compose.go
@@ -176,7 +176,7 @@ func getCollectorConfigFileContents(ui cliUI.UI, config configuration) []byte {
 	exporter := "otlp/1"
 	exporters := msa{
 		"otlp/1": msa{
-			"endpoint": config.String("tracetest.backend.endpoint.collector"),
+			"endpoint": config.String("tracetest.backend.endpoint"),
 			"tls": msa{
 				"insecure": config.Bool("tracetest.backend.tls.insecure"),
 			},
@@ -252,7 +252,7 @@ func replaceService(project *types.Project, service string, sc types.ServiceConf
 
 func getFileContentsForVersion(path, version string) ([]byte, error) {
 	if version == "dev" {
-		version = "main"
+		version = "1630-in-app-config-installer-changes"
 	}
 	url := fmt.Sprintf("https://raw.githubusercontent.com/kubeshop/tracetest/%s/%s", version, path)
 	resp, err := http.Get(url)

--- a/cli/installer/installer.go
+++ b/cli/installer/installer.go
@@ -86,7 +86,7 @@ func setInstallationType(ui cliUI.UI, config configuration) {
 		{"I have a tracing environment already. Just install Tracetest", func(ui cliUI.UI) {
 			config.set("installer.only_tracetest", true)
 		}},
-		{"Just learning tracing! Install Tracetest, Jaeger, OpenTelemetry Collector and the sample app.", func(ui cliUI.UI) {
+		{"Just learning tracing! Install Tracetest, OpenTelemetry Collector and the sample app.", func(ui cliUI.UI) {
 			config.set("installer.only_tracetest", false)
 		}},
 	}, 0)

--- a/cli/installer/kubernetes.go
+++ b/cli/installer/kubernetes.go
@@ -3,7 +3,6 @@ package installer
 import (
 	"encoding/csv"
 	"fmt"
-	"log"
 	"os"
 	"path"
 	"regexp"
@@ -128,15 +127,11 @@ func installOtelCollector(conf configuration, ui cliUI.UI) {
 	cc := createTmpFile("collector-config", string(getCollectorConfigFileContents(ui, conf)), ui)
 	defer os.Remove(cc.Name())
 
-	log.Println(">>>>content", string(getCollectorConfigFileContents(ui, conf)))
-
 	cmdString := kubectlNamespaceCmd(conf,
 		"create configmap collector-config --from-file="+cc.Name()+" -o yaml --dry-run=client",
 		"| sed 's#"+path.Base(cc.Name())+"#collector.yaml#' |",
 		kubectlNamespaceCmd(conf, "replace -f -"),
 	)
-
-	log.Println("cmdString", cmdString)
 
 	execCmd(
 		cmdString,
@@ -224,17 +219,6 @@ func createTmpFile(name, contents string, ui cliUI.UI) *os.File {
 	}
 
 	return f
-}
-
-func crdExists(config configuration, crd string) bool {
-	cmd := fmt.Sprintf(
-		"%s > /dev/null 2>&1; echo $?",
-		kubectlCmd(config, "get crd "+crd),
-	)
-	out := getCmdOutputClean(cmd)
-
-	// if output is 0, it means the CRD exists
-	return out == "0"
 }
 
 func kubectlNamespaceCmd(config configuration, cmd ...string) string {

--- a/cli/installer/kubernetes.go
+++ b/cli/installer/kubernetes.go
@@ -3,6 +3,7 @@ package installer
 import (
 	"encoding/csv"
 	"fmt"
+	"log"
 	"os"
 	"path"
 	"regexp"
@@ -23,7 +24,6 @@ var kubernetes = installer{
 	configs: []configurator{
 		configureKubernetes,
 		configureTracetest,
-		configureKubernetesInstalls,
 		configureIngress,
 		configureDemoApp,
 	},
@@ -70,15 +70,10 @@ func kubernetesInstaller(config configuration, ui cliUI.UI) {
 	trackInstall("kubernetes", config, nil)
 
 	installCertManager(config, ui)
-	installJaegerOperator(config, ui)
 
 	execCmdIgnoreErrors(kubectlCmd(config, "create namespace "+config.String("k8s.namespace")))
 
-	installJaeger(config, ui)
-	installCollector(config, ui)
-
 	installTracetest(config, ui)
-
 }
 
 func installTracetest(conf configuration, ui cliUI.UI) {
@@ -87,11 +82,15 @@ func installTracetest(conf configuration, ui cliUI.UI) {
 	installTracetestChart(conf, ui)
 	fixTracetestConfiguration(conf, ui)
 
-	installOtelCollector(conf, ui)
+	if !conf.Bool("installer.only_tracetest") {
+		installOtelCollector(conf, ui)
+	}
 
 	execCmd(kubectlNamespaceCmd(conf, "delete pods -l app.kubernetes.io/name=tracetest"), ui)
 
-	installDemo(conf, ui)
+	if !conf.Bool("installer.only_tracetest") {
+		installDemo(conf, ui)
+	}
 
 	ui.Success("Install successful!")
 	ui.Println(fmt.Sprintf(`
@@ -115,25 +114,25 @@ func installDemo(conf configuration, ui cliUI.UI) {
 
 	helm := helmCmd(conf, "")
 	script := strings.ReplaceAll(demoScript, "#helm#", helm)
-	script = fmt.Sprintf(script, conf.String("tracetest.collector.endpoint"))
+	script = fmt.Sprintf(script, conf.String("tracetest.backend.endpoint.collector"))
 
 	execCmd(script, ui)
 }
 
 func installOtelCollector(conf configuration, ui cliUI.UI) {
-	if !conf.Bool("tracetest.collector.install") {
-		return
-	}
-
 	cc := createTmpFile("collector-config", string(getCollectorConfigFileContents(ui, conf)), ui)
 	defer os.Remove(cc.Name())
 
+	cmdString := kubectlNamespaceCmd(conf,
+		"create configmap collector-config --from-file="+cc.Name()+" -o yaml --dry-run=client",
+		"| sed 's#"+path.Base(cc.Name())+"#collector.yaml#' |",
+		kubectlNamespaceCmd(conf, "replace -f -"),
+	)
+
+	log.Println("cmdString", cmdString)
+
 	execCmd(
-		kubectlNamespaceCmd(conf,
-			"create configmap collector-config --from-file="+cc.Name()+" -o yaml --dry-run=client",
-			"| sed 's#"+path.Base(cc.Name())+"#collector.yaml#' |",
-			kubectlNamespaceCmd(conf, "replace -f -"),
-		),
+		cmdString,
 		ui,
 	)
 	execCmd(kubectlNamespaceCmd(conf, "delete pods -l app.kubernetes.io/name=otel-collector"), ui)
@@ -201,13 +200,6 @@ metadata:
 spec:
   selfSigned: {}
 `
-	jaegerOperatorYaml = "https://github.com/jaegertracing/jaeger-operator/releases/download/v1.32.0/jaeger-operator.yaml"
-	jaegerManifest     = `
-apiVersion: jaegertracing.io/v1
-kind: Jaeger
-metadata:
-  name: jaeger
-`
 	collectorYaml = "https://raw.githubusercontent.com/kubeshop/tracetest/main/k8s/collector.yml"
 
 	demoScript = `
@@ -227,22 +219,8 @@ cd $tmpdir/helm-chart
 `
 )
 
-func installCollector(config configuration, ui cliUI.UI) {
-	if !config.Bool("tracetest.collector.install") {
-		return
-	}
-
-	execCmd(
-		kubectlNamespaceCmd(config, "create -f "+collectorYaml),
-		ui,
-	)
-
-	ui.Println(ui.Green("✔ collector ready"))
-
-}
-
 func installCertManager(config configuration, ui cliUI.UI) {
-	if !config.Bool("k8s.cert-manager.install") {
+	if crdExists(config, "certificaterequests.cert-manager.io") {
 		return
 	}
 
@@ -267,45 +245,6 @@ func installCertManager(config configuration, ui cliUI.UI) {
 	)
 
 	ui.Println(ui.Green("✔ cert-manager ready"))
-}
-
-func installJaegerOperator(config configuration, ui cliUI.UI) {
-	if !config.Bool("k8s.jaeger-operator.install") {
-		return
-	}
-
-	execCmdIgnoreError(
-		kubectlCmd(config, "create namespace observability "),
-		ui,
-	)
-	execCmd(
-		kubectlCmd(config, "--namespace observability create -f "+jaegerOperatorYaml),
-		ui,
-	)
-
-	execCmd(
-		kubectlCmd(config, "--namespace observability wait --for=condition=ready pod -l name=jaeger-operator --timeout 5m"),
-		ui,
-	)
-
-	ui.Println(ui.Green("✔ jaeger-operator ready"))
-
-}
-
-func installJaeger(config configuration, ui cliUI.UI) {
-	if !config.Bool("tracetest.backend.install") {
-		return
-	}
-
-	jmf := createTmpFile("tracetest-jaeger", jaegerManifest, ui)
-	defer os.Remove(jmf.Name())
-
-	execCmd(
-		kubectlNamespaceCmd(config, "apply -f "+jmf.Name()),
-		ui,
-	)
-	ui.Println(ui.Green("✔ jaeger instance ready"))
-
 }
 
 func createTmpFile(name, contents string, ui cliUI.UI) *os.File {
@@ -393,7 +332,7 @@ func getKubernetesContextArray(kubeconfig string) ([][]string, error) {
 }
 
 func configureKubernetes(conf configuration, ui cliUI.UI) configuration {
-	conf.set("k8s.kubeconfig", ui.TextInput("Kubeconfig file", "${HOME}/.kube/config"))
+	conf.set("k8s.kubeconfig", "${HOME}/.kube/config")
 
 	contexts := getK8sContexts(conf, ui)
 	if len(contexts) == 0 {
@@ -403,6 +342,7 @@ func configureKubernetes(conf configuration, ui cliUI.UI) configuration {
 				createIssueMsg,
 		)
 	}
+
 	options := []cliUI.Option{}
 	defaultIndex := 0
 	for i, c := range contexts {
@@ -414,51 +354,14 @@ func configureKubernetes(conf configuration, ui cliUI.UI) configuration {
 
 	selected := ui.Select("Kubectl context", options, defaultIndex)
 	conf.set("k8s.context", selected.Text)
-
-	conf.set("k8s.namespace", ui.TextInput("Namespace", "tracetest"))
+	conf.set("k8s.namespace", "tracetest")
 
 	return conf
 }
 
 func configureIngress(conf configuration, ui cliUI.UI) configuration {
-	expose := ui.Confirm("Do you want to expose tracetest (via ingress)?", false)
-	if expose {
-		conf.set("k8s.ingress-host", ui.TextInput("Host", ""))
-	}
-	conf.set("k8s.expose", expose)
-	return conf
-}
-
-func configureKubernetesInstalls(conf configuration, ui cliUI.UI) configuration {
-	installCertManager := false
-	installJaegerOperator := false
-	if conf.Bool("tracetest.backend.install") {
-		ui.Warning("I am going to install Jaeger in your cluster!")
-		ui.Println("This requires the Jaeger Operator and cert-manager")
-
-		if crdExists(conf, "certificates.cert-manager.io") {
-			ui.Println(ui.Green("✔ cert-manager ready"))
-		} else {
-			ui.Println(ui.Red("✘ cert-manager not available"))
-			installCertManager = ui.Confirm("Do you want me to install it?", false)
-			if !installCertManager {
-				ui.Exit("cert-manager is requried to run the Jaeger Operator. Check the docs at https://cert-manager.io/. " + createIssueMsg)
-			}
-		}
-
-		if crdExists(conf, "jaegers.jaegertracing.io") {
-			ui.Println(ui.Green("✔ jaeger-operator ready"))
-		} else {
-			ui.Println(ui.Red("✘ jaeger-operator not available"))
-			installJaegerOperator = ui.Confirm("Do you want me to install it?", false)
-			if !installJaegerOperator {
-				ui.Exit("jaeger-operator is requried. Check the docs at https://www.jaegertracing.io/docs/latest/operator/. " + createIssueMsg)
-			}
-		}
-	}
-	conf.set("k8s.cert-manager.install", installCertManager)
-	conf.set("k8s.jaeger-operator.install", installJaegerOperator)
-
+	conf.set("k8s.ingress-host", "tracetest")
+	conf.set("k8s.expose", true)
 	return conf
 }
 
@@ -468,21 +371,7 @@ func helmChecker(ui cliUI.UI) {
 		return
 	}
 
-	ui.Warning("I didn't find helm in your system")
-	option := ui.Select("What do you want to do?", []cliUI.Option{
-		{"Install Helm", installHelm},
-		{"Fix it manually", exitOption(
-			"Check the helm install docs on https://helm.sh/docs/intro/install/",
-		)},
-	}, 0)
-
-	option.Fn(ui)
-
-	if commandExists("helm") {
-		ui.Println(ui.Green("✔ helm was successfully installed"))
-	} else {
-		ui.Exit(ui.Red("✘ helm could not be installed. Check output for errors. " + createIssueMsg))
-	}
+	ui.Exit("I didn't find helm in your system. Check the helm install docs on https://helm.sh/docs/intro/install/")
 }
 
 func kubectlChecker(ui cliUI.UI) {
@@ -491,49 +380,16 @@ func kubectlChecker(ui cliUI.UI) {
 		return
 	}
 
-	ui.Warning("I didn't find kubectl in your system")
-	option := ui.Select("What do you want to do?", []cliUI.Option{
-		{"Install Kubectl", installKubectl},
-		{"Fix it manually", exitOption(
-			"Check the kubectl install docs on https://kubernetes.io/docs/tasks/tools/#kubectl",
-		)},
-	}, 0)
-
-	option.Fn(ui)
-
-	if commandExists("kubectl") {
-		ui.Println(ui.Green("✔ kubectl was successfully installed"))
-	} else {
-		ui.Exit(ui.Red("✘ kubectl could not be installed. Check output for errors. " + createIssueMsg))
-	}
+	ui.Exit("I didn't find kubectl in your system")
 }
 
 func localEnvironmentChecker(ui cliUI.UI) {
-
 	option := ui.Select("Are you going to run it locally or in a remote cluster?", []cliUI.Option{
-		{"Locally", confirmLocalK8sRunning},
+		{"Locally", minikubeChecker},
 		{"Remote cluster", func(ui cliUI.UI) {}},
 	}, 0)
 
 	option.Fn(ui)
-}
-
-func confirmLocalK8sRunning(ui cliUI.UI) {
-	localK8sRunning := ui.Confirm("Do you have a local kubernentes running?", true)
-	if !localK8sRunning {
-		if isWindows() {
-			ui.Exit("You should have a kubernetes instance running before installing Tracetest. Try minikube (https://minikube.sigs.k8s.io/docs/start/)")
-		}
-
-		option := ui.Select("We can fix that:", []cliUI.Option{
-			{"Install minikube", minikubeChecker},
-			{"Fix manually", exitOption(
-				"Check the minikube install docs on https://minikube.sigs.k8s.io/docs/start/",
-			)},
-		}, 0)
-
-		option.Fn(ui)
-	}
 }
 
 func minikubeChecker(ui cliUI.UI) {
@@ -547,146 +403,5 @@ func minikubeChecker(ui cliUI.UI) {
 		return
 	}
 
-	installMinikube(ui)
-
-	if commandExists("minikube") {
-		ui.Println(ui.Green("✔ minikube was successfully installed"))
-	} else {
-		ui.Exit(ui.Red("✘ minikube could not be installed. Check output for errors. " + createIssueMsg))
-	}
-
-	if !commandExists("docker") {
-		ui.Warning("Docker is required to run your minikube instance")
-		dockerChecker(ui)
-	}
-}
-
-func installHelm(ui cliUI.UI) {
-	(cmd{
-		sudo:          true,
-		notConfirmMsg: "No worries, you can try installing helm manually. See https://helm.sh/docs/intro/install/",
-		installDocs:   "https://helm.sh/docs/intro/install/",
-		args:          map[string]string{},
-		apt: `
-			sudo apt update -y
-			sudo apt install -y curl gpg
-
-			curl https://baltocdn.com/helm/signing.asc | gpg --dearmor | sudo tee /usr/share/keyrings/helm.gpg > /dev/null
-			sudo apt-get install apt-transport-https --yes
-			echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/helm.gpg] https://baltocdn.com/helm/stable/debian/ all main" | sudo tee /etc/apt/sources.list.d/helm-stable-debian.list
-			sudo apt-get update
-			sudo apt-get install helm
-		`,
-		yum:      "sudo yum -y install helm",
-		dnf:      "sudo dnf -y install helm",
-		homebrew: "brew install helm",
-		macIntelChipManual: `
-			curl -fsSL -o get_helm.sh https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3
-			chmod 700 get_helm.sh
-			./get_helm.sh
-		`,
-		macAppleChipManual: `
-			curl -fsSL -o get_helm.sh https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3
-			chmod 700 get_helm.sh
-			./get_helm.sh
-		`,
-		windows: "choco install kubernetes-helm",
-		other:   "",
-	}).exec(ui)
-}
-
-func installKubectl(ui cliUI.UI) {
-	(cmd{
-		sudo:          true,
-		notConfirmMsg: "No worries, you can try installing kubectl manually. See https://kubernetes.io/docs/tasks/tools/#kubectl",
-		installDocs:   "https://kubernetes.io/docs/tasks/tools/#kubectl",
-		args:          map[string]string{},
-		apt: `
-			sudo apt-get update
-			sudo apt-get install -y ca-certificates curl apt-transport-https
-
-			sudo curl -fsSLo /usr/share/keyrings/kubernetes-archive-keyring.gpg https://packages.cloud.google.com/apt/doc/apt-key.gpg
-			echo "deb [signed-by=/usr/share/keyrings/kubernetes-archive-keyring.gpg] https://apt.kubernetes.io/ kubernetes-xenial main" | sudo tee /etc/apt/sources.list.d/kubernetes.list
-
-			sudo apt-get update
-			sudo apt-get install -y kubectl
-		`,
-		yum: `
-cat <<EOF > /etc/yum.repos.d/kubernetes.repo
-[kubernetes]
-name=Kubernetes
-baseurl=https://packages.cloud.google.com/yum/repos/kubernetes-el7-\$basearch
-enabled=1
-gpgcheck=1
-gpgkey=https://packages.cloud.google.com/yum/doc/yum-key.gpg https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg
-EOF
-sudo yum -y install kubectl
-		`,
-		dnf: `
-cat <<EOF > /etc/yum.repos.d/kubernetes.repo
-[kubernetes]
-name=Kubernetes
-baseurl=https://packages.cloud.google.com/yum/repos/kubernetes-el7-\$basearch
-enabled=1
-gpgcheck=1
-gpgkey=https://packages.cloud.google.com/yum/doc/yum-key.gpg https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg
-EOF
-sudo dnf -y install kubectl
-		`,
-		homebrew: "brew install helm",
-		macIntelChipManual: `
-			curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/darwin/amd64/kubectl"
-			chmod +x ./kubectl
-			sudo mv ./kubectl /usr/local/bin/kubectl
-			sudo chown root: /usr/local/bin/kubectl
-		`,
-		macAppleChipManual: `
-			curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/darwin/arm64/kubectl"
-			chmod +x ./kubectl
-			sudo mv ./kubectl /usr/local/bin/kubectl
-			sudo chown root: /usr/local/bin/kubectl
-		`,
-		windows: "choco install kubernetes-cli",
-		other:   "",
-	}).exec(ui)
-}
-
-func installMinikube(ui cliUI.UI) {
-	(cmd{
-		sudo:          true,
-		notConfirmMsg: "No worries, you can try installing minikube manually. See https://minikube.sigs.k8s.io/docs/start/",
-		installDocs:   "https://minikube.sigs.k8s.io/docs/start/",
-		args: map[string]string{
-			"Architecture":    detectArchitecture(),
-			"RpmArchitecture": strings.Replace(detectArchitecture(), "amd64", "x86_64", 1),
-		},
-		apt: `
-			sudo apt update
-			sudo apt install curl -y
-			curl -LO https://storage.googleapis.com/minikube/releases/latest/minikube_latest_{{.Architecture}}.deb
-			sudo dpkg -i minikube_latest_{{.Architecture}}.deb
-			rm minikube_latest_{{.Architecture}}.deb
-		`,
-		yum: `
-			curl -LO https://storage.googleapis.com/minikube/releases/latest/minikube-latest.{{.RpmArchitecture}}.rpm
-			sudo rpm -Uvh minikube-latest.{{.RpmArchitecture}}.rpm
-			rm minikube-latest.{{.RpmArchitecture}}.rpm
-		`,
-		dnf: `
-			curl -LO https://storage.googleapis.com/minikube/releases/latest/minikube-latest.{{.RpmArchitecture}}.rpm
-			sudo rpm -Uvh minikube-latest.{{.RpmArchitecture}}.rpm
-			rm minikube-latest.{{.RpmArchitecture}}.rpm
-		`,
-		homebrew: "brew install minikube",
-		macIntelChipManual: `
-			curl -LO https://storage.googleapis.com/minikube/releases/latest/minikube-darwin-amd64
-			sudo install minikube-darwin-amd64 /usr/local/bin/minikube
-		`,
-		macAppleChipManual: `
-			curl -LO https://storage.googleapis.com/minikube/releases/latest/minikube-darwin-arm64
-			sudo install minikube-darwin-arm64 /usr/local/bin/minikube
-		`,
-		windows: "",
-		other:   "",
-	}).exec(ui)
+	ui.Exit(ui.Red("✘ minikube could not be installed. Check output for errors. " + createIssueMsg))
 }

--- a/cli/installer/kubernetes.go
+++ b/cli/installer/kubernetes.go
@@ -8,6 +8,7 @@ import (
 	"regexp"
 	"strings"
 
+	cliConfig "github.com/kubeshop/tracetest/cli/config"
 	cliUI "github.com/kubeshop/tracetest/cli/ui"
 )
 
@@ -159,6 +160,10 @@ func installTracetestChart(conf configuration, ui cliUI.UI) {
 	cmd := []string{
 		"upgrade --install tracetest kubeshop/tracetest",
 		"--namespace " + conf.String("k8s.namespace") + " --create-namespace",
+	}
+
+	if cliConfig.Version == "dev" {
+		cmd = append(cmd, "--set image.tag=latest")
 	}
 
 	execCmd(helmCmd(conf, cmd...), ui)

--- a/cli/installer/kubernetes.go
+++ b/cli/installer/kubernetes.go
@@ -343,19 +343,25 @@ func configureKubernetes(conf configuration, ui cliUI.UI) configuration {
 		)
 	}
 
-	options := []cliUI.Option{}
-	defaultIndex := 0
-	for i, c := range contexts {
-		if c.selected {
-			defaultIndex = i
-		}
-		options = append(options, cliUI.Option{Text: c.name, Fn: func(ui cliUI.UI) {}})
+	if len(contexts) == 1 {
+		conf.set("k8s.context", contexts[0].name)
 	}
 
-	selected := ui.Select("Kubectl context", options, defaultIndex)
-	conf.set("k8s.context", selected.Text)
-	conf.set("k8s.namespace", "tracetest")
+	if len(contexts) > 1 {
+		options := []cliUI.Option{}
+		defaultIndex := 0
+		for i, c := range contexts {
+			if c.selected {
+				defaultIndex = i
+			}
+			options = append(options, cliUI.Option{Text: c.name, Fn: func(ui cliUI.UI) {}})
+		}
 
+		selected := ui.Select("Kubectl context", options, defaultIndex)
+		conf.set("k8s.context", selected.Text)
+	}
+
+	conf.set("k8s.namespace", "tracetest")
 	return conf
 }
 

--- a/cli/installer/kubernetes.go
+++ b/cli/installer/kubernetes.go
@@ -190,7 +190,7 @@ func helmCmd(config configuration, cmd ...string) string {
 }
 
 const (
-	collectorYaml = "https://raw.githubusercontent.com/kubeshop/tracetest/1630-in-app-config-installer-changes/k8s/collector.yml"
+	collectorYaml = "https://raw.githubusercontent.com/kubeshop/tracetest/main/k8s/collector.yml"
 
 	demoScript = `
 tmpdir=$(mktemp -d)

--- a/cli/installer/kubernetes.go
+++ b/cli/installer/kubernetes.go
@@ -190,7 +190,7 @@ func helmCmd(config configuration, cmd ...string) string {
 }
 
 const (
-	collectorYaml = "https://raw.githubusercontent.com/kubeshop/tracetest/main/k8s/collector.yml"
+	collectorYaml = "https://raw.githubusercontent.com/kubeshop/tracetest/1630-in-app-config-installer-changes/k8s/collector.yml"
 
 	demoScript = `
 tmpdir=$(mktemp -d)

--- a/cli/installer/tracetest.go
+++ b/cli/installer/tracetest.go
@@ -53,11 +53,13 @@ func configureBackend(conf configuration, ui cliUI.UI) configuration {
 		case "docker-compose":
 			conf.set("tracetest.backend.type", "otlp")
 			conf.set("tracetest.backend.tls.insecure", true)
-			conf.set("tracetest.backend.endpoint.collector", "tracetest:21321")
+			conf.set("tracetest.backend.endpoint.collector", "otel-collector:21321")
+			conf.set("tracetest.backend.endpoint", "tracetest:21321")
 		case "kubernetes":
 			conf.set("tracetest.backend.type", "otlp")
 			conf.set("tracetest.backend.tls.insecure", true)
-			conf.set("tracetest.backend.endpoint.collector", "tracetest:21321")
+			conf.set("tracetest.backend.endpoint.collector", "otel-collector.tracetest:4317")
+			conf.set("tracetest.backend.endpoint", "tracetest:21321")
 
 		default:
 			conf.set("tracetest.backend.type", "")

--- a/cli/installer/tracetest.go
+++ b/cli/installer/tracetest.go
@@ -12,17 +12,8 @@ import (
 )
 
 func configureDemoApp(conf configuration, ui cliUI.UI) configuration {
-	conf.set(
-		"demo.enable.pokeshop",
-		ui.Confirm("Do you want to enable the PokeShop demo app? (https://github.com/kubeshop/pokeshop/)", true),
-	)
-
+	conf.set("demo.enable.pokeshop", !conf.Bool("installer.only_tracetest"))
 	conf.set("demo.enable.otel", false)
-	// TODO: enable this
-	// conf.set(
-	// 	"demo.enable.otel",
-	// 	ui.Confirm("Do you want to enable the OpenTelemetry Community Demo app? (https://github.com/open-telemetry/opentelemetry-demo)", true),
-	// )
 
 	switch conf.String("installer") {
 	case "docker-compose":
@@ -46,107 +37,36 @@ func configureDemoApp(conf configuration, ui cliUI.UI) configuration {
 
 func configureTracetest(conf configuration, ui cliUI.UI) configuration {
 	conf = configureBackend(conf, ui)
-	conf = configureCollector(conf, ui)
+	conf.set("tracetest.analytics", true)
 
-	conf.set(
-		"tracetest.analytics",
-		ui.Confirm("Do you want to help improve tracetest by providing anonymous analytics information?", true),
-	)
-
-	return conf
-}
-func configureCollector(conf configuration, ui cliUI.UI) configuration {
-	installCollector := false
-
-	hasCollector := ui.Confirm("Do you have an OpenTelemetry Collector?", false)
-	if hasCollector {
-		conf.set("tracetest.collector.endpoint", ui.TextInput("Endpoint", "otel-collector:4317"))
-	} else {
-		if !ui.Confirm("Do you want me to set up one?", true) {
-			ui.Exit(`
-TraceTest requires OpenTelemetry Collector to work. You can rerun this installer and let me set it up for you,
-or you can set one up manually. See https://opentelemetry.io/docs/collector/
-`)
-		}
-		installCollector = true
-
-		// default values
-		conf.set("tracetest.collector.endpoint", "otel-collector:4317")
-	}
-
-	conf.set("tracetest.collector.install", installCollector)
 	return conf
 }
 
 func configureBackend(conf configuration, ui cliUI.UI) configuration {
-	installBackend := false
+	installBackend := !conf.Bool("installer.only_tracetest")
+	conf.set("tracetest.backend.install", installBackend)
 
-	hasBackend := ui.Confirm("Do you have a supported tracing backend you want to use? (Jaeger, Tempo, OpenSearch, SignalFX)", false)
-	if hasBackend {
-		conf = configureBackendOptions(conf, ui)
-	} else {
-		if !ui.Confirm("Do you want me to set up Jaeger?", true) {
-			ui.Exit(`
-TraceTest requires a supported tracing backend to work. I only know how to install Jaeger.
-If you want to use other option, check the supported backends and manually install one.
-See https://kubeshop.github.io/tracetest/supported-backends/
-			`)
-		}
-		installBackend = true
+	if installBackend {
 
 		// default values
 		switch conf.String("installer") {
 		case "docker-compose":
-			conf.set("tracetest.backend.type", "jaeger")
-			conf.set("tracetest.backend.endpoint.query", "jaeger:16685")
-			conf.set("tracetest.backend.endpoint.collector", "jaeger:14250")
-			conf.set("tracetest.backend.endpoint.agent", "jaeger")
+			conf.set("tracetest.backend.type", "otlp")
 			conf.set("tracetest.backend.tls.insecure", true)
+			conf.set("tracetest.backend.endpoint.collector", "tracetest:21321")
 		case "kubernetes":
-			conf.set("tracetest.backend.type", "jaeger")
-			conf.set("tracetest.backend.endpoint.query", "jaeger-query:16685")
-			conf.set("tracetest.backend.endpoint.collector", "jaeger-collector:14250")
+			conf.set("tracetest.backend.type", "otlp")
 			conf.set("tracetest.backend.tls.insecure", true)
-			conf.set("tracetest.backend.endpoint.agent", "jaeger-agent."+conf.String("k8s.namespace"))
+			conf.set("tracetest.backend.endpoint.collector", "tracetest:21321")
+
+		default:
+			conf.set("tracetest.backend.type", "")
 		}
 
+		return conf
 	}
 
-	conf.set("tracetest.backend.install", installBackend)
-
-	return conf
-}
-
-func configureBackendOptions(conf configuration, ui cliUI.UI) configuration {
-	option := ui.Select("Which tracing backend do you want to use?", []cliUI.Option{
-		{"Jaeger", func(ui cliUI.UI) {
-			conf.set("tracetest.backend.type", "jaeger")
-			conf.set("tracetest.backend.endpoint.query", ui.TextInput("Query Endpoint", "jaeger:16685"))
-			conf.set("tracetest.backend.endpoint.collector", ui.TextInput("Collector Endpoint", "jaeger:14250"))
-			conf.set("tracetest.backend.endpoint.exporter", "")
-			conf.set("tracetest.backend.tls.insecure", ui.Confirm("TLS/Insecure", true))
-		}},
-		{"Tempo", func(ui cliUI.UI) {
-			conf.set("tracetest.backend.type", "tempo")
-			conf.set("tracetest.backend.endpoint", ui.TextInput("Endpoint", "tempo:9095"))
-			conf.set("tracetest.backend.tls.insecure", ui.Confirm("Insecure", true))
-		}},
-		{"OpenSearch", func(ui cliUI.UI) {
-			conf.set("tracetest.backend.type", "opensearch")
-			conf.set("tracetest.backend.addresses", ui.TextInput("Addresses (comma separated list)", "http://opensearch:9200"))
-			conf.set("tracetest.backend.index", ui.TextInput("Index", "traces"))
-			conf.set("tracetest.backend.data-prepper.endpoint", ui.TextInput("Data Prepper Endpont", "data-prepper:21890"))
-			conf.set("tracetest.backend.data-prepper.insecure", ui.Confirm("Insecure", true))
-		}},
-		{"SignalFX", func(ui cliUI.UI) {
-			conf.set("tracetest.backend.type", "signalfx")
-			conf.set("tracetest.backend.token", ui.TextInput("Token", ""))
-			conf.set("tracetest.backend.realm", ui.TextInput("Realm", "us1"))
-		}},
-	}, 0)
-
-	option.Fn(ui)
-
+	conf.set("tracetest.backend.type", "")
 	return conf
 }
 
@@ -163,12 +83,13 @@ func getTracetestConfigFileContents(psql string, ui cliUI.UI, config configurati
 	}
 
 	sc.Telemetry = telemetryConfig(ui, config)
-	sc.Server = serverConfig.ServerConfig{
-		Telemetry: serverConfig.ServerTelemetryConfig{
-			Exporter:            "collector",
-			ApplicationExporter: "collector",
-			DataStore:           config.String("tracetest.backend.type"),
-		},
+
+	if config.Bool("tracetest.backend.install") {
+		sc.Server = serverConfig.ServerConfig{
+			Telemetry: serverConfig.ServerTelemetryConfig{
+				DataStore: config.String("tracetest.backend.type"),
+			},
+		}
 	}
 
 	enabledDemos := []string{}
@@ -196,9 +117,11 @@ func getTracetestConfigFileContents(psql string, ui cliUI.UI, config configurati
 		ui.Exit(fmt.Errorf("cannot marshal tracetest config file: %w", err).Error())
 	}
 
-	out, err = fixConfigs(out)
-	if err != nil {
-		ui.Exit(fmt.Errorf("cannot fix tracertest config: %w", err).Error())
+	if config.Bool("tracetest.backend.install") {
+		out, err = fixConfigs(out)
+		if err != nil {
+			ui.Exit(fmt.Errorf("cannot fix tracertest config: %w", err).Error())
+		}
 	}
 
 	return out
@@ -239,27 +162,19 @@ func fixConfigs(conf []byte) ([]byte, error) {
 }
 
 func telemetryConfig(ui cliUI.UI, conf configuration) serverConfig.Telemetry {
+	if conf.Bool("tracetest.backend.install") {
+		return serverConfig.Telemetry{
+			DataStores: dataStoreConfig(ui, conf),
+			Exporters:  map[string]serverConfig.TelemetryExporterOption{},
+		}
+	}
+
 	return serverConfig.Telemetry{
-		DataStores: dataStoreConfig(ui, conf),
-		Exporters:  exportersConfig(ui, conf),
+		DataStores: map[string]serverConfig.TracingBackendDataStoreConfig{},
+		Exporters:  map[string]serverConfig.TelemetryExporterOption{},
 	}
 }
 
-func exportersConfig(ui cliUI.UI, conf configuration) map[string]serverConfig.TelemetryExporterOption {
-	return map[string]serverConfig.TelemetryExporterOption{
-		"collector": {
-			ServiceName: "tracetest",
-			Sampling:    100,
-			Exporter: serverConfig.ExporterConfig{
-				Type: "collector",
-				CollectorConfiguration: serverConfig.OTELCollectorConfig{
-					Endpoint: conf.String("tracetest.collector.endpoint"),
-				},
-			},
-		},
-	}
-
-}
 func dataStoreConfig(ui cliUI.UI, conf configuration) map[string]serverConfig.TracingBackendDataStoreConfig {
 	dstype := conf.String("tracetest.backend.type")
 	var c serverConfig.TracingBackendDataStoreConfig
@@ -299,6 +214,10 @@ func dataStoreConfig(ui cliUI.UI, conf configuration) map[string]serverConfig.Tr
 				Token: conf.String("tracetest.backend.token"),
 				Realm: conf.String("tracetest.backend.realm"),
 			},
+		}
+	case "otlp":
+		c = serverConfig.TracingBackendDataStoreConfig{
+			Type: dstype,
 		}
 	default:
 		ui.Panic(fmt.Errorf("unsupported dataStore type %s", dstype))

--- a/cli/installer/tracetest.go
+++ b/cli/installer/tracetest.go
@@ -53,12 +53,12 @@ func configureBackend(conf configuration, ui cliUI.UI) configuration {
 		case "docker-compose":
 			conf.set("tracetest.backend.type", "otlp")
 			conf.set("tracetest.backend.tls.insecure", true)
-			conf.set("tracetest.backend.endpoint.collector", "otel-collector:21321")
+			conf.set("tracetest.backend.endpoint.collector", "http://otel-collector:4317")
 			conf.set("tracetest.backend.endpoint", "tracetest:21321")
 		case "kubernetes":
 			conf.set("tracetest.backend.type", "otlp")
 			conf.set("tracetest.backend.tls.insecure", true)
-			conf.set("tracetest.backend.endpoint.collector", "otel-collector.tracetest:4317")
+			conf.set("tracetest.backend.endpoint.collector", "http://otel-collector.tracetest:4317")
 			conf.set("tracetest.backend.endpoint", "tracetest:21321")
 
 		default:

--- a/cli/installer/windows.go
+++ b/cli/installer/windows.go
@@ -10,15 +10,6 @@ func isWindows() bool {
 	return runtime.GOOS == "windows"
 }
 
-func installChocolatey(ui cliUI.UI) {
-	(cmd{
-		sudo:          true,
-		notConfirmMsg: "No worries. You can try installing Chocolatey manually. See https://chocolatey.org/install#individual",
-		installDocs:   "https://chocolatey.org/install#individual",
-		windows:       "Set-ExecutionPolicy Bypass -Scope Process -Force; [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072; iex ((New-Object System.Net.WebClient).DownloadString('https://community.chocolatey.org/install.ps1'))",
-	}).exec(ui)
-}
-
 func chocolateyForWindowsChecker(ui cliUI.UI) {
 	if !isWindows() {
 		return
@@ -30,22 +21,9 @@ func chocolateyForWindowsChecker(ui cliUI.UI) {
 	}
 
 	ui.Warning("I didn't find chocolatey in your system")
-	option := ui.Select("What do you want to do?", []cliUI.Option{
-		{"Install Chocolatey", installChocolatey},
-		{"Fix manually", exitOption(
-			"Check the chocolatey install docs on https://chocolatey.org/install#individual",
-		)},
-	}, 0)
-
-	option.Fn(ui)
-
-	refreshEnvVariables()
-
-	if commandExists("choco.exe") {
-		ui.Println(ui.Green("✔ chocolatey was successfully installed"))
-	} else {
-		ui.Exit(ui.Red("✘ chocolatey could not be installed. Check output for errors. " + createIssueMsg))
-	}
+	exitOption(
+		"Check the chocolatey install docs on https://chocolatey.org/install#individual",
+	)(ui)
 }
 
 func wslChecker(ui cliUI.UI) {

--- a/examples/collector/collector.config.yaml
+++ b/examples/collector/collector.config.yaml
@@ -30,5 +30,5 @@ service:
   pipelines:
     traces/1:
       receivers: [otlp]
-      processors: [batch]
+      processors: [tail_sampling, batch]
       exporters: [otlp/1]

--- a/examples/collector/collector.config.yaml
+++ b/examples/collector/collector.config.yaml
@@ -30,5 +30,5 @@ service:
   pipelines:
     traces/1:
       receivers: [otlp]
-      processors: [tail_sampling, batch]
+      processors: [batch]
       exporters: [otlp/1]

--- a/k8s/collector.yml
+++ b/k8s/collector.yml
@@ -52,7 +52,7 @@ spec:
         - name: otelcol
           args:
             - --config=/conf/collector.yaml
-          image: otel/opentelemetry-collector:0.67.0
+          image: otel/opentelemetry-collector-contrib:0.67.0
           volumeMounts:
             - mountPath: /conf
               name: collector-config

--- a/k8s/collector.yml
+++ b/k8s/collector.yml
@@ -34,7 +34,6 @@ data:
           processors: [probabilistic_sampler, batch]
           exporters: [jaeger, otlphttp]
 ---
-
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -50,32 +49,31 @@ spec:
         app.kubernetes.io/name: otel-collector
     spec:
       containers:
-      - name: otelcol
-        args:
-        - --config=/conf/collector.yaml
-        image: otel/opentelemetry-collector:0.54.0
-        volumeMounts:
-        - mountPath: /conf
-          name: collector-config
+        - name: otelcol
+          args:
+            - --config=/conf/collector.yaml
+          image: otel/opentelemetry-collector:0.67.0
+          volumeMounts:
+            - mountPath: /conf
+              name: collector-config
       volumes:
-      - configMap:
-          items:
-          - key: collector.yaml
-            path: collector.yaml
+        - configMap:
+            items:
+              - key: collector.yaml
+                path: collector.yaml
+            name: collector-config
           name: collector-config
-        name: collector-config
 ---
-
 apiVersion: v1
 kind: Service
 metadata:
   name: otel-collector
 spec:
   ports:
-  - name: grpc-otlp
-    port: 4317
-    protocol: TCP
-    targetPort: 4317
+    - name: grpc-otlp
+      port: 4317
+      protocol: TCP
+      targetPort: 4317
   selector:
     app.kubernetes.io/name: otel-collector
   type: ClusterIP


### PR DESCRIPTION
This PR removes much of the installer logic to just center on installing tracetest and its immediate dependencies.

There are two new branches, one for the express install where only tracetest + Postgres are installed
And a second option includes the pokeshop app plus the otel collector.

## Changes

- Removed automatic install for heml, minikube, docker, docker compose, etc.
- Only two main branches when installing.

## Fixes

- #1630 

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

Docker compose
https://www.loom.com/share/3050548a668b4add96d77f0528350ef0

Kubernetes
https://www.loom.com/share/479305e6b30a418c8765a98ab5e8c813
