### PR TITLE
Adding an example docker-compose test for Elastic APM

### DIFF
--- a/examples/tracetest-elasticapm-with-otel/.env
+++ b/examples/tracetest-elasticapm-with-otel/.env
@@ -1,0 +1,26 @@
+# Password for the 'elastic' user (at least 6 characters)
+ELASTIC_PASSWORD=changeme
+
+# Password for the 'kibana_system' user (at least 6 characters)
+KIBANA_PASSWORD=changeme
+
+# Version of Elastic products
+STACK_VERSION=8.6.0
+
+# Set the cluster name
+CLUSTER_NAME=docker-cluster
+
+# Set to 'basic' or 'trial' to automatically start the 30-day trial
+LICENSE=basic
+
+# Port to expose Elasticsearch HTTP API to the host
+ES_PORT=9200
+
+# Port to expose Kibana to the host
+KIBANA_PORT=5601
+
+# Increase or decrease based on the available host memory (in bytes)
+MEM_LIMIT=1073741824
+
+# Project namespace (defaults to the current folder name if not set)
+# COMPOSE_PROJECT_NAME=test

--- a/examples/tracetest-elasticapm-with-otel/Dockerfile
+++ b/examples/tracetest-elasticapm-with-otel/Dockerfile
@@ -1,0 +1,7 @@
+FROM node:slim
+WORKDIR /usr/src/app
+COPY package*.json ./
+RUN npm install
+COPY . .
+EXPOSE 8080
+CMD [ "npm", "run", "with-grpc-tracer" ]

--- a/examples/tracetest-elasticapm-with-otel/README.md
+++ b/examples/tracetest-elasticapm-with-otel/README.md
@@ -8,10 +8,21 @@ docker compose up -d
 ```
 
 ## Open Tracetest UI
-Open http://localhost:11633/ and create a new test:
+Open http://localhost:11633/ to configure the connection to Elasticsearch:
+1. In Settings, configure Elastic APM as the Data Store.
+2. Set `apm-*` as the Index name.
+3. Add the Address and set it to `https://es01:9200`.
+4. Set the Username to `elastic` and password to `changeme`.
+5. You will need to download the CA certificate from the docker image and upload it to the config under "Upload CA file".
+    * The command to download the `ca.crt` file is:
+    `docker cp tracetest-elasticapm-with-otel-es01-1:/usr/share/elasticsearch/config/certs/ca/ca.crt .`
+6. Test the commection and Save it, if all is successful.
+
+Create a new test:
 1. Use the "HTTP Request" option. Hit Next.
 2. Name your test and add a description. Hit Next.
 3. Configure the GET url to be `http://app:8080` since the tests will be running in docker compose network. Hit Create.
+4. Running the test should succeed.
 
 
 ## Open Kibana

--- a/examples/tracetest-elasticapm-with-otel/README.md
+++ b/examples/tracetest-elasticapm-with-otel/README.md
@@ -1,0 +1,31 @@
+# Tracetest + Elastic APM + OTel
+
+This repository objective is to show how you can configure your tracetest instance to connect to Elastic stack instance and use it as its tracing backend.
+
+## Steps to start the environment
+```bash
+docker compose up -d
+```
+
+## Open Tracetest UI
+Open http://localhost:11633/ and create a new test:
+1. Use the "HTTP Request" option. Hit Next.
+2. Name your test and add a description. Hit Next.
+3. Configure the GET url to be `http://app:8080` since the tests will be running in docker compose network. Hit Create.
+
+
+## Open Kibana
+Open https://localhost:5601 and login using `elastic:changeme` credentials. The credentials can be changed in the `.env` file. Navigate to APM (upper lefthand corner menu) -> Services and you should see the `tracetest` service with the rest of the details.
+
+## Steps to stop the environment
+```bash
+docker compose down -v
+```
+
+## Project structure
+* `docker-compose.yml` - docker compose file that starts the whole environment
+    * Elastic stack single node cluster with Elasticsearch, Kibana and the APM Server.
+    * OTel collector sending the OTel trace data to Elastic stack.
+    * Tracetest instance configured to send the trace data to OTel collector.
+* `collector-config.yml` - OTel collector configuration file
+* `*.js/*.json` - sample NodeJS application listening on port 8080

