### PR TITLE
chore: adding k6 to examples folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ server/vendor
 
 # .DS_Store
 .DS_Store
+config.yml

--- a/examples/tracetest-k6/README.md
+++ b/examples/tracetest-k6/README.md
@@ -1,0 +1,42 @@
+# Tracetest + K6
+
+This repository objective is to show how you can configure your tracetest to run alongside your k6 load tests against an instrumented service
+
+## Steps
+
+1. [Install the tracetest CLI](https://docs.tracetest.io/installing/)
+2. Run `tracetest configure --endpoint http://localhost:11633` on a terminal
+3. Run the project by using docker-compose: `docker-compose up` (Linux) or `docker compose up` (Mac)
+4. Test if it works by running: `tracetest test run -d tests/test.yaml`. This will create and run a test with trace id as trigger
+5. In as separate folder outside of the the Tracetest repo, build the k6 binary with the extension by using `xk6 build v0.42.0 --with github.com/kubeshop/xk6-tracetest`
+6. Now you are ready to run your load test, you can achieve this by running the following command: `path/to/binary/k6 run import-pokemon.js -o xk6-tracetest`
+7. After the load test finishes you should be able to see an output like the following:
+
+  ```bash
+  ./k6 run tracetest/examples/tracetest-k6/import-pokemon.js -o xk6-tracetest
+
+            /\      |‾‾| /‾‾/   /‾‾/   
+      /\  /  \     |  |/  /   /  /    
+      /  \/    \    |     (   /   ‾‾\  
+    /          \   |  |\  \ |  (‾)  | 
+    / __________ \  |__| \__\ \_____/ .io
+
+    execution: local
+      script: tracetest/examples/tracetest-k6/import-pokemon.js
+      output: xk6-tracetest-output (TestRunID: 46145)
+
+    scenarios: (100.00%) 1 scenario, 1 max VUs, 36s max duration (incl. graceful stop):
+            * default: 1 looping VUs for 6s (gracefulStop: 30s)
+
+
+  running (06.0s), 0/1 VUs, 6 complete and 0 interrupted iterations
+  default ✓ [======================================] 1 VUs  6s
+  [TotalRuns=6, SuccessfulRus=6, FailedRuns=0] 
+  [SUCCESSFUL] 
+  [Request=POST - http://localhost:8081/pokemon/import, TraceID=dc0718dae7fd8dde305bb00c9a3ff4d3, RunState=FINISHED FailingSpecs=false, TracetestURL= http://localhost:11633/test/kc_MgKoVR/run/6] 
+  [Request=POST - http://localhost:8081/pokemon/import, TraceID=dc0718eddffd8dde3070aa912cf76fff, RunState=FINISHED FailingSpecs=false, TracetestURL= http://localhost:11633/test/kc_MgKoVR/run/7] 
+  [Request=POST - http://localhost:8081/pokemon/import, TraceID=dc0718b2f7fd8dde3023788d4498a1a9, RunState=FINISHED FailingSpecs=false, TracetestURL= http://localhost:11633/test/kc_MgKoVR/run/3] 
+  [Request=POST - http://localhost:8081/pokemon/import, TraceID=dc071892d0fd8dde30da7fa44694f64c, RunState=FINISHED FailingSpecs=false, TracetestURL= http://localhost:11633/test/kc_MgKoVR/run/2] 
+  [Request=POST - http://localhost:8081/pokemon/import, TraceID=dc0718c6effd8dde30f35102cd0afcd0, RunState=FINISHED FailingSpecs=false, TracetestURL= http://localhost:11633/test/kc_MgKoVR/run/4] 
+  [Request=POST - http://localhost:8081/pokemon/import, TraceID=dc071880d8fd8dde3049cbe7f9bb5367, RunState=FINISHED FailingSpecs=false, TracetestURL= http://localhost:11633/test/kc_MgKoVR/run/5]   
+  ```

--- a/examples/tracetest-k6/collector.config.yaml
+++ b/examples/tracetest-k6/collector.config.yaml
@@ -1,0 +1,27 @@
+receivers:
+  otlp:
+    protocols:
+      grpc:
+      http:
+
+processors:
+  batch:
+    timeout: 100ms
+
+  # Data sources: traces
+  probabilistic_sampler:
+    hash_seed: 22
+    sampling_percentage: 100
+
+exporters:
+  jaeger:
+    endpoint: jaeger:14250
+    tls:
+      insecure: true
+
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [probabilistic_sampler, batch]
+      exporters: [jaeger]

--- a/examples/tracetest-k6/docker-compose.yml
+++ b/examples/tracetest-k6/docker-compose.yml
@@ -1,0 +1,151 @@
+version: "3"
+services:
+  tracetest:
+    image: kubeshop/tracetest:${TAG:-latest}
+    platform: linux/amd64
+    volumes:
+      - type: bind
+        source: ./tracetest-config.yaml
+        target: /app/config.yaml
+    ports:
+      - 11633:11633
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    depends_on:
+      postgres:
+        condition: service_healthy
+      otel-collector:
+        condition: service_started
+    healthcheck:
+      test: ["CMD", "wget", "--spider", "localhost:11633"]
+      interval: 1s
+      timeout: 3s
+      retries: 60
+    environment:
+      TRACETEST_DEV: ${TRACETEST_DEV}
+
+  postgres:
+    image: postgres:14
+    environment:
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_USER: postgres
+    healthcheck:
+      test: pg_isready -U "$$POSTGRES_USER" -d "$$POSTGRES_DB"
+      interval: 1s
+      timeout: 5s
+      retries: 60
+    ports:
+      - 5432:5432
+
+  otel-collector:
+    image: otel/opentelemetry-collector:0.54.0
+    command:
+      - "--config"
+      - "/otel-local-config.yaml"
+    volumes:
+      - ./collector.config.yaml:/otel-local-config.yaml
+    depends_on:
+      - jaeger
+    ports:
+      - 4317:4317
+
+  jaeger:
+    image: jaegertracing/all-in-one:latest
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "wget", "--spider", "localhost:16686"]
+      interval: 1s
+      timeout: 3s
+      retries: 60
+    ports:
+      - 16685:16685
+      - 16686:16686
+
+  cache:
+    image: redis:6
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 1s
+      timeout: 3s
+      retries: 60
+
+  queue:
+    image: rabbitmq:3.8-management
+    restart: unless-stopped
+    healthcheck:
+      test: rabbitmq-diagnostics -q check_running
+      interval: 1s
+      timeout: 5s
+      retries: 60
+
+  demo-api:
+    image: kubeshop/demo-pokemon-api:latest
+    restart: unless-stopped
+    pull_policy: always
+    environment:
+      REDIS_URL: cache
+      DATABASE_URL: postgresql://postgres:postgres@postgres:5432/postgres?schema=public
+      RABBITMQ_HOST: queue
+      POKE_API_BASE_URL: https://pokeapi.co/api/v2
+      COLLECTOR_ENDPOINT: http://otel-collector:4317
+      NPM_RUN_COMMAND: api
+    ports:
+      - "8081:8081"
+    healthcheck:
+      test: ["CMD", "wget", "--spider", "localhost:8081"]
+      interval: 1s
+      timeout: 3s
+      retries: 60
+    depends_on:
+      postgres:
+        condition: service_healthy
+      cache:
+        condition: service_healthy
+      queue:
+        condition: service_healthy
+
+  demo-worker:
+    image: kubeshop/demo-pokemon-api:latest
+    restart: unless-stopped
+    pull_policy: always
+    environment:
+      REDIS_URL: cache
+      DATABASE_URL: postgresql://postgres:postgres@postgres:5432/postgres?schema=public
+      RABBITMQ_HOST: queue
+      POKE_API_BASE_URL: https://pokeapi.co/api/v2
+      COLLECTOR_ENDPOINT: http://otel-collector:4317
+      NPM_RUN_COMMAND: worker
+    depends_on:
+      postgres:
+        condition: service_healthy
+      cache:
+        condition: service_healthy
+      queue:
+        condition: service_healthy
+
+  demo-rpc:
+    image: kubeshop/demo-pokemon-api:latest
+    restart: unless-stopped
+    pull_policy: always
+    environment:
+      REDIS_URL: cache
+      DATABASE_URL: postgresql://postgres:postgres@postgres:5432/postgres?schema=public
+      RABBITMQ_HOST: queue
+      POKE_API_BASE_URL: https://pokeapi.co/api/v2
+      COLLECTOR_ENDPOINT: http://otel-collector:4317
+      NPM_RUN_COMMAND: rpc
+    ports:
+      - 8082:8082
+    healthcheck:
+      test: ["CMD", "lsof", "-i", "8082"]
+      interval: 1s
+      timeout: 3s
+      retries: 60
+    depends_on:
+      postgres:
+        condition: service_healthy
+      cache:
+        condition: service_healthy
+      queue:
+        condition: service_healthy

