### PR TITLE
Removing unused redirect that was breaking docusaurus build

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -136,10 +136,6 @@ const config = {
             to: '/ci-cd-automation/github-actions-pipeline',
             from: ['/ci-cd-automation/ci-cd-best-practices' /*, '/docs/legacyDocFrom2016'*/],
           },
-          {
-            to: '/live-examples/pokeshop',
-            from: ['/pokeshop', '/pokeshop/' /*, '/docs/legacyDocFrom2016'*/],
-          },
         ],
         // createRedirects(existingPath) {
         //   if (existingPath.includes('/community')) {


### PR DESCRIPTION
This PR fixes the documentation build process, which was broken on #1892 

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