--- a/examples/tracetest-elasticapm-with-otel/app.js
+++ b/examples/tracetest-elasticapm-with-otel/app.js
@@ -1,0 +1,8 @@
+const express = require("express")
+const app = express()
+app.get("/", (req, res) => {
+  res.send("Hello World")
+})
+app.listen(8080, () => {
+  console.log(`Listening for requests on http://localhost:8080`)
+})

--- a/examples/tracetest-elasticapm-with-otel/collector.config.yaml
+++ b/examples/tracetest-elasticapm-with-otel/collector.config.yaml
@@ -1,0 +1,29 @@
+receivers:
+  otlp:
+    protocols:
+      grpc:
+      http:
+
+
+processors:
+  batch:
+    timeout: 100ms
+
+  # Data sources: traces
+  probabilistic_sampler:
+    hash_seed: 22
+    sampling_percentage: 100
+
+exporters:
+  otlp/elastic:
+    endpoint: apm-server:8200
+    tls:
+      insecure: true
+      insecure_skip_verify: true
+
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [probabilistic_sampler, batch]
+      exporters: [otlp/elastic]

--- a/examples/tracetest-elasticapm-with-otel/docker-compose.yaml
+++ b/examples/tracetest-elasticapm-with-otel/docker-compose.yaml
@@ -1,0 +1,227 @@
+version: "3"
+
+services:
+  setup:
+    image: docker.elastic.co/elasticsearch/elasticsearch:${STACK_VERSION}
+    volumes:
+      - certs:/usr/share/elasticsearch/config/certs
+    user: "0"
+    command: >
+      bash -c '
+        if [ x${ELASTIC_PASSWORD} == x ]; then
+          echo "Set the ELASTIC_PASSWORD environment variable in the .env file";
+          exit 1;
+        elif [ x${KIBANA_PASSWORD} == x ]; then
+          echo "Set the KIBANA_PASSWORD environment variable in the .env file";
+          exit 1;
+        fi;
+        if [ ! -f config/certs/ca.zip ]; then
+          echo "Creating CA";
+          bin/elasticsearch-certutil ca --silent --pem -out config/certs/ca.zip;
+          unzip config/certs/ca.zip -d config/certs;
+        fi;
+        if [ ! -f config/certs/certs.zip ]; then
+          echo "Creating certs";
+          echo -ne \
+          "instances:\n"\
+          "  - name: es01\n"\
+          "    dns:\n"\
+          "      - es01\n"\
+          "      - localhost\n"\
+          "    ip:\n"\
+          "      - 127.0.0.1\n"\
+          "  - name: kib01\n"\
+          "    dns:\n"\
+          "      - kib01\n"\
+          "      - localhost\n"\
+          "    ip:\n"\
+          "      - 127.0.0.1\n"\
+          "  - name: fleet\n"\
+          "    dns:\n"\
+          "      - fleet\n"\
+          "      - localhost\n"\
+          "    ip:\n"\
+          "      - 127.0.0.1\n"\
+          > config/certs/instances.yml;
+          bin/elasticsearch-certutil cert --silent --pem -out config/certs/certs.zip --in config/certs/instances.yml --ca-cert config/certs/ca/ca.crt --ca-key config/certs/ca/ca.key;
+          unzip config/certs/certs.zip -d config/certs;
+        fi;
+        echo "Setting file permissions"
+        chown -R root:root config/certs;
+        find . -type d -exec chmod 750 \{\} \;;
+        find . -type f -exec chmod 640 \{\} \;;
+        echo "Waiting for Elasticsearch availability";
+        until curl -s --cacert config/certs/ca/ca.crt https://es01:9200 | grep -q "missing authentication credentials"; do sleep 30; done;
+        echo "Setting kibana_system password";
+        until curl -s -X POST --cacert config/certs/ca/ca.crt -u elastic:${ELASTIC_PASSWORD} -H "Content-Type: application/json" https://es01:9200/_security/user/kibana_system/_password -d "{\"password\":\"${KIBANA_PASSWORD}\"}" | grep -q "^{}"; do sleep 10; done;
+        echo "All done!";
+      '
+    healthcheck:
+      test: ["CMD-SHELL", "[ -f config/certs/es01/es01.crt ]"]
+      interval: 1s
+      timeout: 5s
+      retries: 120
+
+  es01:
+    depends_on:
+      setup:
+        condition: service_healthy
+    image: docker.elastic.co/elasticsearch/elasticsearch:${STACK_VERSION}
+    volumes:
+      - certs:/usr/share/elasticsearch/config/certs
+    ports:
+      - ${ES_PORT}:9200
+    environment:
+      - node.name=es01
+      - cluster.name=${CLUSTER_NAME}
+      - cluster.initial_master_nodes=es01
+      - ELASTIC_PASSWORD=${ELASTIC_PASSWORD}
+      - bootstrap.memory_lock=true
+      - xpack.security.enabled=true
+      - xpack.security.http.ssl.enabled=true
+      - xpack.security.http.ssl.key=certs/es01/es01.key
+      - xpack.security.http.ssl.certificate=certs/es01/es01.crt
+      - xpack.security.http.ssl.certificate_authorities=certs/ca/ca.crt
+      - xpack.security.http.ssl.verification_mode=certificate
+      - xpack.security.transport.ssl.enabled=true
+      - xpack.security.transport.ssl.key=certs/es01/es01.key
+      - xpack.security.transport.ssl.certificate=certs/es01/es01.crt
+      - xpack.security.transport.ssl.certificate_authorities=certs/ca/ca.crt
+      - xpack.security.transport.ssl.verification_mode=certificate
+      - xpack.license.self_generated.type=${LICENSE}
+    mem_limit: ${MEM_LIMIT}
+    ulimits:
+      memlock:
+        soft: -1
+        hard: -1
+    healthcheck:
+      test:
+        [
+          "CMD-SHELL",
+          "curl -s --cacert config/certs/ca/ca.crt https://es01:9200 | grep -q 'missing authentication credentials'",
+        ]
+      interval: 10s
+      timeout: 10s
+      retries: 120
+
+  kib01:
+    depends_on:
+      es01:
+        condition: service_healthy
+    image: docker.elastic.co/kibana/kibana:${STACK_VERSION}
+    volumes:
+      - certs:/usr/share/kibana/config/certs
+      - ./kibana.yml:/usr/share/kibana/config/kibana.yml
+    ports:
+      - ${KIBANA_PORT}:5601
+    environment:
+      - SERVERNAME=kibana
+      - ELASTICSEARCH_HOSTS=https://es01:9200
+      - ELASTICSEARCH_USERNAME=kibana_system
+      - ELASTICSEARCH_PASSWORD=${KIBANA_PASSWORD}
+      - ELASTICSEARCH_SSL_CERTIFICATEAUTHORITIES=config/certs/ca/ca.crt
+      - SERVER_SSL_ENABLED=true
+      - SERVER_SSL_KEY=config/certs/kib01/kib01.key
+      - SERVER_SSL_CERTIFICATE=config/certs/kib01/kib01.crt
+      - XPACK_ENCRYPTEDSAVEDOBJECTS_ENCRYPTIONKEY=abc45678901234567890123456789012
+      - XPACK_ACTIONS_PRECONFIGUREDALERTHISTORYESINDEX=true     
+
+      - ES_URL=https://es01:9200
+    mem_limit: ${MEM_LIMIT}
+    healthcheck:
+      test:
+        [
+          "CMD-SHELL",
+          "curl -s -I --cacert config/certs/ca/ca.crt https://kib01:5601 | grep -q 'HTTP/1.1 302 Found'",
+        ]
+      interval: 10s
+      timeout: 10s
+      retries: 120
+
+  apm-server:
+    depends_on:
+      es01:
+        condition: service_healthy
+      kib01:
+        condition: service_healthy  
+    image: docker.elastic.co/apm/apm-server:${STACK_VERSION}
+    volumes:
+      - certs:/usr/share/apm-server/config/certs    
+    ports:
+      - 8200:8200
+    command: >
+      apm-server -e
+        -E apm-server.rum.enabled=false
+        -E apm-server.host=0.0.0.0:8200
+        -E apm-server.ssl.enabled=false
+
+        -E output.elasticsearch.hosts=["https://es01:9200"]
+        -E output.elasticsearch.username=elastic
+        -E output.elasticsearch.password=${ELASTIC_PASSWORD}
+        -E output.elasticsearch.ssl.certificate_authorities=config/certs/ca/ca.crt
+    # healthcheck:
+    #   interval: 10s
+    #   timeout: 10s
+    #   retries: 120
+    #   test: ["CMD", "nc", "-z", "localhost", "8200"]
+
+  tracetest:
+    image: kubeshop/tracetest:${TAG:-latest}
+    # platform: linux/amd64
+    volumes:
+      - type: bind
+        source: ./tracetest-config.yaml
+        target: /app/config.yaml
+    ports:
+      - 11633:11633
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    depends_on:
+      postgres:
+        condition: service_healthy
+      otel-collector:
+        condition: service_started
+    healthcheck:
+      test: ["CMD", "wget", "--spider", "localhost:11633"]
+      interval: 10s
+      timeout: 30s
+      retries: 120
+
+  postgres:
+    image: postgres:14
+    environment:
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_USER: postgres
+    ports:
+      - 5432:5432
+    healthcheck:
+      test: pg_isready -U "$$POSTGRES_USER" -d "$$POSTGRES_DB"
+      interval: 10s
+      timeout: 10s
+      retries: 120
+
+  otel-collector:
+    image: otel/opentelemetry-collector:0.54.0
+    ports:
+      - "55679:55679"
+      - "4317:4317"
+      - "8888:8888"
+    command:
+      - "--config"
+      - "/otel-local-config.yaml"
+    volumes:
+      - ./collector.config.yaml:/otel-local-config.yaml
+    depends_on:
+      apm-server:
+        condition: service_started
+
+  app:
+    image: quick-start-nodejs
+    hostname: app
+    build: .
+    ports:
+      - "8080:8080"
+
+volumes:
+  certs:
+    driver: local

