### PR TITLE
fix(test): update trace names asserition on Pokeshop

### DIFF
--- a/tracetesting/features/http_test/05_create_http_test.yml
+++ b/tracetesting/features/http_test/05_create_http_test.yml
@@ -32,7 +32,7 @@ spec:
             "specs": [
               {
                 "selector": {
-                  "query": "span[name = \"pg.query:SELECT\"]"
+                  "query": "span[name = \"pg.query:SELECT pokeshop\"]"
                 },
                 "assertions": ["attr:tracetest.selected_spans.count > 0"]
               }

--- a/tracetesting/features/transaction/01_create_transaction_step.yml
+++ b/tracetesting/features/transaction/01_create_transaction_step.yml
@@ -32,7 +32,7 @@ spec:
             "specs": [
               {
                 "selector": {
-                  "query": "span[name = \"pg.query:SELECT\"]"
+                  "query": "span[name = \"pg.query:SELECT pokeshop\"]"
                 },
                 "assertions": ["attr:tracetest.selected_spans.count > 0"]
               }


### PR DESCRIPTION
This PR aims to fix a change in a dogfood test. As we updated Pokeshop example, one of the spans that we were validating has his name changed.

Context: https://github.com/open-telemetry/opentelemetry-js-contrib/pull/1306 needed to change they way that the spans where reported for `pg`

## Checklist

- [ ] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
