### PR TITLE
fix min span count for trace poller after removal of trigger span

### DIFF
--- a/server/tracedb/tracedb.go
+++ b/server/tracedb/tracedb.go
@@ -97,4 +97,4 @@ func (f *traceDBFactory) New(ds model.DataStore) (tdb TraceDB, err error) {
 type realTraceDB struct{}
 
 func (db *realTraceDB) ShouldRetry() bool { return true }
-func (db *realTraceDB) MinSpanCount() int { return 1 }
+func (db *realTraceDB) MinSpanCount() int { return 0 }


### PR DESCRIPTION
We were using `1` so we would ignore traces that only contained only the trigger root span. Now that we are not sending that span, we have to set the minimum as `0` instead. Otherwise, traces with only one span will never be polled.

## Fixes

- #1858 

## Checklist

- [ ] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