--- a/examples/tracetest-elasticapm-with-otel/docker-compose.yaml
+++ b/examples/tracetest-elasticapm-with-otel/docker-compose.yaml
@@ -168,6 +168,8 @@ services:
   tracetest:
     image: kubeshop/tracetest:${TAG:-latest}
     # platform: linux/amd64
+    environment:
+      - ELASTICSEARCH_SSL_VERIFICATION_MODE=none
     volumes:
       - type: bind
         source: ./tracetest-config.yaml

--- a/examples/tracetest-elasticapm-with-otel/kibana.yml
+++ b/examples/tracetest-elasticapm-with-otel/kibana.yml
@@ -1,0 +1,29 @@
+server.host: 0.0.0.0
+
+xpack.fleet.packages:
+  - name: fleet_server
+    version: latest
+  - name: apm
+    version: latest
+xpack.fleet.agentPolicies:
+  - name: Fleet Server policy
+    id: fleet-server-policy
+    namespace: default
+    is_default_fleet_server: true
+    data_output_id: es01
+    monitoring_output_id: es01    
+    package_policies:
+      - name: fleet_server-1
+        package:
+          name: fleet_server
+
+xpack.fleet.outputs:
+  - id: es01
+    name: ES01
+    type: elasticsearch
+    hosts:
+      - ${ES_URL}
+    config:
+      ssl.verification_mode: none
+    is_default: true
+    is_default_monitoring: true

