### PR TITLE
chore(examples): adding quick start example on how to integrate Tracetest and Datadog

### DIFF
--- a/examples/quick-start-datadog-nodejs/.gitignore
+++ b/examples/quick-start-datadog-nodejs/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+.DS_Store
+.env

--- a/examples/quick-start-datadog-nodejs/Dockerfile
+++ b/examples/quick-start-datadog-nodejs/Dockerfile
@@ -1,0 +1,7 @@
+FROM node:slim
+WORKDIR /usr/src/app
+COPY package*.json ./
+RUN npm install
+COPY . .
+EXPOSE 8080
+CMD [ "npm", "run", "with-grpc-tracer" ]

--- a/examples/quick-start-datadog-nodejs/app.js
+++ b/examples/quick-start-datadog-nodejs/app.js
@@ -1,0 +1,10 @@
+const express = require("express")
+const app = express()
+app.get("/", (req, res) => {
+  setTimeout(() => {
+    res.send("Hello World")
+  }, 1000);
+})
+app.listen(8080, () => {
+  console.log(`Listening for requests on http://localhost:8080`)
+})

--- a/examples/quick-start-datadog-nodejs/docker-compose.yaml
+++ b/examples/quick-start-datadog-nodejs/docker-compose.yaml
@@ -1,0 +1,9 @@
+version: '3'
+services:
+  app:
+    image: quick-start-nodejs
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    build: .
+    ports:
+      - "8080:8080"

--- a/examples/quick-start-datadog-nodejs/package.json
+++ b/examples/quick-start-datadog-nodejs/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "quick-start-nodejs",
+  "version": "1.0.0",
+  "description": "",
+  "main": "app.js",
+  "scripts": {
+    "with-grpc-tracer":"node -r ./tracing.otel.grpc.js app.js",
+    "with-http-tracer":"node -r ./tracing.otel.http.js app.js"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "@opentelemetry/auto-instrumentations-node": "^0.33.1",
+    "@opentelemetry/exporter-trace-otlp-grpc": "^0.34.0",
+    "@opentelemetry/exporter-trace-otlp-http": "^0.33.0",
+    "@opentelemetry/sdk-node": "^0.33.0",
+    "express": "^4.18.2"
+  }
+}

--- a/examples/quick-start-datadog-nodejs/test-api.yaml
+++ b/examples/quick-start-datadog-nodejs/test-api.yaml
@@ -1,0 +1,18 @@
+type: Test
+spec:
+  id: W656Q0c4g
+  name: http://app:8080
+  description: akadlkasjdf
+  trigger:
+    type: http
+    httpRequest:
+      url: http://app:8080
+      method: GET
+      headers:
+      - key: Content-Type
+        value: application/json
+  specs:
+  - selector: span[tracetest.span.type="http" name="GET /" http.target="/" http.method="GET"]
+    assertions:
+    - attr:http.status_code  =  200
+    - attr:tracetest.span.duration  <  500ms

--- a/examples/quick-start-datadog-nodejs/tracetest/collector.config.yaml
+++ b/examples/quick-start-datadog-nodejs/tracetest/collector.config.yaml
@@ -1,0 +1,37 @@
+# One example on how to set up a collector configuration for Datadog can be seen here:
+# https://docs.datadoghq.com/opentelemetry/otel_collector_datadog_exporter/?tab=onahost
+
+receivers:
+  otlp:
+    protocols:
+      http:
+      grpc:
+
+processors:
+  batch:
+    send_batch_max_size: 100
+    send_batch_size: 10
+    timeout: 10s
+
+exporters:
+  # OTLP for Tracetest
+  otlp/tt:
+    endpoint: tracetest:21321 # Send traces to Tracetest. Read more in docs here:  https://docs.tracetest.io/configuration/connecting-to-data-stores/opentelemetry-collector
+    tls:
+      insecure: true
+  # Datadog exporter
+  datadog:
+    api:
+      site: datadoghq.com
+      key: ${DATADOG_API_KEY} # Add here you API key for Datadog
+
+service:
+  pipelines:
+    traces/tt:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [otlp/tt]
+    traces/dd:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [datadog]

