### PR TITLE
fix: machine id fallback

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,8 +45,7 @@ COPY .goreleaser.yaml .
 RUN cd cli && make build
 
 FROM alpine AS release
-# Enable machine-id on alpine-linux (https://gitlab.alpinelinux.org/alpine/aports/-/issues/8761)
-RUN apk add dbus
+
 WORKDIR /app
 COPY --from=build-server /go/src/tracetest-server ./
 COPY --from=build-server /go/src/migrations/ ./migrations/

--- a/server/config/machine-id.go
+++ b/server/config/machine-id.go
@@ -9,15 +9,25 @@ import (
 )
 
 func GetMachineID() string {
-	id, err := machineid.ProtectedID("tracetest")
-	// fallback to hostname based machine id in case of error
-	if err != nil {
-		name, err := os.Hostname()
-		if err != nil {
-			return "default"
-		}
-		sum := md5.Sum([]byte(name))
-		return hex.EncodeToString(sum[:])
+	id := getMachineID()
+	if len(id) > 10 {
+		return id[:10] // limit lenght to avoid issues with GA
 	}
+
 	return id
+}
+
+func getMachineID() string {
+	id, err := machineid.ProtectedID("tracetest")
+	if err == nil {
+		return id
+	}
+
+	// fallback to hostname based machine id in case of error
+	name, err := os.Hostname()
+	if err != nil {
+		return "default"
+	}
+	sum := md5.Sum([]byte(name))
+	return hex.EncodeToString(sum[:])
 }

--- a/server/config/machine-id.go
+++ b/server/config/machine-id.go
@@ -1,0 +1,23 @@
+package config
+
+import (
+	"crypto/md5"
+	"encoding/hex"
+	"os"
+
+	"github.com/denisbrodbeck/machineid"
+)
+
+func GetMachineID() string {
+	id, err := machineid.ProtectedID("tracetest")
+	// fallback to hostname based machine id in case of error
+	if err != nil {
+		name, err := os.Hostname()
+		if err != nil {
+			return "default"
+		}
+		sum := md5.Sum([]byte(name))
+		return hex.EncodeToString(sum[:])
+	}
+	return id
+}

--- a/server/config/machine-id.go
+++ b/server/config/machine-id.go
@@ -10,7 +10,7 @@ import (
 
 func GetMachineID() string {
 	id := getMachineID()
-	if len(id) > 10 {
+	if len(id) >= 10 {
 		return id[:10] // limit lenght to avoid issues with GA
 	}
 

--- a/server/migrations/17_reset_server_id.down.sql
+++ b/server/migrations/17_reset_server_id.down.sql
@@ -1,0 +1,1 @@
+-- nothing to be done because it's impossible to retrieve the deleted id

--- a/server/migrations/17_reset_server_id.up.sql
+++ b/server/migrations/17_reset_server_id.up.sql
@@ -1,0 +1,7 @@
+-- Before this version, all tracetest versions had a hard-coded machine-id
+-- this means that the id stored in this table changed by version, but two
+-- users running the same version would share the same id.
+--
+-- With the problem fixed, we need to make sure we reset the server id so all
+-- users have real unique ids.
+DELETE FROM "server";

--- a/server/testdb/postgres.go
+++ b/server/testdb/postgres.go
@@ -8,7 +8,6 @@ import (
 	"github.com/golang-migrate/migrate/v4"
 	"github.com/golang-migrate/migrate/v4/database/postgres"
 	_ "github.com/golang-migrate/migrate/v4/source/file"
-	"github.com/kubeshop/tracetest/server/config"
 	"github.com/kubeshop/tracetest/server/id"
 )
 
@@ -61,44 +60,6 @@ func (p *postgresDB) ensureLatestMigration() error {
 	}
 
 	return nil
-}
-
-func (td *postgresDB) ServerID() (id string, isNew bool, err error) {
-	isNew = false
-	id = ""
-
-	err = td.db.
-		QueryRow(`SELECT id FROM "server" LIMIT 1`).
-		Scan(&id)
-	if err != nil && err != sql.ErrNoRows {
-		err = fmt.Errorf("could not get serverID from DB: %w", err)
-		return
-	}
-
-	if id != "" {
-		return
-	}
-
-	// no id, let's creat it
-	isNew = true
-	id = config.GetMachineID()
-	id = id[:10] // limit lenght to avoid issues with GA
-
-	stmt, err := td.db.Prepare(`INSERT INTO "server" (id) VALUES ($1)`)
-	if err != nil {
-		err = fmt.Errorf("could not prepare stmt: %w", err)
-		return
-	}
-	defer stmt.Close()
-
-	_, err = stmt.Exec(id)
-	if err != nil {
-		err = fmt.Errorf("could not save serverID into DB: %w", err)
-		return
-	}
-
-	return
-
 }
 
 func (td *postgresDB) Drop() error {

--- a/server/testdb/postgres.go
+++ b/server/testdb/postgres.go
@@ -5,10 +5,10 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/denisbrodbeck/machineid"
 	"github.com/golang-migrate/migrate/v4"
 	"github.com/golang-migrate/migrate/v4/database/postgres"
 	_ "github.com/golang-migrate/migrate/v4/source/file"
+	"github.com/kubeshop/tracetest/server/config"
 	"github.com/kubeshop/tracetest/server/id"
 )
 
@@ -81,11 +81,7 @@ func (td *postgresDB) ServerID() (id string, isNew bool, err error) {
 
 	// no id, let's creat it
 	isNew = true
-	id, err = machineid.ProtectedID("tracetest")
-	if err != nil {
-		err = fmt.Errorf("could not get machineID: %w", err)
-		return
-	}
+	id = config.GetMachineID()
 	id = id[:10] // limit lenght to avoid issues with GA
 
 	stmt, err := td.db.Prepare(`INSERT INTO "server" (id) VALUES ($1)`)

--- a/server/testdb/server.go
+++ b/server/testdb/server.go
@@ -1,0 +1,45 @@
+package testdb
+
+import (
+	"database/sql"
+	"fmt"
+
+	"github.com/kubeshop/tracetest/server/config"
+)
+
+func (td *postgresDB) ServerID() (id string, isNew bool, err error) {
+	isNew = false
+	id = ""
+
+	err = td.db.
+		QueryRow(`SELECT id FROM "server" LIMIT 1`).
+		Scan(&id)
+	if err != nil && err != sql.ErrNoRows {
+		err = fmt.Errorf("could not get serverID from DB: %w", err)
+		return
+	}
+
+	if id != "" {
+		return
+	}
+
+	// no id, let's creat it
+	isNew = true
+	id = config.GetMachineID()
+
+	stmt, err := td.db.Prepare(`INSERT INTO "server" (id) VALUES ($1)`)
+	if err != nil {
+		err = fmt.Errorf("could not prepare stmt: %w", err)
+		return
+	}
+	defer stmt.Close()
+
+	_, err = stmt.Exec(id)
+	if err != nil {
+		err = fmt.Errorf("could not save serverID into DB: %w", err)
+		return
+	}
+
+	return
+
+}

--- a/server/testdb/server_test.go
+++ b/server/testdb/server_test.go
@@ -1,0 +1,34 @@
+package testdb_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetServerIDForFirstTime(t *testing.T) {
+	db, clean := getDB()
+	defer clean()
+
+	id, isNew, err := db.ServerID()
+	assert.Len(t, id, 9)
+	assert.True(t, isNew)
+	assert.NoError(t, err)
+}
+
+func TestGetServerIDForSecondTime(t *testing.T) {
+	db, clean := getDB()
+	defer clean()
+
+	firstId, isNew, err := db.ServerID()
+	assert.Len(t, firstId, 9)
+	assert.True(t, isNew)
+	assert.NoError(t, err)
+
+	secondId, isNew, err := db.ServerID()
+	assert.Len(t, secondId, 9)
+	assert.False(t, isNew)
+	assert.NoError(t, err)
+
+	assert.Equal(t, firstId, secondId)
+}

--- a/server/testdb/server_test.go
+++ b/server/testdb/server_test.go
@@ -11,7 +11,7 @@ func TestGetServerIDForFirstTime(t *testing.T) {
 	defer clean()
 
 	id, isNew, err := db.ServerID()
-	assert.Len(t, id, 9)
+	assert.Len(t, id, 10)
 	assert.True(t, isNew)
 	assert.NoError(t, err)
 }
@@ -21,12 +21,12 @@ func TestGetServerIDForSecondTime(t *testing.T) {
 	defer clean()
 
 	firstId, isNew, err := db.ServerID()
-	assert.Len(t, firstId, 9)
+	assert.Len(t, firstId, 10)
 	assert.True(t, isNew)
 	assert.NoError(t, err)
 
 	secondId, isNew, err := db.ServerID()
-	assert.Len(t, secondId, 9)
+	assert.Len(t, secondId, 10)
 	assert.False(t, isNew)
 	assert.NoError(t, err)
 


### PR DESCRIPTION
This PR makes tracetest consider the hostname as a fallback in case it cannot get the machine-id from the host. It also will make old servers reset the server table, so all old users will get new server ids.

## Checklist

- [ ] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
