### PR TITLE
feat: add environment apply command

### DIFF
--- a/cli/actions/apply_environment_action.go
+++ b/cli/actions/apply_environment_action.go
@@ -43,7 +43,7 @@ func (a applyEnvironmentAction) Run(ctx context.Context, args ApplyEnvironmentCo
 	}
 
 	if fileContent.Definition().Type != "Environment" {
-		return fmt.Errorf(`file must be of type "DataStore"`)
+		return fmt.Errorf(`file must be of type "Environment"`)
 	}
 
 	fileContentString := fileContent.Contents()

--- a/cli/actions/apply_environment_action.go
+++ b/cli/actions/apply_environment_action.go
@@ -1,0 +1,73 @@
+package actions
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/kubeshop/tracetest/cli/file"
+	"github.com/kubeshop/tracetest/cli/openapi"
+	"go.uber.org/zap"
+)
+
+type ApplyEnvironmentConfig struct {
+	File string
+}
+
+type applyEnvironmentAction struct {
+	logger *zap.Logger
+	client *openapi.APIClient
+}
+
+var _ Action[ApplyEnvironmentConfig] = &applyEnvironmentAction{}
+
+func NewApplyEnvironmentAction(logger *zap.Logger, client *openapi.APIClient) applyEnvironmentAction {
+	return applyEnvironmentAction{
+		logger: logger,
+		client: client,
+	}
+}
+
+func (a applyEnvironmentAction) Run(ctx context.Context, args ApplyEnvironmentConfig) error {
+	if args.File == "" {
+		return fmt.Errorf("you must specify a file to be applied")
+	}
+
+	a.logger.Debug(
+		"applying environment",
+		zap.String("file", args.File),
+	)
+
+	fileContent, err := file.Read(args.File)
+	if err != nil {
+		return fmt.Errorf("could not read file: %w", err)
+	}
+
+	if fileContent.Definition().Type != "Environment" {
+		return fmt.Errorf(`file must be of type "DataStore"`)
+	}
+
+	fileContentString := fileContent.Contents()
+
+	req := a.client.ApiApi.ExecuteDefinition(ctx)
+	req = req.TextDefinition(openapi.TextDefinition{
+		RunInformation: &openapi.RunInformation{},
+		Content:        &fileContentString,
+	})
+
+	response, _, err := req.Execute()
+	if err != nil {
+		return fmt.Errorf("could not apply environment: %w", err)
+	}
+
+	if fileContent.HasID() || response.Id == nil {
+		return nil
+	}
+
+	newFile, err := fileContent.SetID(*response.Id)
+	if err != nil {
+		return fmt.Errorf("could not set id into environment file: %w", err)
+	}
+
+	_, err = newFile.Write()
+	return err
+}

--- a/cli/cmd/environment_apply.go
+++ b/cli/cmd/environment_apply.go
@@ -1,0 +1,38 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/kubeshop/tracetest/cli/actions"
+	"github.com/kubeshop/tracetest/cli/analytics"
+	"github.com/spf13/cobra"
+)
+
+var environmentApplyFile string
+
+var environmentApplyCmd = &cobra.Command{
+	Use:    "apply",
+	Short:  "Apply environment to tracetest",
+	Long:   "Apply environment to tracetest",
+	PreRun: setupCommand(),
+	Run: func(cmd *cobra.Command, args []string) {
+		analytics.Track("Environment apply", "cmd", map[string]string{})
+		action := actions.NewApplyEnvironmentAction(cliLogger, getAPIClient())
+
+		err := action.Run(context.Background(), actions.ApplyEnvironmentConfig{
+			File: environmentApplyFile,
+		})
+		if err != nil {
+			fmt.Println(err.Error())
+			os.Exit(1)
+		}
+	},
+	PostRun: teardownCommand,
+}
+
+func init() {
+	environmentApplyCmd.PersistentFlags().StringVarP(&environmentApplyFile, "file", "f", "", "--file environment.yaml")
+	environmentCmd.AddCommand(environmentApplyCmd)
+}

--- a/cli/cmd/environment_cmd.go
+++ b/cli/cmd/environment_cmd.go
@@ -1,0 +1,25 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/kubeshop/tracetest/cli/analytics"
+	"github.com/spf13/cobra"
+)
+
+var environmentCmd = &cobra.Command{
+	Use:    "environment",
+	Short:  "Manage your tracetest environments",
+	Long:   "Manage your tracetest environments",
+	PreRun: setupCommand(),
+	Run: func(cmd *cobra.Command, args []string) {
+		analytics.Track("Environment", "cmd", map[string]string{})
+
+		fmt.Println("Manage your environments")
+	},
+	PostRun: teardownCommand,
+}
+
+func init() {
+	rootCmd.AddCommand(environmentCmd)
+}

--- a/docs/docs/cli/creating-environments.md
+++ b/docs/docs/cli/creating-environments.md
@@ -1,0 +1,25 @@
+# Creating Environments
+
+Just like Data Stores, you can also manage your environments using the CLI and definition files.
+
+A definition  file looks like the following:
+
+```yaml
+type: Environment
+spec:
+    name: Production
+    description: Production env variables
+    values:
+    - key: URL
+      value: https://app-production.company.com
+    - key: API_KEY
+      value: mysecret
+```
+
+In order to apply this configuration to your Tracetest instance, make sure to have your [CLI configured](./configuring-your-cli.md) and run:
+
+```
+tracetest environment apply -f <environment.yaml>
+```
+
+> If the file contains the property `spec.id`, the operation will be considered an environment udpate. If you try to apply an environment and you get an error: `could not apply environment: 404 Not Found`, it means the provided id doesn't exist. Either update the id to reference an existing environment, or just remove the property from the file, so Tracetest will create a new environmenta and a new id.

--- a/server/testdb/environments.go
+++ b/server/testdb/environments.go
@@ -64,7 +64,7 @@ func (td *postgresDB) CreateEnvironment(ctx context.Context, environment model.E
 func (td *postgresDB) UpdateEnvironment(ctx context.Context, environment model.Environment) (model.Environment, error) {
 	oldEnvironment, err := td.GetEnvironment(ctx, environment.ID)
 	if err != nil {
-		return model.Environment{}, fmt.Errorf("could not get the environment while updating: %w", err)
+		return model.Environment{}, err
 	}
 
 	// keep the same creation date to keep sort order


### PR DESCRIPTION
This PR introduces the command `tracetest environment apply -f file.yaml` to make the CLI more coherent 

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
