### PR TITLE
Update Elastic APM examples to leverage `insecureSkipVerify` option

### DIFF
--- a/examples/tracetest-elasticapm-with-elastic-agent/README.md
+++ b/examples/tracetest-elasticapm-with-elastic-agent/README.md
@@ -16,6 +16,7 @@ Open http://localhost:11633/ to configure the connection to Elasticsearch:
 5. You will need to download the CA certificate from the docker image and upload it to the config under "Upload CA file".
     * The command to download the `ca.crt` file is:
     `docker cp tracetest-elasticapm-with-elastic-agent-es01-1:/usr/share/elasticsearch/config/certs/ca/ca.crt .`
+    * Alternatively, you can skip CA certificate validation by setting the `Enable TLS but don't verify the certificate` option.
 6. Test the connection and Save it, if all is successful.
 
 Create a new test:

--- a/examples/tracetest-elasticapm-with-elastic-agent/app.js
+++ b/examples/tracetest-elasticapm-with-elastic-agent/app.js
@@ -1,9 +1,3 @@
-// Add this to the VERY top of the first file loaded in your app
-const apm = require('elastic-apm-node').start({
-  serviceName: 'sample-app',
-  serverUrl: 'http://apm-server:8200',
-})
-
 const express = require("express")
 const app = express()
 app.get("/", (req, res) => {

--- a/examples/tracetest-elasticapm-with-elastic-agent/docker-compose.yaml
+++ b/examples/tracetest-elasticapm-with-elastic-agent/docker-compose.yaml
@@ -219,7 +219,7 @@ services:
       retries: 120
 
   app:
-    image: quick-start-nodejs
+    image: quick-start-nodejs-elastic-apm
     hostname: app
     build: .
     ports:

--- a/examples/tracetest-elasticapm-with-elastic-agent/elastic-apm-agent.js
+++ b/examples/tracetest-elasticapm-with-elastic-agent/elastic-apm-agent.js
@@ -1,0 +1,4 @@
+const apm = require('elastic-apm-node').start({
+    serviceName: 'sample-app',
+    serverUrl: 'http://apm-server:8200',
+  })

--- a/examples/tracetest-elasticapm-with-elastic-agent/package.json
+++ b/examples/tracetest-elasticapm-with-elastic-agent/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "app.js",
   "scripts": {
-    "with-elastic-apm-tracer":"node -r ./app.js"
+    "with-elastic-apm-tracer":"node -r ./elastic-apm-agent.js app.js"
   },
   "keywords": [],
   "author": "",

--- a/examples/tracetest-elasticapm-with-elastic-agent/tracetest-config.yaml
+++ b/examples/tracetest-elasticapm-with-elastic-agent/tracetest-config.yaml
@@ -22,6 +22,7 @@ telemetry:
         username: elastic
         password: changeme
         index: traces-apm-default
+        insecureSkipVerify: true
 
   exporters:
     collector:

--- a/examples/tracetest-elasticapm-with-otel/README.md
+++ b/examples/tracetest-elasticapm-with-otel/README.md
@@ -16,6 +16,7 @@ Open http://localhost:11633/ to configure the connection to Elasticsearch:
 5. You will need to download the CA certificate from the docker image and upload it to the config under "Upload CA file".
     * The command to download the `ca.crt` file is:
     `docker cp tracetest-elasticapm-with-otel-es01-1:/usr/share/elasticsearch/config/certs/ca/ca.crt .`
+    * Alternatively, you can skip CA certificate validation by setting the `Enable TLS but don't verify the certificate` option.
 6. Test the connection and Save it, if all is successful.
 
 Create a new test:

--- a/examples/tracetest-elasticapm-with-otel/docker-compose.yaml
+++ b/examples/tracetest-elasticapm-with-otel/docker-compose.yaml
@@ -219,7 +219,7 @@ services:
         condition: service_started
 
   app:
-    image: quick-start-nodejs
+    image: quick-start-nodejs-otel
     hostname: app
     build: .
     ports:

--- a/examples/tracetest-elasticapm-with-otel/tracetest-config.yaml
+++ b/examples/tracetest-elasticapm-with-otel/tracetest-config.yaml
@@ -22,6 +22,7 @@ telemetry:
         username: elastic
         password: changeme
         index: traces-apm-default
+        insecureSkipVerify: true
 
   exporters:
     collector:


### PR DESCRIPTION
This PR updates the Elastic APM examples to leverage the `insecureSkipVerify` option. It also changes the default names of the `app.js` containers to avoid names clash.

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
