### PR TITLE
feature(frontend): updating trace id trigger form

### DIFF
--- a/web/src/components/CreateTestPlugins/TraceID/TraceID.ts
+++ b/web/src/components/CreateTestPlugins/TraceID/TraceID.ts
@@ -1,11 +1,11 @@
 import {IPluginComponentMap} from 'types/Plugins.types';
-import Value from './steps/Value';
+import VariableName from './steps/VariableName';
 import Default from '../Default';
 
 export const PluginComponentMap: IPluginComponentMap = {
   SelectPlugin: Default.SelectPlugin,
   BasicDetails: Default.BasicDetails,
-  TraceIDValue: Value,
+  TraceIdVariableName: VariableName,
 };
 
 export default PluginComponentMap;

--- a/web/src/components/CreateTestPlugins/TraceID/steps/VariableName/VariableName.tsx
+++ b/web/src/components/CreateTestPlugins/TraceID/steps/VariableName/VariableName.tsx
@@ -5,9 +5,9 @@ import * as Step from 'components/CreateTestPlugins/Step.styled';
 import {ComponentNames} from 'constants/Plugins.constants';
 import {useCreateTest} from 'providers/CreateTest/CreateTest.provider';
 import {ITraceIDValues} from 'types/Test.types';
-import ValueForm from './ValueForm';
+import ValueForm from './VariableNameForm';
 
