### PR TITLE
feat: allow cli to accept an `address` override param

### DIFF
--- a/cli/cmd/config.go
+++ b/cli/cmd/config.go
@@ -53,10 +53,14 @@ func setupCommand(options ...setupOption) func(cmd *cobra.Command, args []string
 
 func overrideConfig() {
 	if overrideEndpoint != "" {
-		cliConfig.Endpoint = overrideEndpoint
-	}
-	if overrideScheme != "" {
-		cliConfig.Scheme = overrideScheme
+		scheme, endpoint, err := config.ParseServerURL(overrideEndpoint)
+		if err != nil {
+			msg := fmt.Sprintf("cannot parse endpoint %s", overrideEndpoint)
+			cliLogger.Error(msg, zap.Error(err))
+			os.Exit(1)
+		}
+		cliConfig.Scheme = scheme
+		cliConfig.Endpoint = endpoint
 	}
 }
 

--- a/cli/cmd/config.go
+++ b/cli/cmd/config.go
@@ -41,12 +41,22 @@ func setupCommand(options ...setupOption) func(cmd *cobra.Command, args []string
 		setupOutputFormat()
 		setupLogger(cmd, args)
 		loadConfig(cmd, args)
+		overrideConfig()
 
 		if config.shouldValidateConfig {
 			validateConfig(cmd, args)
 		}
 
 		analytics.Init(cliConfig)
+	}
+}
+
+func overrideConfig() {
+	if overrideEndpoint != "" {
+		cliConfig.Endpoint = overrideEndpoint
+	}
+	if overrideScheme != "" {
+		cliConfig.Scheme = overrideScheme
 	}
 }
 

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -19,7 +19,6 @@ var (
 
 	// overrides
 	overrideEndpoint string
-	overrideScheme   string
 )
 
 var rootCmd = &cobra.Command{
@@ -43,5 +42,4 @@ func init() {
 	rootCmd.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, "display debug information")
 
 	rootCmd.PersistentFlags().StringVarP(&overrideEndpoint, "endpoint", "e", "", "endpoint")
-	rootCmd.PersistentFlags().StringVarP(&overrideScheme, "scheme", "s", "", "scheme")
 }

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -41,5 +41,5 @@ func init() {
 	rootCmd.PersistentFlags().StringVarP(&configFile, "config", "c", "config.yml", "config file will be used by the CLI")
 	rootCmd.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, "display debug information")
 
-	rootCmd.PersistentFlags().StringVarP(&overrideEndpoint, "endpoint", "e", "", "endpoint")
+	rootCmd.PersistentFlags().StringVarP(&overrideEndpoint, "address", "a", "", "server address")
 }

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -41,5 +41,5 @@ func init() {
 	rootCmd.PersistentFlags().StringVarP(&configFile, "config", "c", "config.yml", "config file will be used by the CLI")
 	rootCmd.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, "display debug information")
 
-	rootCmd.PersistentFlags().StringVarP(&overrideEndpoint, "address", "a", "", "server address")
+	rootCmd.PersistentFlags().StringVarP(&overrideEndpoint, "server-url", "s", "", "server url")
 }

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -16,6 +16,10 @@ var (
 
 	outputFormats       = formatters.OuputsStr()
 	outputFormatsString = strings.Join(outputFormats, "|")
+
+	// overrides
+	overrideEndpoint string
+	overrideScheme   string
 )
 
 var rootCmd = &cobra.Command{
@@ -37,4 +41,7 @@ func init() {
 	rootCmd.PersistentFlags().StringVarP(&output, "output", "o", string(formatters.DefaultOutput), fmt.Sprintf("output format [%s]", outputFormatsString))
 	rootCmd.PersistentFlags().StringVarP(&configFile, "config", "c", "config.yml", "config file will be used by the CLI")
 	rootCmd.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, "display debug information")
+
+	rootCmd.PersistentFlags().StringVarP(&overrideEndpoint, "endpoint", "e", "", "endpoint")
+	rootCmd.PersistentFlags().StringVarP(&overrideScheme, "scheme", "s", "", "scheme")
 }

--- a/cli/config/config.go
+++ b/cli/config/config.go
@@ -75,3 +75,23 @@ func loadConfig(configFile string) (Config, error) {
 
 	return config, nil
 }
+
+func ValidateServerURL(serverURL string) error {
+	if !strings.HasPrefix(serverURL, "http://") && !strings.HasPrefix(serverURL, "https://") {
+		return fmt.Errorf(`the server URL must start with the scheme, either "http://" or "https://"`)
+	}
+
+	return nil
+}
+
+func ParseServerURL(serverURL string) (scheme, endpoint string, err error) {
+	urlParts := strings.Split(serverURL, "://")
+	if len(urlParts) != 2 {
+		return "", "", fmt.Errorf("invalid server url")
+	}
+
+	scheme = urlParts[0]
+	endpoint = strings.TrimSuffix(urlParts[1], "/")
+
+	return scheme, endpoint, nil
+}


### PR DESCRIPTION
This PR allows users to override the target endpoint of cli requests through a flag. Example:

```
tracetest test list --address http://some-host.com:1234
# short version
tracetest test list -a http://some-host.com:1234
````

**UPDATE** renamed flag from `--endpoint|-e` to `--server-url|-s` to avoid conflict with `--environment|-e` flag

## Changes

-

## Fixes

- #1893 

## Checklist

- [ ] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
