### PR TITLE
fix(backend): ignoring incoming otel collector traffic when data store is not enabled

### DIFF
--- a/local-config/collector.config.yaml
+++ b/local-config/collector.config.yaml
@@ -33,5 +33,5 @@ service:
   pipelines:
     traces/1:
       receivers: [otlp]
-      processors: [tail_sampling, batch]
+      processors: [batch]
       exporters: [otlp/1]


### PR DESCRIPTION
This PR adds a check to the Export function that is part of the otlp listener to validate if a default data store is enabled and its the otlp one.

## Changes

- Adds otlp default data store validation

## Fixes

- #1739 

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

https://www.loom.com/share/71080bf4b5a64192a2867bbdb148b1b1

