### PR TITLE
fix(frontend): fix output container styles

### DIFF
--- a/web/src/components/TestOutput/TestOutput.styled.ts
+++ b/web/src/components/TestOutput/TestOutput.styled.ts
@@ -24,7 +24,8 @@ export const Row = styled.div<{$justifyContent?: string}>`
 export const Entry = styled.div``;
 
 export const OutputDetails = styled.div`
-  align-items: center;
+  align-items: flex-start;
+  column-gap: 8px;
   display: grid;
   flex: 1;
   grid-template-columns: 1fr 2fr 1fr;


### PR DESCRIPTION
This PR fixes some styles in the `output` container.

## Changes

- fix css styles

## Fixes

- fixes #1814 

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Screenshot

<img width="1497" alt="Screenshot 2023-01-20 at 11 38 44" src="https://user-images.githubusercontent.com/3879892/213754369-7884ce87-570e-45ac-9b10-ed08fa5d3080.png">