### PR TITLE
fix(ui): convert zipcode to string in otel checkout demo

### DIFF
--- a/web/src/constants/Demo.constants.ts
+++ b/web/src/constants/Demo.constants.ts
@@ -225,7 +225,7 @@ export const OtelDemo = {
           state: 'CA',
           country: 'United States',
           city: 'Mountain View',
-          zip_code: 94043,
+          zip_code: '94043',
         },
         email: 'someone@example.com',
         credit_card: {


### PR DESCRIPTION
This PR aims to fix a small issue that we have on our OTel demo. In new versions of the OpenTelemetry Community Demo, the checkout service emits error if we try to send a numeric zipcode.

## Changes

- Convert zipcode to string in otel checkout demo

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
