### PR TITLE
feat(frontend): add empty state in environment tab

### DIFF
--- a/web/src/components/RunDetailTriggerResponse/ResponseEnvironment.tsx
+++ b/web/src/components/RunDetailTriggerResponse/ResponseEnvironment.tsx
@@ -1,4 +1,5 @@
 import KeyValueRow from 'components/KeyValueRow';
+import {ENVIRONMENTS_DOCUMENTATION_URL} from 'constants/Common.constants';
 import {useTestRun} from 'providers/TestRun/TestRun.provider';
 import * as S from './RunDetailTriggerResponse.styled';
 
@@ -6,6 +7,21 @@ const ResponseEnvironment = () => {
   const {
     run: {environment},
   } = useTestRun();
+
+  if (!environment?.values?.length) {
+    return (
+      <S.EmptyContainer>
+        <S.EmptyIcon />
+        <S.EmptyTitle>There are no environment variables used in this test</S.EmptyTitle>
+        <S.EmptyText>
+          Learn more about environments{' '}
+          <a href={ENVIRONMENTS_DOCUMENTATION_URL} target="_blank">
+            here
+          </a>
+        </S.EmptyText>
+      </S.EmptyContainer>
+    );
+  }
 
   return (
     <S.ResponseEnvironmentContainer>

--- a/web/src/components/RunDetailTriggerResponse/RunDetailTriggerResponse.styled.ts
+++ b/web/src/components/RunDetailTriggerResponse/RunDetailTriggerResponse.styled.ts
@@ -1,5 +1,6 @@
 import {Typography} from 'antd';
 import styled from 'styled-components';
+import noResultsIcon from 'assets/SpanAssertionsEmptyState.svg';
 
 export const Container = styled.div`
   display: flex;
@@ -108,3 +109,26 @@ export const Actions = styled.div`
 export const ResponseEnvironmentContainer = styled.div`
   padding: 16px 0;
 `;
+
+export const EmptyContainer = styled.div`
+  align-items: center;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  margin-top: 100px;
+  text-align: center;
+`;
+
+export const EmptyIcon = styled.img.attrs({
+  src: noResultsIcon,
+})`
+  height: auto;
+  margin-bottom: 16px;
+  width: 90px;
+`;
+
+export const EmptyText = styled(Typography.Text)`
+  color: ${({theme}) => theme.color.textSecondary};
+`;
+
+export const EmptyTitle = styled(Typography.Title).attrs({level: 3})``;

--- a/web/src/constants/Common.constants.ts
+++ b/web/src/constants/Common.constants.ts
@@ -17,6 +17,7 @@ export const TRACE_DOCUMENTATION_URL =
 
 export const ADD_TEST_SPECS_DOCUMENTATION_URL = 'https://docs.tracetest.io/web-ui/creating-test-specifications';
 export const ADD_TEST_OUTPUTS_DOCUMENTATION_URL = 'https://docs.tracetest.io/web-ui/creating-test-outputs';
+export const ENVIRONMENTS_DOCUMENTATION_URL = 'https://docs.tracetest.io/concepts/environments';
 
 export const SELECTOR_LANGUAGE_CHEAT_SHEET_URL = `${process.env.PUBLIC_URL}/SL_cheat_sheet.pdf`;
 


### PR DESCRIPTION
This PR adds an empty state in the `environment` tab in the run detail page

## Changes

- empty state for environment tab

## Fixes

- fixes #1816 

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Screenshot

<img width="1508" alt="Screenshot 2023-01-20 at 11 19 23" src="https://user-images.githubusercontent.com/3879892/213749867-836ef38c-db4d-45af-9e76-11aa2ad23625.png">