--- a/examples/tracetest-k6/import-pokemon.js
+++ b/examples/tracetest-k6/import-pokemon.js
@@ -1,0 +1,45 @@
+import { check } from "k6";
+import { Http, Tracetest } from "k6/x/tracetest";
+import { sleep } from "k6";
+
+export const options = {
+  vus: 1,
+  duration: "6s",
+};
+
+const tracetest = Tracetest({
+  serverUrl: "http://localhost:11633",
+});
+const testId = "kc_MgKoVR";
+const pokemonId = 6;
+const http = new Http();
+const url = "http://localhost:8081/pokemon/import";
+
+export default function () {
+  const payload = JSON.stringify({
+    id: pokemonId,
+  });
+  const params = {
+    tracetest: {
+      testId,
+    },
+    headers: {
+      "Content-Type": "application/json",
+    },
+  };
+
+  const response = http.post(url, payload, params);
+
+  check(response, {
+    "is status 200": (r) => r.status === 200,
+    "body matches de id": (r) => JSON.parse(r.body).id === pokemonId,
+  });
+  sleep(1);
+}
+
+export function handleSummary() {
+  return {
+    stdout: tracetest.summary(),
+    "tracetest.json": tracetest.json(),
+  };
+}

--- a/examples/tracetest-k6/tests/test.yaml
+++ b/examples/tracetest-k6/tests/test.yaml
@@ -1,0 +1,21 @@
+type: Test
+spec:
+  id: kc_MgKoVR
+  name: K6
+  description: K6
+  trigger:
+    type: traceid
+    traceid:
+      id: ${env:TRACE_ID}
+  specs:
+    - selector: span[tracetest.span.type="general" name="import pokemon"]
+      assertions:
+        - attr:tracetest.selected_spans.count = 1
+    - selector: span[tracetest.span.type="http" name="HTTP GET pokeapi.pokemon" http.method="GET"]
+      assertions:
+        - attr:http.url = "https://pokeapi.co/api/v2/pokemon/6"
+    - selector:
+        span[tracetest.span.type="database" name="create pokeshop.pokemon" db.system="postgres"
+        db.name="postgres" db.user="postgres" db.operation="create" db.sql.table="pokemon"]
+      assertions:
+        - attr:db.result | json_path '.name' = "charizard"

