### PR TITLE
feat: create/update/list data stores via CLI

### DIFF
--- a/cli/actions/apply_datastore_action.go
+++ b/cli/actions/apply_datastore_action.go
@@ -1,0 +1,98 @@
+package actions
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/fluidtruck/deepcopy"
+	"github.com/kubeshop/tracetest/cli/file"
+	"github.com/kubeshop/tracetest/cli/openapi"
+	"go.uber.org/zap"
+)
+
+type ApplyDataStoreConfig struct {
+	File string
+}
+
+type applyDataStoreAction struct {
+	logger *zap.Logger
+	client *openapi.APIClient
+}
+
+var _ Action[ApplyDataStoreConfig] = &applyDataStoreAction{}
+
+func NewApplyDataStoreAction(logger *zap.Logger, client *openapi.APIClient) applyDataStoreAction {
+	return applyDataStoreAction{
+		logger: logger,
+		client: client,
+	}
+}
+
+func (a applyDataStoreAction) Run(ctx context.Context, args ApplyDataStoreConfig) error {
+	if args.File == "" {
+		return fmt.Errorf("you must specify a file to be applied")
+	}
+
+	a.logger.Debug(
+		"applying data store",
+		zap.String("file", args.File),
+	)
+
+	fileContent, err := file.Read(args.File)
+	if err != nil {
+		return fmt.Errorf("could not read file: %w", err)
+	}
+
+	if fileContent.Definition().Type != "DataStore" {
+		return fmt.Errorf(`file must be of type "DataStore"`)
+	}
+
+	var dataStore openapi.DataStore
+	deepcopy.DeepCopy(fileContent.Definition().Spec, &dataStore)
+
+	if dataStore.Id == nil || *dataStore.Id == "" {
+		err := a.createDataStore(ctx, fileContent, dataStore)
+		if err != nil {
+			return err
+		}
+	} else {
+		err := a.updateDataStore(ctx, fileContent, dataStore)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (a applyDataStoreAction) createDataStore(ctx context.Context, file file.File, dataStore openapi.DataStore) error {
+	req := a.client.ApiApi.CreateDataStore(ctx)
+	req = req.DataStore(dataStore)
+	createdDataStore, _, err := a.client.ApiApi.CreateDataStoreExecute(req)
+	if err != nil {
+		return fmt.Errorf("could not create data store: %w", err)
+	}
+
+	f, err := file.SetID(*createdDataStore.Id)
+	if err != nil {
+		return fmt.Errorf("could no set data store id: %w", err)
+	}
+
+	_, err = f.Write()
+	if err != nil {
+		return fmt.Errorf("could not write to data store file: %w", err)
+	}
+
+	return nil
+}
+
+func (a applyDataStoreAction) updateDataStore(ctx context.Context, file file.File, dataStore openapi.DataStore) error {
+	req := a.client.ApiApi.UpdateDataStore(ctx, *dataStore.Id)
+	req = req.DataStore(dataStore)
+	_, err := a.client.ApiApi.UpdateDataStoreExecute(req)
+	if err != nil {
+		return fmt.Errorf("could not update data store: %w", err)
+	}
+
+	return nil
+}

--- a/cli/actions/list_datastore_action.go
+++ b/cli/actions/list_datastore_action.go
@@ -1,0 +1,42 @@
+package actions
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/kubeshop/tracetest/cli/config"
+	"github.com/kubeshop/tracetest/cli/formatters"
+	"github.com/kubeshop/tracetest/cli/openapi"
+	"go.uber.org/zap"
+)
+
+type ListDataStoreConfig struct{}
+
+type listDataStoreAction struct {
+	config config.Config
+	logger *zap.Logger
+	client *openapi.APIClient
+}
+
+var _ Action[ListDataStoreConfig] = &listDataStoreAction{}
+
+func NewListDataStoreAction(config config.Config, logger *zap.Logger, client *openapi.APIClient) listDataStoreAction {
+	return listDataStoreAction{
+		logger: logger,
+		client: client,
+	}
+}
+
+func (a listDataStoreAction) Run(ctx context.Context, args ListDataStoreConfig) error {
+	req := a.client.ApiApi.GetDataStores(ctx)
+	dataStores, _, err := a.client.ApiApi.GetDataStoresExecute(req)
+	if err != nil {
+		return fmt.Errorf("could not list data stores: %w", err)
+	}
+
+	formatter := formatters.DataStoreList(a.config)
+	output := formatter.Format(dataStores)
+	fmt.Println(output)
+
+	return nil
+}

--- a/cli/cmd/datastore_apply_cmd.go
+++ b/cli/cmd/datastore_apply_cmd.go
@@ -1,0 +1,45 @@
+package cmd
+
+import (
+	"context"
+	"os"
+
+	"github.com/kubeshop/tracetest/cli/actions"
+	"github.com/kubeshop/tracetest/cli/analytics"
+	"github.com/spf13/cobra"
+	"go.uber.org/zap"
+)
+
+var dataStoreApplyFile string
+
+var dataStoreApplyCmd = &cobra.Command{
+	Use:    "apply",
+	Short:  "Apply data store configuration to your tracetest server",
+	Long:   "Apply data store configuration to your tracetest server",
+	PreRun: setupCommand(),
+	Run: func(cmd *cobra.Command, args []string) {
+		analytics.Track("Datastore Apply", "cmd", map[string]string{})
+
+		ctx := context.Background()
+		client := getAPIClient()
+
+		applyDataStoreAction := actions.NewApplyDataStoreAction(cliLogger, client)
+		actionArgs := actions.ApplyDataStoreConfig{
+			File: dataStoreApplyFile,
+		}
+
+		err := applyDataStoreAction.Run(ctx, actionArgs)
+		if err != nil {
+			cliLogger.Error("failed to run test", zap.Error(err))
+			os.Exit(1)
+			return
+		}
+
+	},
+	PostRun: teardownCommand,
+}
+
+func init() {
+	dataStoreApplyCmd.PersistentFlags().StringVarP(&dataStoreApplyFile, "file", "f", "", "--file my-datastore.yaml")
+	dataStoreCmd.AddCommand(dataStoreApplyCmd)
+}

--- a/cli/cmd/datastore_cmd.go
+++ b/cli/cmd/datastore_cmd.go
@@ -1,0 +1,25 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/kubeshop/tracetest/cli/analytics"
+	"github.com/spf13/cobra"
+)
+
+var dataStoreCmd = &cobra.Command{
+	Use:    "datastore",
+	Short:  "Manage your tracetest data stores",
+	Long:   "Manage your tracetest data stores",
+	PreRun: setupCommand(),
+	Run: func(cmd *cobra.Command, args []string) {
+		analytics.Track("Datastore", "cmd", map[string]string{})
+
+		fmt.Println("Manage your data stores")
+	},
+	PostRun: teardownCommand,
+}
+
+func init() {
+	rootCmd.AddCommand(dataStoreCmd)
+}