--- a/examples/quick-start-datadog-nodejs/tracetest/docker-compose.yaml
+++ b/examples/quick-start-datadog-nodejs/tracetest/docker-compose.yaml
@@ -1,0 +1,46 @@
+version: "3.2"
+services:
+  tracetest:
+    restart: unless-stopped
+    image: kubeshop/tracetest:${TAG:-latest}
+    platform: linux/amd64
+    ports:
+      - 11633:11633
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    volumes:
+      - type: bind
+        source: ./tracetest/tracetest.config.yaml
+        target: /app/config.yaml
+    healthcheck:
+      test: ["CMD", "wget", "--spider", "localhost:11633"]
+      interval: 1s
+      timeout: 3s
+      retries: 60
+    depends_on:
+      postgres:
+        condition: service_healthy
+      otel-collector:
+        condition: service_started
+    environment:
+      TRACETEST_DEV: ${TRACETEST_DEV}
+
+  postgres:
+    image: postgres
+    environment:
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_USER: postgres
+    healthcheck:
+      test: pg_isready -U "$$POSTGRES_USER" -d "$$POSTGRES_DB"
+      interval: 1s
+      timeout: 5s
+      retries: 60
+
+  otel-collector:
+    image: otel/opentelemetry-collector-contrib:0.71.0
+    restart: unless-stopped
+    command:
+      - "--config"
+      - "/otel-local-config.yaml"
+    volumes:
+      - ./tracetest/collector.config.yaml:/otel-local-config.yaml

--- a/examples/quick-start-datadog-nodejs/tracetest/tracetest.config.yaml
+++ b/examples/quick-start-datadog-nodejs/tracetest/tracetest.config.yaml
@@ -1,0 +1,31 @@
+---
+postgresConnString: "host=postgres user=postgres password=postgres port=5432 sslmode=disable"
+
+poolingConfig:
+  maxWaitTimeForTrace: 30s
+  retryDelay: 500ms
+
+experimentalFeatures: []
+
+googleAnalytics:
+  enabled: false
+
+telemetry:
+  dataStores:
+    otlp:
+      type: otlp
+
+  exporters:
+    collector:
+      serviceName: tracetest
+      sampling: 100
+      exporter:
+        type: collector
+        collector:
+          endpoint: otel-collector:4317
+
+server:
+  telemetry:
+    dataStore: otlp
+    exporter: collector
+    applicationExporter: collector

--- a/examples/quick-start-datadog-nodejs/tracing.otel.grpc.js
+++ b/examples/quick-start-datadog-nodejs/tracing.otel.grpc.js
@@ -1,0 +1,10 @@
+const opentelemetry = require('@opentelemetry/sdk-node')
+const { getNodeAutoInstrumentations } = require('@opentelemetry/auto-instrumentations-node')
+const { OTLPTraceExporter } = require('@opentelemetry/exporter-trace-otlp-grpc');
+
+const sdk = new opentelemetry.NodeSDK({
+  traceExporter: new OTLPTraceExporter({ url: 'http://otel-collector:4317' }),
+  instrumentations: [getNodeAutoInstrumentations()],
+  serviceName: 'quick-start-nodejs'
+})
+sdk.start()

--- a/examples/quick-start-datadog-nodejs/tracing.otel.http.js
+++ b/examples/quick-start-datadog-nodejs/tracing.otel.http.js
@@ -1,0 +1,9 @@
+const opentelemetry = require('@opentelemetry/sdk-node')
+const { getNodeAutoInstrumentations } = require('@opentelemetry/auto-instrumentations-node')
+const { OTLPTraceExporter } = require('@opentelemetry/exporter-trace-otlp-http')
+
+const sdk = new opentelemetry.NodeSDK({
+  traceExporter: new OTLPTraceExporter({ url: 'http://otel-collector:4318/v1/traces' }),
+  instrumentations: [getNodeAutoInstrumentations()],
+})
+sdk.start()


### PR DESCRIPTION
This PR aims to create a first example of how to integrate Datadog with Tracetest.

To run it just replace the placeholder `${DATADOG_API_KEY}` for a valid Datadog API Key and run this demo using the command:
```sh
docker compose -f docker-compose.yaml -f tracetest/docker-compose.yaml up
```

## Changes

- Added example with a `collector.config.yaml` tailored to send data to Datadog and Tracetest.

## Fixes

- https://github.com/kubeshop/tracetest/issues/1959

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
