### PR TITLE
feat(frontend): pre fill selector when adding an output

### DIFF
--- a/web/cypress/e2e/TestRunDetail/Outputs.spec.ts
+++ b/web/cypress/e2e/TestRunDetail/Outputs.spec.ts
@@ -20,7 +20,9 @@ describe('Outputs', () => {
     cy.get('[data-cy=output-add-button]').click();
     cy.get('form#testOutput').within(() => {
       cy.get('#testOutput_name').type('status_code');
-      cy.get('[data-cy=selector-editor] [contenteditable=true]').type('span[tracetest.span.type = "http"]:first');
+      cy.get('[data-cy=selector-editor] [contenteditable=true]')
+        .clear()
+        .type('span[tracetest.span.type = "http"]:first');
       cy.get('[data-cy=expression-editor] [contenteditable=true]').type('attr:http.status_code');
     });
     cy.wait('@getSelect');
@@ -56,7 +58,9 @@ describe('Outputs', () => {
     cy.get('[data-cy=output-add-button]').click();
     cy.get('form#testOutput').within(() => {
       cy.get('#testOutput_name').type('status_code');
-      cy.get('[data-cy=selector-editor] [contenteditable=true]').type('span[tracetest.span.type = "http"]:first');
+      cy.get('[data-cy=selector-editor] [contenteditable=true]')
+        .clear()
+        .type('span[tracetest.span.type = "http"]:first');
       cy.get('[data-cy=expression-editor] [contenteditable=true]').type('attr:http.status_code');
     });
     cy.wait('@getSelect');

--- a/web/src/components/TestOutputForm/SelectorInput.tsx
+++ b/web/src/components/TestOutputForm/SelectorInput.tsx
@@ -28,8 +28,11 @@ const SelectorInput = ({form, runId, spanIdList, testId}: IProps) => {
         {required: true, message: 'Please enter a valid selector'},
         {
           message: 'Please select a single span',
-          validator: async () => {
-            if (spanIdList.length !== 1 && !isLoading) throw new Error('Please select a single span');
+          validator: () => {
+            if (spanIdList.length !== 1 && !isLoading) {
+              return Promise.reject(new Error('Please select a single span'));
+            }
+            return Promise.resolve();
           },
           validateTrigger: 'onSubmit',
         },

--- a/web/src/components/TestOutputForm/TestOutputForm.tsx
+++ b/web/src/components/TestOutputForm/TestOutputForm.tsx
@@ -29,7 +29,7 @@ const TestOutputForm = ({isEditing = false, isLoading = false, onCancel, onSubmi
   const selector = Form.useWatch('selector', form) || '';
 
   useEffect(() => {
-    if (form.getFieldValue('selector')) {
+    if (form.getFieldValue('selector') && form.getFieldValue('value') && form.getFieldValue('name')) {
       onValidate(null, form.getFieldsValue());
       form.validateFields();
     }

--- a/web/src/components/TestOutputForm/TestOutputForm.tsx
+++ b/web/src/components/TestOutputForm/TestOutputForm.tsx
@@ -2,7 +2,7 @@ import {Button, Form, Input, Tag} from 'antd';
 import {useEffect} from 'react';
 
 import Editor from 'components/Editor';
-import {SELECTOR_LANGUAGE_CHEAT_SHEET_URL} from 'constants/Common.constants';
+import {EXPRESSIONS_DOCUMENTATION_URL, SELECTOR_LANGUAGE_CHEAT_SHEET_URL} from 'constants/Common.constants';
 import {SupportedEditors} from 'constants/Editor.constants';
 import {useAppSelector} from 'redux/hooks';
 import SpanSelectors from 'selectors/Span.selectors';
@@ -67,7 +67,10 @@ const TestOutputForm = ({isEditing = false, isLoading = false, onCancel, onSubmi
         <S.FormSection>
           <S.FormSectionTitle>2. Select the attribute</S.FormSectionTitle>
           <S.FormSectionRow>
-            <S.FormSectionText>Choose one attribute from the selected span or use an expression</S.FormSectionText>
+            <S.FormSectionText>Choose one attribute from the selected span or use an </S.FormSectionText>
+            <a href={EXPRESSIONS_DOCUMENTATION_URL} target="_blank">
+              expression
+            </a>
           </S.FormSectionRow>
           <Form.Item name="value" rules={[{required: true, message: 'Please enter an attribute or expression'}]}>
             <Editor

--- a/web/src/components/TestOutputs/TestOutputs.tsx
+++ b/web/src/components/TestOutputs/TestOutputs.tsx
@@ -1,10 +1,13 @@
 import {Button} from 'antd';
 
 import TestOutput from 'components/TestOutput';
+import TestOutputModel from 'models/TestOutput.model';
+import {useSpan} from 'providers/Span/Span.provider';
 import {useTestOutput} from 'providers/TestOutput/TestOutput.provider';
+import SpanService from 'services/Span.service';
+import {TTestOutput} from 'types/TestOutput.types';
 import Empty from './Empty';
 import * as S from './TestOutputs.styled';
-import {TTestOutput} from '../../types/TestOutput.types';
 
 interface IProps {
   outputs: TTestOutput[];
@@ -12,11 +15,17 @@ interface IProps {
 
 const TestOutputs = ({outputs}: IProps) => {
   const {onDelete, onOpen} = useTestOutput();
+  const {selectedSpan} = useSpan();
+
+  const handleOnAddTestOutput = () => {
+    const query = selectedSpan ? SpanService.getSelectorInformation(selectedSpan) : '';
+    onOpen(TestOutputModel({selector: {query}}));
+  };
 
   return (
     <S.Container>
       <S.HeaderContainer>
-        <Button data-cy="output-add-button" onClick={() => onOpen()} type="primary">
+        <Button data-cy="output-add-button" onClick={handleOnAddTestOutput} type="primary">
           Add Test Output
         </Button>
       </S.HeaderContainer>

--- a/web/src/constants/Common.constants.ts
+++ b/web/src/constants/Common.constants.ts
@@ -17,6 +17,7 @@ export const TRACE_DOCUMENTATION_URL =
 
 export const ADD_TEST_SPECS_DOCUMENTATION_URL = 'https://docs.tracetest.io/web-ui/creating-test-specifications';
 export const ADD_TEST_OUTPUTS_DOCUMENTATION_URL = 'https://docs.tracetest.io/web-ui/creating-test-outputs';
+export const EXPRESSIONS_DOCUMENTATION_URL = 'https://docs.tracetest.io/concepts/expressions';
 
 export const SELECTOR_LANGUAGE_CHEAT_SHEET_URL = `${process.env.PUBLIC_URL}/SL_cheat_sheet.pdf`;
 


### PR DESCRIPTION
This PR adds the logic to pre-fill the selector when adding a `test output` based on the current selected span. It also adds a link to the expressions docs in the test output form.

## Changes

- pre-fill selector in test output
- add link to expressions docs in test output form

## Fixes

- fixes #1809 
- fixes #1807 

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Loom
https://www.loom.com/share/fd90c71d8795404191e3de1962b83e35