### PR TITLE
ci: add danielbdias to team and remove issue notification

### DIFF
--- a/.github/workflows/community-issue-notification.yml
+++ b/.github/workflows/community-issue-notification.yml
@@ -15,7 +15,7 @@ jobs:
         if: github.event.action == 'opened'
         uses: mathnogueira/user-blocklist@1.0.0
         with:
-          blocked_users: adnanrahic, jfermi, jorgeepc, kdhamric, mathnogueira, olha23, schoren, xoscar
+          blocked_users: adnanrahic, danielbdias, jfermi, jorgeepc, kdhamric, mathnogueira, olha23, schoren, xoscar
 
       - name: Notify us if not a kubeshop member
         if: |


### PR DESCRIPTION
This PR adds @danielbdias  to the team and remove the PR notification pipeline

## Changes

-

## Fixes

-

## Checklist

- [ ] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