--- a/examples/tracetest-k6/tracetest-config.yaml
+++ b/examples/tracetest-k6/tracetest-config.yaml
@@ -1,0 +1,21 @@
+postgresConnString: "host=postgres user=postgres password=postgres port=5432 sslmode=disable"
+
+poolingConfig:
+  maxWaitTimeForTrace: 10m
+  retryDelay: 5s
+
+googleAnalytics:
+  enabled: true
+
+telemetry:
+  dataStores:
+    jaeger:
+      type: jaeger
+      jaeger:
+        endpoint: jaeger:16685
+        tls:
+          insecure: true
+
+server:
+  telemetry:
+    dataStore: jaeger

--- a/server/model/yaml/test.go
+++ b/server/model/yaml/test.go
@@ -76,6 +76,10 @@ func (t TestTrigger) Validate() error {
 		if err := t.GRPC.Validate(); err != nil {
 			return fmt.Errorf("grpc request must be valid: %w", err)
 		}
+	case "traceid":
+		if err := t.TRACEID.Validate(); err != nil {
+			return fmt.Errorf("traceid request must be valid: %w", err)
+		}
 	case "":
 		return fmt.Errorf("type cannot be empty")
 	default:

--- a/server/model/yaml/traceid.go
+++ b/server/model/yaml/traceid.go
@@ -1,5 +1,15 @@
 package yaml
 
+import "fmt"
+
 type TRACEIDRequest struct {
 	ID string `yaml:"id"`
+}
+
+func (t TRACEIDRequest) Validate() error {
+	if t.ID == "" {
+		return fmt.Errorf("ID cannot be empty")
+	}
+
+	return nil
 }


### PR DESCRIPTION
This PR adds k6 to the examples folder as a way for users that want to learn how to start using Tracetest alongside the k6 load tests for observability-driven tests.

## Changes

- Adds the examples folder for k6
- Updates the cli/server code to support the trace id definition files as input.

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
