### PR TITLE
chore: add makefile targets for local builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,15 @@ help: Makefile ## show list of commands
 	@echo ""
 	@awk 'BEGIN {FS = ":.*?## "} /[a-zA-Z_-]+:.*?## / {sub("\\\\n",sprintf("\n%22c"," "), $$2);printf "\033[36m%-40s\033[0m %s\n", $$1, $$2}' $(MAKEFILE_LIST) | sort
 
+.PHONY: build-docker build-go build-web
+build-docker: build-go build-web
+	VERSION=latest \
+		goreleaser release --clean --skip-announce --snapshot -f .goreleaser.dev.yaml
+
+build-web:
+	cd web; npm install
+	cd web; npm run build
+
 build-go:
 	goreleaser build --single-target --clean --snapshot
 	find ./dist -name 'tracetest*' -exec cp {} ./dist \;

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,10 @@ help: Makefile ## show list of commands
 	@echo ""
 	@awk 'BEGIN {FS = ":.*?## "} /[a-zA-Z_-]+:.*?## / {sub("\\\\n",sprintf("\n%22c"," "), $$2);printf "\033[36m%-40s\033[0m %s\n", $$1, $$2}' $(MAKEFILE_LIST) | sort
 
+build-go:
+	goreleaser build --single-target --clean --snapshot
+	find ./dist -name 'tracetest*' -exec cp {} ./dist \;
+
 generate: generate-server generate-cli generate-web
 
 generate-web: ## generates OpenAPI types for WebUI

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -5,13 +5,6 @@ services:
     image: kubeshop/tracetest:latest
     extra_hosts:
       - "host.docker.internal:host-gateway"
-    build:
-      context: .
-      platforms:
-        - linux/amd64
-      args:
-        VERSION: dev
-        TRACETEST_ENV: docker-compose
     volumes:
       - type: bind
         source: ./local-config/config.tests.yaml


### PR DESCRIPTION
This PR adds new root makefile targets to build locally.

New targets:
- `make build-go`: builds both server and CLI, and puts them in `dist/tractest-server` and `dist/tracetest` respectively
- `make build-web`:  installs deps and builds the frontend
- `make build-docker`: build the docker image with the `latest`
