### PR TITLE
feat(frontend): add data store warning when saving config

### DIFF
--- a/web/src/components/ConfirmationModal/ConfirmationModal.tsx
+++ b/web/src/components/ConfirmationModal/ConfirmationModal.tsx
@@ -4,7 +4,7 @@ interface IProps {
   isOpen: boolean;
   onClose(): void;
   onConfirm(): void;
-  title: string;
+  title: React.ReactNode;
   heading?: string;
   okText?: string;
   cancelText?: string;
@@ -29,7 +29,7 @@ const ConfirmationModal = ({
       visible={isOpen}
       data-cy="confirmation-modal"
     >
-      <p>{title}</p>
+      {typeof title === 'string' ? <p>{title}</p> : title}
     </Modal>
   );
 };

--- a/web/src/providers/ConfirmationModal/ConfirmationModal.provider.tsx
+++ b/web/src/providers/ConfirmationModal/ConfirmationModal.provider.tsx
@@ -4,7 +4,7 @@ import ConfirmationModal from 'components/ConfirmationModal';
 
 type TOnConfirm = typeof noop;
 type TOnOPenProps = {
-  title: string;
+  title: React.ReactNode;
   heading?: string;
   okText?: string;
   cancelText?: string;

--- a/web/src/providers/DataStore/DataStore.provider.tsx
+++ b/web/src/providers/DataStore/DataStore.provider.tsx
@@ -1,19 +1,19 @@
 import {noop} from 'lodash';
 import {createContext, useCallback, useContext, useMemo, useState} from 'react';
 
+import {NoTestConnectionDataStoreList, SupportedDataStoresToName} from 'constants/DataStore.constants';
+import ConnectionResult from 'models/ConnectionResult.model';
 import {
   useTestConnectionMutation,
   useCreateDataStoreMutation,
   useUpdateDataStoreMutation,
   useDeleteDataStoreMutation,
 } from 'redux/apis/TraceTest.api';
-import {TConnectionResult, TDataStore, TDraftDataStore} from 'types/Config.types';
 import DataStoreService from 'services/DataStore.service';
-import ConnectionResult from 'models/ConnectionResult.model';
+import {SupportedDataStores, TConnectionResult, TDataStore, TDraftDataStore} from 'types/Config.types';
 import useDataStoreNotification from './hooks/useDataStoreNotification';
 import {useConfirmationModal} from '../ConfirmationModal/ConfirmationModal.provider';
 import {useDataStoreConfig} from '../DataStoreConfig/DataStoreConfig.provider';
-import {NoTestConnectionDataStoreList} from '../../constants/DataStore.constants';
 
 interface IContext {
   isFormValid: boolean;
@@ -53,8 +53,20 @@ const DataStoreProvider = ({children}: IProps) => {
 
   const onSaveConfig = useCallback(
     async (draft: TDraftDataStore, defaultDataStore: TDataStore) => {
+      const warningMessage =
+        !!defaultDataStore.id && draft.dataStoreType !== defaultDataStore.type
+          ? `Saving will delete your previous configuration of the ${
+              SupportedDataStoresToName[defaultDataStore.type || SupportedDataStores.JAEGER]
+            } data store`
+          : '';
+
       onOpen({
-        title: 'Are you sure you want to save this Data Store configuration?',
+        title: (
+          <>
+            <p>Are you sure you want to save this Data Store configuration?</p>
+            <p>{warningMessage}</p>
+          </>
+        ),
         heading: 'Save Confirmation',
         okText: 'Save',
         onConfirm: async () => {


### PR DESCRIPTION
This PR adds a warning when changing the data store configuration explaining that your current configuration will be deleted.

The message does not include the warning if:
- you have no data store configured
- if you are just altering the current config (ie staying with the same data store type)

## Changes

- Data store warning message

## Fixes

- fixes #1799 

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Screenshot

<img width="1486" alt="Screenshot 2023-01-23 at 16 51 28" src="https://user-images.githubusercontent.com/3879892/214158482-139e2fb1-3be8-42c4-a548-d1033e05a912.png">