### PR TITLE
fix(frontend): add standard layout for data store forms and ui fixes

### DIFF
--- a/web/src/components/Settings/DataStore/DataStore.tsx
+++ b/web/src/components/Settings/DataStore/DataStore.tsx
@@ -1,16 +1,14 @@
 import {Button, Form} from 'antd';
 import {SupportedDataStoresToName} from 'constants/DataStore.constants';
-import {useSetupConfig} from 'providers/DataStore/DataStore.provider';
+import {useDataStore} from 'providers/DataStore/DataStore.provider';
+import {useDataStoreConfig} from 'providers/DataStoreConfig/DataStoreConfig.provider';
 import {useCallback} from 'react';
-import {TDraftDataStore, TDataStoreConfig, ConfigMode} from 'types/Config.types';
+import {TDraftDataStore, ConfigMode} from 'types/Config.types';
 import DataStoreForm from '../DataStoreForm';
 import * as S from './DataStore.styled';
 
-interface IProps {
-  dataStoreConfig: TDataStoreConfig;
-}
-
-const DataStore = ({dataStoreConfig}: IProps) => {
+const DataStore = () => {
+  const {dataStoreConfig} = useDataStoreConfig();
   const {
     isLoading,
     isFormValid,
@@ -19,7 +17,7 @@ const DataStore = ({dataStoreConfig}: IProps) => {
     isTestConnectionLoading,
     onTestConnection,
     onDeleteConfig,
-  } = useSetupConfig();
+  } = useDataStore();
   const isConfigReady = dataStoreConfig.mode === ConfigMode.READY;
   const [form] = Form.useForm<TDraftDataStore>();
 
@@ -36,14 +34,14 @@ const DataStore = ({dataStoreConfig}: IProps) => {
   }, [form, onTestConnection, dataStoreConfig.defaultDataStore]);
 
   return (
-    <S.Wrapper data-cy="config-datastore-form">
+    <S.Wrapper>
       <S.FormContainer>
         <div>
           <S.Description>
             Tracetest needs configuration information to be able to retrieve your trace from your distributed tracing
             solution. Select your tracing data store and enter the configuration info.
           </S.Description>
-          <S.Title>Choose OpenTelemetry data store</S.Title>
+          <S.Title>Choose your OpenTelemetry data store</S.Title>
           <DataStoreForm
             form={form}
             dataStoreConfig={dataStoreConfig}
@@ -54,7 +52,6 @@ const DataStore = ({dataStoreConfig}: IProps) => {
         <S.ButtonsContainer>
           {isConfigReady ? (
             <Button
-              data-cy="config-datastore-delete"
               disabled={isLoading}
               type="primary"
               ghost
@@ -68,7 +65,6 @@ const DataStore = ({dataStoreConfig}: IProps) => {
           )}
           <S.SaveContainer>
             <Button
-              data-cy="config-datastore-submit"
               loading={isTestConnectionLoading}
               disabled={!isFormValid}
               type="primary"
@@ -77,13 +73,7 @@ const DataStore = ({dataStoreConfig}: IProps) => {
             >
               Test Connection
             </Button>
-            <Button
-              data-cy="config-datastore-submit"
-              disabled={!isFormValid}
-              loading={isLoading}
-              type="primary"
-              onClick={() => form.submit()}
-            >
+            <Button disabled={!isFormValid} loading={isLoading} type="primary" onClick={() => form.submit()}>
               Save
             </Button>
           </S.SaveContainer>

--- a/web/src/components/Settings/DataStoreForm/DataStoreForm.tsx
+++ b/web/src/components/Settings/DataStoreForm/DataStoreForm.tsx
@@ -49,8 +49,8 @@ const DataStoreForm = ({form, onSubmit, dataStoreConfig, onIsFormValid}: IProps)
           <DataStoreSelectionInput />
         </Form.Item>
         <DataStoreDocsBanner dataStoreType={dataStoreType!} />
-        {explanation ? <S.Explanation>{explanation}</S.Explanation> : <S.Title>Provide connection info</S.Title>}
-        <DataStoreComponentFactory dataStoreType={dataStoreType} />
+        {explanation ? <S.Explanation>{explanation}</S.Explanation> : <S.Title>Provide the connection info</S.Title>}
+        {dataStoreType && <DataStoreComponentFactory dataStoreType={dataStoreType} />}
       </S.FormContainer>
     </Form>
   );

--- a/web/src/components/Settings/DataStorePlugin/forms/GrpcClient/GrpcClient.tsx
+++ b/web/src/components/Settings/DataStorePlugin/forms/GrpcClient/GrpcClient.tsx
@@ -1,5 +1,4 @@
 import {Checkbox, Col, Form, Input, Row, Select, Space, Switch} from 'antd';
-import {useState} from 'react';
 
 import RequestDetailsHeadersInput from 'components/CreateTestPlugins/Rest/steps/RequestDetails/RequestDetailsHeadersInput';
 import {TDraftDataStore} from 'types/Config.types';
@@ -21,8 +20,7 @@ const GrpcClient = () => {
   const form = Form.useFormInstance<TDraftDataStore>();
   const dataStoreType = form.getFieldValue('dataStoreType');
   const baseName = ['dataStore', dataStoreType];
-  const insecureValue = form.getFieldValue([...baseName, 'tls', 'insecure']);
-  const [isSecure, setIsSecure] = useState(!insecureValue);
+  const insecureValue = Form.useWatch([...baseName, 'tls', 'insecure'], form) ?? true;
 
   return (
     <>
@@ -87,9 +85,8 @@ const GrpcClient = () => {
         <Switch
           onChange={checked => {
             form.setFieldsValue({dataStore: {[dataStoreType]: {tls: {insecure: !checked}}}});
-            setIsSecure(checked);
           }}
-          checked={isSecure}
+          checked={!insecureValue}
         />{' '}
         Secure options
         <Form.Item hidden initialValue name={[...baseName, 'tls', 'insecure']} valuePropName="checked">
@@ -97,7 +94,7 @@ const GrpcClient = () => {
         </Form.Item>
       </Space>
 
-      {isSecure && <GrpcClientSecure baseName={baseName} />}
+      {!insecureValue && <GrpcClientSecure baseName={baseName} />}
     </>
   );
 };

--- a/web/src/components/Settings/DataStorePlugin/forms/OpenSearch/OpenSearch.tsx
+++ b/web/src/components/Settings/DataStorePlugin/forms/OpenSearch/OpenSearch.tsx
@@ -1,4 +1,4 @@
-import {Form, Input} from 'antd';
+import {Col, Form, Input, Row} from 'antd';
 import {SupportedDataStores} from 'types/Config.types';
 import * as S from '../../DataStorePluginForm.styled';
 import AddressesList from './AddressesList';
@@ -7,35 +7,38 @@ const OpenSearch = () => {
   const baseName = ['dataStore', SupportedDataStores.OpenSearch];
 
   return (
-    <S.FormContainer>
-      <S.FormColumn>
-        <Form.Item
-          label="Username"
-          name={[...baseName, 'username']}
-          rules={[{required: true, message: 'Username is required'}]}
-        >
-          <Input placeholder="Username" />
-        </Form.Item>
-        <Form.Item
-          label="Password"
-          name={[...baseName, 'password']}
-          rules={[{required: true, message: 'Password is required'}]}
-        >
-          <Input placeholder="Password" type="password" />
-        </Form.Item>
-      </S.FormColumn>
-      <S.FormColumn>
-        <Form.Item label="Index" name={[...baseName, 'index']} rules={[{required: true, message: 'Index is required'}]}>
-          <Input placeholder="Index" />
-        </Form.Item>
-        <div>
+    <>
+      <Row gutter={[16, 16]}>
+        <Col span={12}>
+          <Form.Item
+            label="Index"
+            name={[...baseName, 'index']}
+            rules={[{required: true, message: 'Index is required'}]}
+          >
+            <Input placeholder="Index" />
+          </Form.Item>
+        </Col>
+        <Col span={12}>
           <S.ItemListLabel>Addresses</S.ItemListLabel>
           <Form.List name={[...baseName, 'addresses']}>
             {(fields, {add, remove}) => <AddressesList fields={fields} add={add} remove={remove} />}
           </Form.List>
-        </div>
-      </S.FormColumn>
-    </S.FormContainer>
+        </Col>
+      </Row>
+
+      <Row gutter={[16, 16]}>
+        <Col span={12}>
+          <Form.Item label="Username" name={[...baseName, 'username']}>
+            <Input placeholder="Username" />
+          </Form.Item>
+        </Col>
+        <Col span={12}>
+          <Form.Item label="Password" name={[...baseName, 'password']}>
+            <Input placeholder="Password" type="password" />
+          </Form.Item>
+        </Col>
+      </Row>
+    </>
   );
 };
 

--- a/web/src/components/Settings/DataStorePlugin/forms/SignalFx/SignalFx.tsx
+++ b/web/src/components/Settings/DataStorePlugin/forms/SignalFx/SignalFx.tsx
@@ -1,23 +1,22 @@
-import {Form, Input} from 'antd';
+import {Col, Form, Input, Row} from 'antd';
 import {SupportedDataStores} from 'types/Config.types';
-import * as S from '../../DataStorePluginForm.styled';
 
 const SignalFx = () => {
   const baseName = ['dataStore', SupportedDataStores.SignalFX];
 
   return (
-    <S.FormContainer>
-      <S.FormColumn>
+    <Row gutter={[16, 16]}>
+      <Col span={12}>
         <Form.Item label="Realm" name={[...baseName, 'realm']} rules={[{required: true, message: 'Realm is required'}]}>
           <Input placeholder="Realm" />
         </Form.Item>
-      </S.FormColumn>
-      <S.FormColumn>
+      </Col>
+      <Col span={12}>
         <Form.Item label="Token" name={[...baseName, 'token']} rules={[{required: true, message: 'Token is required'}]}>
           <Input placeholder="Token" type="password" />
         </Form.Item>
-      </S.FormColumn>
-    </S.FormContainer>
+      </Col>
+    </Row>
   );
 };
 

--- a/web/src/pages/Settings/Content.tsx
+++ b/web/src/pages/Settings/Content.tsx
@@ -1,30 +1,25 @@
 // import {Tabs} from 'antd';
 import DataStore from 'components/Settings/DataStore';
-import {useDataStoreConfig} from 'providers/DataStoreConfig/DataStoreConfig.provider';
 import * as S from './Settings.styled';
 
 /* const TabsKeys = {
   DataStore: 'dataStore',
 }; */
 
-const Content = () => {
-  const {dataStoreConfig} = useDataStoreConfig();
+const Content = () => (
+  <S.Container>
+    <S.Header>
+      <S.Title>Configure Data Store</S.Title>
+    </S.Header>
 
-  return (
-    <S.Container>
-      <S.Header>
-        <S.Title>Configure Data Store</S.Title>
-      </S.Header>
-
-      {/* <S.TabsContainer>
+    {/* <S.TabsContainer>
         <Tabs size="small">
           <Tabs.TabPane key={TabsKeys.DataStore} tab="Configure Data Store"> */}
-      <DataStore dataStoreConfig={dataStoreConfig} />
-      {/* </Tabs.TabPane>
+    <DataStore />
+    {/* </Tabs.TabPane>
         </Tabs>
       </S.TabsContainer> */}
-    </S.Container>
-  );
-};
+  </S.Container>
+);
 
 export default Content;

--- a/web/src/providers/DataStore/DataStore.provider.tsx
+++ b/web/src/providers/DataStore/DataStore.provider.tsx
@@ -38,7 +38,7 @@ interface IProps {
   children: React.ReactNode;
 }
 
-export const useSetupConfig = () => useContext(Context);
+export const useDataStore = () => useContext(Context);
 
 const DataStoreProvider = ({children}: IProps) => {
   const {isFetching} = useDataStoreConfig();

--- a/web/src/services/DataStore.service.ts
+++ b/web/src/services/DataStore.service.ts
@@ -25,7 +25,7 @@ const DataStoreService = (): IDataStoreService => ({
     const isUpdate = !!defaultDataStore.id;
 
     const dataStore: TRawDataStore = isUpdate
-      ? {id: defaultDataStore.id, name: defaultDataStore.name, ...dataStoreValues, isDefault: true}
+      ? {id: defaultDataStore.id, name: dataStoreType, ...dataStoreValues, isDefault: true}
       : {
           ...dataStoreValues,
           name: dataStoreType,

--- a/web/src/services/DataStores/OpenSearch.service.ts
+++ b/web/src/services/DataStores/OpenSearch.service.ts
@@ -13,9 +13,9 @@ const OpenSearchService = (): TDataStoreService => ({
       },
     });
   },
-  validateDraft({dataStore: {openSearch: {index = '', username = '', password = '', addresses = []} = {}} = {}}) {
+  validateDraft({dataStore: {openSearch: {index = '', addresses = []} = {}} = {}}) {
     const [address] = addresses;
-    if (!index || !username || !password || !Validator.url(address)) return Promise.resolve(false);
+    if (!index || !Validator.url(address)) return Promise.resolve(false);
 
     return Promise.resolve(true);
   },


### PR DESCRIPTION
This PR adds a standard layout for the data store forms and also fixes minor UI issues.

## Changes

- Data store forms layout
- Remove required `username`/`password` for `openSearch`
- Fix `insecure switch` issue in the grpc client form (`jaeger`/`tempo`)

## Fixes

-

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Screenshots

<img width="1624" alt="Screenshot 2022-12-28 at 16 05 52" src="https://user-images.githubusercontent.com/3879892/209871939-a0b296af-0739-4f89-aba0-0d5f3e544d0b.png">
<img width="1624" alt="Screenshot 2022-12-28 at 16 05 57" src="https://user-images.githubusercontent.com/3879892/209871944-db1491ff-1314-4385-9039-6a888afd3ee3.png">
<img width="1624" alt="Screenshot 2022-12-28 at 16 06 04" src="https://user-images.githubusercontent.com/3879892/209871948-d4ce3fad-2c86-4081-aa99-7e6519d632dc.png">