### PR TITLE
feature(cli): removing the remove vs local k8 question

### DIFF
--- a/cli/installer/kubernetes.go
+++ b/cli/installer/kubernetes.go
@@ -18,7 +18,6 @@ var kubernetes = installer{
 		windowsGnuToolsChecker,
 		kubectlChecker,
 		helmChecker,
-		localEnvironmentChecker,
 	},
 	configs: []configurator{
 		configureKubernetes,
@@ -337,22 +336,4 @@ func kubectlChecker(ui cliUI.UI) {
 	}
 
 	ui.Exit("I didn't find kubectl in your system")
-}
-
-func localEnvironmentChecker(ui cliUI.UI) {
-	option := ui.Select("Are you going to run it locally or in a remote cluster?", []cliUI.Option{
-		{"Locally", minikubeChecker},
-		{"Remote cluster", func(ui cliUI.UI) {}},
-	}, 0)
-
-	option.Fn(ui)
-}
-
-func minikubeChecker(ui cliUI.UI) {
-	if commandExists("minikube") {
-		ui.Println(ui.Green("✔ minikube already installed"))
-		return
-	}
-
-	ui.Exit(ui.Red("✘ minikube could not be installed. Check output for errors. " + createIssueMsg))
 }


### PR DESCRIPTION
This PR removes the question asked to the user if he wants to install tracetest in a local or remote cluster.

## Changes

- Removes minikube check and question

## Fixes

- #1630 

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
