### PR TITLE
docs(redirect): add introduction redirect

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -97,6 +97,10 @@ const config = {
           //   from: ['/test-definition-file' /*, '/docs/legacyDocFrom2016'*/],
           // },
           {
+            to: '/',
+            from: ['/introduction' /*, '/docs/legacyDocFrom2016'*/],
+          },
+          {
             to: '/concepts/selectors',
             from: ['/advanced-selectors' /*, '/docs/legacyDocFrom2016'*/],
           },


### PR DESCRIPTION
This PR adds a 301 redirect from `/introduction` to `/`.

## Changes

-

## Fixes

-

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [x] updated the docs
- [ ] added a test
