### PR TITLE
fix: fix CLI panic when response is empty

### DIFF
--- a/cli/actions/run_test_action.go
+++ b/cli/actions/run_test_action.go
@@ -139,7 +139,7 @@ func (a runTestAction) processEnv(ctx context.Context, envID string) (string, er
 		Environment(req).
 		Execute()
 	if err != nil {
-		if resp.StatusCode == http.StatusBadRequest {
+		if resp != nil && resp.StatusCode == http.StatusBadRequest {
 			return a.updateEnv(ctx, req)
 		}
 


### PR DESCRIPTION
This PR fixes the CLI when a test response returns an empty object.

## Changes

-

## Fixes

-

## Checklist

- [ ] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
