### PR TITLE
feat(frontend): add tracetest version

### DIFF
--- a/web/src/components/Header/Header.styled.tsx
+++ b/web/src/components/Header/Header.styled.tsx
@@ -1,5 +1,5 @@
 import {QuestionCircleOutlined} from '@ant-design/icons';
-import {Layout, Menu} from 'antd';
+import {Layout, Menu, Typography} from 'antd';
 import styled from 'styled-components';
 
 export const Header = styled(Layout.Header)`
@@ -51,4 +51,15 @@ export const NavMenu = styled(Menu).attrs({
 export const QuestionIcon = styled(QuestionCircleOutlined)`
   color: ${({theme}) => theme.color.primary};
   font-size: ${({theme}) => theme.size.lg};
+`;
+
+export const AppVersionContainer = styled.div`
+  border-top: ${({theme}) => `1px solid ${theme.color.borderLight}`};
+`;
+
+export const AppVersion = styled(Typography.Text)`
+  && {
+    color: ${({theme}) => theme.color.textLight};
+    font-size: ${({theme}) => theme.size.sm};
+  }
 `;

--- a/web/src/components/Header/HeaderMenu.tsx
+++ b/web/src/components/Header/HeaderMenu.tsx
@@ -5,11 +5,14 @@ import {useGuidedTour} from 'providers/GuidedTour/GuidedTour.provider';
 import {useCallback, useMemo} from 'react';
 import {useLocation, useParams} from 'react-router-dom';
 import HomeAnalyticsService from 'services/Analytics/HomeAnalytics.service';
+import Env from 'utils/Env';
 import {switchTraceMode} from '../GuidedTour/traceStepList';
 import * as S from './Header.styled';
 import {ShowOnboardingContent} from './ShowOnboardingContent';
 
 const {onGuidedTourClick} = HomeAnalyticsService;
+
+const appVersion = Env.get('appVersion');
 
 const HeaderMenu = () => {
   const {pathname} = useLocation();
@@ -69,6 +72,15 @@ const HeaderMenu = () => {
                   <a key="guidedTour" onClick={onStartOnboarding}>
                     Show Onboarding
                   </a>
+                ),
+              },
+              {
+                key: 'App version',
+                disabled: true,
+                label: (
+                  <S.AppVersionContainer>
+                    <S.AppVersion>App version: {appVersion}</S.AppVersion>
+                  </S.AppVersionContainer>
                 ),
               },
             ],


### PR DESCRIPTION
This PR adds access via UI to determine what version the Tracetest server is running.

## Changes

- add tracetest version

## Fixes

- fixes #1763 

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Screenshot

<img width="1624" alt="Screenshot 2023-01-12 at 10 56 53" src="https://user-images.githubusercontent.com/3879892/212115950-b675029f-69c8-4871-9559-eaf99e9e6dbd.png">