### PR TITLE
1894 fixing modal window height

### DIFF
--- a/web/src/components/FileViewerModal/FileViewerModal.styled.ts
+++ b/web/src/components/FileViewerModal/FileViewerModal.styled.ts
@@ -14,8 +14,12 @@ export const CodeContainer = styled.div`
 `;
 
 export const FileViewerModal = styled(Modal)`
+  top: 50px;
+
   & .ant-modal-body {
     background: ${({theme}) => theme.color.background};
+    max-height: calc(100vh - 250px);
+    overflow: scroll;
   }
 `;
 

--- a/web/src/components/MissingVariablesModal/MissingVariablesModal.styled.ts
+++ b/web/src/components/MissingVariablesModal/MissingVariablesModal.styled.ts
@@ -3,9 +3,11 @@ import {Form, Modal as AntModal, Typography} from 'antd';
 import {InfoCircleOutlined} from '@ant-design/icons';
 
 export const Modal = styled(AntModal)`
+  top: 50px;
+
   .ant-modal-body {
     background: ${({theme}) => theme.color.background};
-    max-height: 560px;
+    max-height: calc(100vh - 250px);
     overflow-y: scroll;
   }
 `;

--- a/web/src/pages/Environments/EnvironmentModal.styled.ts
+++ b/web/src/pages/Environments/EnvironmentModal.styled.ts
@@ -8,8 +8,12 @@ export const Footer = styled.div`
 `;
 
 export const Modal = styled(AntModal)`
-  .ant-modal-body {
+  top: 50px;
+
+  & .ant-modal-body {
     background: ${({theme}) => theme.color.background};
+    max-height: calc(100vh - 250px);
+    overflow: scroll;
   }
 `;
 


### PR DESCRIPTION
This PR fixes the modal window height so users do not have to scroll to see the footer actions.

## Changes

- Updates the max height for modals

## Fixes

- #1894 

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
