### PR TITLE
fix(cli): add cli on PATH env

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -51,5 +51,9 @@ COPY --from=build-server /go/src/tracetest-server ./
 COPY --from=build-server /go/src/migrations/ ./migrations/
 COPY --from=build-cli /go/src/cli/dist/tracetest ./
 COPY --from=build-js /app/build /app/html
+
+ENV PATH="$PATH:/app"
+
 EXPOSE 11633/tcp
+
 ENTRYPOINT ["/app/tracetest-server"]


### PR DESCRIPTION
This PR adds the CLI on PATH env in our docker image, permitting us to run `tracetest` command on the container without the `./` prefix.

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
