### PR TITLE
fix(frontend): fixing home page not refreshing after transaction or test run

### DIFF
--- a/web/src/components/TransactionPlugin/steps/BasicDetails/BasicDetails.tsx
+++ b/web/src/components/TransactionPlugin/steps/BasicDetails/BasicDetails.tsx
@@ -19,7 +19,7 @@ const BasicDetails = () => {
 
   const onValidate = useCallback(
     async (changedValues, draft: TDraftTransaction) => {
-      onIsFormValid(Boolean(draft.name && draft.description));
+      onIsFormValid(!!draft.name);
     },
     [onIsFormValid]
   );

--- a/web/src/redux/apis/endpoints/TestRun.endpoints.ts
+++ b/web/src/redux/apis/endpoints/TestRun.endpoints.ts
@@ -29,6 +29,7 @@ const TestRunEndpoint = (builder: TTestApiEndpointBuilder) => ({
     invalidatesTags: (response, error, {testId}) => [
       {type: TracetestApiTags.TEST_RUN, id: `${testId}-LIST`},
       {type: TracetestApiTags.TEST, id: 'LIST'},
+      {type: TracetestApiTags.RESOURCE, id: 'LIST'},
     ],
     transformResponse: (rawTestRun: TRawTestRun) => TestRun(rawTestRun),
   }),
@@ -64,6 +65,7 @@ const TestRunEndpoint = (builder: TTestApiEndpointBuilder) => ({
     invalidatesTags: (response, error, {testId, runId}) => [
       {type: TracetestApiTags.TEST_RUN, id: `${testId}-LIST`},
       {type: TracetestApiTags.TEST_RUN, id: runId},
+      {type: TracetestApiTags.RESOURCE, id: 'LIST'},
     ],
     transformResponse: (rawTestRun: TRawTestRun) => TestRun(rawTestRun),
   }),
@@ -80,6 +82,7 @@ const TestRunEndpoint = (builder: TTestApiEndpointBuilder) => ({
     invalidatesTags: (result, error, {testId}) => [
       {type: TracetestApiTags.TEST_RUN},
       {type: TracetestApiTags.TEST, id: `${testId}-LIST`},
+      {type: TracetestApiTags.RESOURCE, id: 'LIST'},
     ],
   }),
   getJUnitByRunId: builder.query<string, {testId: string; runId: string}>({

--- a/web/src/redux/apis/endpoints/TransactionRun.endpoint.ts
+++ b/web/src/redux/apis/endpoints/TransactionRun.endpoint.ts
@@ -21,6 +21,7 @@ const TransactionRunEndpoint = (builder: TTestApiEndpointBuilder) => ({
     }),
     invalidatesTags: (result, error, {transactionId}) => [
       {type: TracetestApiTags.TRANSACTION_RUN, id: `${transactionId}-LIST`},
+      {type: TracetestApiTags.RESOURCE, id: 'LIST'},
     ],
     transformResponse: (rawTransactionRun: TRawTransactionRun) => TransactionRun(rawTransactionRun),
   }),
@@ -32,6 +33,7 @@ const TransactionRunEndpoint = (builder: TTestApiEndpointBuilder) => ({
     query: ({transactionId, take = 25, skip = 0}) => `/transactions/${transactionId}/run?take=${take}&skip=${skip}`,
     providesTags: (result, error, {transactionId}) => [
       {type: TracetestApiTags.TRANSACTION_RUN, id: `${transactionId}-LIST`},
+      {type: TracetestApiTags.RESOURCE, id: 'LIST'},
     ],
     transformResponse: (rawTransactionRuns: TRawTransactionRun[], meta) => ({
       total: getTotalCountFromHeaders(meta),
@@ -64,6 +66,7 @@ const TransactionRunEndpoint = (builder: TTestApiEndpointBuilder) => ({
     }),
     invalidatesTags: (result, error, {transactionId}) => [
       {type: TracetestApiTags.TRANSACTION_RUN, id: `${transactionId}-LIST`},
+      {type: TracetestApiTags.RESOURCE, id: 'LIST'},
     ],
   }),
 });


### PR DESCRIPTION
This PR fixes an issue where the home page wasn't refreshing after running or executing an action over the resources displayed in the list.

## Changes
- Updates the invalidate tags config to refresh the resource list

## Fixes

- #1598 

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
