### PR TITLE
fix(frontend): fixing overlapping icon

### DIFF
--- a/web/src/components/FileViewerModal/FileViewerModal.styled.ts
+++ b/web/src/components/FileViewerModal/FileViewerModal.styled.ts
@@ -35,5 +35,5 @@ export const CopyIconContainer = styled.div`
   border-radius: 2px;
   cursor: pointer;
   background-color: ${({theme}) => theme.color.textHighlight};
-  z-index: 99999;
+  z-index: 101;
 `;


### PR DESCRIPTION
This PR fixes a small bug with the copy to clipboard icon overlapping with the save settings modal

## Changes

- Updates the z-index property for the copy to clipboard container

## Fixes

- #1739 

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
