### PR TITLE
Correcting docker-compose command in quickstart

### DIFF
--- a/docs/docs/getting-started/installation.md
+++ b/docs/docs/getting-started/installation.md
@@ -73,7 +73,7 @@ Start Docker Compose from the directory where you ran `tracetest server install`
   language="bash"
   title="Terminal"
 >
-{`docker compose -f docker-compose.yaml -f tracetest/docker-compose.yaml up -d`}
+{`docker compose -f tracetest/docker-compose.yaml up -d`}
 </CodeBlock>
 <CodeBlock
   language="bash"


### PR DESCRIPTION
Displayed command does not work with the extra `-f` argument.
