### PR TITLE
fix(cli): fixing rabbitMQ version

### DIFF
--- a/examples/docker-compose.demo.yaml
+++ b/examples/docker-compose.demo.yaml
@@ -10,7 +10,7 @@ services:
       retries: 60
 
   queue:
-    image: rabbitmq:3.9
+    image: rabbitmq:3.8-management
     restart: unless-stopped
     healthcheck:
       test: rabbitmq-diagnostics -q check_running


### PR DESCRIPTION
This PR downgrades the rabbit MQ version to avoid a bug with some docker versions

## Changes

-

## Fixes

-

## Checklist

- [ ] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
