### PR TITLE
fix(backend): fixing the get test run query join condition

### DIFF
--- a/server/testdb/runs.go
+++ b/server/testdb/runs.go
@@ -337,7 +337,7 @@ SELECT
 FROM test_runs
 LEFT OUTER JOIN
 	transaction_run_steps transaction_run
-ON transaction_run.test_run_id = id
+ON transaction_run.test_run_id = id AND transaction_run.test_run_test_id = test_id
 `
 
 func (td *postgresDB) GetRun(ctx context.Context, testID id.ID, runID int) (model.Run, error) {


### PR DESCRIPTION
This PR fixes a bug we have in meta where all runs are matching at least one transaction because a missing condition as part of the join query.

## Changes

- Fixing the query at the testdb level

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
