### PR TITLE
feat: disable analytics if `TRACETEST_DEV` env is defined in the host machine

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -26,6 +26,8 @@ services:
     depends_on:
       postgres:
         condition: service_healthy
+    environment:
+      TRACETEST_DEV: ${TRACETEST_DEV}
 
   postgres:
     image: postgres

--- a/examples/collector/docker-compose.yml
+++ b/examples/collector/docker-compose.yml
@@ -22,6 +22,8 @@ services:
             interval: 1s
             timeout: 3s
             retries: 60
+        environment:
+            TRACETEST_DEV: ${TRACETEST_DEV}
 
     postgres:
         image: postgres:14

--- a/examples/quick-start-jaeger-nodejs/tracetest/docker-compose.yaml
+++ b/examples/quick-start-jaeger-nodejs/tracetest/docker-compose.yaml
@@ -20,6 +20,8 @@ services:
       interval: 1s
       timeout: 3s
       retries: 60
+    environment:
+      TRACETEST_DEV: ${TRACETEST_DEV}
 
   postgres:
     image: postgres:14

--- a/examples/quick-start-nodejs/tracetest/docker-compose.yaml
+++ b/examples/quick-start-nodejs/tracetest/docker-compose.yaml
@@ -18,6 +18,8 @@ services:
       interval: 1s
       timeout: 3s
       retries: 60
+    environment:
+      TRACETEST_DEV: ${TRACETEST_DEV}
 
   postgres:
     image: postgres:14

--- a/examples/quick-start-opensearch-nodejs/tracetest/docker-compose.yaml
+++ b/examples/quick-start-opensearch-nodejs/tracetest/docker-compose.yaml
@@ -18,6 +18,8 @@ services:
       interval: 1s
       timeout: 3s
       retries: 60
+    environment:
+      TRACETEST_DEV: ${TRACETEST_DEV}
 
   postgres:
     image: postgres:14

--- a/examples/quick-start-tempo-nodejs/tracetest/docker-compose.yaml
+++ b/examples/quick-start-tempo-nodejs/tracetest/docker-compose.yaml
@@ -20,6 +20,8 @@ services:
       interval: 1s
       timeout: 3s
       retries: 60
+    environment:
+      TRACETEST_DEV: ${TRACETEST_DEV}
 
   postgres:
     image: postgres:14

--- a/examples/tracetest-jaeger/docker-compose.yml
+++ b/examples/tracetest-jaeger/docker-compose.yml
@@ -22,6 +22,8 @@ services:
             interval: 1s
             timeout: 3s
             retries: 60
+        environment:
+            TRACETEST_DEV: ${TRACETEST_DEV}
 
     postgres:
         image: postgres:14

--- a/examples/tracetest-lightstep/tracetest/docker-compose.yaml
+++ b/examples/tracetest-lightstep/tracetest/docker-compose.yaml
@@ -22,6 +22,8 @@ services:
         condition: service_healthy
       otel-collector:
         condition: service_started
+    environment:
+      TRACETEST_DEV: ${TRACETEST_DEV}
 
   postgres:
     image: postgres

--- a/examples/tracetest-new-relic/tracetest/docker-compose.yaml
+++ b/examples/tracetest-new-relic/tracetest/docker-compose.yaml
@@ -22,6 +22,8 @@ services:
         condition: service_healthy
       otel-collector:
         condition: service_started
+    environment:
+      TRACETEST_DEV: ${TRACETEST_DEV}
 
   postgres:
     image: postgres

--- a/examples/tracetest-no-tracing/docker-compose.yml
+++ b/examples/tracetest-no-tracing/docker-compose.yml
@@ -20,6 +20,8 @@ services:
             interval: 1s
             timeout: 3s
             retries: 60
+        environment:
+            TRACETEST_DEV: ${TRACETEST_DEV}
 
     postgres:
         image: postgres:14

--- a/examples/tracetest-opensearch/docker-compose.yml
+++ b/examples/tracetest-opensearch/docker-compose.yml
@@ -21,6 +21,8 @@ services:
       interval: 1s
       timeout: 3s
       retries: 60
+    environment:
+      TRACETEST_DEV: ${TRACETEST_DEV}
 
   postgres:
     image: postgres:14

--- a/examples/tracetest-otel-demo/docker-compose.yaml
+++ b/examples/tracetest-otel-demo/docker-compose.yaml
@@ -24,6 +24,8 @@ services:
         condition: service_healthy
       otel-collector:
         condition: service_started
+    environment:
+      TRACETEST_DEV: ${TRACETEST_DEV}
 
   postgres:
     image: postgres

--- a/examples/tracetest-signalfx/docker-compose.yml
+++ b/examples/tracetest-signalfx/docker-compose.yml
@@ -22,6 +22,8 @@ services:
             interval: 1s
             timeout: 3s
             retries: 60
+        environment:
+            TRACETEST_DEV: ${TRACETEST_DEV}
 
     postgres:
         image: postgres:14

--- a/examples/tracetest-tempo/docker-compose.yml
+++ b/examples/tracetest-tempo/docker-compose.yml
@@ -22,6 +22,8 @@ services:
             interval: 1s
             timeout: 3s
             retries: 60
+        environment:
+            TRACETEST_DEV: ${TRACETEST_DEV}
 
     postgres:
         image: postgres:14

--- a/server/app/app.go
+++ b/server/app/app.go
@@ -99,6 +99,12 @@ func (a *App) Start() error {
 		return err
 	}
 
+	if os.Getenv("TRACETEST_DEV") != "" {
+		// non-empty TRACETEST_DEV variable means it's running by a dev
+		// and we should totally ignore analytics
+		a.config.GA.Enabled = false
+	}
+
 	err = analytics.Init(a.config.GA.Enabled, serverID, Version, Env)
 	if err != nil {
 		return err

--- a/server/app/app.go
+++ b/server/app/app.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"os"
 
 	"github.com/davecgh/go-spew/spew"
 	"github.com/gorilla/handlers"


### PR DESCRIPTION
This PR disables analytics if the env `TRACETEST_DEV` is defined.

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