--- a/cli/cmd/datastore_list_cmd.go
+++ b/cli/cmd/datastore_list_cmd.go
@@ -1,0 +1,40 @@
+package cmd
+
+import (
+	"context"
+	"os"
+
+	"github.com/kubeshop/tracetest/cli/actions"
+	"github.com/kubeshop/tracetest/cli/analytics"
+	"github.com/spf13/cobra"
+	"go.uber.org/zap"
+)
+
+var dataStoreListCmd = &cobra.Command{
+	Use:    "list",
+	Short:  "List data store configurations to your tracetest server",
+	Long:   "List data store configurations to your tracetest server",
+	PreRun: setupCommand(),
+	Run: func(cmd *cobra.Command, args []string) {
+		analytics.Track("Datastore List", "cmd", map[string]string{})
+
+		ctx := context.Background()
+		client := getAPIClient()
+
+		applyDataStoreAction := actions.NewListDataStoreAction(cliConfig, cliLogger, client)
+		actionArgs := actions.ListDataStoreConfig{}
+
+		err := applyDataStoreAction.Run(ctx, actionArgs)
+		if err != nil {
+			cliLogger.Error("failed to run test", zap.Error(err))
+			os.Exit(1)
+			return
+		}
+
+	},
+	PostRun: teardownCommand,
+}
+
+func init() {
+	dataStoreCmd.AddCommand(dataStoreListCmd)
+}

--- a/cli/formatters/datastore_list.go
+++ b/cli/formatters/datastore_list.go
@@ -1,0 +1,76 @@
+package formatters
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/alexeyco/simpletable"
+	"github.com/kubeshop/tracetest/cli/config"
+	"github.com/kubeshop/tracetest/cli/openapi"
+)
+
+type dataStoreList struct {
+	config config.Config
+}
+
+func DataStoreList(config config.Config) dataStoreList {
+	return dataStoreList{
+		config: config,
+	}
+}
+
+func (f dataStoreList) Format(dataStores []openapi.DataStore) string {
+	switch CurrentOutput {
+	case Pretty:
+		return f.pretty(dataStores)
+	case JSON:
+		return f.json(dataStores)
+	}
+
+	return ""
+}
+
+func (f dataStoreList) json(dataStores []openapi.DataStore) string {
+	bytes, err := json.Marshal(dataStores)
+	if err != nil {
+		panic(fmt.Errorf("could not marshal output json: %w", err))
+	}
+
+	return string(bytes)
+}
+
+func (f dataStoreList) pretty(dataStores []openapi.DataStore) string {
+	if len(dataStores) == 0 {
+		return "No tests"
+	}
+
+	table := simpletable.New()
+
+	table.Header = &simpletable.Header{
+		Cells: []*simpletable.Cell{
+			{Text: "ID"},
+			{Text: "NAME"},
+			{Text: "DEFAULT"},
+		},
+	}
+
+	for _, t := range dataStores {
+		table.Body.Cells = append(table.Body.Cells, []*simpletable.Cell{
+			{Text: *t.Id},
+			{Text: *t.Name},
+			{Text: f.getDefaultMark(t)},
+		})
+	}
+
+	table.SetStyle(simpletable.StyleCompactLite)
+
+	return table.String()
+}
+
+func (f dataStoreList) getDefaultMark(dataStore openapi.DataStore) string {
+	if dataStore.IsDefault != nil && *dataStore.IsDefault {
+		return "*"
+	}
+
+	return ""
+}

--- a/cli/go.mod
+++ b/cli/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/compose-spec/compose-go v1.5.1
 	github.com/cucumber/ci-environment/go v0.0.0-20220915001957-711b1c82415f
 	github.com/denisbrodbeck/machineid v1.0.1
+	github.com/fluidtruck/deepcopy v1.0.0
 	github.com/joho/godotenv v1.3.0
 	github.com/kubeshop/tracetest/server v0.0.0
 	github.com/pterm/pterm v0.12.46
