### PR TITLE
feat: show help page when user tries to run placeholder commands

### DIFF
--- a/cli/cmd/datastore_cmd.go
+++ b/cli/cmd/datastore_cmd.go
@@ -1,9 +1,6 @@
 package cmd
 
 import (
-	"fmt"
-
-	"github.com/kubeshop/tracetest/cli/analytics"
 	"github.com/spf13/cobra"
 )
 
@@ -13,9 +10,7 @@ var dataStoreCmd = &cobra.Command{
 	Long:   "Manage your tracetest data stores",
 	PreRun: setupCommand(),
 	Run: func(cmd *cobra.Command, args []string) {
-		analytics.Track("Datastore", "cmd", map[string]string{})
-
-		fmt.Println("Manage your data stores")
+		cmd.Help()
 	},
 	PostRun: teardownCommand,
 }

--- a/cli/cmd/environment_cmd.go
+++ b/cli/cmd/environment_cmd.go
@@ -1,9 +1,6 @@
 package cmd
 
 import (
-	"fmt"
-
-	"github.com/kubeshop/tracetest/cli/analytics"
 	"github.com/spf13/cobra"
 )
 
@@ -13,9 +10,7 @@ var environmentCmd = &cobra.Command{
 	Long:   "Manage your tracetest environments",
 	PreRun: setupCommand(),
 	Run: func(cmd *cobra.Command, args []string) {
-		analytics.Track("Environment", "cmd", map[string]string{})
-
-		fmt.Println("Manage your environments")
+		cmd.Help()
 	},
 	PostRun: teardownCommand,
 }

--- a/cli/cmd/server_cmd.go
+++ b/cli/cmd/server_cmd.go
@@ -1,9 +1,6 @@
 package cmd
 
 import (
-	"fmt"
-
-	"github.com/kubeshop/tracetest/cli/analytics"
 	"github.com/spf13/cobra"
 )
 
@@ -13,8 +10,7 @@ var serverCmd = &cobra.Command{
 	Long:   "Manage your tracetest server",
 	PreRun: setupCommand(),
 	Run: func(cmd *cobra.Command, args []string) {
-		analytics.Track("Server", "cmd", map[string]string{})
-		fmt.Println("Manage your server")
+		cmd.Help()
 	},
 	PostRun: teardownCommand,
 }

--- a/cli/cmd/test_cmd.go
+++ b/cli/cmd/test_cmd.go
@@ -1,9 +1,6 @@
 package cmd
 
 import (
-	"fmt"
-
-	"github.com/kubeshop/tracetest/cli/analytics"
 	"github.com/spf13/cobra"
 )
 
@@ -13,9 +10,7 @@ var testCmd = &cobra.Command{
 	Long:   "Manage your tracetest tests",
 	PreRun: setupCommand(),
 	Run: func(cmd *cobra.Command, args []string) {
-		analytics.Track("Test", "cmd", map[string]string{})
-
-		fmt.Println("Manage your tests")
+		cmd.Help()
 	},
 	PostRun: teardownCommand,
 }


### PR DESCRIPTION
If user tries to run the following commands, it will get a help page for the command:

* tracetest
* tracetest datastore
* tracetest environment
* tracetest server
* tracetest test

based on @danielbdias's idea.

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
