### PR TITLE
add(ui): edit button on context menu

### DIFF
--- a/web/src/components/ResourceCard/ResourceCardActions.tsx
+++ b/web/src/components/ResourceCard/ResourceCardActions.tsx
@@ -1,16 +1,16 @@
 import {Dropdown, Menu} from 'antd';
-import {useCallback} from 'react';
+import {useCallback, useMemo} from 'react';
 
 import * as S from './ResourceCard.styled';
 
 interface IProps {
   id: string;
-  canEdit: boolean;
+  shouldEdit: boolean;
   onDelete(): void;
   onEdit(): void;
 }
 
-const ResourceCardActions = ({id, canEdit = true, onDelete, onEdit}: IProps) => {
+const ResourceCardActions = ({id, shouldEdit = true, onDelete, onEdit}: IProps) => {
   const onDeleteClick = useCallback(
     ({domEvent}) => {
       domEvent?.stopPropagation();
@@ -27,11 +27,11 @@ const ResourceCardActions = ({id, canEdit = true, onDelete, onEdit}: IProps) => 
     [onEdit]
   );
 
-  const menuItems = [];
-  if (canEdit) {
-    menuItems.push({key: 'edit', label: <span data-cy="test-card-edit">Edit</span>, onClick: onEditClick});
-  }
-  menuItems.push({key: 'delete', label: <span data-cy="test-card-delete">Delete</span>, onClick: onDeleteClick});
+  const menuItems = useMemo(() => {
+    const defaultItems = [{key: 'delete', label: <span data-cy="test-card-delete">Delete</span>, onClick: onDeleteClick}];
+
+    return shouldEdit ? [{key: 'edit', label: <span data-cy="test-card-edit">Edit</span>, onClick: onEditClick}, ...defaultItems] : defaultItems;
+  }, [onDeleteClick, onEditClick, shouldEdit]);
 
   return (
     <Dropdown

--- a/web/src/components/ResourceCard/ResourceCardActions.tsx
+++ b/web/src/components/ResourceCard/ResourceCardActions.tsx
@@ -5,11 +5,13 @@ import * as S from './ResourceCard.styled';
 
 interface IProps {
   id: string;
+  canEdit: boolean;
   onDelete(): void;
+  onEdit(): void;
 }
 
-const ResourceCardActions = ({id, onDelete}: IProps) => {
-  const onClick = useCallback(
+const ResourceCardActions = ({id, canEdit = true, onDelete, onEdit}: IProps) => {
+  const onDeleteClick = useCallback(
     ({domEvent}) => {
       domEvent?.stopPropagation();
       onDelete();
@@ -17,9 +19,23 @@ const ResourceCardActions = ({id, onDelete}: IProps) => {
     [onDelete]
   );
 
+  const onEditClick = useCallback(
+    ({domEvent}) => {
+      domEvent?.stopPropagation();
+      onEdit();
+    },
+    [onEdit]
+  );
+
+  const menuItems = [];
+  if (canEdit) {
+    menuItems.push({key: 'edit', label: <span data-cy="test-card-edit">Edit</span>, onClick: onEditClick});
+  }
+  menuItems.push({key: 'delete', label: <span data-cy="test-card-delete">Delete</span>, onClick: onDeleteClick});
+
   return (
     <Dropdown
-      overlay={<Menu items={[{key: 'delete', label: <span data-cy="test-card-delete">Delete</span>, onClick}]} />}
+      overlay={<Menu items={menuItems} />}
       placement="bottomLeft"
       trigger={['click']}
     >

--- a/web/src/components/ResourceCard/TestCard.tsx
+++ b/web/src/components/ResourceCard/TestCard.tsx
@@ -13,18 +13,22 @@ import ResourceCardSummary from './ResourceCardSummary';
 import useRuns from './useRuns';
 
 interface IProps {
+  onEdit(id: string, lastRunId: string, type: ResourceType): void;
   onDelete(id: string, name: string, type: ResourceType): void;
   onRun(test: TTest, type: ResourceType): void;
   onViewAll(id: string, type: ResourceType): void;
   test: TTest;
 }
 
-const TestCard = ({onDelete, onRun, onViewAll, test}: IProps) => {
+const TestCard = ({onEdit, onDelete, onRun, onViewAll, test}: IProps) => {
   const queryParams = useMemo(() => ({take: 5, testId: test.id}), [test.id]);
   const {isCollapsed, isLoading, list, onClick} = useRuns<TTestRun, {testId: string}>(
     useLazyGetRunListQuery,
     queryParams
   );
+
+  const canEdit = list.length > 0;
+  const lastRunId = list[0]?.id; // TODO: can we assume that the first item on the list is the last run?
 
   return (
     <S.Container $type={ResourceType.Test}>
@@ -54,7 +58,12 @@ const TestCard = ({onDelete, onRun, onViewAll, test}: IProps) => {
           >
             Run
           </S.RunButton>
-          <ResourceCardActions id={test.id} onDelete={() => onDelete(test.id, test.name, ResourceType.Test)} />
+          <ResourceCardActions
+            id={test.id}
+            canEdit={canEdit}
+            onDelete={() => onDelete(test.id, test.name, ResourceType.Test)}
+            onEdit={() => onEdit(test.id, lastRunId, ResourceType.Test)}
+           />
         </S.Row>
       </S.TestContainer>
 

--- a/web/src/components/ResourceCard/TestCard.tsx
+++ b/web/src/components/ResourceCard/TestCard.tsx
@@ -27,7 +27,7 @@ const TestCard = ({onEdit, onDelete, onRun, onViewAll, test}: IProps) => {
     queryParams
   );
 
-  const canEdit = test.summary.runs > 0;
+  const shouldEdit = test.summary.hasRuns;
   const lastRunId = test.summary.runs; // assume the total of runs as the last run
 
   return (
@@ -60,7 +60,7 @@ const TestCard = ({onEdit, onDelete, onRun, onViewAll, test}: IProps) => {
           </S.RunButton>
           <ResourceCardActions
             id={test.id}
-            canEdit={canEdit}
+            shouldEdit={shouldEdit}
             onDelete={() => onDelete(test.id, test.name, ResourceType.Test)}
             onEdit={() => onEdit(test.id, lastRunId, ResourceType.Test)}
            />

--- a/web/src/components/ResourceCard/TestCard.tsx
+++ b/web/src/components/ResourceCard/TestCard.tsx
@@ -13,7 +13,7 @@ import ResourceCardSummary from './ResourceCardSummary';
 import useRuns from './useRuns';
 
 interface IProps {
-  onEdit(id: string, lastRunId: string, type: ResourceType): void;
+  onEdit(id: string, lastRunId: number, type: ResourceType): void;
   onDelete(id: string, name: string, type: ResourceType): void;
   onRun(test: TTest, type: ResourceType): void;
   onViewAll(id: string, type: ResourceType): void;
@@ -27,8 +27,8 @@ const TestCard = ({onEdit, onDelete, onRun, onViewAll, test}: IProps) => {
     queryParams
   );
 
-  const canEdit = list.length > 0;
-  const lastRunId = list[0]?.id; // TODO: can we assume that the first item on the list is the last run?
+  const canEdit = test.summary.runs > 0;
+  const lastRunId = test.summary.runs; // assume the total of runs as the last run
 
   return (
     <S.Container $type={ResourceType.Test}>

--- a/web/src/components/ResourceCard/TransactionCard.tsx
+++ b/web/src/components/ResourceCard/TransactionCard.tsx
@@ -13,7 +13,7 @@ import ResourceCardSummary from './ResourceCardSummary';
 import useRuns from './useRuns';
 
 interface IProps {
-  onEdit(id: string, lastRunId: string, type: ResourceType): void;
+  onEdit(id: string, lastRunId: number, type: ResourceType): void;
   onDelete(id: string, name: string, type: ResourceType): void;
   onRun(transaction: TTransaction, type: ResourceType): void;
   onViewAll(id: string, type: ResourceType): void;
@@ -34,8 +34,8 @@ const TransactionCard = ({
     queryParams
   );
 
-  const canEdit = list.length > 0;
-  const lastRunId = list[0]?.id; // TODO: can we assume that the first item on the list is the last run?
+  const canEdit = summary.runs > 0;
+  const lastRunId = summary.runs; // assume the total of runs as the last run
 
   return (
     <S.Container $type={ResourceType.Transaction}>

--- a/web/src/components/ResourceCard/TransactionCard.tsx
+++ b/web/src/components/ResourceCard/TransactionCard.tsx
@@ -13,6 +13,7 @@ import ResourceCardSummary from './ResourceCardSummary';
 import useRuns from './useRuns';
 
 interface IProps {
+  onEdit(id: string, lastRunId: string, type: ResourceType): void;
   onDelete(id: string, name: string, type: ResourceType): void;
   onRun(transaction: TTransaction, type: ResourceType): void;
   onViewAll(id: string, type: ResourceType): void;
@@ -20,6 +21,7 @@ interface IProps {
 }
 
 const TransactionCard = ({
+  onEdit,
   onDelete,
   onRun,
   onViewAll,
@@ -31,6 +33,9 @@ const TransactionCard = ({
     useLazyGetTransactionRunsQuery,
     queryParams
   );
+
+  const canEdit = list.length > 0;
+  const lastRunId = list[0]?.id; // TODO: can we assume that the first item on the list is the last run?
 
   return (
     <S.Container $type={ResourceType.Transaction}>
@@ -60,7 +65,9 @@ const TransactionCard = ({
           </S.RunButton>
           <ResourceCardActions
             id={transactionId}
+            canEdit={canEdit}
             onDelete={() => onDelete(transactionId, name, ResourceType.Transaction)}
+            onEdit={() => onEdit(transactionId, lastRunId, ResourceType.Transaction)}
           />
         </S.Row>
       </S.TestContainer>

--- a/web/src/components/ResourceCard/TransactionCard.tsx
+++ b/web/src/components/ResourceCard/TransactionCard.tsx
@@ -34,7 +34,7 @@ const TransactionCard = ({
     queryParams
   );
 
-  const canEdit = summary.runs > 0;
+  const shouldEdit = summary.hasRuns;
   const lastRunId = summary.runs; // assume the total of runs as the last run
 
   return (
@@ -65,7 +65,7 @@ const TransactionCard = ({
           </S.RunButton>
           <ResourceCardActions
             id={transactionId}
-            canEdit={canEdit}
+            shouldEdit={shouldEdit}
             onDelete={() => onDelete(transactionId, name, ResourceType.Transaction)}
             onEdit={() => onEdit(transactionId, lastRunId, ResourceType.Transaction)}
           />

--- a/web/src/components/ResourceCard/__tests__/ResourceCardActions.test.tsx
+++ b/web/src/components/ResourceCard/__tests__/ResourceCardActions.test.tsx
@@ -4,10 +4,10 @@ import ResourceCardActions from '../ResourceCardActions';
 
 test('ResourceCardActions', async () => {
   const onEdit = jest.fn();
-  const canEdit = true;
+  const shouldEdit = true;
   const onDelete = jest.fn();
   const testId = faker.datatype.uuid();
 
-  const {getByTestId} = render(<ResourceCardActions canEdit={canEdit} onEdit={onEdit} onDelete={onDelete} id={testId} />);
+  const {getByTestId} = render(<ResourceCardActions shouldEdit={shouldEdit} onEdit={onEdit} onDelete={onDelete} id={testId} />);
   await waitFor(() => getByTestId(`test-actions-button-${testId}`));
 });

--- a/web/src/components/ResourceCard/__tests__/ResourceCardActions.test.tsx
+++ b/web/src/components/ResourceCard/__tests__/ResourceCardActions.test.tsx
@@ -3,9 +3,11 @@ import {render, waitFor} from 'test-utils';
 import ResourceCardActions from '../ResourceCardActions';
 
 test('ResourceCardActions', async () => {
+  const onEdit = jest.fn();
+  const canEdit = true;
   const onDelete = jest.fn();
   const testId = faker.datatype.uuid();
 
-  const {getByTestId} = render(<ResourceCardActions onDelete={onDelete} id={testId} />);
+  const {getByTestId} = render(<ResourceCardActions canEdit={canEdit} onEdit={onEdit} onDelete={onDelete} id={testId} />);
   await waitFor(() => getByTestId(`test-actions-button-${testId}`));
 });

--- a/web/src/components/ResourceCard/__tests__/TestCard.test.tsx
+++ b/web/src/components/ResourceCard/__tests__/TestCard.test.tsx
@@ -3,13 +3,14 @@ import TestMock from '../../../models/__mocks__/Test.mock';
 import TestCard from '../TestCard';
 
 test('TestCard', async () => {
+  const onEdit = jest.fn();
   const onDelete = jest.fn();
   const onRunTest = jest.fn();
   const onClick = jest.fn();
   const test = TestMock.model();
 
   const {getByTestId, getByText} = render(
-    <TestCard onDelete={onDelete} onRun={onRunTest} onViewAll={onClick} test={test} />
+    <TestCard onEdit={onEdit} onDelete={onDelete} onRun={onRunTest} onViewAll={onClick} test={test} />
   );
   const mouseEvent = new MouseEvent('click', {bubbles: true});
   fireEvent(getByTestId(`test-actions-button-${test.id}`), mouseEvent);

--- a/web/src/components/RunActionsMenu/RunActionsMenu.tsx
+++ b/web/src/components/RunActionsMenu/RunActionsMenu.tsx
@@ -1,4 +1,6 @@
 import {Dropdown, Menu} from 'antd';
+import {useNavigate} from 'react-router-dom';
+
 import {useFileViewerModal} from 'components/FileViewerModal/FileViewerModal.provider';
 import useDeleteResourceRun from 'hooks/useDeleteResourceRun';
 import TestRunAnalyticsService from 'services/Analytics/TestRunAnalytics.service';
@@ -14,6 +16,8 @@ interface IProps {
 
 const RunActionsMenu = ({resultId, testId, testVersion, isRunView = false}: IProps) => {
   const {loadJUnit, loadDefinition} = useFileViewerModal();
+
+  const navigate = useNavigate();
 
   const onDelete = useDeleteResourceRun({id: testId, isRunView, type: ResourceType.Test});
 
@@ -41,6 +45,16 @@ const RunActionsMenu = ({resultId, testId, testVersion, isRunView = false}: IPro
               }}
             >
               Test Definition
+            </Menu.Item>
+            <Menu.Item
+              data-cy="test-edit-button"
+              onClick={({domEvent}) => {
+                domEvent.stopPropagation();
+                navigate(`/test/${testId}/run/${resultId}`);
+              }}
+              key="edit"
+            >
+              Edit
             </Menu.Item>
             <Menu.Item
               data-cy="test-delete-button"

--- a/web/src/components/TestHeader/TestHeader.tsx
+++ b/web/src/components/TestHeader/TestHeader.tsx
@@ -5,12 +5,14 @@ import * as S from './TestHeader.styled';
 interface IProps {
   description: string;
   id: string;
+  canEdit: boolean;
+  onEdit(): void;
   onDelete(): void;
   title: string;
   runButton: React.ReactElement;
 }
 
-const TestHeader = ({description, id, onDelete, title, runButton}: IProps) => (
+const TestHeader = ({description, id, canEdit, onEdit, onDelete, title, runButton}: IProps) => (
   <S.Container $isWhite>
     <S.Section>
       <Link to="/" data-cy="test-header-back-button">
@@ -23,7 +25,7 @@ const TestHeader = ({description, id, onDelete, title, runButton}: IProps) => (
     </S.Section>
     <S.Section>
       {runButton}
-      <ResourceCardActions id={id} onDelete={onDelete} />
+      <ResourceCardActions id={id} onDelete={onDelete} onEdit={onEdit} canEdit={canEdit} />
     </S.Section>
   </S.Container>
 );

--- a/web/src/components/TestHeader/TestHeader.tsx
+++ b/web/src/components/TestHeader/TestHeader.tsx
@@ -5,14 +5,14 @@ import * as S from './TestHeader.styled';
 interface IProps {
   description: string;
   id: string;
-  canEdit: boolean;
+  shouldEdit: boolean;
   onEdit(): void;
   onDelete(): void;
   title: string;
   runButton: React.ReactElement;
 }
 
-const TestHeader = ({description, id, canEdit, onEdit, onDelete, title, runButton}: IProps) => (
+const TestHeader = ({description, id, shouldEdit, onEdit, onDelete, title, runButton}: IProps) => (
   <S.Container $isWhite>
     <S.Section>
       <Link to="/" data-cy="test-header-back-button">
@@ -25,7 +25,7 @@ const TestHeader = ({description, id, canEdit, onEdit, onDelete, title, runButto
     </S.Section>
     <S.Section>
       {runButton}
-      <ResourceCardActions id={id} onDelete={onDelete} onEdit={onEdit} canEdit={canEdit} />
+      <ResourceCardActions id={id} onDelete={onDelete} onEdit={onEdit} shouldEdit={shouldEdit} />
     </S.Section>
   </S.Container>
 );

--- a/web/src/components/TestHeader/__tests__/TestHeader.test.tsx
+++ b/web/src/components/TestHeader/__tests__/TestHeader.test.tsx
@@ -4,8 +4,13 @@ import TestHeader from '../TestHeader';
 
 test('SpanAttributesTable', () => {
   const test = TestMock.model();
+
+  const onDelete = jest.fn;
+  const onEdit = jest.fn;
+  const canEdit = true;
+
   const {getByTestId} = render(
-    <TestHeader description={test.description} id={test.id} onDelete={jest.fn} title={test.name} runButton={<div />} />
+    <TestHeader description={test.description} id={test.id} canEdit={canEdit} onEdit={onEdit} onDelete={onDelete} title={test.name} runButton={<div />} />
   );
   expect(getByTestId('test-details-name')).toBeInTheDocument();
 });

--- a/web/src/components/TestHeader/__tests__/TestHeader.test.tsx
+++ b/web/src/components/TestHeader/__tests__/TestHeader.test.tsx
@@ -7,10 +7,10 @@ test('SpanAttributesTable', () => {
 
   const onDelete = jest.fn;
   const onEdit = jest.fn;
-  const canEdit = true;
+  const shouldEdit = true;
 
   const {getByTestId} = render(
-    <TestHeader description={test.description} id={test.id} canEdit={canEdit} onEdit={onEdit} onDelete={onDelete} title={test.name} runButton={<div />} />
+    <TestHeader description={test.description} id={test.id} shouldEdit={shouldEdit} onEdit={onEdit} onDelete={onDelete} title={test.name} runButton={<div />} />
   );
   expect(getByTestId('test-details-name')).toBeInTheDocument();
 });

--- a/web/src/components/TransactionRunActionsMenu/TransactionRunActionsMenu.tsx
+++ b/web/src/components/TransactionRunActionsMenu/TransactionRunActionsMenu.tsx
@@ -1,4 +1,6 @@
 import {Dropdown, Menu} from 'antd';
+import {useNavigate} from 'react-router-dom';
+
 import useDeleteResourceRun from 'hooks/useDeleteResourceRun';
 import {ResourceType} from 'types/Resource.type';
 import {useFileViewerModal} from '../FileViewerModal/FileViewerModal.provider';
@@ -13,6 +15,9 @@ interface IProps {
 
 const TransactionRunActionsMenu = ({runId, transactionId, isRunView = false, transactionVersion}: IProps) => {
   const {loadDefinition} = useFileViewerModal();
+
+  const navigate = useNavigate();
+
   const onDelete = useDeleteResourceRun({id: transactionId, isRunView, type: ResourceType.Transaction});
 
   return (
@@ -26,6 +31,16 @@ const TransactionRunActionsMenu = ({runId, transactionId, isRunView = false, tra
               onClick={() => loadDefinition(ResourceType.Transaction, transactionId, transactionVersion)}
             >
               Transaction Definition
+            </Menu.Item>
+            <Menu.Item
+              data-cy="test-edit-button"
+              onClick={({domEvent}) => {
+                domEvent.stopPropagation();
+                navigate(`/transaction/${transactionId}/run/${runId}`);
+              }}
+              key="edit"
+            >
+              Edit
             </Menu.Item>
             <Menu.Item
               data-cy="test-delete-button"

--- a/web/src/models/TestSummary.model.ts
+++ b/web/src/models/TestSummary.model.ts
@@ -2,6 +2,7 @@ import {TRawTestSummary, TSummary} from 'types/Test.types';
 
 const TestSummary = (summary: TRawTestSummary = {}): TSummary => ({
   runs: summary.runs ?? 0,
+  hasRuns: !!summary.runs && summary.runs > 0,
   lastRun: {
     time: summary.lastRun?.time ?? '',
     passes: summary.lastRun?.passes ?? 0,

--- a/web/src/models/__mocks__/Transaction.mock.ts
+++ b/web/src/models/__mocks__/Transaction.mock.ts
@@ -21,6 +21,7 @@ const TransactionMock: IMockFactory<TTransaction, TTransaction> = () => ({
       },
       summary: {
         runs: 0,
+        hasRuns: false,
         lastRun: {
           time: '',
           passes: 0,

--- a/web/src/pages/Home/Resources.tsx
+++ b/web/src/pages/Home/Resources.tsx
@@ -48,7 +48,7 @@ const Resources = () => {
     onTestClick(id);
   }, []);
 
-  const handleOnEdit = (id: string, lastRunId: string, type: ResourceType) => {
+  const handleOnEdit = (id: string, lastRunId: number, type: ResourceType) => {
     if (type === ResourceType.Test) navigate(`/test/${id}/run/${lastRunId}`);
     else if (type === ResourceType.Transaction) navigate(`/transaction/${id}/run/${lastRunId}`);
   };

--- a/web/src/pages/Home/Resources.tsx
+++ b/web/src/pages/Home/Resources.tsx
@@ -9,6 +9,7 @@ import useDeleteResource from 'hooks/useDeleteResource';
 import usePagination from 'hooks/usePagination';
 import useTestCrud from 'providers/Test/hooks/useTestCrud';
 import {useCallback, useState} from 'react';
+import {useNavigate} from 'react-router-dom';
 import {useGetResourcesQuery} from 'redux/apis/TraceTest.api';
 import HomeAnalyticsService from 'services/Analytics/HomeAnalytics.service';
 import {ResourceType, TResource} from 'types/Resource.type';
@@ -33,6 +34,7 @@ const Resources = () => {
   const onDeleteResource = useDeleteResource();
   const {runTest} = useTestCrud();
   const {runTransaction} = useTransactionCrud();
+  const navigate = useNavigate();
 
   const handleOnRun = useCallback(
     (resource: TTransaction | TTest, type: ResourceType) => {
@@ -45,6 +47,11 @@ const Resources = () => {
   const handleOnViewAll = useCallback((id: string) => {
     onTestClick(id);
   }, []);
+
+  const handleOnEdit = (id: string, lastRunId: string, type: ResourceType) => {
+    if (type === ResourceType.Test) navigate(`/test/${id}/run/${lastRunId}`);
+    else if (type === ResourceType.Transaction) navigate(`/transaction/${id}/run/${lastRunId}`);
+  };
 
   return (
     <>
@@ -76,6 +83,7 @@ const Resources = () => {
               resource.type === ResourceType.Test ? (
                 <TestCard
                   key={resource.item.id}
+                  onEdit={handleOnEdit}
                   onDelete={onDeleteResource}
                   onRun={handleOnRun}
                   onViewAll={handleOnViewAll}
@@ -84,6 +92,7 @@ const Resources = () => {
               ) : (
                 <TransactionCard
                   key={resource.item.id}
+                  onEdit={handleOnEdit}
                   onDelete={onDeleteResource}
                   onRun={handleOnRun}
                   onViewAll={handleOnViewAll}

--- a/web/src/pages/Home/Resources.tsx
+++ b/web/src/pages/Home/Resources.tsx
@@ -48,10 +48,13 @@ const Resources = () => {
     onTestClick(id);
   }, []);
 
-  const handleOnEdit = (id: string, lastRunId: number, type: ResourceType) => {
-    if (type === ResourceType.Test) navigate(`/test/${id}/run/${lastRunId}`);
-    else if (type === ResourceType.Transaction) navigate(`/transaction/${id}/run/${lastRunId}`);
-  };
+  const handleOnEdit = useCallback(
+    (id: string, lastRunId: number, type: ResourceType) => {
+      if (type === ResourceType.Test) navigate(`/test/${id}/run/${lastRunId}`);
+      else if (type === ResourceType.Transaction) navigate(`/transaction/${id}/run/${lastRunId}`);
+    },
+    [navigate]
+  );
 
   return (
     <>

--- a/web/src/pages/Test/Content.tsx
+++ b/web/src/pages/Test/Content.tsx
@@ -1,5 +1,6 @@
 import {useMemo} from 'react';
 import {Button} from 'antd';
+import {useNavigate} from 'react-router-dom';
 import PaginatedList from 'components/PaginatedList';
 import TestRunCard from 'components/RunCard/TestRunCard';
 import TestHeader from 'components/TestHeader';
@@ -15,11 +16,15 @@ import {Steps} from 'components/GuidedTour/testDetailsStepList';
 import * as S from './Test.styled';
 
 const Content = () => {
-  const {test} = useTest();
+  const {test, testLastRun} = useTest();
   const onDeleteResource = useDeleteResource();
   const {runTest, isLoadingRunTest} = useTestCrud();
   const params = useMemo(() => ({testId: test.id}), [test.id]);
   useDocumentTitle(`${test.name}`);
+
+  const navigate = useNavigate();
+  const canEdit = test != null;
+  const onEdit = () => navigate(`/test/${test.id}/run/${testLastRun.id}`);
 
   return (
     <S.Container $isWhite>
@@ -29,6 +34,8 @@ const Content = () => {
         }`}
         id={test.id}
         onDelete={() => onDeleteResource(test.id, test.name, ResourceType.Test)}
+        onEdit={onEdit}
+        canEdit={canEdit}
         title={`${test.name} (v${test.version})`}
         runButton={
           <Button

--- a/web/src/pages/Test/Content.tsx
+++ b/web/src/pages/Test/Content.tsx
@@ -16,15 +16,16 @@ import {Steps} from 'components/GuidedTour/testDetailsStepList';
 import * as S from './Test.styled';
 
 const Content = () => {
-  const {test, testLastRun} = useTest();
+  const {test} = useTest();
   const onDeleteResource = useDeleteResource();
   const {runTest, isLoadingRunTest} = useTestCrud();
   const params = useMemo(() => ({testId: test.id}), [test.id]);
   useDocumentTitle(`${test.name}`);
 
   const navigate = useNavigate();
-  const canEdit = test != null;
-  const onEdit = () => navigate(`/test/${test.id}/run/${testLastRun.id}`);
+
+  const canEdit = test.summary.runs > 0;
+  const onEdit = () => navigate(`/test/${test.id}/run/${test.summary.runs}`);
 
   return (
     <S.Container $isWhite>

--- a/web/src/pages/Test/Content.tsx
+++ b/web/src/pages/Test/Content.tsx
@@ -24,7 +24,7 @@ const Content = () => {
 
   const navigate = useNavigate();
 
-  const canEdit = test.summary.runs > 0;
+  const shouldEdit = test.summary.hasRuns;
   const onEdit = () => navigate(`/test/${test.id}/run/${test.summary.runs}`);
 
   return (
@@ -36,7 +36,7 @@ const Content = () => {
         id={test.id}
         onDelete={() => onDeleteResource(test.id, test.name, ResourceType.Test)}
         onEdit={onEdit}
-        canEdit={canEdit}
+        shouldEdit={shouldEdit}
         title={`${test.name} (v${test.version})`}
         runButton={
           <Button

--- a/web/src/pages/Transaction/Content.tsx
+++ b/web/src/pages/Transaction/Content.tsx
@@ -25,7 +25,7 @@ const Content = () => {
 
   const navigate = useNavigate();
 
-  const canEdit = transaction.summary.runs > 0;
+  const shouldEdit = transaction.summary.hasRuns;
   const onEdit = () => navigate(`/transaction/${transaction.id}/run/${transaction.summary.runs}`);
 
   return (
@@ -35,7 +35,7 @@ const Content = () => {
         id={transaction.id}
         onDelete={() => onDelete(transaction.id, transaction.name)}
         onEdit={onEdit}
-        canEdit={canEdit}
+        shouldEdit={shouldEdit}
         title={`${transaction.name} (v${transaction.version})`}
         runButton={
           <Button onClick={handleRunTest} loading={isEditLoading} type="primary" ghost>

--- a/web/src/pages/Transaction/Content.tsx
+++ b/web/src/pages/Transaction/Content.tsx
@@ -24,8 +24,9 @@ const Content = () => {
   }, [runTransaction, transaction]);
 
   const navigate = useNavigate();
-  const canEdit = test != null;
-  const onEdit = () => navigate(`/transaction/${transaction.id}/run/${transaction.version}`);
+
+  const canEdit = transaction.summary.runs > 0;
+  const onEdit = () => navigate(`/transaction/${transaction.id}/run/${transaction.summary.runs}`);
 
   return (
     <S.Container $isWhite>

--- a/web/src/pages/Transaction/Content.tsx
+++ b/web/src/pages/Transaction/Content.tsx
@@ -1,5 +1,6 @@
 import {Button} from 'antd';
 import {useCallback, useMemo} from 'react';
+import {useNavigate} from 'react-router-dom';
 
 import PaginatedList from 'components/PaginatedList';
 import TransactionRunCard from 'components/RunCard/TransactionRunCard';
@@ -22,12 +23,18 @@ const Content = () => {
     if (transaction.id) runTransaction(transaction);
   }, [runTransaction, transaction]);
 
+  const navigate = useNavigate();
+  const canEdit = test != null;
+  const onEdit = () => navigate(`/transaction/${transaction.id}/run/${transaction.version}`);
+
   return (
     <S.Container $isWhite>
       <TestHeader
         description={transaction.description}
         id={transaction.id}
         onDelete={() => onDelete(transaction.id, transaction.name)}
+        onEdit={onEdit}
+        canEdit={canEdit}
         title={`${transaction.name} (v${transaction.version})`}
         runButton={
           <Button onClick={handleRunTest} loading={isEditLoading} type="primary" ghost>

--- a/web/src/types/Test.types.ts
+++ b/web/src/types/Test.types.ts
@@ -65,6 +65,7 @@ export type TTrigger = {
 export type TRawTestSummary = TTestSchemas['TestSummary'];
 export type TSummary = {
   runs: number;
+  hasRuns: boolean;
   lastRun: {
     time: string;
     passes: number;


### PR DESCRIPTION
This PR aims to add an edit button on some menus, redirecting the user to the last test/transaction run. The idea is to help the user to find quick ways to edit a test/transaction name/description.

Loom: https://www.loom.com/share/04d0f6d596744800abead6364970c909

## Changes

- Add Edit button on Tests/Transactions context menu on Resources page
- Add Edit button on context menu on Test page
- Add Edit button on context menu on Transactions page

## Fixes

- #1848

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
