### PR TITLE
fix: only print test and transaction result in json format

### DIFF
--- a/cli/actions/run_test_action.go
+++ b/cli/actions/run_test_action.go
@@ -259,7 +259,7 @@ func (a runTestAction) runDefinitionFile(ctx context.Context, f file.File, param
 		}).
 		Execute()
 
-	if resp.StatusCode == http.StatusUnprocessableEntity {
+	if resp != nil && resp.StatusCode == http.StatusUnprocessableEntity {
 		filledVariables, err := a.askForMissingVariables(resp)
 		if err != nil {
 			return err

--- a/cli/formatters/test_run.go
+++ b/cli/formatters/test_run.go
@@ -61,8 +61,14 @@ func (f testRun) Format(output TestRunOutput) string {
 }
 
 func (f testRun) json(output TestRunOutput) string {
-	output.RunWebURL = f.GetRunLink(output.Test.GetId(), output.Run.GetId())
-	bytes, err := json.MarshalIndent(output.Run.Result, "", "  ")
+	result := struct {
+		RunWebURL string                   `json:"testRunWebUrl"`
+		Results   openapi.AssertionResults `json:"results"`
+	}{
+		RunWebURL: f.GetRunLink(output.Test.GetId(), output.Run.GetId()),
+		Results:   *output.Run.Result,
+	}
+	bytes, err := json.MarshalIndent(result, "", "  ")
 	if err != nil {
 		panic(fmt.Errorf("could not marshal output json: %w", err))
 	}

--- a/cli/formatters/test_run.go
+++ b/cli/formatters/test_run.go
@@ -62,7 +62,7 @@ func (f testRun) Format(output TestRunOutput) string {
 
 func (f testRun) json(output TestRunOutput) string {
 	output.RunWebURL = f.GetRunLink(output.Test.GetId(), output.Run.GetId())
-	bytes, err := json.MarshalIndent(output, "", "  ")
+	bytes, err := json.MarshalIndent(output.Run.Result, "", "  ")
 	if err != nil {
 		panic(fmt.Errorf("could not marshal output json: %w", err))
 	}

--- a/cli/formatters/test_run_test.go
+++ b/cli/formatters/test_run_test.go
@@ -32,7 +32,7 @@ func TestJSON(t *testing.T) {
 	formatters.SetOutput(formatters.JSON)
 	actual := formatter.Format(in)
 
-	expected := `{"test":{"id":"9876543","name":"Testcase 1"},"testRun":{"id":"1", "result":{"allPassed":true},"state":"FINISHED"},"testRunWebUrl":"http://localhost:11633/test/9876543/run/1/test"}`
+	expected := `{"results":{"allPassed":true},"testRunWebUrl":"http://localhost:11633/test/9876543/run/1/test"}`
 
 	assert.JSONEq(t, expected, actual)
 	formatters.SetOutput(formatters.DefaultOutput)

--- a/cli/formatters/transaction_run.go
+++ b/cli/formatters/transaction_run.go
@@ -45,8 +45,13 @@ func (f transactionRun) Format(output TransactionRunOutput) string {
 
 func (f transactionRun) json(output TransactionRunOutput) string {
 	type stepResult struct {
-		Name    string
-		Results openapi.AssertionResults
+		Name    string                   `json:"name"`
+		Results openapi.AssertionResults `json:"results"`
+	}
+
+	type transactionResult struct {
+		RunWebURL string       `json:"testRunWebUrl"`
+		Steps     []stepResult `json:"steps"`
 	}
 
 	stepsResults := make([]stepResult, 0, len(output.Run.Steps))
@@ -59,7 +64,12 @@ func (f transactionRun) json(output TransactionRunOutput) string {
 		})
 	}
 
-	bytes, err := json.MarshalIndent(stepsResults, "", "  ")
+	result := transactionResult{
+		RunWebURL: output.RunWebURL,
+		Steps:     stepsResults,
+	}
+
+	bytes, err := json.MarshalIndent(result, "", "  ")
 	if err != nil {
 		panic(fmt.Errorf("could not marshal output json: %w", err))
 	}

--- a/cli/formatters/transaction_run.go
+++ b/cli/formatters/transaction_run.go
@@ -44,7 +44,22 @@ func (f transactionRun) Format(output TransactionRunOutput) string {
 }
 
 func (f transactionRun) json(output TransactionRunOutput) string {
-	bytes, err := json.MarshalIndent(output, "", "  ")
+	type stepResult struct {
+		Name    string
+		Results openapi.AssertionResults
+	}
+
+	stepsResults := make([]stepResult, 0, len(output.Run.Steps))
+
+	for i, step := range output.Run.Steps {
+		test := output.Transaction.Steps[i]
+		stepsResults = append(stepsResults, stepResult{
+			Name:    *test.Name,
+			Results: *step.Result,
+		})
+	}
+
+	bytes, err := json.MarshalIndent(stepsResults, "", "  ")
 	if err != nil {
 		panic(fmt.Errorf("could not marshal output json: %w", err))
 	}


### PR DESCRIPTION
This PR changes the CLI to only display result information when the option `--output json` is defined. This makes it simpler for users to parse the result of the tests.
## Fixes

- #1854

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
