### PR TITLE
fix(cli): check TRACETEST_DEV env to disable analytics

### DIFF
--- a/cli/analytics/analytics.go
+++ b/cli/analytics/analytics.go
@@ -4,6 +4,7 @@ import (
 	"github.com/denisbrodbeck/machineid"
 	"github.com/kubeshop/tracetest/cli/config"
 	segment "github.com/segmentio/analytics-go/v3"
+	"os"
 )
 
 var (
@@ -17,7 +18,9 @@ func ClientID() string {
 }
 
 func Init(conf config.Config) {
-	if !conf.AnalyticsEnabled {
+	if !conf.AnalyticsEnabled || os.Getenv("TRACETEST_DEV") != "" {
+		// non-empty TRACETEST_DEV variable means it's running by a dev,
+		// and we should totally ignore analytics
 		return
 	}
 

--- a/server/app/app.go
+++ b/server/app/app.go
@@ -100,7 +100,7 @@ func (a *App) Start() error {
 	}
 
 	if os.Getenv("TRACETEST_DEV") != "" {
-		// non-empty TRACETEST_DEV variable means it's running by a dev
+		// non-empty TRACETEST_DEV variable means it's running by a dev,
 		// and we should totally ignore analytics
 		a.config.GA.Enabled = false
 	}


### PR DESCRIPTION
This PR adds the validation of the TRACETEST_DEV env variable to disable CLI analytics.

## Changes

- Add TRACETEST_DEV validation

## Fixes

-

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
