### PR TITLE
chore: reuse cli build on pr pipeline

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -49,12 +49,13 @@ jobs:
       run: |
         cd cli
         make build
-    - name: Archive CLI binary``
+    - name: Archive CLI binary
       uses: actions/upload-artifact@v3
       with:
         retention-days: 1
         name: cli-binary
-        path: ./dist/tracetest
+        path: ./cli/dist/tracetest
+        if-no-files-found: error
 
   unit-test-backend:
     name: Run backend unit tests

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -311,7 +311,7 @@ jobs:
 
   cleanup:
     runs-on: ubuntu-latest
-    needs: [trace-testing, e2e, deploy]
+    needs: [trace-testing, e2e]
     if: always()
     steps:
       - uses: google-github-actions/setup-gcloud@94337306dda8180d967a56932ceb4ddcf01edae7

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -304,7 +304,6 @@ jobs:
 
       - name: Run integration tests
         run: |
-          chmod +x ./tracetest
           cd tracetesting
           TRACETEST_CLI="/tmp/tracetest-main/cli/dist/tracetest" \
           TARGET_URL="http://tracetest-pr-${{ github.event.pull_request.number }}.tracetest-pr-${{ github.event.pull_request.number }}:11633" \

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -33,6 +33,29 @@ jobs:
           cd cli/
           make test
 
+  build-cli:
+    needs:  [unit-test-cli]
+    name: Build and save CLI
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+    - name: Setup go
+      uses: actions/setup-go@v3
+      with:
+        go-version: '^1.18'
+    - name: Build CLI
+      run: |
+        cd cli
+        make build
+    - name: Archive CLI binary``
+      uses: actions/upload-artifact@v3
+      with:
+        retention-days: 1
+        name: cli-binary
+        path: ./dist/tracetest
+
   unit-test-backend:
     name: Run backend unit tests
     runs-on: ubuntu-latest
@@ -131,7 +154,7 @@ jobs:
         mv /tmp/.buildx-cache-new /tmp/.buildx-cache
 
   test-examples:
-    needs:  [build-docker]
+    needs:  [build-docker, build-cli]
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -140,23 +163,19 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-      - name: Setup go
-        uses: actions/setup-go@v3
-        with:
-          go-version: '^1.18'
-      - name: Build example
+      - name: Start example
         run: |
           cd examples/${{ matrix.example_dir }}
           TAG=pr-${{ github.event.pull_request.number }} docker-compose up -d
-      - name: Build CLI
-        run: |
-          cd cli
-          make build
-          ./dist/tracetest configure -g --endpoint http://localhost:11633 --analytics=false
+      - name: Download CLI binary
+        uses: actions/download-artifact@v3
+        with:
+          name: cli-binary
       - name: Run example test
         run: |
           ./scripts/wait-for-port.sh 11633
-          ./cli/dist/tracetest test run -d examples/${{ matrix.example_dir }}/tests/list-tests.yaml --wait-for-result
+          ./tracetest configure -g --endpoint http://localhost:11633 --analytics=false
+          ./tracetest test run -d examples/${{ matrix.example_dir }}/tests/list-tests.yaml --wait-for-result
 
   deploy:
     needs:  [unit-test-frontend, unit-test-backend, unit-test-cli, build-docker]
@@ -248,7 +267,7 @@ jobs:
           CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
 
   trace-testing:
-    needs: deploy
+    needs: [deploy, build-cli]
     name: Run trace testing using tracetest
     runs-on: ubuntu-latest
 
@@ -269,6 +288,11 @@ jobs:
           cluster_name: ${{ secrets.GKE_CLUSTER }}
           location: ${{ secrets.GKE_ZONE }}
           credentials: ${{ secrets.GKE_SA_KEY }}
+
+      - name: Download CLI binary
+        uses: actions/download-artifact@v3
+        with:
+          name: cli-binary
 
       - name: Install CLI integration version (latest main)
         run: |

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -175,6 +175,7 @@ jobs:
       - name: Run example test
         run: |
           ./scripts/wait-for-port.sh 11633
+          chmod +x ./tracetest
           ./tracetest configure -g --endpoint http://localhost:11633 --analytics=false
           ./tracetest test run -d examples/${{ matrix.example_dir }}/tests/list-tests.yaml --wait-for-result
 
@@ -308,6 +309,7 @@ jobs:
 
       - name: Run integration tests
         run: |
+          chmod +x ./tracetest
           cd tracetesting
           TRACETEST_CLI="/tmp/tracetest-main/cli/dist/tracetest" \
           TARGET_URL="http://tracetest-pr-${{ github.event.pull_request.number }}.tracetest-pr-${{ github.event.pull_request.number }}:11633" \

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -269,7 +269,7 @@ jobs:
           CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
 
   trace-testing:
-    needs: [deploy, build-cli]
+    needs: [deploy]
     name: Run trace testing using tracetest
     runs-on: ubuntu-latest
 
@@ -290,11 +290,6 @@ jobs:
           cluster_name: ${{ secrets.GKE_CLUSTER }}
           location: ${{ secrets.GKE_ZONE }}
           credentials: ${{ secrets.GKE_SA_KEY }}
-
-      - name: Download CLI binary
-        uses: actions/download-artifact@v3
-        with:
-          name: cli-binary
 
       - name: Install CLI integration version (latest main)
         run: |
@@ -317,7 +312,7 @@ jobs:
 
   cleanup:
     runs-on: ubuntu-latest
-    needs: [trace-testing, e2e]
+    needs: [trace-testing, e2e, deploy]
     if: always()
     steps:
       - uses: google-github-actions/setup-gcloud@94337306dda8180d967a56932ceb4ddcf01edae7


### PR DESCRIPTION
This PR archives the CLI build so it's not neccesary to rebuilt it on every step that needs to use the cli

## Checklist

- [ ] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
