### PR TITLE
fix(frontend): fix data store confirmation message

### DIFF
--- a/web/src/components/Settings/DataStorePlugin/forms/GrpcClient/GrpcClient.tsx
+++ b/web/src/components/Settings/DataStorePlugin/forms/GrpcClient/GrpcClient.tsx
@@ -1,7 +1,6 @@
 import {Checkbox, Col, Form, Input, Row, Select, Space, Switch} from 'antd';
 import {useState} from 'react';
 
-import RequestDetailsAuthInput from 'components/CreateTestPlugins/Rest/steps/RequestDetails/RequestDetailsAuthInput/RequestDetailsAuthInput';
 import RequestDetailsHeadersInput from 'components/CreateTestPlugins/Rest/steps/RequestDetails/RequestDetailsHeadersInput';
 import {TDraftDataStore} from 'types/Config.types';
 import * as S from './GrcpClient.styled';
@@ -79,9 +78,6 @@ const GrpcClient = () => {
       </Row>
 
       <Row gutter={[16, 16]}>
-        <Col span={12}>
-          <RequestDetailsAuthInput hasBaseApikeyFields name={[...baseName, 'auth']} />
-        </Col>
         <Col span={12}>
           <RequestDetailsHeadersInput initialValue={HEADER_DEFAULT_VALUES} name={[...baseName, 'rawHeaders']} />
         </Col>

--- a/web/src/providers/DataStore/hooks/useDataStoreNotification.tsx
+++ b/web/src/providers/DataStore/hooks/useDataStoreNotification.tsx
@@ -4,13 +4,13 @@ import {useTheme} from 'styled-components';
 import {SupportedDataStores, TConnectionResult} from 'types/Config.types';
 import TestConnectionNotification from 'components/TestConnectionNotification/TestConnectionNotification';
 
-const useTestConnectionNotification = () => {
+const useDataStoreNotification = () => {
   const [api, contextHolder] = notification.useNotification();
   const {
     notification: {success, error},
   } = useTheme();
 
-  const showNotification = useCallback(
+  const showTestConnectionNotification = useCallback(
     (result: TConnectionResult, dataStoreType: SupportedDataStores) => {
       if (dataStoreType === SupportedDataStores.OtelCollector) {
         return api.info({
@@ -40,7 +40,15 @@ const useTestConnectionNotification = () => {
     [api, error, success]
   );
 
-  return {showNotification, contextHolder};
+  const showSuccessNotification = useCallback(() => {
+    return api.success({
+      message: 'Data Store saved',
+      description: 'Your configuration was added',
+      ...success,
+    });
+  }, [api, success]);
+
+  return {contextHolder, showSuccessNotification, showTestConnectionNotification};
 };
 
-export default useTestConnectionNotification;
+export default useDataStoreNotification;


### PR DESCRIPTION
This PR updates the data store confirmation message to remove the `restart server` warning. It also adds a success notification when saving a data store.

## Changes

- Updates data store confirmation message
- Add success notification when saving a data store

## Fixes

-

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Screenshots

![Screenshot 2022-12-21 at 14 34 24](https://user-images.githubusercontent.com/3879892/208989198-446c337f-1a72-4913-ad5c-8b54f7b617d0.png)
![Screenshot 2022-12-21 at 14 34 30](https://user-images.githubusercontent.com/3879892/208989201-f35716d1-f8da-4364-a353-1fbc1ecb64b3.png)