### PR TITLE
fix(frontend): fix update dataStores service

### DIFF
--- a/server/model/data_stores.go
+++ b/server/model/data_stores.go
@@ -2,7 +2,6 @@ package model
 
 import (
 	"fmt"
-	"strings"
 	"time"
 
 	"github.com/kubeshop/tracetest/server/config"
@@ -31,10 +30,6 @@ type (
 
 func (ds DataStore) IsZero() bool {
 	return ds.Type == ""
-}
-
-func (ds DataStore) Slug() string {
-	return strings.ToLower(strings.ReplaceAll(strings.TrimSpace(ds.Name), " ", "-"))
 }
 
 var validTypes = []openapi.SupportedDataStores{

--- a/server/testdb/data_stores.go
+++ b/server/testdb/data_stores.go
@@ -62,7 +62,7 @@ const (
 )
 
 func (td *postgresDB) CreateDataStore(ctx context.Context, dataStore model.DataStore) (model.DataStore, error) {
-	dataStore.ID = dataStore.Slug()
+	dataStore.ID = IDGen.ID().String()
 	dataStore.CreatedAt = time.Now()
 
 	return td.insertIntoDataStores(ctx, dataStore)

--- a/server/testdb/data_stores_test.go
+++ b/server/testdb/data_stores_test.go
@@ -26,7 +26,6 @@ func TestCreateDataStore(t *testing.T) {
 
 	actual, err := db.GetDataStore(context.TODO(), created.ID)
 	require.NoError(t, err)
-	assert.Equal(t, actual.ID, "datastore")
 	assert.Equal(t, dataStore.Name, actual.Name)
 	assert.Equal(t, dataStore.Type, actual.Type)
 	assert.Equal(t, dataStore.IsDefault, actual.IsDefault)

--- a/web/src/services/DataStore.service.ts
+++ b/web/src/services/DataStore.service.ts
@@ -22,10 +22,10 @@ const DataStoreService = (): IDataStoreService => ({
   async getRequest(draft, defaultDataStore) {
     const dataStoreType = draft.dataStoreType || SupportedDataStores.JAEGER;
     const dataStoreValues = await dataStoreServiceMap[dataStoreType].getRequest(draft, dataStoreType);
-    const isUpdate = !!defaultDataStore.id && defaultDataStore.type === dataStoreType;
+    const isUpdate = !!defaultDataStore.id;
 
     const dataStore: TRawDataStore = isUpdate
-      ? {...defaultDataStore, ...dataStoreValues, isDefault: true}
+      ? {id: defaultDataStore.id, name: defaultDataStore.name, ...dataStoreValues, isDefault: true}
       : {
           ...dataStoreValues,
           name: dataStoreType,


### PR DESCRIPTION
This PR fixes a duplicate key issue when trying to create data stores with the same name.

## Changes

- Change ID generation method in the backend service
- Fix frontend to always update instead of creating new records

## Fixes

-

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