@@ -32,7 +33,6 @@ require (
 	github.com/distribution/distribution/v3 v3.0.0-20220907155224-78b9c98c5c31 // indirect
 	github.com/docker/go-connections v0.4.0 // indirect
 	github.com/docker/go-units v0.5.0 // indirect
-	github.com/fluidtruck/deepcopy v1.0.0 // indirect
 	github.com/fsnotify/fsnotify v1.6.0 // indirect
 	github.com/go-logr/logr v1.2.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect

--- a/cli/openapi/api_api.go
+++ b/cli/openapi/api_api.go
@@ -47,8 +47,8 @@ CreateDataStore Create a new Data Store
 
 Create a new Data Store
 
-	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-	@return ApiCreateDataStoreRequest
+ @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+ @return ApiCreateDataStoreRequest
 */
 func (a *ApiApiService) CreateDataStore(ctx context.Context) ApiCreateDataStoreRequest {
 	return ApiCreateDataStoreRequest{
@@ -58,8 +58,7 @@ func (a *ApiApiService) CreateDataStore(ctx context.Context) ApiCreateDataStoreR
 }
 
 // Execute executes the request
-//
-//	@return DataStore
+//  @return DataStore
 func (a *ApiApiService) CreateDataStoreExecute(r ApiCreateDataStoreRequest) (*DataStore, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPost
@@ -155,8 +154,8 @@ CreateEnvironment Create new environment
 
 Create new environment action
 
-	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-	@return ApiCreateEnvironmentRequest
+ @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+ @return ApiCreateEnvironmentRequest
 */
 func (a *ApiApiService) CreateEnvironment(ctx context.Context) ApiCreateEnvironmentRequest {
 	return ApiCreateEnvironmentRequest{
@@ -166,8 +165,7 @@ func (a *ApiApiService) CreateEnvironment(ctx context.Context) ApiCreateEnvironm
 }
 
 // Execute executes the request
-//
-//	@return Environment
+//  @return Environment
 func (a *ApiApiService) CreateEnvironmentExecute(r ApiCreateEnvironmentRequest) (*Environment, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPost
@@ -263,8 +261,8 @@ CreateTest Create new test
 
 Create new test action
 
-	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-	@return ApiCreateTestRequest
+ @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+ @return ApiCreateTestRequest
 */
 func (a *ApiApiService) CreateTest(ctx context.Context) ApiCreateTestRequest {
 	return ApiCreateTestRequest{
@@ -274,8 +272,7 @@ func (a *ApiApiService) CreateTest(ctx context.Context) ApiCreateTestRequest {
 }
 
 // Execute executes the request
-//
-//	@return Test
+//  @return Test
 func (a *ApiApiService) CreateTestExecute(r ApiCreateTestRequest) (*Test, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPost
@@ -371,8 +368,8 @@ CreateTransaction Create new transaction
 
 Create new transaction
 
-	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-	@return ApiCreateTransactionRequest
+ @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+ @return ApiCreateTransactionRequest
 */
 func (a *ApiApiService) CreateTransaction(ctx context.Context) ApiCreateTransactionRequest {
 	return ApiCreateTransactionRequest{
@@ -382,8 +379,7 @@ func (a *ApiApiService) CreateTransaction(ctx context.Context) ApiCreateTransact
 }
 
 // Execute executes the request
-//
-//	@return Transaction
+//  @return Transaction
 func (a *ApiApiService) CreateTransactionExecute(r ApiCreateTransactionRequest) (*Transaction, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPost
@@ -474,9 +470,9 @@ DeleteDataStore Delete a Data Store
 
 Delete a Data Store
 
-	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-	@param dataStoreId
-	@return ApiDeleteDataStoreRequest
+ @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+ @param dataStoreId
+ @return ApiDeleteDataStoreRequest
 */
 func (a *ApiApiService) DeleteDataStore(ctx context.Context, dataStoreId string) ApiDeleteDataStoreRequest {
 	return ApiDeleteDataStoreRequest{
@@ -566,9 +562,9 @@ DeleteEnvironment delete a environment
 
 delete a environment
 
-	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-	@param environmentId
-	@return ApiDeleteEnvironmentRequest
+ @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+ @param environmentId
+ @return ApiDeleteEnvironmentRequest
 */
 func (a *ApiApiService) DeleteEnvironment(ctx context.Context, environmentId string) ApiDeleteEnvironmentRequest {
 	return ApiDeleteEnvironmentRequest{
@@ -658,9 +654,9 @@ DeleteTest delete a test
 
 delete a test
 
-	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-	@param testId
-	@return ApiDeleteTestRequest
+ @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+ @param testId
+ @return ApiDeleteTestRequest
 */
 func (a *ApiApiService) DeleteTest(ctx context.Context, testId string) ApiDeleteTestRequest {
 	return ApiDeleteTestRequest{
@@ -751,10 +747,10 @@ DeleteTestRun delete a test run
 
 delete a test run
 
-	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-	@param testId
-	@param runId
-	@return ApiDeleteTestRunRequest
+ @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+ @param testId
+ @param runId
+ @return ApiDeleteTestRunRequest
 */
 func (a *ApiApiService) DeleteTestRun(ctx context.Context, testId string, runId string) ApiDeleteTestRunRequest {
 	return ApiDeleteTestRunRequest{
@@ -846,9 +842,9 @@ DeleteTransaction delete a transaction
 
 delete a transaction
 
-	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-	@param transactionId
-	@return ApiDeleteTransactionRequest
+ @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+ @param transactionId
+ @return ApiDeleteTransactionRequest
 */
 func (a *ApiApiService) DeleteTransaction(ctx context.Context, transactionId string) ApiDeleteTransactionRequest {
 	return ApiDeleteTransactionRequest{
@@ -939,10 +935,10 @@ DeleteTransactionRun Delete a specific run from a particular transaction
 
 Delete a specific run from a particular transaction
 
-	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-	@param transactionId
-	@param runId
-	@return ApiDeleteTransactionRunRequest
+ @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+ @param transactionId
+ @param runId
+ @return ApiDeleteTransactionRunRequest
 */
 func (a *ApiApiService) DeleteTransactionRun(ctx context.Context, transactionId string, runId int32) ApiDeleteTransactionRunRequest {
 	return ApiDeleteTransactionRunRequest{
@@ -1041,10 +1037,10 @@ DryRunAssertion run given assertions against the traces from the given run witho
 
 use this method to test a definition against an actual trace without creating a new version or persisting anything
 
-	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-	@param testId
-	@param runId
-	@return ApiDryRunAssertionRequest
+ @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+ @param testId
+ @param runId
+ @return ApiDryRunAssertionRequest
 */
 func (a *ApiApiService) DryRunAssertion(ctx context.Context, testId string, runId string) ApiDryRunAssertionRequest {
 	return ApiDryRunAssertionRequest{
@@ -1056,8 +1052,7 @@ func (a *ApiApiService) DryRunAssertion(ctx context.Context, testId string, runI
 }
 
 // Execute executes the request
-//
-//	@return AssertionResults
+//  @return AssertionResults
 func (a *ApiApiService) DryRunAssertionExecute(r ApiDryRunAssertionRequest) (*AssertionResults, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPut
@@ -1155,8 +1150,8 @@ ExecuteDefinition Execute a definition
 
 Execute a definition
 
-	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-	@return ApiExecuteDefinitionRequest
+ @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+ @return ApiExecuteDefinitionRequest
 */
 func (a *ApiApiService) ExecuteDefinition(ctx context.Context) ApiExecuteDefinitionRequest {
 	return ApiExecuteDefinitionRequest{
@@ -1166,8 +1161,7 @@ func (a *ApiApiService) ExecuteDefinition(ctx context.Context) ApiExecuteDefinit
 }
 
 // Execute executes the request
-//
-//	@return ExecuteDefinitionResponse
+//  @return ExecuteDefinitionResponse
 func (a *ApiApiService) ExecuteDefinitionExecute(r ApiExecuteDefinitionRequest) (*ExecuteDefinitionResponse, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPost
@@ -1259,10 +1253,10 @@ ExportTestRun export test and test run information
 
 export test and test run information for debugging
 
-	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-	@param testId
-	@param runId
-	@return ApiExportTestRunRequest
+ @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+ @param testId
+ @param runId
+ @return ApiExportTestRunRequest
 */
 func (a *ApiApiService) ExportTestRun(ctx context.Context, testId string, runId string) ApiExportTestRunRequest {
 	return ApiExportTestRunRequest{
@@ -1274,8 +1268,7 @@ func (a *ApiApiService) ExportTestRun(ctx context.Context, testId string, runId 
 }
 
 // Execute executes the request
-//
-//	@return ExportedTestInformation
+//  @return ExportedTestInformation
 func (a *ApiApiService) ExportTestRunExecute(r ApiExportTestRunRequest) (*ExportedTestInformation, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
@@ -1371,8 +1364,8 @@ ExpressionResolve resolves an expression and returns the result string
 
 resolves an expression and returns the result string
 
-	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-	@return ApiExpressionResolveRequest
+ @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+ @return ApiExpressionResolveRequest
 */
 func (a *ApiApiService) ExpressionResolve(ctx context.Context) ApiExpressionResolveRequest {
 	return ApiExpressionResolveRequest{
@@ -1382,8 +1375,7 @@ func (a *ApiApiService) ExpressionResolve(ctx context.Context) ApiExpressionReso
 }
 
 // Execute executes the request
-//
-//	@return ResolveResponseInfo
+//  @return ResolveResponseInfo
 func (a *ApiApiService) ExpressionResolveExecute(r ApiExpressionResolveRequest) (*ResolveResponseInfo, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPost
@@ -1474,9 +1466,9 @@ GetDataStore Get a Data Store
 
 Get a Data Store
 
-	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-	@param dataStoreId
-	@return ApiGetDataStoreRequest
+ @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+ @param dataStoreId
+ @return ApiGetDataStoreRequest
 */
 func (a *ApiApiService) GetDataStore(ctx context.Context, dataStoreId string) ApiGetDataStoreRequest {
 	return ApiGetDataStoreRequest{
@@ -1487,8 +1479,7 @@ func (a *ApiApiService) GetDataStore(ctx context.Context, dataStoreId string) Ap
 }
 
 // Execute executes the request
-//
-//	@return DataStore
+//  @return DataStore
 func (a *ApiApiService) GetDataStoreExecute(r ApiGetDataStoreRequest) (*DataStore, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
@@ -1612,8 +1603,8 @@ GetDataStores Get all Data Stores
 
 Get all Data Stores
 
-	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-	@return ApiGetDataStoresRequest
+ @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+ @return ApiGetDataStoresRequest
 */
 func (a *ApiApiService) GetDataStores(ctx context.Context) ApiGetDataStoresRequest {
 	return ApiGetDataStoresRequest{
@@ -1623,8 +1614,7 @@ func (a *ApiApiService) GetDataStores(ctx context.Context) ApiGetDataStoresReque
 }
 
 // Execute executes the request
-//
-//	@return []DataStore
+//  @return []DataStore
 func (a *ApiApiService) GetDataStoresExecute(r ApiGetDataStoresRequest) ([]DataStore, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
@@ -1728,9 +1718,9 @@ GetEnvironment get environment
 
 get environment
 
-	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-	@param environmentId
-	@return ApiGetEnvironmentRequest
+ @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+ @param environmentId
+ @return ApiGetEnvironmentRequest
 */
 func (a *ApiApiService) GetEnvironment(ctx context.Context, environmentId string) ApiGetEnvironmentRequest {
 	return ApiGetEnvironmentRequest{
@@ -1741,8 +1731,7 @@ func (a *ApiApiService) GetEnvironment(ctx context.Context, environmentId string
 }
 
 // Execute executes the request
-//
-//	@return Environment
+//  @return Environment
 func (a *ApiApiService) GetEnvironmentExecute(r ApiGetEnvironmentRequest) (*Environment, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
@@ -1832,9 +1821,9 @@ GetEnvironmentDefinitionFile Get the environment definition as an YAML file
 
 Get the environment as an YAML file
 
-	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-	@param environmentId
-	@return ApiGetEnvironmentDefinitionFileRequest
+ @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+ @param environmentId
+ @return ApiGetEnvironmentDefinitionFileRequest
 */
 func (a *ApiApiService) GetEnvironmentDefinitionFile(ctx context.Context, environmentId string) ApiGetEnvironmentDefinitionFileRequest {
 	return ApiGetEnvironmentDefinitionFileRequest{
@@ -1845,8 +1834,7 @@ func (a *ApiApiService) GetEnvironmentDefinitionFile(ctx context.Context, enviro
 }
 
 // Execute executes the request
-//
-//	@return string
+//  @return string
 func (a *ApiApiService) GetEnvironmentDefinitionFileExecute(r ApiGetEnvironmentDefinitionFileRequest) (string, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
@@ -1970,8 +1958,8 @@ GetEnvironments Get Environments
 
 Get Environments
 
-	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-	@return ApiGetEnvironmentsRequest
+ @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+ @return ApiGetEnvironmentsRequest
 */
 func (a *ApiApiService) GetEnvironments(ctx context.Context) ApiGetEnvironmentsRequest {
 	return ApiGetEnvironmentsRequest{
@@ -1981,8 +1969,7 @@ func (a *ApiApiService) GetEnvironments(ctx context.Context) ApiGetEnvironmentsR
 }
 
 // Execute executes the request
-//
-//	@return []Environment
+//  @return []Environment
 func (a *ApiApiService) GetEnvironmentsExecute(r ApiGetEnvironmentsRequest) ([]Environment, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
@@ -2120,8 +2107,8 @@ GetResources Get resources
 
 get resources
 
-	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-	@return ApiGetResourcesRequest
+ @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+ @return ApiGetResourcesRequest
 */
 func (a *ApiApiService) GetResources(ctx context.Context) ApiGetResourcesRequest {
 	return ApiGetResourcesRequest{
@@ -2131,8 +2118,7 @@ func (a *ApiApiService) GetResources(ctx context.Context) ApiGetResourcesRequest
 }
 
 // Execute executes the request
-//
-//	@return []Resource
+//  @return []Resource
 func (a *ApiApiService) GetResourcesExecute(r ApiGetResourcesRequest) ([]Resource, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
@@ -2237,10 +2223,10 @@ GetRunResultJUnit get test run results in JUnit xml format
 
 get test run results in JUnit xml format
 
-	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-	@param testId
-	@param runId
-	@return ApiGetRunResultJUnitRequest
+ @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+ @param testId
+ @param runId
+ @return ApiGetRunResultJUnitRequest
 */
 func (a *ApiApiService) GetRunResultJUnit(ctx context.Context, testId string, runId string) ApiGetRunResultJUnitRequest {
 	return ApiGetRunResultJUnitRequest{
@@ -2252,8 +2238,7 @@ func (a *ApiApiService) GetRunResultJUnit(ctx context.Context, testId string, ru
 }
 
 // Execute executes the request
-//
-//	@return string
+//  @return string
 func (a *ApiApiService) GetRunResultJUnitExecute(r ApiGetRunResultJUnitRequest) (string, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
@@ -2344,9 +2329,9 @@ GetTest get test
 
 get test
 
-	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-	@param testId
-	@return ApiGetTestRequest
+ @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+ @param testId
+ @return ApiGetTestRequest
 */
 func (a *ApiApiService) GetTest(ctx context.Context, testId string) ApiGetTestRequest {
 	return ApiGetTestRequest{
@@ -2357,8 +2342,7 @@ func (a *ApiApiService) GetTest(ctx context.Context, testId string) ApiGetTestRe
 }
 
 // Execute executes the request
-//
-//	@return Test
+//  @return Test
 func (a *ApiApiService) GetTestExecute(r ApiGetTestRequest) (*Test, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
@@ -2455,10 +2439,10 @@ GetTestResultSelectedSpans retrieve spans that will be selected by selector
 
 get the spans ids that would be selected by a specific selector query
 
-	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-	@param testId
-	@param runId
-	@return ApiGetTestResultSelectedSpansRequest
+ @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+ @param testId
+ @param runId
+ @return ApiGetTestResultSelectedSpansRequest
 */
 func (a *ApiApiService) GetTestResultSelectedSpans(ctx context.Context, testId string, runId string) ApiGetTestResultSelectedSpansRequest {
 	return ApiGetTestResultSelectedSpansRequest{
@@ -2470,8 +2454,7 @@ func (a *ApiApiService) GetTestResultSelectedSpans(ctx context.Context, testId s
 }
 
 // Execute executes the request
-//
-//	@return SelectedSpansResult
+//  @return SelectedSpansResult
 func (a *ApiApiService) GetTestResultSelectedSpansExecute(r ApiGetTestResultSelectedSpansRequest) (*SelectedSpansResult, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
@@ -2566,10 +2549,10 @@ GetTestRun get test Run
 
 get a particular test Run
 
-	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-	@param testId
-	@param runId
-	@return ApiGetTestRunRequest
+ @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+ @param testId
+ @param runId
+ @return ApiGetTestRunRequest
 */
 func (a *ApiApiService) GetTestRun(ctx context.Context, testId string, runId string) ApiGetTestRunRequest {
 	return ApiGetTestRunRequest{
@@ -2581,8 +2564,7 @@ func (a *ApiApiService) GetTestRun(ctx context.Context, testId string, runId str
 }
 
 // Execute executes the request
-//
-//	@return TestRun
+//  @return TestRun
 func (a *ApiApiService) GetTestRunExecute(r ApiGetTestRunRequest) (*TestRun, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
@@ -2687,9 +2669,9 @@ GetTestRuns get the runs for a test
 
 get the runs from a particular test
 
-	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-	@param testId
-	@return ApiGetTestRunsRequest
+ @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+ @param testId
+ @return ApiGetTestRunsRequest
 */
 func (a *ApiApiService) GetTestRuns(ctx context.Context, testId string) ApiGetTestRunsRequest {
 	return ApiGetTestRunsRequest{
@@ -2700,8 +2682,7 @@ func (a *ApiApiService) GetTestRuns(ctx context.Context, testId string) ApiGetTe
 }
 
 // Execute executes the request
-//
-//	@return []TestRun
+//  @return []TestRun
 func (a *ApiApiService) GetTestRunsExecute(r ApiGetTestRunsRequest) ([]TestRun, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
@@ -2797,9 +2778,9 @@ GetTestSpecs Get definition for a test
 
 Gets definition for a test
 
-	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-	@param testId
-	@return ApiGetTestSpecsRequest
+ @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+ @param testId
+ @return ApiGetTestSpecsRequest
 */
 func (a *ApiApiService) GetTestSpecs(ctx context.Context, testId string) ApiGetTestSpecsRequest {
 	return ApiGetTestSpecsRequest{
@@ -2810,8 +2791,7 @@ func (a *ApiApiService) GetTestSpecs(ctx context.Context, testId string) ApiGetT
 }
 
 // Execute executes the request
-//
-//	@return []TestSpecs
+//  @return []TestSpecs
 func (a *ApiApiService) GetTestSpecsExecute(r ApiGetTestSpecsRequest) ([]TestSpecs, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
@@ -2902,10 +2882,10 @@ GetTestVersion get a test specific version
 
 get a test specific version
 
-	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-	@param testId
-	@param version
-	@return ApiGetTestVersionRequest
+ @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+ @param testId
+ @param version
+ @return ApiGetTestVersionRequest
 */
 func (a *ApiApiService) GetTestVersion(ctx context.Context, testId string, version int32) ApiGetTestVersionRequest {
 	return ApiGetTestVersionRequest{
@@ -2917,8 +2897,7 @@ func (a *ApiApiService) GetTestVersion(ctx context.Context, testId string, versi
 }
 
 // Execute executes the request
-//
-//	@return Test
+//  @return Test
 func (a *ApiApiService) GetTestVersionExecute(r ApiGetTestVersionRequest) (*Test, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
@@ -3010,10 +2989,10 @@ GetTestVersionDefinitionFile Get the test definition as an YAML file
 
 Get the test definition as an YAML file
 
-	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-	@param testId
-	@param version
-	@return ApiGetTestVersionDefinitionFileRequest
+ @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+ @param testId
+ @param version
+ @return ApiGetTestVersionDefinitionFileRequest
 */
 func (a *ApiApiService) GetTestVersionDefinitionFile(ctx context.Context, testId string, version int32) ApiGetTestVersionDefinitionFileRequest {
 	return ApiGetTestVersionDefinitionFileRequest{
@@ -3025,8 +3004,7 @@ func (a *ApiApiService) GetTestVersionDefinitionFile(ctx context.Context, testId
 }
 
 // Execute executes the request
-//
-//	@return string
+//  @return string
 func (a *ApiApiService) GetTestVersionDefinitionFileExecute(r ApiGetTestVersionDefinitionFileRequest) (string, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
@@ -3151,8 +3129,8 @@ GetTests Get tests
 
 get tests
 
-	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-	@return ApiGetTestsRequest
+ @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+ @return ApiGetTestsRequest
 */
 func (a *ApiApiService) GetTests(ctx context.Context) ApiGetTestsRequest {
 	return ApiGetTestsRequest{
@@ -3162,8 +3140,7 @@ func (a *ApiApiService) GetTests(ctx context.Context) ApiGetTestsRequest {
 }
 
 // Execute executes the request
-//
-//	@return []Test
+//  @return []Test
 func (a *ApiApiService) GetTestsExecute(r ApiGetTestsRequest) ([]Test, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
@@ -3267,9 +3244,9 @@ GetTransaction get transaction
 
 get transaction
 
-	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-	@param transactionId
-	@return ApiGetTransactionRequest
+ @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+ @param transactionId
+ @return ApiGetTransactionRequest
 */
 func (a *ApiApiService) GetTransaction(ctx context.Context, transactionId string) ApiGetTransactionRequest {
 	return ApiGetTransactionRequest{
@@ -3280,8 +3257,7 @@ func (a *ApiApiService) GetTransaction(ctx context.Context, transactionId string
 }
 
 // Execute executes the request
-//
-//	@return Transaction
+//  @return Transaction
 func (a *ApiApiService) GetTransactionExecute(r ApiGetTransactionRequest) (*Transaction, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
@@ -3372,10 +3348,10 @@ GetTransactionRun Get a specific run from a particular transaction
 
 Get a specific run from a particular transaction
 
-	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-	@param transactionId
-	@param runId
-	@return ApiGetTransactionRunRequest
+ @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+ @param transactionId
+ @param runId
+ @return ApiGetTransactionRunRequest
 */
 func (a *ApiApiService) GetTransactionRun(ctx context.Context, transactionId string, runId int32) ApiGetTransactionRunRequest {
 	return ApiGetTransactionRunRequest{
@@ -3387,8 +3363,7 @@ func (a *ApiApiService) GetTransactionRun(ctx context.Context, transactionId str
 }
 
 // Execute executes the request
-//
-//	@return TransactionRun
+//  @return TransactionRun
 func (a *ApiApiService) GetTransactionRunExecute(r ApiGetTransactionRunRequest) (*TransactionRun, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
@@ -3493,9 +3468,9 @@ GetTransactionRuns Get all runs from a particular transaction
 
 Get all runs from a particular transaction
 
-	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-	@param transactionId
-	@return ApiGetTransactionRunsRequest
+ @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+ @param transactionId
+ @return ApiGetTransactionRunsRequest
 */
 func (a *ApiApiService) GetTransactionRuns(ctx context.Context, transactionId string) ApiGetTransactionRunsRequest {
 	return ApiGetTransactionRunsRequest{
@@ -3506,8 +3481,7 @@ func (a *ApiApiService) GetTransactionRuns(ctx context.Context, transactionId st
 }
 
 // Execute executes the request
-//
-//	@return []TransactionRun
+//  @return []TransactionRun
 func (a *ApiApiService) GetTransactionRunsExecute(r ApiGetTransactionRunsRequest) ([]TransactionRun, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
@@ -3604,10 +3578,10 @@ GetTransactionVersion get a transaction specific version
 
 get a transaction specific version
 
-	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-	@param transactionId
-	@param version
-	@return ApiGetTransactionVersionRequest
+ @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+ @param transactionId
+ @param version
+ @return ApiGetTransactionVersionRequest
 */
 func (a *ApiApiService) GetTransactionVersion(ctx context.Context, transactionId string, version int32) ApiGetTransactionVersionRequest {
 	return ApiGetTransactionVersionRequest{
@@ -3619,8 +3593,7 @@ func (a *ApiApiService) GetTransactionVersion(ctx context.Context, transactionId
 }
 
 // Execute executes the request
-//
-//	@return Transaction
+//  @return Transaction
 func (a *ApiApiService) GetTransactionVersionExecute(r ApiGetTransactionVersionRequest) (*Transaction, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
@@ -3712,10 +3685,10 @@ GetTransactionVersionDefinitionFile Get the transaction definition as an YAML fi
 
 Get the transaction as an YAML file
 
-	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-	@param transactionId
-	@param version
-	@return ApiGetTransactionVersionDefinitionFileRequest
+ @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+ @param transactionId
+ @param version
+ @return ApiGetTransactionVersionDefinitionFileRequest
 */
 func (a *ApiApiService) GetTransactionVersionDefinitionFile(ctx context.Context, transactionId string, version int32) ApiGetTransactionVersionDefinitionFileRequest {
 	return ApiGetTransactionVersionDefinitionFileRequest{
@@ -3727,8 +3700,7 @@ func (a *ApiApiService) GetTransactionVersionDefinitionFile(ctx context.Context,
 }
 
 // Execute executes the request
-//
-//	@return string
+//  @return string
 func (a *ApiApiService) GetTransactionVersionDefinitionFileExecute(r ApiGetTransactionVersionDefinitionFileRequest) (string, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
@@ -3853,8 +3825,8 @@ GetTransactions Get transactions
 
 get transactions
 
-	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-	@return ApiGetTransactionsRequest
+ @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+ @return ApiGetTransactionsRequest
 */
 func (a *ApiApiService) GetTransactions(ctx context.Context) ApiGetTransactionsRequest {
 	return ApiGetTransactionsRequest{
@@ -3864,8 +3836,7 @@ func (a *ApiApiService) GetTransactions(ctx context.Context) ApiGetTransactionsR
 }
 
 // Execute executes the request
-//
-//	@return []Transaction
+//  @return []Transaction
 func (a *ApiApiService) GetTransactionsExecute(r ApiGetTransactionsRequest) ([]Transaction, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
@@ -3974,8 +3945,8 @@ ImportTestRun import test and test run information
 
 import test and test run information for debugging
 
-	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-	@return ApiImportTestRunRequest
+ @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+ @return ApiImportTestRunRequest
 */
 func (a *ApiApiService) ImportTestRun(ctx context.Context) ApiImportTestRunRequest {
 	return ApiImportTestRunRequest{
@@ -3985,8 +3956,7 @@ func (a *ApiApiService) ImportTestRun(ctx context.Context) ApiImportTestRunReque
 }
 
 // Execute executes the request
-//
-//	@return ExportedTestInformation
+//  @return ExportedTestInformation
 func (a *ApiApiService) ImportTestRunExecute(r ApiImportTestRunRequest) (*ExportedTestInformation, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPost
@@ -4078,10 +4048,10 @@ RerunTestRun rerun a test run
 
 rerun a test run
 
-	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-	@param testId
-	@param runId
-	@return ApiRerunTestRunRequest
+ @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+ @param testId
+ @param runId
+ @return ApiRerunTestRunRequest
 */
 func (a *ApiApiService) RerunTestRun(ctx context.Context, testId string, runId string) ApiRerunTestRunRequest {
 	return ApiRerunTestRunRequest{
@@ -4093,8 +4063,7 @@ func (a *ApiApiService) RerunTestRun(ctx context.Context, testId string, runId s
 }
 
 // Execute executes the request
-//
-//	@return TestRun
+//  @return TestRun
 func (a *ApiApiService) RerunTestRunExecute(r ApiRerunTestRunRequest) (*TestRun, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPost
@@ -4191,9 +4160,9 @@ RunTest run test
 
 run a particular test
 
-	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-	@param testId
-	@return ApiRunTestRequest
+ @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+ @param testId
+ @return ApiRunTestRequest
 */
 func (a *ApiApiService) RunTest(ctx context.Context, testId string) ApiRunTestRequest {
 	return ApiRunTestRequest{
@@ -4204,8 +4173,7 @@ func (a *ApiApiService) RunTest(ctx context.Context, testId string) ApiRunTestRe
 }
 
 // Execute executes the request
-//
-//	@return TestRun
+//  @return TestRun
 func (a *ApiApiService) RunTestExecute(r ApiRunTestRequest) (*TestRun, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPost
@@ -4303,9 +4271,9 @@ RunTransaction run transaction
 
 run a particular transaction
 
-	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-	@param transactionId
-	@return ApiRunTransactionRequest
+ @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+ @param transactionId
+ @return ApiRunTransactionRequest
 */
 func (a *ApiApiService) RunTransaction(ctx context.Context, transactionId string) ApiRunTransactionRequest {
 	return ApiRunTransactionRequest{
@@ -4316,8 +4284,7 @@ func (a *ApiApiService) RunTransaction(ctx context.Context, transactionId string
 }
 
 // Execute executes the request
-//
-//	@return TransactionRun
+//  @return TransactionRun
 func (a *ApiApiService) RunTransactionExecute(r ApiRunTransactionRequest) (*TransactionRun, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPost
@@ -4414,8 +4381,8 @@ TestConnection Tests the config data store/exporter connection
 
 Tests the config data store/exporter connection
 
-	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-	@return ApiTestConnectionRequest
+ @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+ @return ApiTestConnectionRequest
 */
 func (a *ApiApiService) TestConnection(ctx context.Context) ApiTestConnectionRequest {
 	return ApiTestConnectionRequest{
@@ -4425,8 +4392,7 @@ func (a *ApiApiService) TestConnection(ctx context.Context) ApiTestConnectionReq
 }
 
 // Execute executes the request
-//
-//	@return TestConnectionResponse
+//  @return TestConnectionResponse
 func (a *ApiApiService) TestConnectionExecute(r ApiTestConnectionRequest) (*TestConnectionResponse, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPost
@@ -4523,9 +4489,9 @@ UpdateDataStore Update a Data Store
 
 Update a Data Store
 
-	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-	@param dataStoreId
-	@return ApiUpdateDataStoreRequest
+ @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+ @param dataStoreId
+ @return ApiUpdateDataStoreRequest
 */
 func (a *ApiApiService) UpdateDataStore(ctx context.Context, dataStoreId string) ApiUpdateDataStoreRequest {
 	return ApiUpdateDataStoreRequest{
@@ -4623,9 +4589,9 @@ UpdateEnvironment update environment
 
 update environment action
 
-	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-	@param environmentId
-	@return ApiUpdateEnvironmentRequest
+ @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+ @param environmentId
+ @return ApiUpdateEnvironmentRequest
 */
 func (a *ApiApiService) UpdateEnvironment(ctx context.Context, environmentId string) ApiUpdateEnvironmentRequest {
 	return ApiUpdateEnvironmentRequest{
@@ -4723,9 +4689,9 @@ UpdateTest update test
 
 update test action
 
-	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-	@param testId
-	@return ApiUpdateTestRequest
+ @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+ @param testId
+ @return ApiUpdateTestRequest
 */
 func (a *ApiApiService) UpdateTest(ctx context.Context, testId string) ApiUpdateTestRequest {
 	return ApiUpdateTestRequest{
@@ -4823,9 +4789,9 @@ UpdateTransaction update transaction
 
 update transaction action
 
-	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-	@param transactionId
-	@return ApiUpdateTransactionRequest
+ @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+ @param transactionId
+ @return ApiUpdateTransactionRequest
 */
 func (a *ApiApiService) UpdateTransaction(ctx context.Context, transactionId string) ApiUpdateTransactionRequest {
 	return ApiUpdateTransactionRequest{
@@ -4922,8 +4888,8 @@ UpsertDefinition Upsert a definition
 
 Upsert a definition
 
-	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-	@return ApiUpsertDefinitionRequest
+ @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+ @return ApiUpsertDefinitionRequest
 */
 func (a *ApiApiService) UpsertDefinition(ctx context.Context) ApiUpsertDefinitionRequest {
 	return ApiUpsertDefinitionRequest{
@@ -4933,8 +4899,7 @@ func (a *ApiApiService) UpsertDefinition(ctx context.Context) ApiUpsertDefinitio
 }
 
 // Execute executes the request
-//
-//	@return UpsertDefinitionResponse
+//  @return UpsertDefinitionResponse
 func (a *ApiApiService) UpsertDefinitionExecute(r ApiUpsertDefinitionRequest) (*UpsertDefinitionResponse, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPut

--- a/server/model/yaml/encoding.go
+++ b/server/model/yaml/encoding.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"reflect"
 
+	"github.com/kubeshop/tracetest/server/openapi"
 	"github.com/mitchellh/mapstructure"
 	"gopkg.in/yaml.v2"
 )
@@ -42,6 +43,13 @@ func Decode(contents []byte) (File, error) {
 			return File{}, fmt.Errorf("cannot decode environment: %w", err)
 		}
 		f.Spec = environment
+	case FileTypeDataStore:
+		var dataStore openapi.DataStore
+		err := mapstructure.Decode(f.Spec, &dataStore)
+		if err != nil {
+			return File{}, fmt.Errorf("cannot decode datastore: %w", err)
+		}
+		f.Spec = dataStore
 	default:
 		return File{}, fmt.Errorf("invalid file type %s", f.Type)
 	}

--- a/server/model/yaml/file.go
+++ b/server/model/yaml/file.go
@@ -16,6 +16,7 @@ const (
 	FileTypeTest        FileType = "Test"
 	FileTypeTransaction FileType = "Transaction"
 	FileTypeEnvironment FileType = "Environment"
+	FileTypeDataStore   FileType = "DataStore"
 )
 
 type File struct {

--- a/server/openapi/impl.go
+++ b/server/openapi/impl.go
@@ -9,7 +9,7 @@
 
 package openapi
 
-// Implementation response defines an error code with the associated body
+//Implementation response defines an error code with the associated body
 type ImplResponse struct {
 	Code int
 	Body interface{}

--- a/server/testdb/data_stores.go
+++ b/server/testdb/data_stores.go
@@ -76,7 +76,7 @@ func (td *postgresDB) UpdateDataStore(ctx context.Context, dataStore model.DataS
 
 	// keep the same creation date to keep sort order
 	dataStore.CreatedAt = oldDataStore.CreatedAt
-	dataStore.ID = dataStore.Slug()
+	dataStore.ID = oldDataStore.ID
 
 	return td.updateIntoDataStores(ctx, dataStore, oldDataStore.ID)
 }
@@ -314,7 +314,7 @@ func (td *postgresDB) updateIntoDataStores(ctx context.Context, dataStore model.
 
 	_, err = tx.ExecContext(ctx, updateIntoDataStoresQuery,
 		oldId,
-		dataStore.Slug(),
+		dataStore.ID,
 		dataStore.Name,
 		dataStore.Type,
 		dataStore.IsDefault,

--- a/server/testdb/data_stores_test.go
+++ b/server/testdb/data_stores_test.go
@@ -2,11 +2,12 @@ package testdb_test
 
 import (
 	"context"
+	"testing"
+
 	"github.com/kubeshop/tracetest/server/model"
 	"github.com/kubeshop/tracetest/server/testdb"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"testing"
 )
 
 func TestCreateDataStore(t *testing.T) {
@@ -82,7 +83,7 @@ func TestUpdateDataStore(t *testing.T) {
 	_, err := db.UpdateDataStore(context.TODO(), dataStore)
 	require.NoError(t, err)
 
-	latestDataStore, err := db.GetDataStore(context.TODO(), dataStore.Slug())
+	latestDataStore, err := db.GetDataStore(context.TODO(), dataStore.ID)
 	assert.NoError(t, err)
 	assert.Equal(t, "1 v2", latestDataStore.Name)
 	assert.Equal(t, "openSearch", string(latestDataStore.Type))


### PR DESCRIPTION
This PR adds a command `tracetest datastore apply -f <file>` which creates/updates a data store based on the file. And also creates a command for listing data stores

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
