### PR TITLE
chore: add labels to external issues

### DIFF
--- a/.github/TEAM_MEMBERS.txt
+++ b/.github/TEAM_MEMBERS.txt
@@ -1,0 +1,9 @@
+adnanrahic
+danielbdias
+jfermi
+jorgeepc
+kdhamric
+mathnogueira
+olha23
+schoren
+xoscar

--- a/.github/workflows/community-issue-notification.yaml
+++ b/.github/workflows/community-issue-notification.yaml
@@ -1,23 +1,38 @@
-# Send us messages on slack when users from the community either open new issues or PRs
+# Send the tracetest team a notification about a new
+# issue opened by a user
+
 on:
   issues:
     types:
       - opened
+
+permissions:
+  id-token: write
+  contents: read
+  issues: write
+  pull-requests: write
 
 jobs:
   notify_slack:
     name: Notify team
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Load team members
+        id: load_team_members
+        run:
+          echo "team_members=$(cat .github/TEAM_MEMBERS.txt | tr '\n' ',')" >> $GITHUB_OUTPUT
 
       - name: Check if it's team member
         id: is_team_member
         if: github.event.action == 'opened'
         uses: mathnogueira/user-blocklist@1.0.0
         with:
-          blocked_users: adnanrahic, danielbdias, jfermi, jorgeepc, kdhamric, mathnogueira, olha23, schoren, xoscar
+          blocked_users: ${{ steps.load_team_members.outputs.team_members }}
 
-      - name: Notify us if not a kubeshop member
+      - name: Notify team about issue
         if: |
           steps.is_team_member.outputs.result == 'false'
         uses: rtCamp/action-slack-notify@v2
@@ -32,4 +47,3 @@ jobs:
           SLACK_LINK_NAMES: true
           SLACK_FOOTER: ${{ github.event.issue.html_url }}
           MSG_MINIMAL: true
-

--- a/.github/workflows/community-label-user-requests.yaml
+++ b/.github/workflows/community-label-user-requests.yaml
@@ -1,0 +1,46 @@
+# Label PRs and issues created by users that are not part
+# of the tracetest team.
+
+on:
+  issues:
+    types:
+      - opened
+
+permissions:
+  id-token: write
+  contents: read
+  issues: write
+  pull-requests: write
+
+jobs:
+  notify_slack:
+    name: Label user request
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Load team members
+        id: load_team_members
+        run:
+          echo "team_members=$(cat .github/TEAM_MEMBERS.txt | tr '\n' ',')" >> $GITHUB_OUTPUT
+
+      - name: Check if it's team member
+        id: is_team_member
+        if: github.event.action == 'opened'
+        uses: mathnogueira/user-blocklist@1.0.0
+        with:
+          blocked_users: ${{ steps.load_team_members.outputs.team_members }}
+
+      - name: Label issue
+        if: |
+          steps.is_team_member.outputs.result == 'false'
+        uses: actions/github-script@v6
+        with:
+          script: |
+            github.rest.issues.addLabels({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              labels: ['user-request']
+            })


### PR DESCRIPTION
This PR add a label `user-request` for issues opened by external users.

This also changes how we maintain team members.

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
