### PR TITLE
feature: adding test run outputs UX/UI improvements

### DIFF
--- a/api/tests.yaml
+++ b/api/tests.yaml
@@ -170,6 +170,8 @@ components:
             properties:
               name:
                 type: string
+              spanId:
+                type: string
               value:
                 type: string
 

--- a/cli/openapi/model_test_run_outputs.go
+++ b/cli/openapi/model_test_run_outputs.go
@@ -16,8 +16,9 @@ import (
 
 // TestRunOutputs struct for TestRunOutputs
 type TestRunOutputs struct {
-	Name  *string `json:"name,omitempty"`
-	Value *string `json:"value,omitempty"`
+	Name   *string `json:"name,omitempty"`
+	SpanId *string `json:"spanId,omitempty"`
+	Value  *string `json:"value,omitempty"`
 }
 
 // NewTestRunOutputs instantiates a new TestRunOutputs object
@@ -69,6 +70,38 @@ func (o *TestRunOutputs) SetName(v string) {
 	o.Name = &v
 }
 
+// GetSpanId returns the SpanId field value if set, zero value otherwise.
+func (o *TestRunOutputs) GetSpanId() string {
+	if o == nil || o.SpanId == nil {
+		var ret string
+		return ret
+	}
+	return *o.SpanId
+}
+
+// GetSpanIdOk returns a tuple with the SpanId field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *TestRunOutputs) GetSpanIdOk() (*string, bool) {
+	if o == nil || o.SpanId == nil {
+		return nil, false
+	}
+	return o.SpanId, true
+}
+
+// HasSpanId returns a boolean if a field has been set.
+func (o *TestRunOutputs) HasSpanId() bool {
+	if o != nil && o.SpanId != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetSpanId gets a reference to the given string and assigns it to the SpanId field.
+func (o *TestRunOutputs) SetSpanId(v string) {
+	o.SpanId = &v
+}
+
 // GetValue returns the Value field value if set, zero value otherwise.
 func (o *TestRunOutputs) GetValue() string {
 	if o == nil || o.Value == nil {
@@ -105,6 +138,9 @@ func (o TestRunOutputs) MarshalJSON() ([]byte, error) {
 	toSerialize := map[string]interface{}{}
 	if o.Name != nil {
 		toSerialize["name"] = o.Name
+	}
+	if o.SpanId != nil {
+		toSerialize["spanId"] = o.SpanId
 	}
 	if o.Value != nil {
 		toSerialize["value"] = o.Value

--- a/server/executor/assertion_runner.go
+++ b/server/executor/assertion_runner.go
@@ -149,12 +149,12 @@ func (e *defaultAssertionRunner) executeAssertions(ctx context.Context, req Asse
 	return run, nil
 }
 
-func createEnvironment(environment model.Environment, outputs model.OrderedMap[string, string]) model.Environment {
+func createEnvironment(environment model.Environment, outputs model.OrderedMap[string, model.RunOutput]) model.Environment {
 	outputVariables := make([]model.EnvironmentValue, 0)
-	outputs.ForEach(func(key, val string) error {
+	outputs.ForEach(func(key string, val model.RunOutput) error {
 		outputVariables = append(outputVariables, model.EnvironmentValue{
-			Key:   key,
-			Value: val,
+			Key:   val.Name,
+			Value: val.Value,
 		})
 
 		return nil

--- a/server/executor/transaction_runner.go
+++ b/server/executor/transaction_runner.go
@@ -178,12 +178,12 @@ func (r persistentTransactionRunner) updateStepRun(ctx context.Context, tr model
 	return tr, nil
 }
 
-func mergeOutputsIntoEnv(env model.Environment, outputs model.OrderedMap[string, string]) model.Environment {
+func mergeOutputsIntoEnv(env model.Environment, outputs model.OrderedMap[string, model.RunOutput]) model.Environment {
 	newEnv := make([]model.EnvironmentValue, 0, outputs.Len())
-	outputs.ForEach(func(key, val string) error {
+	outputs.ForEach(func(key string, val model.RunOutput) error {
 		newEnv = append(newEnv, model.EnvironmentValue{
 			Key:   key,
-			Value: val,
+			Value: val.Value,
 		})
 
 		return nil

--- a/server/executor/transaction_runner_test.go
+++ b/server/executor/transaction_runner_test.go
@@ -43,7 +43,9 @@ func (r *fakeTestRunner) Run(ctx context.Context, test model.Test, metadata mode
 
 		r.uid++
 
-		newRun.Outputs = (model.OrderedMap[string, string]{}).MustAdd("USER_ID", strconv.Itoa(r.uid))
+		newRun.Outputs = (model.OrderedMap[string, model.RunOutput]{}).MustAdd("USER_ID", model.RunOutput{
+			Value: strconv.Itoa(r.uid),
+		})
 
 		err = r.db.UpdateRun(ctx, newRun)
 		r.subscriptionManager.PublishUpdate(subscription.Message{
@@ -66,7 +68,7 @@ func TestTransactionRunner(t *testing.T) {
 			assert.Equal(t, actual.Steps[1].State, model.RunStateFinished)
 			assert.Equal(t, "http://my-service.com", actual.Environment.Get("url"))
 
-			assert.Equal(t, "1", actual.Steps[0].Outputs.Get("USER_ID"))
+			assert.Equal(t, model.RunOutput{Name: "", Value: "1", SpanID: ""}, actual.Steps[0].Outputs.Get("USER_ID"))
 
 			// this assertom is supposed to test that the output from the previous step
 			// is injected in the env for the next. In practice, this depends
@@ -74,7 +76,7 @@ func TestTransactionRunner(t *testing.T) {
 			// to the test run, like the real test runner would.
 			// see line 27
 			assert.Equal(t, "1", actual.Steps[1].Environment.Get("USER_ID"))
-			assert.Equal(t, "2", actual.Steps[1].Outputs.Get("USER_ID"))
+			assert.Equal(t, model.RunOutput{Name: "", Value: "2", SpanID: ""}, actual.Steps[1].Outputs.Get("USER_ID"))
 
 			assert.Equal(t, "2", actual.Environment.Get("USER_ID"))
 

--- a/server/http/mappings/tests.go
+++ b/server/http/mappings/tests.go
@@ -314,13 +314,14 @@ func (m OpenAPI) Run(in *model.Run) openapi.TestRun {
 	}
 }
 
-func (m OpenAPI) RunOutputs(in model.OrderedMap[string, string]) []openapi.TestRunOutputs {
+func (m OpenAPI) RunOutputs(in model.OrderedMap[string, model.RunOutput]) []openapi.TestRunOutputs {
 	res := make([]openapi.TestRunOutputs, 0, in.Len())
 
-	in.ForEach(func(key, val string) error {
+	in.ForEach(func(key string, val model.RunOutput) error {
 		res = append(res, openapi.TestRunOutputs{
-			Name:  key,
-			Value: val,
+			Name:   key,
+			Value:  val.Value,
+			SpanId: val.SpanID,
 		})
 		return nil
 	})
@@ -484,11 +485,15 @@ func (m Model) Run(in openapi.TestRun) (*model.Run, error) {
 	}, nil
 }
 
-func (m Model) RunOutputs(in []openapi.TestRunOutputs) model.OrderedMap[string, string] {
-	res := model.OrderedMap[string, string]{}
+func (m Model) RunOutputs(in []openapi.TestRunOutputs) model.OrderedMap[string, model.RunOutput] {
+	res := model.OrderedMap[string, model.RunOutput]{}
 
 	for _, output := range in {
-		res.Add(output.Name, output.Value)
+		res.Add(output.Name, model.RunOutput{
+			Value:  output.Value,
+			Name:   output.Name,
+			SpanID: output.SpanId,
+		})
 	}
 
 	return res

--- a/server/model/run.go
+++ b/server/model/run.go
@@ -101,7 +101,7 @@ func (r Run) SuccessfullyPolledTraces(t *Trace) Run {
 }
 
 func (r Run) SuccessfullyAsserted(
-	outputs OrderedMap[string, string],
+	outputs OrderedMap[string, RunOutput],
 	environment Environment,
 	res OrderedMap[SpanQuery, []AssertionResult],
 	allPassed bool,

--- a/server/model/tests.go
+++ b/server/model/tests.go
@@ -96,7 +96,7 @@ type (
 		TriggerResult TriggerResult
 		Results       *RunResults
 		Trace         *Trace
-		Outputs       OrderedMap[string, string]
+		Outputs       OrderedMap[string, RunOutput]
 		LastError     error
 		Pass          int
 		Fail          int
@@ -110,6 +110,12 @@ type (
 	RunResults struct {
 		AllPassed bool
 		Results   OrderedMap[SpanQuery, []AssertionResult]
+	}
+
+	RunOutput struct {
+		Name   string
+		Value  string
+		SpanID string
 	}
 
 	AssertionResult struct {

--- a/server/openapi/model_test_run_outputs.go
+++ b/server/openapi/model_test_run_outputs.go
@@ -12,6 +12,8 @@ package openapi
 type TestRunOutputs struct {
 	Name string `json:"name,omitempty"`
 
+	SpanId string `json:"spanId,omitempty"`
+
 	Value string `json:"value,omitempty"`
 }
 

--- a/server/testdb/runs.go
+++ b/server/testdb/runs.go
@@ -483,7 +483,21 @@ func readRunRow(row scanner) (model.Run, error) {
 
 		err = json.Unmarshal(jsonOutputs, &r.Outputs)
 		if err != nil {
-			return model.Run{}, fmt.Errorf("cannot parse Outputs: %w", err)
+			// try with raw outputs
+			var rawOutputs []model.EnvironmentValue
+			err = json.Unmarshal(jsonOutputs, &rawOutputs)
+
+			for _, value := range rawOutputs {
+				r.Outputs.Add(value.Key, model.RunOutput{
+					Name:   value.Key,
+					Value:  value.Value,
+					SpanID: "",
+				})
+			}
+
+			if err != nil {
+				return model.Run{}, fmt.Errorf("cannot parse Outputs: %w", err)
+			}
 		}
 
 		err = json.Unmarshal(jsonMetadata, &r.Metadata)

--- a/server/testdb/runs_test.go
+++ b/server/testdb/runs_test.go
@@ -116,8 +116,10 @@ func TestUpdateRun(t *testing.T) {
 		}),
 	}
 
-	run.Outputs = (model.OrderedMap[string, string]{}).
-		MustAdd("key", "value")
+	run.Outputs = (model.OrderedMap[string, model.RunOutput]{}).
+		MustAdd("key", model.RunOutput{
+			Value: "value",
+		})
 
 	err := db.UpdateRun(context.TODO(), run)
 	require.NoError(t, err)

--- a/web/src/components/AttributeList/AttributeList.tsx
+++ b/web/src/components/AttributeList/AttributeList.tsx
@@ -3,6 +3,7 @@ import {OtelReference} from 'components/TestSpecForm/hooks/useGetOTELSemanticCon
 import {TResultAssertions} from 'types/Assertion.types';
 import {TSpanFlatAttribute} from 'types/Span.types';
 import TraceAnalyticsService from 'services/Analytics/TestRunAnalytics.service';
+import {TTestOutput} from 'types/TestOutput.types';
 import * as S from './AttributeList.styled';
 import EmptyAttributeList from './EmptyAttributeList';
 
@@ -13,9 +14,18 @@ interface IProps {
   searchText?: string;
   semanticConventions: OtelReference;
   onCreateOutput(attribute: TSpanFlatAttribute): void;
+  outputs: TTestOutput[];
 }
 
-const AttributeList = ({assertions, attributeList, onCreateTestSpec, onCreateOutput, searchText, semanticConventions}: IProps) => {
+const AttributeList = ({
+  assertions,
+  attributeList,
+  onCreateTestSpec,
+  onCreateOutput,
+  searchText,
+  semanticConventions,
+  outputs,
+}: IProps) => {
   const onCopy = (value: string) => {
     TraceAnalyticsService.onAttributeCopy();
     navigator.clipboard.writeText(value);
@@ -33,6 +43,7 @@ const AttributeList = ({assertions, attributeList, onCreateTestSpec, onCreateOut
           onCreateTestSpec={onCreateTestSpec}
           onCreateOutput={onCreateOutput}
           semanticConventions={semanticConventions}
+          outputs={outputs}
         />
       ))}
     </S.AttributeList>

--- a/web/src/components/AttributeList/__tests__/AttributeList.test.tsx
+++ b/web/src/components/AttributeList/__tests__/AttributeList.test.tsx
@@ -19,6 +19,7 @@ describe('AttributeList', () => {
         onCreateOutput={onCreateOutput}
         onCreateTestSpec={onCreateTestSpec}
         semanticConventions={{}}
+        outputs={[]}
       />
     );
 
@@ -32,6 +33,7 @@ describe('AttributeList', () => {
         onCreateOutput={onCreateOutput}
         onCreateTestSpec={onCreateTestSpec}
         semanticConventions={{}}
+        outputs={[]}
       />
     );
 

--- a/web/src/components/AttributeRow/AttributeRow.styled.ts
+++ b/web/src/components/AttributeRow/AttributeRow.styled.ts
@@ -1,6 +1,7 @@
 import {InfoCircleOutlined} from '@ant-design/icons';
 import {Tag as AntdTag, Typography} from 'antd';
 import styled from 'styled-components';
+import TestOutputMark from 'components/TestOutputMark';
 
 export {default as AttributeTitle} from './AttributeTitle';
 
@@ -65,4 +66,11 @@ export const InfoIcon = styled(InfoCircleOutlined)`
   color: ${({theme}) => theme.color.textSecondary};
   cursor: pointer;
   margin: 4px;
+`;
+
+export const OutputsMark = styled(TestOutputMark)`
+  && {
+    color: ${({theme}) => theme.color.textSecondary};
+    margin: 4px;
+  }
 `;

--- a/web/src/components/AttributeRow/AttributeRow.tsx
+++ b/web/src/components/AttributeRow/AttributeRow.tsx
@@ -9,6 +9,7 @@ import {OtelReference} from 'components/TestSpecForm/hooks/useGetOTELSemanticCon
 import SpanAttributeService from 'services/SpanAttribute.service';
 import {TResultAssertions} from 'types/Assertion.types';
 import {TSpanFlatAttribute} from 'types/Span.types';
+import {TTestOutput} from 'types/TestOutput.types';
 import * as S from './AttributeRow.styled';
 import AssertionResultChecks from '../AssertionResultChecks/AssertionResultChecks';
 
@@ -20,6 +21,7 @@ interface IProps {
   onCreateTestSpec(attribute: TSpanFlatAttribute): void;
   onCreateOutput(attribute: TSpanFlatAttribute): void;
   semanticConventions: OtelReference;
+  outputs: TTestOutput[];
 }
 
 enum Action {
@@ -37,6 +39,7 @@ const AttributeRow = ({
   searchText,
   semanticConventions,
   onCreateOutput,
+  outputs,
 }: IProps) => {
   const semanticConvention = SpanAttributeService.getReferencePicker(semanticConventions, key);
   const description = useMemo(() => parse(MarkdownIt().render(semanticConvention.description)), [semanticConvention]);
@@ -44,6 +47,10 @@ const AttributeRow = ({
   const {failed, passed} = useMemo(
     () => SpanAttributeService.getAttributeAssertionResults(key, assertions),
     [assertions, key]
+  );
+  const attributeOutputs = useMemo(
+    () => SpanAttributeService.getOutputsFromAttributeName(key, outputs),
+    [key, outputs]
   );
 
   const handleOnClick = ({key: option}: {key: string}) => {
@@ -106,6 +113,8 @@ const AttributeRow = ({
               <S.InfoIcon />
             </Popover>
           )}
+
+          {!!attributeOutputs.length && <S.OutputsMark outputs={attributeOutputs} />}
         </S.SectionTitle>
 
         <S.AttributeValueRow>

--- a/web/src/components/AttributeRow/__tests__/AttributeRow.test.tsx
+++ b/web/src/components/AttributeRow/__tests__/AttributeRow.test.tsx
@@ -21,6 +21,7 @@ describe('AttributeRow', () => {
         onCreateTestSpec={onCreateTestSpec}
         onCopy={onCopy}
         semanticConventions={{}}
+        outputs={[]}
       />
     );
 

--- a/web/src/components/Editor/Expression/hooks/useAutoComplete.ts
+++ b/web/src/components/Editor/Expression/hooks/useAutoComplete.ts
@@ -29,7 +29,7 @@ const useAutoComplete = ({testId, runId, onSelect = noop, autocompleteCustomValu
   const getSelectedEnvironmentEntryList = useCallback(() => {
     const state = getState();
 
-    return EnvironmentSelectors.selectSelectedEnvironmentValues(state);
+    return EnvironmentSelectors.selectSelectedEnvironmentValues(state, true);
   }, [getState]);
 
   return useCallback(

--- a/web/src/components/Editor/Interpolation/hooks/useAutoComplete.ts
+++ b/web/src/components/Editor/Interpolation/hooks/useAutoComplete.ts
@@ -11,7 +11,7 @@ const useAutoComplete = () => {
   const getSelectedEnvironmentEntryList = useCallback(() => {
     const state = getState();
 
-    return EnvironmentSelectors.selectSelectedEnvironmentValues(state);
+    return EnvironmentSelectors.selectSelectedEnvironmentValues(state, false);
   }, [getState]);
 
   return useCallback(

--- a/web/src/components/RunDetailTest/RunDetailTest.tsx
+++ b/web/src/components/RunDetailTest/RunDetailTest.tsx
@@ -166,6 +166,7 @@ const RunDetailTest = ({run, testId}: IProps) => {
               {!isTestSpecFormOpen && !isTestOutputFormOpen && (
                 <S.TabsContainer>
                   <Tabs
+                    activeKey={query.get('tab') || TABS.SPECS}
                     defaultActiveKey={query.get('tab') || TABS.SPECS}
                     onChange={tab =>
                       updateQuery(

--- a/web/src/components/SpanDetail/Attributes.tsx
+++ b/web/src/components/SpanDetail/Attributes.tsx
@@ -4,6 +4,7 @@ import AttributeList from 'components/AttributeList';
 import {OtelReference} from 'components/TestSpecForm/hooks/useGetOTELSemanticConventionAttributesInfo';
 import {TResultAssertions} from 'types/Assertion.types';
 import {TSpanFlatAttribute} from 'types/Span.types';
+import { TTestOutput } from 'types/TestOutput.types';
 import * as S from './SpanDetail.styled';
 
 interface IProps {
@@ -13,9 +14,10 @@ interface IProps {
   onCreateTestSpec(attribute: TSpanFlatAttribute): void;
   onCreateOutput(attribute: TSpanFlatAttribute): void;
   semanticConventions: OtelReference;
+  outputs: TTestOutput[];
 }
 
-const Attributes = ({assertions, attributeList, onCreateTestSpec, onCreateOutput, searchText, semanticConventions}: IProps) => {
+const Attributes = ({assertions, attributeList, outputs, onCreateTestSpec, onCreateOutput, searchText, semanticConventions}: IProps) => {
   const containerRef = useRef<HTMLDivElement>(null);
   const [topPosition, setTopPosition] = useState(0);
 
@@ -32,6 +34,7 @@ const Attributes = ({assertions, attributeList, onCreateTestSpec, onCreateOutput
         onCreateOutput={onCreateOutput}
         searchText={searchText}
         semanticConventions={semanticConventions}
+        outputs={outputs}
       />
     </S.AttributesContainer>
   );

--- a/web/src/components/SpanDetail/SpanDetail.tsx
+++ b/web/src/components/SpanDetail/SpanDetail.tsx
@@ -17,6 +17,7 @@ import TestOutput from 'models/TestOutput.model';
 import Attributes from './Attributes';
 import Header from './Header';
 import * as S from './SpanDetail.styled';
+import {selectOutputsBySpanId} from '../../redux/testOutputs/selectors';
 
 interface IProps {
   onCreateTestSpec?(): void;
@@ -28,6 +29,7 @@ const SpanDetail = ({onCreateTestSpec = noop, searchText, span}: IProps) => {
   const {open} = useTestSpecForm();
   const {onNavigateAndOpen} = useTestOutput();
   const assertions = useAppSelector(state => TestSpecsSelectors.selectAssertionResultsBySpan(state, span?.id || ''));
+  const outputs = useAppSelector(state => selectOutputsBySpanId(state, span?.id || ''));
   const [search, setSearch] = useState('');
   const semanticConventions = useGetOTELSemanticConventionAttributesInfo();
 
@@ -67,7 +69,7 @@ const SpanDetail = ({onCreateTestSpec = noop, searchText, span}: IProps) => {
         value: `attr:${key}`,
       });
 
-      onNavigateAndOpen(output);
+      onNavigateAndOpen({...output, spanId: span!.id});
     },
     [onNavigateAndOpen, span]
   );
@@ -97,6 +99,7 @@ const SpanDetail = ({onCreateTestSpec = noop, searchText, span}: IProps) => {
         onCreateOutput={handleCreateOutput}
         searchText={searchText}
         semanticConventions={semanticConventions}
+        outputs={outputs}
       />
     </>
   );

--- a/web/src/components/TestOutput/TestOutput.styled.ts
+++ b/web/src/components/TestOutput/TestOutput.styled.ts
@@ -2,13 +2,15 @@ import {MoreOutlined} from '@ant-design/icons';
 import {Typography} from 'antd';
 import styled from 'styled-components';
 
-export const Container = styled.div<{$isDeleted: boolean}>`
+export const Container = styled.div<{$isDeleted: boolean; $isSelected: boolean}>`
   background: ${({theme}) => theme.color.white};
-  border: ${({theme}) => `1px solid ${theme.color.border}`};
+  border: ${({$isSelected, theme}) =>
+    $isSelected ? `1px solid ${theme.color.interactive}` : `1px solid ${theme.color.borderLight}`};
   display: flex;
   flex-direction: column;
   padding: 7px 16px;
   transition: background-color 0.2s ease;
+  cursor: pointer;
 
   > div:nth-child(2) {
     opacity: ${({$isDeleted}) => ($isDeleted ? 0.5 : 1)};

--- a/web/src/components/TestOutput/TestOutput.tsx
+++ b/web/src/components/TestOutput/TestOutput.tsx
@@ -1,9 +1,14 @@
 import {Tag} from 'antd';
+import {useCallback} from 'react';
 
 import AttributeValue from 'components/AttributeValue';
 import {TTestOutput} from 'types/TestOutput.types';
+import {useTestOutput} from 'providers/TestOutput/TestOutput.provider';
+import {useSpan} from 'providers/Span/Span.provider';
 import * as S from './TestOutput.styled';
 import Actions from './Actions';
+import {selectIsSelectedOutput} from '../../redux/testOutputs/selectors';
+import {useAppSelector} from '../../redux/hooks';
 
 interface IProps {
   index: number;
@@ -12,47 +17,69 @@ interface IProps {
   onEdit(values: TTestOutput): void;
 }
 
-const TestOutput = ({index, output, onEdit, onDelete}: IProps) => (
-  <S.Container $isDeleted={output.isDeleted} data-cy="output-item-container">
-    {output.isDraft && (
-      <S.Row $justifyContent="flex-end">
-        <Tag data-cy="output-pending-tag">pending {output.isDeleted && '/ deleted'}</Tag>
+const TestOutput = ({
+  index,
+  output: {id, name, isDeleted, isDraft, spanId, selector, value, valueRun, valueRunDraft},
+  output,
+  onEdit,
+  onDelete,
+}: IProps) => {
+  const {onSelectedOutputs} = useTestOutput();
+  const {onSelectSpan} = useSpan();
+  const isSelected = useAppSelector(state => selectIsSelectedOutput(state, id));
+
+  const handleOutputClick = useCallback(() => {
+    onSelectedOutputs([output]);
+    onSelectSpan(spanId);
+  }, [onSelectSpan, onSelectedOutputs, output, spanId]);
+
+  return (
+    <S.Container
+      $isDeleted={isDeleted}
+      data-cy="output-item-container"
+      $isSelected={isSelected}
+      onClick={handleOutputClick}
+    >
+      {isDraft && (
+        <S.Row $justifyContent="flex-end">
+          <Tag data-cy="output-pending-tag">pending {isDeleted && '/ deleted'}</Tag>
+        </S.Row>
+      )}
+      <S.Row>
+        <S.OutputDetails>
+          <S.Entry>
+            <S.Key>Name</S.Key>
+            <S.Value>{name}</S.Value>
+          </S.Entry>
+          <S.Entry>
+            <S.Key>Selector</S.Key>
+            <S.Value>{selector}</S.Value>
+          </S.Entry>
+          <S.Entry>
+            <S.Key>Value</S.Key>
+            <S.Value>{value}</S.Value>
+          </S.Entry>
+        </S.OutputDetails>
+        <Actions isDeleted={isDeleted} onDelete={() => onDelete(index)} onEdit={() => onEdit(output)} />
       </S.Row>
-    )}
-    <S.Row>
-      <S.OutputDetails>
+      <S.Row>
         <S.Entry>
-          <S.Key>Name</S.Key>
-          <S.Value>{output.name}</S.Value>
+          {!isDraft && Boolean(valueRun) && (
+            <>
+              <S.Key>Run value</S.Key>
+              <AttributeValue value={valueRun} />
+            </>
+          )}
+          {isDraft && Boolean(valueRunDraft) && (
+            <>
+              <S.Key>Run value</S.Key>
+              <AttributeValue value={valueRunDraft} />
+            </>
+          )}
         </S.Entry>
-        <S.Entry>
-          <S.Key>Selector</S.Key>
-          <S.Value>{output.selector}</S.Value>
-        </S.Entry>
-        <S.Entry>
-          <S.Key>Value</S.Key>
-          <S.Value>{output.value}</S.Value>
-        </S.Entry>
-      </S.OutputDetails>
-      <Actions isDeleted={output.isDeleted} onDelete={() => onDelete(index)} onEdit={() => onEdit(output)} />
-    </S.Row>
-    <S.Row>
-      <S.Entry>
-        {!output.isDraft && Boolean(output.valueRun) && (
-          <>
-            <S.Key>Run value</S.Key>
-            <AttributeValue value={output.valueRun} />
-          </>
-        )}
-        {output.isDraft && Boolean(output.valueRunDraft) && (
-          <>
-            <S.Key>Run value</S.Key>
-            <AttributeValue value={output.valueRunDraft} />
-          </>
-        )}
-      </S.Entry>
-    </S.Row>
-  </S.Container>
-);
+      </S.Row>
+    </S.Container>
+  );
+};
 
 export default TestOutput;

--- a/web/src/components/TestOutputForm/TestOutputForm.tsx
+++ b/web/src/components/TestOutputForm/TestOutputForm.tsx
@@ -48,6 +48,7 @@ const TestOutputForm = ({isEditing = false, isLoading = false, onCancel, onSubmi
         onFinish={values => onSubmit(values, spanIdList[0])}
         onValuesChange={onValidate}
       >
+        <Form.Item name="spanId" />
         <S.FormSection>
           <S.FormSectionHeaderSelector>
             <S.FormSectionRow1>

--- a/web/src/components/TestOutputMark/TestOutputMark.styled.ts
+++ b/web/src/components/TestOutputMark/TestOutputMark.styled.ts
@@ -1,0 +1,9 @@
+import {Typography} from 'antd';
+import styled from 'styled-components';
+
+export const Mark = styled(Typography.Text)`
+  && {
+    cursor: pointer;
+    font-size: ${({theme}) => theme.size.xs};
+  }
+`;

--- a/web/src/components/TestOutputMark/TestOutputMark.tsx
+++ b/web/src/components/TestOutputMark/TestOutputMark.tsx
@@ -1,0 +1,20 @@
+import {TTestOutput} from 'types/TestOutput.types';
+import {useTestOutput} from '../../providers/TestOutput/TestOutput.provider';
+import * as S from './TestOutputMark.styled';
+
+interface IProps {
+  className?: string;
+  outputs: TTestOutput[];
+}
+
+const TestOutputMark = ({className, outputs}: IProps) => {
+  const {onSelectedOutputs} = useTestOutput();
+
+  return (
+    <S.Mark onClick={() => onSelectedOutputs(outputs)} className={className}>
+      [x]
+    </S.Mark>
+  );
+};
+
+export default TestOutputMark;

--- a/web/src/components/TestOutputMark/index.ts
+++ b/web/src/components/TestOutputMark/index.ts
@@ -1,0 +1,2 @@
+// eslint-disable-next-line no-restricted-exports
+export {default} from './TestOutputMark';

--- a/web/src/components/Visualization/components/DAG/SpanNode.styled.ts
+++ b/web/src/components/Visualization/components/DAG/SpanNode.styled.ts
@@ -81,6 +81,8 @@ export const Container = styled.div<{$matched: boolean; $selected: boolean}>`
 export const Footer = styled.div`
   bottom: 12px;
   position: absolute;
+  flex-direction: column;
+  align-items: flex-end;
   right: 10px;
   display: flex;
 `;

--- a/web/src/components/Visualization/components/DAG/SpanNode.tsx
+++ b/web/src/components/Visualization/components/DAG/SpanNode.tsx
@@ -8,13 +8,16 @@ import {useAppSelector} from 'redux/hooks';
 import SpanService from 'services/Span.service';
 import TestSpecsSelectors from 'selectors/TestSpecs.selectors';
 import {INodeDataSpan} from 'types/DAG.types';
+import AssertionResultChecks from 'components/AssertionResultChecks/AssertionResultChecks';
+import {selectOutputsBySpanId} from 'redux/testOutputs/selectors';
+import TestOutputMark from 'components/TestOutputMark';
 import * as S from './SpanNode.styled';
-import AssertionResultChecks from '../../../AssertionResultChecks/AssertionResultChecks';
 
 interface IProps extends NodeProps<INodeDataSpan> {}
 
 const SpanNode = ({data, id, selected}: IProps) => {
   const assertions = useAppSelector(state => TestSpecsSelectors.selectAssertionResultsBySpan(state, data?.id || ''));
+  const outputs = useAppSelector(state => selectOutputsBySpanId(state, data?.id || ''));
   const {failed, passed} = useMemo(() => SpanService.getAssertionResultSummary(assertions), [assertions]);
 
   const className = data.isMatched ? 'matched' : '';
@@ -57,6 +60,7 @@ const SpanNode = ({data, id, selected}: IProps) => {
       </S.Body>
 
       <S.Footer>
+        {!!outputs.length && <TestOutputMark outputs={outputs} />}
         <AssertionResultChecks failed={failed} passed={passed} styleType="node" />
       </S.Footer>
 

--- a/web/src/models/TestOutput.model.ts
+++ b/web/src/models/TestOutput.model.ts
@@ -10,13 +10,15 @@ function TestOutput({name = '', selector = {}, value = ''}: TRawTestOutput, id =
     value,
     valueRun: '',
     valueRunDraft: '',
+    spanId: '',
   };
 }
 
-export function TestRunOutput({name = '', value = ''}: TRawTestRunOutput): TTestRunOutput {
+export function TestRunOutput({name = '', value = '', spanId = ''}: TRawTestRunOutput): TTestRunOutput {
   return {
     name,
     value,
+    spanId,
   };
 }
 

--- a/web/src/providers/TestOutput/TestOutput.provider.tsx
+++ b/web/src/providers/TestOutput/TestOutput.provider.tsx
@@ -123,13 +123,14 @@ const TestOutputProvider = ({children, runId, testId}: IProps) => {
   );
 
   const onSubmit = useCallback(
-    async (values: TTestOutput, spanId?: string) => {
+    async (values: TTestOutput, matchedSpanId?: string) => {
+      const spanId = values.spanId || matchedSpanId || '';
       const props = {
         expression: values.value,
         context: {
           testId,
           runId,
-          spanId: spanId ?? '',
+          spanId,
           selector: values.selector,
           environmentId: selectedEnvironment?.id,
         },
@@ -140,10 +141,10 @@ const TestOutputProvider = ({children, runId, testId}: IProps) => {
       setIsOpen(false);
       if (isEditing) {
         setIsEditing(false);
-        dispatch(outputUpdated({output: {...values, valueRunDraft, id: draft?.id ?? -1}}));
+        dispatch(outputUpdated({output: {...values, spanId, valueRunDraft, id: draft?.id ?? -1}}));
         return;
       }
-      dispatch(outputAdded({...values, valueRunDraft}));
+      dispatch(outputAdded({...values, valueRunDraft, spanId}));
     },
     [dispatch, draft?.id, isEditing, parseExpressionMutation, runId, selectedEnvironment?.id, testId]
   );

--- a/web/src/redux/actions/TestSpecs.actions.ts
+++ b/web/src/redux/actions/TestSpecs.actions.ts
@@ -10,8 +10,8 @@ import {TAssertionResults} from 'types/Assertion.types';
 import {TTest} from 'types/Test.types';
 import {TTestRun} from 'types/TestRun.types';
 import {TTestSpecEntry} from 'types/TestSpecs.types';
+import TestService from 'services/Test.service';
 import {RootState} from '../store';
-import TestService from '../../services/Test.service';
 
 export type TChange = {
   selector: string;
@@ -24,7 +24,7 @@ const TestSpecsActions = () => ({
     'testDefinition/publish',
     async ({test, testId, runId}, {dispatch, getState}) => {
       const specs = TestSpecsSelectors.selectSpecs(getState() as RootState).filter(def => !def.isDeleted);
-      const outputs = selectTestOutputs(getState() as RootState, testId, runId);
+      const outputs = selectTestOutputs(getState() as RootState);
       const rawTest = await TestService.getUpdatedRawTest(test, {definition: {specs}, outputs});
       await dispatch(TestGateway.edit(rawTest, testId));
       return dispatch(TestRunGateway.reRun(testId, runId)).unwrap();

--- a/web/src/redux/slices/DAG.slice.ts
+++ b/web/src/redux/slices/DAG.slice.ts
@@ -6,6 +6,7 @@ import DAGModel from 'models/DAG.model';
 import {TSpan} from 'types/Span.types';
 import {clearMatchedSpans, setMatchedSpans, setSelectedSpan} from './Span.slice';
 import {setSelectedSpec} from './TestSpecs.slice';
+import {outputsSelectedOutputsChanged} from '../testOutputs/slice';
 
 export interface IDagState {
   edges: Edge[];
@@ -64,6 +65,13 @@ const dagSlice = createSlice({
         state.nodes = state.nodes.map(node => {
           const selected = span.id === node.id;
           return {...node, selected};
+        });
+      })
+      .addCase(outputsSelectedOutputsChanged, (state, {payload: outputs}) => {
+        const spanIds = outputs.map(output => output.spanId);
+        state.nodes = state.nodes.map(node => {
+          const isMatched = spanIds.includes(node.id);
+          return {...node, data: {...node.data, isMatched}};
         });
       });
   },

--- a/web/src/redux/slices/Span.slice.ts
+++ b/web/src/redux/slices/Span.slice.ts
@@ -1,5 +1,6 @@
 import {createSlice, PayloadAction} from '@reduxjs/toolkit';
 import {ISpanState, TSpan} from 'types/Span.types';
+import {outputsSelectedOutputsChanged} from '../testOutputs/slice';
 import {setSelectedSpec} from './TestSpecs.slice';
 
 export const initialState: ISpanState = {
@@ -31,10 +32,15 @@ const testDefinitionSlice = createSlice({
     },
   },
   extraReducers: builder => {
-    builder.addCase(setSelectedSpec, (state, {payload: assertionResult}) => {
-      state.matchedSpans = assertionResult?.spanIds ?? [];
-      state.focusedSpan = state.matchedSpans[0] || '';
-    });
+    builder
+      .addCase(setSelectedSpec, (state, {payload: assertionResult}) => {
+        state.matchedSpans = assertionResult?.spanIds ?? [];
+        state.focusedSpan = state.matchedSpans[0] || '';
+      })
+      .addCase(outputsSelectedOutputsChanged, (state, {payload: outputs}) => {
+        state.matchedSpans = outputs.map(output => output.spanId);
+        state.focusedSpan = state.matchedSpans[0] || '';
+      });
   },
 });
 

--- a/web/src/redux/testOutputs/selectors.ts
+++ b/web/src/redux/testOutputs/selectors.ts
@@ -1,31 +1,23 @@
 import {createSelector} from '@reduxjs/toolkit';
-
-import {TTestOutput} from 'types/TestOutput.types';
 import {RootState} from '../store';
-import {endpoints} from '../apis/TraceTest.api';
 
 const testOutputsStateSelector = (state: RootState) => state.testOutputs;
 
-const selectTestRunOutputs = createSelector(
-  (state: RootState) => state,
-  (state: RootState, testId: string, runId: string) => ({testId, runId}),
-  (state, {testId, runId}) => {
-    const {data} = endpoints.getRunById.select({testId, runId})(state);
+export const selectTestOutputs = createSelector(testOutputsStateSelector, ({outputs}) => outputs);
 
-    return data?.outputs ?? [];
-  }
+export const selectSelectedOutputs = createSelector(testOutputsStateSelector, ({selectedOutputs}) => selectedOutputs);
+
+export const outputIdSelector = (state: RootState, outputId: number) => outputId;
+export const selectIsSelectedOutput = createSelector(
+  selectSelectedOutputs,
+  outputIdSelector,
+  (selectedOutputs, outputId) => !!selectedOutputs.find(selectedOutput => selectedOutput.id === outputId)
 );
 
-export const selectTestOutputs = createSelector(
-  testOutputsStateSelector,
-  selectTestRunOutputs,
-  ({outputs}, testRunOutputs) => {
-    return outputs.map<TTestOutput>((output, index) => ({
-      ...output,
-      valueRun: testRunOutputs[index]?.value ?? '',
-    }));
-  }
-);
+export const spanIdSelector = (state: RootState, spanId: string) => spanId;
+export const selectOutputsBySpanId = createSelector(selectTestOutputs, spanIdSelector, (outputs, spanId) => {
+  return outputs.filter(output => output.spanId === spanId);
+});
 
 export const selectIsPending = createSelector(testOutputsStateSelector, ({outputs}) =>
   outputs.some(output => output.isDraft)

--- a/web/src/redux/testOutputs/slice.ts
+++ b/web/src/redux/testOutputs/slice.ts
@@ -1,43 +1,67 @@
 import {createSlice, PayloadAction} from '@reduxjs/toolkit';
 
-import {TTestOutput} from 'types/TestOutput.types';
+import {TTestOutput, TTestRunOutput} from 'types/TestOutput.types';
 
 interface ITestOutputsState {
   initialOutputs: TTestOutput[];
   outputs: TTestOutput[];
+  selectedOutputs: TTestOutput[];
 }
 
 const initialState: ITestOutputsState = {
   initialOutputs: [],
   outputs: [],
+  selectedOutputs: [],
 };
 
 const testOutputsSlice = createSlice({
   name: 'testOutputs',
   initialState,
   reducers: {
-    outputsInitiated(state, action: PayloadAction<TTestOutput[]>) {
-      state.initialOutputs = action.payload;
-      state.outputs = action.payload;
+    outputsReseted() {
+      return initialState;
     },
-    outputAdded(state, action: PayloadAction<TTestOutput>) {
-      state.outputs.push({...action.payload, isDeleted: false, isDraft: true, id: state.outputs.length});
+    outputsInitiated(state, {payload: outputs}: PayloadAction<TTestOutput[]>) {
+      state.initialOutputs = outputs;
+      state.outputs = outputs;
     },
-    outputUpdated(state, action: PayloadAction<{output: TTestOutput}>) {
-      state.outputs.splice(action.payload.output.id, 1, {...action.payload.output, isDeleted: false, isDraft: true});
+    outputAdded(state, {payload: outputs}: PayloadAction<TTestOutput>) {
+      state.outputs.push({...outputs, isDeleted: false, isDraft: true, id: state.outputs.length});
     },
-    outputDeleted(state, action: PayloadAction<number>) {
-      const output = state.outputs[action.payload];
+    outputUpdated(state, {payload: {output}}: PayloadAction<{output: TTestOutput}>) {
+      state.outputs.splice(output.id, 1, {...output, isDeleted: false, isDraft: true});
+    },
+    outputDeleted(state, {payload: outputId}: PayloadAction<number>) {
+      const output = state.outputs[outputId];
       if (output) {
-        state.outputs.splice(action.payload, 1, {...output, isDeleted: true, isDraft: true});
+        state.outputs.splice(outputId, 1, {...output, isDeleted: true, isDraft: true});
       }
     },
     outputsReverted(state) {
       state.outputs = state.initialOutputs;
     },
+    outputsSelectedOutputsChanged(state, {payload: outputs}: PayloadAction<TTestOutput[]>) {
+      state.selectedOutputs = outputs;
+    },
+    outputsTestRunOutputsMerged(state, {payload: runOutputs}: PayloadAction<TTestRunOutput[]>) {
+      state.outputs = state.outputs.map((output, index) => ({
+        ...output,
+        valueRun: runOutputs[index]?.value ?? '',
+        spanId: runOutputs[index]?.spanId ?? '',
+      }));
+    },
   },
 });
 
-export const {outputsInitiated, outputAdded, outputUpdated, outputDeleted, outputsReverted} = testOutputsSlice.actions;
+export const {
+  outputsInitiated,
+  outputAdded,
+  outputUpdated,
+  outputDeleted,
+  outputsReverted,
+  outputsReseted,
+  outputsSelectedOutputsChanged,
+  outputsTestRunOutputsMerged,
+} = testOutputsSlice.actions;
 
 export default testOutputsSlice.reducer;

--- a/web/src/services/SpanAttribute.service.ts
+++ b/web/src/services/SpanAttribute.service.ts
@@ -8,6 +8,7 @@ import {isEmpty, remove} from 'lodash';
 import {TSpanFlatAttribute} from 'types/Span.types';
 import {getObjectIncludesText, isJson} from 'utils/Common';
 import {TResultAssertions, TResultAssertionsSummary} from 'types/Assertion.types';
+import {TTestOutput} from '../types/TestOutput.types';
 
 const flatAttributes = Object.values(Attributes);
 const flatTraceTestAttributes = Object.values(TraceTestAttributes);
@@ -103,6 +104,10 @@ const SpanAttributeService = () => ({
     );
 
     return resultList;
+  },
+
+  getOutputsFromAttributeName(attributeName: string, outputs: TTestOutput[]): TTestOutput[] {
+    return outputs.filter(({value}) => value.toLowerCase().includes(attributeName.toLowerCase()));
   },
 });
 

--- a/web/src/types/Generated.types.ts
+++ b/web/src/types/Generated.types.ts
@@ -1393,6 +1393,7 @@ export interface external {
           result?: external["tests.yaml"]["components"]["schemas"]["AssertionResults"];
           outputs?: {
             name?: string;
+            spanId?: string;
             value?: string;
           }[];
           metadata?: { [key: string]: string };

--- a/web/src/types/TestOutput.types.ts
+++ b/web/src/types/TestOutput.types.ts
@@ -11,11 +11,13 @@ export type TTestOutput = {
   valueRun: string;
   valueRunDraft: string;
   id: number;
+  spanId: string;
 };
 
 export type TRawTestRunOutput = {
   name?: string;
   value?: string;
+  spanId?: string;
 };
 
 export type TTestRunOutput = Model<TRawTestRunOutput, {}>;


### PR DESCRIPTION
This PR updates the outputs UX/UI to be more interactive as now you can select spans based on outputs and vice-versa.

## Changes

- Output cards are now clickable 
- SpanNodes now have the outputs mark which opens and selects the outputs coming from that span
- AttributeRow now has the outputs mark which opens and selects the outputs coming from that attribute
- The autocomplete feature now adds the ability to include outputs as part of the options

## Fixes

- #1565 
- #1566 

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

https://www.loom.com/share/cbc55581cbfc45108f4b3b9cd0a1a820