-const Value = () => {
+const VariableName = () => {
   const {onNext, draftTest, onIsFormValid} = useCreateTest();
   const [form] = Form.useForm<ITraceIDValues>();
 
@@ -37,9 +37,10 @@ const Value = () => {
   return (
     <Step.Step>
       <Step.FormContainer>
-        <Step.Title>Enter a Trace ID or an Expression</Step.Title>
+        <Step.Title>Enter the variable name to use for the Trace Id</Step.Title>
+        <Step.Subtitle>Please enter a variable name for the trace id or accept the default &apos;traceId&apos; name</Step.Subtitle>
         <Form<ITraceIDValues>
-          id={ComponentNames.TraceIDValue}
+          id={ComponentNames.TraceIdVariableName}
           autoComplete="off"
           form={form}
           layout="vertical"
@@ -52,4 +53,4 @@ const Value = () => {
   );
 };
 
-export default Value;
+export default VariableName;

--- a/web/src/components/CreateTestPlugins/TraceID/steps/VariableName/VariableName.tsx
+++ b/web/src/components/CreateTestPlugins/TraceID/steps/VariableName/VariableName.tsx
@@ -5,7 +5,7 @@ import * as Step from 'components/CreateTestPlugins/Step.styled';
 import {ComponentNames} from 'constants/Plugins.constants';
 import {useCreateTest} from 'providers/CreateTest/CreateTest.provider';
 import {ITraceIDValues} from 'types/Test.types';
-import ValueForm from './VariableNameForm';
+import VariableNameForm from './VariableNameForm';
 
 const VariableName = () => {
   const {onNext, draftTest, onIsFormValid} = useCreateTest();
@@ -37,8 +37,8 @@ const VariableName = () => {
   return (
     <Step.Step>
       <Step.FormContainer>
-        <Step.Title>Enter the variable name to use for the Trace Id</Step.Title>
-        <Step.Subtitle>Please enter a variable name for the trace id or accept the default &apos;traceId&apos; name</Step.Subtitle>
+        <Step.Title>Enter the variable name to use for the Trace ID</Step.Title>
+        <Step.Subtitle>Please enter a variable name for the Trace ID or accept the default &apos;traceId&apos; name</Step.Subtitle>
         <Form<ITraceIDValues>
           id={ComponentNames.TraceIdVariableName}
           autoComplete="off"
@@ -46,7 +46,7 @@ const VariableName = () => {
           layout="vertical"
           onFinish={handleSubmit}
         >
-          <ValueForm />
+          <VariableNameForm />
         </Form>
       </Step.FormContainer>
     </Step.Step>

--- a/web/src/components/CreateTestPlugins/TraceID/steps/VariableName/VariableNameForm.tsx
+++ b/web/src/components/CreateTestPlugins/TraceID/steps/VariableName/VariableNameForm.tsx
@@ -4,18 +4,14 @@ import * as S from 'components/CreateTestPlugins/Default/steps/BasicDetails/Basi
 import Editor from 'components/Editor';
 import {SupportedEditors} from 'constants/Editor.constants';
 
-const ValueForm = () => {
+const VariableNameForm = () => {
   return (
     <S.InputContainer>
-      <Form.Item
-        label="Trace ID"
-        name="id"
-        rules={[{required: true, message: 'Please enter a Trace ID or an Expression'}]}
-      >
-        <Editor type={SupportedEditors.Interpolation} placeholder="Trace ID or Expression" />
+      <Form.Item label="Variable Name" name="id" rules={[{required: true, message: 'Please enter a Variable Name'}]}>
+        <Editor type={SupportedEditors.Interpolation} placeholder="Variable Name" />
       </Form.Item>
     </S.InputContainer>
   );
 };
 
-export default ValueForm;
+export default VariableNameForm;

--- a/web/src/components/CreateTestPlugins/TraceID/steps/VariableName/index.ts
+++ b/web/src/components/CreateTestPlugins/TraceID/steps/VariableName/index.ts
@@ -1,2 +1,2 @@
 // eslint-disable-next-line no-restricted-exports
-export {default} from './Value';
+export {default} from './VariableName';

--- a/web/src/components/EditTestForm/EditRequestDetails/TraceID/TraceID.tsx
+++ b/web/src/components/EditTestForm/EditRequestDetails/TraceID/TraceID.tsx
@@ -1,4 +1,4 @@
-import ValueForm from 'components/CreateTestPlugins/TraceID/steps/Value/ValueForm';
+import ValueForm from 'components/CreateTestPlugins/TraceID/steps/VariableName/VariableNameForm';
 
 const EditDetailsTraceId = () => <ValueForm />;
 

--- a/web/src/constants/Plugins.constants.ts
+++ b/web/src/constants/Plugins.constants.ts
@@ -10,7 +10,7 @@ export enum ComponentNames {
   UploadCollection = 'UploadCollection',
   TestsSelection = 'TestsSelection',
   ImportCommand = 'ImportCommand',
-  TraceIDValue = 'TraceIDValue',
+  TraceIdVariableName = 'TraceIdVariableName',
 }
 
 const Default: IPlugin = {
@@ -145,9 +145,9 @@ const TraceID: IPlugin = {
     ...Default.stepList,
     {
       id: 'trace-id-value',
-      name: 'Trace ID',
-      title: 'Add a Trace ID',
-      component: ComponentNames.TraceIDValue,
+      name: 'Variable Name',
+      title: 'Add a Variable Name',
+      component: ComponentNames.TraceIdVariableName,
     },
   ],
   demoList: [],

--- a/web/src/services/Triggers/TraceID.service.ts
+++ b/web/src/services/Triggers/TraceID.service.ts
@@ -5,7 +5,7 @@ const TraceIDTriggerService = (): ITriggerService => ({
   async getRequest(values): Promise<TRawTRACEIDRequest> {
     const {id} = values as ITraceIDValues;
 
-    return {id};
+    return {id: id.includes('env:') ? id : `\${env:${id}}`};
   },
 
   async validateDraft(draft): Promise<boolean> {


### PR DESCRIPTION
This PR updates the trigger trace form to ask users to add the variable name instead of the actual trace id, to have the trace id be always dynamic.

## Changes

- Updates the trace id trigger

## Fixes

- #1857 

## Checklist
- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

![Screenshot 2023-01-20 at 10 03 53](https://user-images.githubusercontent.com/11051031/213746442-fb009ca8-2673-4e28-9b58-abe2d7363764.png)