### PR TITLE
chore: update typos on test docs and add Makefile docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,12 +5,17 @@ OPENAPI_GENERATOR_IMAGE=openapitools/openapi-generator-cli:$(OPENAPI_GENERATOR_V
 OPENAPI_GENERATOR_CLI=docker run --rm -u ${shell id -u}  -v "$(PROJECT_ROOT):/local" -w "/local" ${OPENAPI_GENERATOR_IMAGE}
 OPENAPI_TARGET_DIR=openapi/
 
+help: Makefile ## show list of commands
+	@echo "Choose a command run:"
+	@echo ""
+	@awk 'BEGIN {FS = ":.*?## "} /[a-zA-Z_-]+:.*?## / {sub("\\\\n",sprintf("\n%22c"," "), $$2);printf "\033[36m%-40s\033[0m %s\n", $$1, $$2}' $(MAKEFILE_LIST) | sort
+
 generate: generate-server generate-cli generate-web
 
-generate-web:
+generate-web: ## generates OpenAPI types for WebUI
 	cd web; npm run types:generate
 
-generate-cli:
+generate-cli: ## generates OpenAPI types for CLI
 	$(eval BASE := ./cli)
 	mkdir -p $(BASE)/tmp
 	rm -rf $(BASE)/$(OPENAPI_TARGET_DIR)
@@ -27,7 +32,7 @@ generate-cli:
 
 	cd $(BASE); go fmt ./...
 
-generate-server:
+generate-server: ## generates OpenAPI types for server
 	$(eval BASE := ./server)
 	mkdir -p $(BASE)/tmp
 	rm -rf $(BASE)/$(OPENAPI_TARGET_DIR)
@@ -45,7 +50,7 @@ generate-server:
 
 	cd $(BASE); go fmt ./...
 
-serve-docs:
+serve-docs: ## serve documentation for Tracetest
 	docker build -t tracetest-docs -f docs-Dockerfile .
 	docker run --network host tracetest-docs
 	sleep 1

--- a/cli/Makefile
+++ b/cli/Makefile
@@ -2,7 +2,12 @@ VERSION ?= "dev"
 TRACETEST_ENV ?= "dev"
 ANALYTICS_BE_KEY ?= ""
 
-build:
+help: Makefile ## show list of commands
+	@echo "Choose a command run:"
+	@echo ""
+	@awk 'BEGIN {FS = ":.*?## "} /[a-zA-Z_-]+:.*?## / {sub("\\\\n",sprintf("\n%22c"," "), $$2);printf "\033[36m%-40s\033[0m %s\n", $$1, $$2}' $(MAKEFILE_LIST) | sort
+
+build: ## build this project using goreleaser
 ifeq (, $(shell which goreleaser))
 	go install github.com/goreleaser/goreleaser@latest
 endif
@@ -12,5 +17,5 @@ endif
 	goreleaser build --single-target --rm-dist --snapshot -f ../.goreleaser.yaml
 	cp `cat ./dist/artifacts.json | jq -rc '.[0].path'` ./dist/tracetest
 
-test:
+test: ## execute unit tests
 	@go test -coverprofile=coverage.out ./...

--- a/docs/docs/cli/creating-tests.md
+++ b/docs/docs/cli/creating-tests.md
@@ -242,7 +242,7 @@ A `selector` is needed only if the provided expression refers to a/some span/s a
 It can be defined using the following YAML definition:
 
 ```yaml
-outpus:
+outputs:
   - name: USER_ID
     selector: span[name = "user creation"]
     value: attr:myapp.users.created_id
@@ -257,7 +257,7 @@ The `value` attribute is an `expression`, and is a very powerful tool.
 You can output basic expressions
 
 ```yaml
-outpus:
+outputs:
 
 - name: ARITHMETIC_RESULT
   value: 1 + 1
@@ -274,7 +274,7 @@ outpus:
 Imagine an hypotetical `/users/create` endpoint that returns the full `user` object, including the new ID, when the operation is successful.
 
 ```yaml
-outpus:
+outputs:
 - name: USER_ID
   selector: span[name = "POST /user/create"]
   value: attr:http.response.body | json_path '.id'
@@ -292,7 +292,7 @@ In this case, the service is instrumented so that each query generates a span of
 You can get a list of sql operations:
 
 ```yaml
-outpus:
+outputs:
 - name: SQL_OPS
   selector: span[tracetest.span.type = "database"]
   value: attr:sql.operation
@@ -302,7 +302,7 @@ outpus:
 Since the value is an array, you can also apply filters to it:
 
 ```yaml
-outpus:
+outputs:
 - name: LAST_SQL_OP
   selector: span[tracetest.span.type = "database"]
   value: attr:sql.operation | get_index 'last'

--- a/server/Makefile
+++ b/server/Makefile
@@ -9,22 +9,27 @@ GO_LDFLAGS := $(shell echo \
 		-X "'github.com/kubeshop/tracetest/server/analytics.FrontendKey=$(ANALYTICS_FE_KEY)'" \
 	| sed 's/ / /g')
 
+help: Makefile ## show list of commands
+	@echo "Choose a command run:"
+	@echo ""
+	@awk 'BEGIN {FS = ":.*?## "} /[a-zA-Z_-]+:.*?## / {sub("\\\\n",sprintf("\n%22c"," "), $$2);printf "\033[36m%-40s\033[0m %s\n", $$1, $$2}' $(MAKEFILE_LIST) | sort
+
 all: init-submodule proto generate
 
 init-submodule:
 	git submodule init
 	git submodule update
 
-test:
+test: # run go tests for this application
 	go test -timeout 90s -coverprofile=coverage.out ./...
 
-vet:
+vet: ## run vet tool to analyze the code for suspicious, abnormal, or useless code
 	go vet -structtag=false ./...
 
-run:
+run: ## run server locally
 	go run -ldflags="$(GO_LDFLAGS)" main.go
 
-build:
+build: ## build tracetest-server binary
 	go build -o tracetest-server -ldflags="$(GO_LDFLAGS)" .
 
 PROTOC_VER=0.3.1
@@ -69,7 +74,7 @@ PROTOC_WITH_GRPC := $(PROTOC) \
 PROTOC_INTERNAL := $(PROTOC) \
 		$(PROTO_INCLUDES)
 
-proto:
+proto: ## generate code client from protobuf definitions
 	rm -rf ./$(PROTO_GEN_GO_DIR)
 	mkdir -p ${PROTO_GEN_GO_DIR}
 


### PR DESCRIPTION
This PR aims to update minor typos in the documentation and add Makefile documentation on go-related makefiles

## Changes

- Added `make help` command on go-related Makefiles

## Fixes

- YAML config on "creating tests" doc

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [x] updated the docs
- [ ] added a test