--- a/examples/tracetest-elasticapm-with-otel/package.json
+++ b/examples/tracetest-elasticapm-with-otel/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "quick-start-nodejs",
+  "version": "1.0.0",
+  "description": "",
+  "main": "app.js",
+  "scripts": {
+    "with-grpc-tracer":"node -r ./tracing.otel.grpc.js app.js",
+    "with-http-tracer":"node -r ./tracing.otel.http.js app.js"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "@opentelemetry/auto-instrumentations-node": "^0.33.1",
+    "@opentelemetry/exporter-trace-otlp-grpc": "^0.34.0",
+    "@opentelemetry/exporter-trace-otlp-http": "^0.33.0",
+    "@opentelemetry/sdk-node": "^0.33.0",
+    "express": "^4.18.2"
+  }
+}

--- a/examples/tracetest-elasticapm-with-otel/tracetest-config.yaml
+++ b/examples/tracetest-elasticapm-with-otel/tracetest-config.yaml
@@ -1,0 +1,36 @@
+postgresConnString: "host=postgres user=postgres password=postgres port=5432 sslmode=disable"
+
+poolingConfig:
+  maxWaitTimeForTrace: 10m
+  retryDelay: 5s
+
+googleAnalytics:
+  enabled: false
+
+demo:
+  enabled: []
+
+experimentalFeatures: []
+
+telemetry:
+  dataStores:
+    opensearch:
+      type: opensearch
+      opensearch:
+        addresses:
+          - http://es01:9200
+        index: apm-*
+
+  exporters:
+    collector:
+      serviceName: tracetest
+      sampling: 100 # 100%
+      exporter:
+        type: collector
+        collector:
+          endpoint: otel-collector:4317
+
+server:
+  telemetry:
+    dataStore: opensearch
+    exporter: collector

