### PR TITLE
feat: add version to tracetest logo on installer

### DIFF
--- a/cli/ui/ui.go
+++ b/cli/ui/ui.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/kubeshop/tracetest/cli/config"
 	"github.com/pterm/pterm"
 	"github.com/pterm/pterm/putils"
 )
@@ -45,6 +46,8 @@ func (ui ptermUI) Banner() {
 	pterm.DefaultBigText.
 		WithLetters(putils.LettersFromString("TraceTest")).
 		Render()
+
+	pterm.Print(fmt.Sprintf("Version: %s", config.Version))
 
 	pterm.Print("\n\n")
 


### PR DESCRIPTION
This PR adds the version  of CLI on tracetest logo when running the installer.

## Changes
![Screenshot from 2023-01-12 14-22-24](https://user-images.githubusercontent.com/2704737/212136102-7f3c0d28-59f9-4c1a-8a6d-adb1b3ee082a.png)


## Fixes

-

## Checklist

- [ ] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
