### PR TITLE
chore: improve makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,33 +1,50 @@
 PROJECT_ROOT=${PWD}
-OPENAPI_GENERATOR_VER=v6.3.0
-OPENAPI_GENERATOR_IMAGE=openapitools/openapi-generator-cli:$(OPENAPI_GENERATOR_VER)
-OPENAPI_GENERATOR_CLI=docker run --rm -u ${shell id -u}  -v "$(PROJECT_ROOT):/local" -w "/local" ${OPENAPI_GENERATOR_IMAGE}
-OPENAPI_TARGET_DIR=openapi/
+
+CLI_SRC_FILES := $(shell find cli -type f)
+dist/tracetest: generate-cli $(CLI_SRC_FILES)
+	goreleaser build --single-target --clean --snapshot --id cli
+	find ./dist -name 'tracetest' -exec cp {} ./dist \;
+
+SERVER_SRC_FILES := $(shell find server -type f)
+dist/tracetest-server: generate-server $(SERVER_SRC_FILES)
+	goreleaser build --single-target --clean --snapshot --id server
+	find ./dist -name 'tracetest-server' -exec cp {} ./dist \;
+
+web/node_modules: web/package.json web/package-lock.json
+	cd web; npm ci
+
+WEB_SRC_FILES := $(shell find web -type f -not -path "*node_modules*" -not -path "*build*" -not -path "*cypress/videos*" -not -path "*cypress/screenshots*")
+web/build: generate-web web/node_modules $(WEB_SRC_FILES)
+	cd web; npm run build
 
 help: Makefile ## show list of commands
 	@echo "Choose a command run:"
 	@echo ""
 	@awk 'BEGIN {FS = ":.*?## "} /[a-zA-Z_-]+:.*?## / {sub("\\\\n",sprintf("\n%22c"," "), $$2);printf "\033[36m%-40s\033[0m %s\n", $$1, $$2}' $(MAKEFILE_LIST) | sort
 
-.PHONY: build-docker build-go build-web
-build-docker: build-go build-web
-	VERSION=latest \
-		goreleaser release --clean --skip-announce --snapshot -f .goreleaser.dev.yaml
+.PHONY: run build build-go build-web build-docker
+run: build-docker ## build and run tracetest using docker compose
+	docker compose up
+build-go: dist/tracetest dist/tracetest-server ## build all go code
+build-web: web/build ## build web
+build-docker: build-go build-web .goreleaser.dev.yaml ## build and tag docker image as defined in .goreleaser.dev.yaml
+	VERSION=latest goreleaser release --clean --skip-announce --snapshot -f .goreleaser.dev.yaml
 
-build-web:
-	cd web; npm install
-	cd web; npm run build
+.PHONY: generate generate-server generate-cli generate-web
+generate: generate-server generate-cli generate-web ## generate code entities from openapi definitions for all parts of the code
+generate-server: $(wildcard server/openapi/*.go) ## generate code entities from openapi definitions for server
+generate-cli: $(wildcard cli/openapi/*.go) ## generate code entities from openapi definitions for cli
+generate-web: web/src/types/Generated.types.ts ## generate code entities from openapi definitions for web
 
-build-go:
-	goreleaser build --single-target --clean --snapshot
-	find ./dist -name 'tracetest*' -exec cp {} ./dist \;
-
-generate: generate-server generate-cli generate-web
-
-generate-web: ## generates OpenAPI types for WebUI
+OPENAPI_SRC_FILES := $(shell find api -type f)
+OPENAPI_GENERATOR_VER=v6.3.0
+OPENAPI_GENERATOR_IMAGE=openapitools/openapi-generator-cli:$(OPENAPI_GENERATOR_VER)
+OPENAPI_GENERATOR_CLI=docker run --rm -u ${shell id -u}  -v "$(PROJECT_ROOT):/local" -w "/local" ${OPENAPI_GENERATOR_IMAGE}
+OPENAPI_TARGET_DIR=openapi/
+web/src/types/Generated.types.ts: $(OPENAPI_SRC_FILES)
 	cd web; npm run types:generate
 
-generate-cli:
+$(wildcard cli/openapi/*.go): $(OPENAPI_SRC_FILES)
 	$(eval BASE := ./cli)
 	mkdir -p $(BASE)/tmp
 	rm -rf $(BASE)/$(OPENAPI_TARGET_DIR)
@@ -44,7 +61,7 @@ generate-cli:
 
 	cd $(BASE); go fmt ./...
 
-generate-server: ## generates OpenAPI types for server
+$(wildcard server/openapi/*.go): $(OPENAPI_SRC_FILES)
 	$(eval BASE := ./server)
 	mkdir -p $(BASE)/tmp
 	rm -rf $(BASE)/$(OPENAPI_TARGET_DIR)


### PR DESCRIPTION
This PR improves makefile so things are faster and easier to use. It uses actual file based targets so make can do its thing and build only outdated targets. This is specially useful for doing `npm ci` and web build when working in backend stuff.

Also added help, and a nice `run` target

![Screenshot 2023-02-09 at 12 35 44](https://user-images.githubusercontent.com/314548/217859164-b5c53319-bd6d-4e2f-acc9-79b253a9b329.png)

## Changes

- Use actual file targets so make can build only outdated things
- added `run` phony target to build and run using docker compose
- added help for targets

## Checklist

- [ ] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