--- a/examples/tracetest-elasticapm-with-otel/tracetest-config.yaml
+++ b/examples/tracetest-elasticapm-with-otel/tracetest-config.yaml
@@ -5,7 +5,7 @@ poolingConfig:
   retryDelay: 5s
 
 googleAnalytics:
-  enabled: false
+  enabled: true
 
 demo:
   enabled: []
@@ -16,9 +16,11 @@ telemetry:
   dataStores:
     opensearch:
       type: opensearch
-      opensearch:
+      elasticsearch:
         addresses:
-          - http://es01:9200
+          - https://es01:9200
+        username: elastic
+        password: changeme
         index: apm-*
 
   exporters:

--- a/examples/tracetest-elasticapm-with-otel/tracing.otel.grpc.js
+++ b/examples/tracetest-elasticapm-with-otel/tracing.otel.grpc.js
@@ -1,0 +1,9 @@
+const opentelemetry = require('@opentelemetry/sdk-node')
+const { getNodeAutoInstrumentations } = require('@opentelemetry/auto-instrumentations-node')
+const { OTLPTraceExporter } = require('@opentelemetry/exporter-trace-otlp-grpc');
+
+const sdk = new opentelemetry.NodeSDK({
+  traceExporter: new OTLPTraceExporter({ url: 'http://otel-collector:4317' }),
+  instrumentations: [getNodeAutoInstrumentations()],
+})
+sdk.start()

--- a/examples/tracetest-elasticapm-with-otel/tracing.otel.http.js
+++ b/examples/tracetest-elasticapm-with-otel/tracing.otel.http.js
@@ -1,0 +1,9 @@
+const opentelemetry = require('@opentelemetry/sdk-node')
+const { getNodeAutoInstrumentations } = require('@opentelemetry/auto-instrumentations-node')
+const { OTLPTraceExporter } = require('@opentelemetry/exporter-trace-otlp-http')
+
+const sdk = new opentelemetry.NodeSDK({
+  traceExporter: new OTLPTraceExporter({ url: 'http://otel-collector:4318/v1/traces' }),
+  instrumentations: [getNodeAutoInstrumentations()],
+})
+sdk.start()


### PR DESCRIPTION
This PR adds a docker-compose example of Elastic stack with APM server integrated with OTel collector and Tracetest.
## Changes
Adds an e2e example for #1777 

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [x] updated the docs
- [ ] added a test
