### PR TITLE
docs: add docs about creating data stores using the CLI

### DIFF
--- a/docs/docs/cli/creating-data-stores.md
+++ b/docs/docs/cli/creating-data-stores.md
@@ -1,5 +1,5 @@
 # Defining Data Stores as Text Files
-You might have multiple tracetest instances that need to be connected to the same data stores. An easy way of sharing the configuration is by using a configuration file that can be applied to your tracetest instance.
+You might have multiple Tracetest instances that need to be connected to the same data stores. An easy way of sharing the configuration is by using a configuration file that can be applied to your Tracetest instance.
 
 ### Jaeger
 ```yaml
@@ -24,7 +24,7 @@ spec:
   tempo:
     endpoint: tempo:9095
     tls:
-      insecure: trues
+      insecure: true
 ```
 
 ### OpenSearch
@@ -61,9 +61,9 @@ spec:
   isDefault: true
 ```
 
-> Consider reading about [how to use the OTEL collector](../configuration/connecting-to-data-stores/opentelemetry-collector.md) to send traces to your tracetest instance.
+> Consider reading about [how to use the OTEL collector](../configuration/connecting-to-data-stores/opentelemetry-collector.md) to send traces to your Tracetest instance.
 
-## Apply configuration
+## Apply Configuration
 
 To apply the configuration, you need a [configured CLI](./configuring-your-cli.md) pointed to the instance you want to apply the data store. Then you just have to enter:
 
@@ -71,5 +71,5 @@ To apply the configuration, you need a [configured CLI](./configuring-your-cli.m
 tracetest data-store apply -f my/data-store/file/location.yaml
 ```
 
-## Additional information
+## Additional Information
 In the current version, you can only have one active data store at any given time. The flag `isDefault` defines which data store should be used by your tests. So, if you want to add a new data store and make sure it will be used in future test runs, make sure to define `isDefault` as `true` in the data store configuration file.

--- a/docs/docs/cli/creating-data-stores.md
+++ b/docs/docs/cli/creating-data-stores.md
@@ -52,6 +52,17 @@ spec:
     token: mytoken
 ```
 
+### Using the OpenTelemetry Collector
+```yaml
+type: DataStore
+spec:
+  name: Opentelemetry Collector pipeline
+  type: otlp
+  isDefault: true
+```
+
+> Consider reading about [how to use the OTEL collector](../configuration/connecting-to-data-stores/opentelemetry-collector.md) to send traces to your tracetest instance.
+
 ## Apply configuration
 
 To apply the configuration, you need a [configured CLI](./configuring-your-cli.md) pointed to the instance you want to apply the data store. Then you just have to enter:

--- a/docs/docs/cli/creating-data-stores.md
+++ b/docs/docs/cli/creating-data-stores.md
@@ -1,0 +1,64 @@
+# Defining Data Stores as Text Files
+You might have multiple tracetest instances that need to be connected to the same data stores. An easy way of sharing the configuration is by using a configuration file that can be applied to your tracetest instance.
+
+### Jaeger
+```yaml
+type: DataStore
+spec:
+    name: development
+    type: jaeger
+    isDefault: true
+    jaeger:
+        endpoint: 127.0.0.1:16685
+        tls:
+            insecure: true
+```
+
+### Tempo
+```yaml
+type: DataStore
+spec:
+  name: Grafana Tempo
+  type: tempo
+  isDefault: true
+  tempo:
+    endpoint: tempo:9095
+    tls:
+      insecure: trues
+```
+
+### OpenSearch
+```yaml
+type: DataStore
+spec:
+  name: OpenSearch Data Store
+  type: openSearch
+  isDefault: true
+  opensearch:
+    addresses:
+      - http://opensearch:9200
+    index: traces
+```
+
+### SignalFX
+```yaml
+type: DataStore
+spec:
+  name: SignalFX
+  type: signalFx
+  isDefault: true
+  signalFx:
+    realm: us1
+    token: mytoken
+```
+
+## Apply configuration
+
+To apply the configuration, you need a [configured CLI](./configuring-your-cli.md) pointed to the instance you want to apply the data store. Then you just have to enter:
+
+```
+tracetest data-store apply -f my/data-store/file/location.yaml
+```
+
+## Additional information
+In the current version, you can only have one active data store at any given time. The flag `isDefault` defines which data store should be used by your tests. So, if you want to add a new data store and make sure it will be used in future test runs, make sure to define `isDefault` as `true` in the data store configuration file.

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -219,6 +219,11 @@ const sidebars = {
           id: "cli/configuring-your-cli",
           label: "Configuring your CLI",
         },
+        {
+          type: "doc",
+          id: "cli/creating-data-stores",
+          label: "Creating Data Stores",
+        },
         // {
         //   type: "doc",
         //   id: "cli/creating-environments",


### PR DESCRIPTION
This PR adds documentation on how you can create data stores using the CLI.

## Checklist

- [ ] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
