### PR TITLE
fix(docs): fixing elasticapm docs url

### DIFF
--- a/web/src/constants/DataStore.constants.tsx
+++ b/web/src/constants/DataStore.constants.tsx
@@ -14,7 +14,7 @@ export const SupportedDataStoresToName = {
 export const SupportedDataStoresToDocsLink = {
   [SupportedDataStores.JAEGER]: 'https://docs.tracetest.io/configuration/connecting-to-data-stores/jaeger',
   [SupportedDataStores.OpenSearch]: 'https://docs.tracetest.io/configuration/connecting-to-data-stores/opensearch',
-  [SupportedDataStores.ElasticApm]: 'https://docs.tracetest.io/configuration/connecting-to-data-stores/elasticsearch',
+  [SupportedDataStores.ElasticApm]: 'https://docs.tracetest.io/configuration/connecting-to-data-stores/elasticapm',
   [SupportedDataStores.NewRelic]: 'https://docs.tracetest.io/configuration/connecting-to-data-stores/new-relic',
   [SupportedDataStores.Lightstep]: 'https://docs.tracetest.io/configuration/connecting-to-data-stores/lightstep',
   [SupportedDataStores.SignalFX]: 'https://docs.tracetest.io/configuration/connecting-to-data-stores/signalfx',


### PR DESCRIPTION
This PR fixes the documentation url for elasticapm