### PR TITLE
fix(server): update analytics unique id generation

### DIFF
--- a/server/testdb/postgres.go
+++ b/server/testdb/postgres.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/denisbrodbeck/machineid"
 	"github.com/golang-migrate/migrate/v4"
 	"github.com/golang-migrate/migrate/v4/database/postgres"
 	_ "github.com/golang-migrate/migrate/v4/source/file"
@@ -61,48 +60,6 @@ func (p *postgresDB) ensureLatestMigration() error {
 	}
 
 	return nil
-}
-
-func (td *postgresDB) ServerID() (id string, isNew bool, err error) {
-	isNew = false
-	id = ""
-
-	err = td.db.
-		QueryRow(`SELECT id FROM "server" LIMIT 1`).
-		Scan(&id)
-	if err != nil && err != sql.ErrNoRows {
-		err = fmt.Errorf("could not get serverID from DB: %w", err)
-		return
-	}
-
-	if id != "" {
-		return
-	}
-
-	// no id, let's creat it
-	isNew = true
-	id, err = machineid.ProtectedID("tracetest")
-	if err != nil {
-		err = fmt.Errorf("could not get machineID: %w", err)
-		return
-	}
-	id = id[:10] // limit lenght to avoid issues with GA
-
-	stmt, err := td.db.Prepare(`INSERT INTO "server" (id) VALUES ($1)`)
-	if err != nil {
-		err = fmt.Errorf("could not prepare stmt: %w", err)
-		return
-	}
-	defer stmt.Close()
-
-	_, err = stmt.Exec(id)
-	if err != nil {
-		err = fmt.Errorf("could not save serverID into DB: %w", err)
-		return
-	}
-
-	return
-
 }
 
 func (td *postgresDB) Drop() error {

--- a/server/testdb/server.go
+++ b/server/testdb/server.go
@@ -4,7 +4,7 @@ import (
 	"database/sql"
 	"fmt"
 
-	"github.com/denisbrodbeck/machineid"
+	"github.com/teris-io/shortid"
 )
 
 func (td *postgresDB) ServerID() (string, bool, error) {
@@ -25,9 +25,9 @@ func (td *postgresDB) ServerID() (string, bool, error) {
 	// there is no ID, let's create a new one and register on database
 	isNew = true
 
-	id, err = generateUniqueServerID()
+	id, err = shortid.Generate()
 	if err != nil {
-		return id, isNew, fmt.Errorf("could not generate serverID: %w", err)
+		return id, isNew, fmt.Errorf("could not generate id: %w", err)
 	}
 
 	stmt, err := td.db.Prepare(`INSERT INTO "server" (id) VALUES ($1)`)
@@ -42,17 +42,4 @@ func (td *postgresDB) ServerID() (string, bool, error) {
 	}
 
 	return id, isNew, nil
-
-}
-
-func generateUniqueServerID() (string, error) {
-	id, err := machineid.ProtectedID("tracetest")
-
-	if err != nil {
-		return "", fmt.Errorf("could not get machineID: %w", err)
-	}
-
-	id = id[:10] // limit lenght to avoid issues with GA
-
-	return id, nil
 }

--- a/server/testdb/server.go
+++ b/server/testdb/server.go
@@ -1,0 +1,58 @@
+package testdb
+
+import (
+	"database/sql"
+	"fmt"
+
+	"github.com/denisbrodbeck/machineid"
+)
+
+func (td *postgresDB) ServerID() (string, bool, error) {
+	isNew := false
+	id := ""
+
+	err := td.db.
+		QueryRow(`SELECT id FROM "server" LIMIT 1`).
+		Scan(&id)
+	if err != nil && err != sql.ErrNoRows {
+		return id, isNew, fmt.Errorf("could not get serverID from DB: %w", err)
+	}
+
+	if id != "" {
+		return id, isNew, err
+	}
+
+	// there is no ID, let's create a new one and register on database
+	isNew = true
+
+	id, err = generateUniqueServerID()
+	if err != nil {
+		return id, isNew, fmt.Errorf("could not generate serverID: %w", err)
+	}
+
+	stmt, err := td.db.Prepare(`INSERT INTO "server" (id) VALUES ($1)`)
+	if err != nil {
+		return id, isNew, fmt.Errorf("could not prepare stmt: %w", err)
+	}
+	defer stmt.Close()
+
+	_, err = stmt.Exec(id)
+	if err != nil {
+		return id, isNew, fmt.Errorf("could not save serverID into DB: %w", err)
+	}
+
+	return id, isNew, nil
+
+}
+
+func generateUniqueServerID() (string, error) {
+	id, err := machineid.ProtectedID("tracetest")
+
+	if err != nil {
+		return "", fmt.Errorf("could not get machineID: %w", err)
+	}
+
+	id = id[:10] // limit lenght to avoid issues with GA
+
+	return id, nil
+}

--- a/server/testdb/server_test.go
+++ b/server/testdb/server_test.go
@@ -1,0 +1,34 @@
+package testdb_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetServerIDForFirstTime(t *testing.T) {
+	db, clean := getDB()
+	defer clean()
+
+	id, isNew, err := db.ServerID()
+	assert.Len(t, id, 9)
+	assert.True(t, isNew)
+	assert.NoError(t, err)
+}
+
+func TestGetServerIDForSecondTime(t *testing.T) {
+	db, clean := getDB()
+	defer clean()
+
+	firstId, isNew, err := db.ServerID()
+	assert.Len(t, firstId, 9)
+	assert.True(t, isNew)
+	assert.NoError(t, err)
+
+	secondId, isNew, err := db.ServerID()
+	assert.Len(t, secondId, 9)
+	assert.False(t, isNew)
+	assert.NoError(t, err)
+
+	assert.Equal(t, firstId, secondId)
+}


### PR DESCRIPTION
This PR aims to change how we generate the server id, to avoid using `machineid`. This is necessary because we don't have any guarantee that the `machineid` will be unique across many Tracetest server containers.

## Changes

- Change ServerID generation to use shortid instead of machineid

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
