### PR TITLE
refactor connectivity test to reuse components

### DIFF
--- a/cli/openapi/api_api.go
+++ b/cli/openapi/api_api.go
@@ -42,8 +42,8 @@ CreateDataStore Create a new Data Store
 
 Create a new Data Store
 
-	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-	@return ApiCreateDataStoreRequest
+ @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+ @return ApiCreateDataStoreRequest
 */
 func (a *ApiApiService) CreateDataStore(ctx context.Context) ApiCreateDataStoreRequest {
 	return ApiCreateDataStoreRequest{
@@ -53,8 +53,7 @@ func (a *ApiApiService) CreateDataStore(ctx context.Context) ApiCreateDataStoreR
 }
 
 // Execute executes the request
-//
-//	@return DataStore
+//  @return DataStore
 func (a *ApiApiService) CreateDataStoreExecute(r ApiCreateDataStoreRequest) (*DataStore, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPost
@@ -150,8 +149,8 @@ CreateEnvironment Create new environment
 
 Create new environment action
 
-	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-	@return ApiCreateEnvironmentRequest
+ @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+ @return ApiCreateEnvironmentRequest
 */
 func (a *ApiApiService) CreateEnvironment(ctx context.Context) ApiCreateEnvironmentRequest {
 	return ApiCreateEnvironmentRequest{
@@ -161,8 +160,7 @@ func (a *ApiApiService) CreateEnvironment(ctx context.Context) ApiCreateEnvironm
 }
 
 // Execute executes the request
-//
-//	@return Environment
+//  @return Environment
 func (a *ApiApiService) CreateEnvironmentExecute(r ApiCreateEnvironmentRequest) (*Environment, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPost
@@ -258,8 +256,8 @@ CreateTest Create new test
 
 Create new test action
 
-	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-	@return ApiCreateTestRequest
+ @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+ @return ApiCreateTestRequest
 */
 func (a *ApiApiService) CreateTest(ctx context.Context) ApiCreateTestRequest {
 	return ApiCreateTestRequest{
@@ -269,8 +267,7 @@ func (a *ApiApiService) CreateTest(ctx context.Context) ApiCreateTestRequest {
 }
 
 // Execute executes the request
-//
-//	@return Test
+//  @return Test
 func (a *ApiApiService) CreateTestExecute(r ApiCreateTestRequest) (*Test, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPost
@@ -366,8 +363,8 @@ CreateTransaction Create new transaction
 
 Create new transaction
 
-	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-	@return ApiCreateTransactionRequest
+ @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+ @return ApiCreateTransactionRequest
 */
 func (a *ApiApiService) CreateTransaction(ctx context.Context) ApiCreateTransactionRequest {
 	return ApiCreateTransactionRequest{
@@ -377,8 +374,7 @@ func (a *ApiApiService) CreateTransaction(ctx context.Context) ApiCreateTransact
 }
 
 // Execute executes the request
-//
-//	@return Transaction
+//  @return Transaction
 func (a *ApiApiService) CreateTransactionExecute(r ApiCreateTransactionRequest) (*Transaction, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPost
@@ -469,9 +465,9 @@ DeleteDataStore Delete a Data Store
 
 Delete a Data Store
 
-	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-	@param dataStoreId
-	@return ApiDeleteDataStoreRequest
+ @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+ @param dataStoreId
+ @return ApiDeleteDataStoreRequest
 */
 func (a *ApiApiService) DeleteDataStore(ctx context.Context, dataStoreId string) ApiDeleteDataStoreRequest {
 	return ApiDeleteDataStoreRequest{
@@ -561,9 +557,9 @@ DeleteEnvironment delete a environment
 
 delete a environment
 
-	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-	@param environmentId
-	@return ApiDeleteEnvironmentRequest
+ @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+ @param environmentId
+ @return ApiDeleteEnvironmentRequest
 */
 func (a *ApiApiService) DeleteEnvironment(ctx context.Context, environmentId string) ApiDeleteEnvironmentRequest {
 	return ApiDeleteEnvironmentRequest{
@@ -653,9 +649,9 @@ DeleteTest delete a test
 
 delete a test
 
-	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-	@param testId
-	@return ApiDeleteTestRequest
+ @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+ @param testId
+ @return ApiDeleteTestRequest
 */
 func (a *ApiApiService) DeleteTest(ctx context.Context, testId string) ApiDeleteTestRequest {
 	return ApiDeleteTestRequest{
@@ -746,10 +742,10 @@ DeleteTestRun delete a test run
 
 delete a test run
 
-	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-	@param testId
-	@param runId
-	@return ApiDeleteTestRunRequest
+ @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+ @param testId
+ @param runId
+ @return ApiDeleteTestRunRequest
 */
 func (a *ApiApiService) DeleteTestRun(ctx context.Context, testId string, runId string) ApiDeleteTestRunRequest {
 	return ApiDeleteTestRunRequest{
@@ -841,9 +837,9 @@ DeleteTransaction delete a transaction
 
 delete a transaction
 
-	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-	@param transactionId
-	@return ApiDeleteTransactionRequest
+ @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+ @param transactionId
+ @return ApiDeleteTransactionRequest
 */
 func (a *ApiApiService) DeleteTransaction(ctx context.Context, transactionId string) ApiDeleteTransactionRequest {
 	return ApiDeleteTransactionRequest{
@@ -934,10 +930,10 @@ DeleteTransactionRun Delete a specific run from a particular transaction
 
 Delete a specific run from a particular transaction
 
-	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-	@param transactionId
-	@param runId
-	@return ApiDeleteTransactionRunRequest
+ @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+ @param transactionId
+ @param runId
+ @return ApiDeleteTransactionRunRequest
 */
 func (a *ApiApiService) DeleteTransactionRun(ctx context.Context, transactionId string, runId int32) ApiDeleteTransactionRunRequest {
 	return ApiDeleteTransactionRunRequest{
@@ -1036,10 +1032,10 @@ DryRunAssertion run given assertions against the traces from the given run witho
 
 use this method to test a definition against an actual trace without creating a new version or persisting anything
 
-	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-	@param testId
-	@param runId
-	@return ApiDryRunAssertionRequest
+ @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+ @param testId
+ @param runId
+ @return ApiDryRunAssertionRequest
 */
 func (a *ApiApiService) DryRunAssertion(ctx context.Context, testId string, runId string) ApiDryRunAssertionRequest {
 	return ApiDryRunAssertionRequest{
@@ -1051,8 +1047,7 @@ func (a *ApiApiService) DryRunAssertion(ctx context.Context, testId string, runI
 }
 
 // Execute executes the request
-//
-//	@return AssertionResults
+//  @return AssertionResults
 func (a *ApiApiService) DryRunAssertionExecute(r ApiDryRunAssertionRequest) (*AssertionResults, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPut
@@ -1150,8 +1145,8 @@ ExecuteDefinition Execute a definition
 
 Execute a definition
 
-	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-	@return ApiExecuteDefinitionRequest
+ @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+ @return ApiExecuteDefinitionRequest
 */
 func (a *ApiApiService) ExecuteDefinition(ctx context.Context) ApiExecuteDefinitionRequest {
 	return ApiExecuteDefinitionRequest{
@@ -1161,8 +1156,7 @@ func (a *ApiApiService) ExecuteDefinition(ctx context.Context) ApiExecuteDefinit
 }
 
 // Execute executes the request
-//
-//	@return ExecuteDefinitionResponse
+//  @return ExecuteDefinitionResponse
 func (a *ApiApiService) ExecuteDefinitionExecute(r ApiExecuteDefinitionRequest) (*ExecuteDefinitionResponse, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPost
@@ -1254,10 +1248,10 @@ ExportTestRun export test and test run information
 
 export test and test run information for debugging
 
-	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-	@param testId
-	@param runId
-	@return ApiExportTestRunRequest
+ @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+ @param testId
+ @param runId
+ @return ApiExportTestRunRequest
 */
 func (a *ApiApiService) ExportTestRun(ctx context.Context, testId string, runId string) ApiExportTestRunRequest {
 	return ApiExportTestRunRequest{
@@ -1269,8 +1263,7 @@ func (a *ApiApiService) ExportTestRun(ctx context.Context, testId string, runId 
 }
 
 // Execute executes the request
-//
-//	@return ExportedTestInformation
+//  @return ExportedTestInformation
 func (a *ApiApiService) ExportTestRunExecute(r ApiExportTestRunRequest) (*ExportedTestInformation, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
@@ -1366,8 +1359,8 @@ ExpressionResolve resolves an expression and returns the result string
 
 resolves an expression and returns the result string
 
-	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-	@return ApiExpressionResolveRequest
+ @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+ @return ApiExpressionResolveRequest
 */
 func (a *ApiApiService) ExpressionResolve(ctx context.Context) ApiExpressionResolveRequest {
 	return ApiExpressionResolveRequest{
@@ -1377,8 +1370,7 @@ func (a *ApiApiService) ExpressionResolve(ctx context.Context) ApiExpressionReso
 }
 
 // Execute executes the request
-//
-//	@return ResolveResponseInfo
+//  @return ResolveResponseInfo
 func (a *ApiApiService) ExpressionResolveExecute(r ApiExpressionResolveRequest) (*ResolveResponseInfo, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPost
@@ -1469,9 +1461,9 @@ GetDataStore Get a Data Store
 
 Get a Data Store
 
-	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-	@param dataStoreId
-	@return ApiGetDataStoreRequest
+ @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+ @param dataStoreId
+ @return ApiGetDataStoreRequest
 */
 func (a *ApiApiService) GetDataStore(ctx context.Context, dataStoreId string) ApiGetDataStoreRequest {
 	return ApiGetDataStoreRequest{
@@ -1482,8 +1474,7 @@ func (a *ApiApiService) GetDataStore(ctx context.Context, dataStoreId string) Ap
 }
 
 // Execute executes the request
-//
-//	@return DataStore
+//  @return DataStore
 func (a *ApiApiService) GetDataStoreExecute(r ApiGetDataStoreRequest) (*DataStore, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
@@ -1573,9 +1564,9 @@ GetDataStoreDefinitionFile Get the data store definition as an YAML file
 
 Get the data store as an YAML file
 
-	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-	@param dataStoreId
-	@return ApiGetDataStoreDefinitionFileRequest
+ @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+ @param dataStoreId
+ @return ApiGetDataStoreDefinitionFileRequest
 */
 func (a *ApiApiService) GetDataStoreDefinitionFile(ctx context.Context, dataStoreId string) ApiGetDataStoreDefinitionFileRequest {
 	return ApiGetDataStoreDefinitionFileRequest{
@@ -1586,8 +1577,7 @@ func (a *ApiApiService) GetDataStoreDefinitionFile(ctx context.Context, dataStor
 }
 
 // Execute executes the request
-//
-//	@return string
+//  @return string
 func (a *ApiApiService) GetDataStoreDefinitionFileExecute(r ApiGetDataStoreDefinitionFileRequest) (string, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
@@ -1711,8 +1701,8 @@ GetDataStores Get all Data Stores
 
 Get all Data Stores
 
-	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-	@return ApiGetDataStoresRequest
+ @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+ @return ApiGetDataStoresRequest
 */
 func (a *ApiApiService) GetDataStores(ctx context.Context) ApiGetDataStoresRequest {
 	return ApiGetDataStoresRequest{
@@ -1722,8 +1712,7 @@ func (a *ApiApiService) GetDataStores(ctx context.Context) ApiGetDataStoresReque
 }
 
 // Execute executes the request
-//
-//	@return []DataStore
+//  @return []DataStore
 func (a *ApiApiService) GetDataStoresExecute(r ApiGetDataStoresRequest) ([]DataStore, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
@@ -1827,9 +1816,9 @@ GetEnvironment get environment
 
 get environment
 
-	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-	@param environmentId
-	@return ApiGetEnvironmentRequest
+ @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+ @param environmentId
+ @return ApiGetEnvironmentRequest
 */
 func (a *ApiApiService) GetEnvironment(ctx context.Context, environmentId string) ApiGetEnvironmentRequest {
 	return ApiGetEnvironmentRequest{
@@ -1840,8 +1829,7 @@ func (a *ApiApiService) GetEnvironment(ctx context.Context, environmentId string
 }
 
 // Execute executes the request
-//
-//	@return Environment
+//  @return Environment
 func (a *ApiApiService) GetEnvironmentExecute(r ApiGetEnvironmentRequest) (*Environment, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
@@ -1931,9 +1919,9 @@ GetEnvironmentDefinitionFile Get the environment definition as an YAML file
 
 Get the environment as an YAML file
 
-	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-	@param environmentId
-	@return ApiGetEnvironmentDefinitionFileRequest
+ @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+ @param environmentId
+ @return ApiGetEnvironmentDefinitionFileRequest
 */
 func (a *ApiApiService) GetEnvironmentDefinitionFile(ctx context.Context, environmentId string) ApiGetEnvironmentDefinitionFileRequest {
 	return ApiGetEnvironmentDefinitionFileRequest{
@@ -1944,8 +1932,7 @@ func (a *ApiApiService) GetEnvironmentDefinitionFile(ctx context.Context, enviro
 }
 
 // Execute executes the request
-//
-//	@return string
+//  @return string
 func (a *ApiApiService) GetEnvironmentDefinitionFileExecute(r ApiGetEnvironmentDefinitionFileRequest) (string, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
@@ -2069,8 +2056,8 @@ GetEnvironments Get Environments
 
 Get Environments
 
-	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-	@return ApiGetEnvironmentsRequest
+ @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+ @return ApiGetEnvironmentsRequest
 */
 func (a *ApiApiService) GetEnvironments(ctx context.Context) ApiGetEnvironmentsRequest {
 	return ApiGetEnvironmentsRequest{
@@ -2080,8 +2067,7 @@ func (a *ApiApiService) GetEnvironments(ctx context.Context) ApiGetEnvironmentsR
 }
 
 // Execute executes the request
-//
-//	@return []Environment
+//  @return []Environment
 func (a *ApiApiService) GetEnvironmentsExecute(r ApiGetEnvironmentsRequest) ([]Environment, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
@@ -2219,8 +2205,8 @@ GetResources Get resources
 
 get resources
 
-	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-	@return ApiGetResourcesRequest
+ @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+ @return ApiGetResourcesRequest
 */
 func (a *ApiApiService) GetResources(ctx context.Context) ApiGetResourcesRequest {
 	return ApiGetResourcesRequest{
@@ -2230,8 +2216,7 @@ func (a *ApiApiService) GetResources(ctx context.Context) ApiGetResourcesRequest
 }
 
 // Execute executes the request
-//
-//	@return []Resource
+//  @return []Resource
 func (a *ApiApiService) GetResourcesExecute(r ApiGetResourcesRequest) ([]Resource, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
@@ -2336,10 +2321,10 @@ GetRunResultJUnit get test run results in JUnit xml format
 
 get test run results in JUnit xml format
 
-	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-	@param testId
-	@param runId
-	@return ApiGetRunResultJUnitRequest
+ @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+ @param testId
+ @param runId
+ @return ApiGetRunResultJUnitRequest
 */
 func (a *ApiApiService) GetRunResultJUnit(ctx context.Context, testId string, runId string) ApiGetRunResultJUnitRequest {
 	return ApiGetRunResultJUnitRequest{
@@ -2351,8 +2336,7 @@ func (a *ApiApiService) GetRunResultJUnit(ctx context.Context, testId string, ru
 }
 
 // Execute executes the request
-//
-//	@return string
+//  @return string
 func (a *ApiApiService) GetRunResultJUnitExecute(r ApiGetRunResultJUnitRequest) (string, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
@@ -2443,9 +2427,9 @@ GetTest get test
 
 get test
 
-	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-	@param testId
-	@return ApiGetTestRequest
+ @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+ @param testId
+ @return ApiGetTestRequest
 */
 func (a *ApiApiService) GetTest(ctx context.Context, testId string) ApiGetTestRequest {
 	return ApiGetTestRequest{
@@ -2456,8 +2440,7 @@ func (a *ApiApiService) GetTest(ctx context.Context, testId string) ApiGetTestRe
 }
 
 // Execute executes the request
-//
-//	@return Test
+//  @return Test
 func (a *ApiApiService) GetTestExecute(r ApiGetTestRequest) (*Test, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
@@ -2554,10 +2537,10 @@ GetTestResultSelectedSpans retrieve spans that will be selected by selector
 
 get the spans ids that would be selected by a specific selector query
 
-	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-	@param testId
-	@param runId
-	@return ApiGetTestResultSelectedSpansRequest
+ @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+ @param testId
+ @param runId
+ @return ApiGetTestResultSelectedSpansRequest
 */
 func (a *ApiApiService) GetTestResultSelectedSpans(ctx context.Context, testId string, runId string) ApiGetTestResultSelectedSpansRequest {
 	return ApiGetTestResultSelectedSpansRequest{
@@ -2569,8 +2552,7 @@ func (a *ApiApiService) GetTestResultSelectedSpans(ctx context.Context, testId s
 }
 
 // Execute executes the request
-//
-//	@return SelectedSpansResult
+//  @return SelectedSpansResult
 func (a *ApiApiService) GetTestResultSelectedSpansExecute(r ApiGetTestResultSelectedSpansRequest) (*SelectedSpansResult, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
@@ -2665,10 +2647,10 @@ GetTestRun get test Run
 
 get a particular test Run
 
-	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-	@param testId
-	@param runId
-	@return ApiGetTestRunRequest
+ @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+ @param testId
+ @param runId
+ @return ApiGetTestRunRequest
 */
 func (a *ApiApiService) GetTestRun(ctx context.Context, testId string, runId string) ApiGetTestRunRequest {
 	return ApiGetTestRunRequest{
@@ -2680,8 +2662,7 @@ func (a *ApiApiService) GetTestRun(ctx context.Context, testId string, runId str
 }
 
 // Execute executes the request
-//
-//	@return TestRun
+//  @return TestRun
 func (a *ApiApiService) GetTestRunExecute(r ApiGetTestRunRequest) (*TestRun, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
@@ -2786,9 +2767,9 @@ GetTestRuns get the runs for a test
 
 get the runs from a particular test
 
-	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-	@param testId
-	@return ApiGetTestRunsRequest
+ @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+ @param testId
+ @return ApiGetTestRunsRequest
 */
 func (a *ApiApiService) GetTestRuns(ctx context.Context, testId string) ApiGetTestRunsRequest {
 	return ApiGetTestRunsRequest{
@@ -2799,8 +2780,7 @@ func (a *ApiApiService) GetTestRuns(ctx context.Context, testId string) ApiGetTe
 }
 
 // Execute executes the request
-//
-//	@return []TestRun
+//  @return []TestRun
 func (a *ApiApiService) GetTestRunsExecute(r ApiGetTestRunsRequest) ([]TestRun, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
@@ -2896,9 +2876,9 @@ GetTestSpecs Get definition for a test
 
 Gets definition for a test
 
-	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-	@param testId
-	@return ApiGetTestSpecsRequest
+ @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+ @param testId
+ @return ApiGetTestSpecsRequest
 */
 func (a *ApiApiService) GetTestSpecs(ctx context.Context, testId string) ApiGetTestSpecsRequest {
 	return ApiGetTestSpecsRequest{
@@ -2909,8 +2889,7 @@ func (a *ApiApiService) GetTestSpecs(ctx context.Context, testId string) ApiGetT
 }
 
 // Execute executes the request
-//
-//	@return []TestSpecs
+//  @return []TestSpecs
 func (a *ApiApiService) GetTestSpecsExecute(r ApiGetTestSpecsRequest) ([]TestSpecs, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
@@ -3001,10 +2980,10 @@ GetTestVersion get a test specific version
 
 get a test specific version
 
-	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-	@param testId
-	@param version
-	@return ApiGetTestVersionRequest
+ @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+ @param testId
+ @param version
+ @return ApiGetTestVersionRequest
 */
 func (a *ApiApiService) GetTestVersion(ctx context.Context, testId string, version int32) ApiGetTestVersionRequest {
 	return ApiGetTestVersionRequest{
@@ -3016,8 +2995,7 @@ func (a *ApiApiService) GetTestVersion(ctx context.Context, testId string, versi
 }
 
 // Execute executes the request
-//
-//	@return Test
+//  @return Test
 func (a *ApiApiService) GetTestVersionExecute(r ApiGetTestVersionRequest) (*Test, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
@@ -3109,10 +3087,10 @@ GetTestVersionDefinitionFile Get the test definition as an YAML file
 
 Get the test definition as an YAML file
 
-	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-	@param testId
-	@param version
-	@return ApiGetTestVersionDefinitionFileRequest
+ @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+ @param testId
+ @param version
+ @return ApiGetTestVersionDefinitionFileRequest
 */
 func (a *ApiApiService) GetTestVersionDefinitionFile(ctx context.Context, testId string, version int32) ApiGetTestVersionDefinitionFileRequest {
 	return ApiGetTestVersionDefinitionFileRequest{
@@ -3124,8 +3102,7 @@ func (a *ApiApiService) GetTestVersionDefinitionFile(ctx context.Context, testId
 }
 
 // Execute executes the request
-//
-//	@return string
+//  @return string
 func (a *ApiApiService) GetTestVersionDefinitionFileExecute(r ApiGetTestVersionDefinitionFileRequest) (string, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
@@ -3250,8 +3227,8 @@ GetTests Get tests
 
 get tests
 
-	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-	@return ApiGetTestsRequest
+ @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+ @return ApiGetTestsRequest
 */
 func (a *ApiApiService) GetTests(ctx context.Context) ApiGetTestsRequest {
 	return ApiGetTestsRequest{
@@ -3261,8 +3238,7 @@ func (a *ApiApiService) GetTests(ctx context.Context) ApiGetTestsRequest {
 }
 
 // Execute executes the request
-//
-//	@return []Test
+//  @return []Test
 func (a *ApiApiService) GetTestsExecute(r ApiGetTestsRequest) ([]Test, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
@@ -3366,9 +3342,9 @@ GetTransaction get transaction
 
 get transaction
 
-	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-	@param transactionId
-	@return ApiGetTransactionRequest
+ @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+ @param transactionId
+ @return ApiGetTransactionRequest
 */
 func (a *ApiApiService) GetTransaction(ctx context.Context, transactionId string) ApiGetTransactionRequest {
 	return ApiGetTransactionRequest{
@@ -3379,8 +3355,7 @@ func (a *ApiApiService) GetTransaction(ctx context.Context, transactionId string
 }
 
 // Execute executes the request
-//
-//	@return Transaction
+//  @return Transaction
 func (a *ApiApiService) GetTransactionExecute(r ApiGetTransactionRequest) (*Transaction, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
@@ -3471,10 +3446,10 @@ GetTransactionRun Get a specific run from a particular transaction
 
 Get a specific run from a particular transaction
 
-	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-	@param transactionId
-	@param runId
-	@return ApiGetTransactionRunRequest
+ @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+ @param transactionId
+ @param runId
+ @return ApiGetTransactionRunRequest
 */
 func (a *ApiApiService) GetTransactionRun(ctx context.Context, transactionId string, runId int32) ApiGetTransactionRunRequest {
 	return ApiGetTransactionRunRequest{
@@ -3486,8 +3461,7 @@ func (a *ApiApiService) GetTransactionRun(ctx context.Context, transactionId str
 }
 
 // Execute executes the request
-//
-//	@return TransactionRun
+//  @return TransactionRun
 func (a *ApiApiService) GetTransactionRunExecute(r ApiGetTransactionRunRequest) (*TransactionRun, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
@@ -3592,9 +3566,9 @@ GetTransactionRuns Get all runs from a particular transaction
 
 Get all runs from a particular transaction
 
-	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-	@param transactionId
-	@return ApiGetTransactionRunsRequest
+ @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+ @param transactionId
+ @return ApiGetTransactionRunsRequest
 */
 func (a *ApiApiService) GetTransactionRuns(ctx context.Context, transactionId string) ApiGetTransactionRunsRequest {
 	return ApiGetTransactionRunsRequest{
@@ -3605,8 +3579,7 @@ func (a *ApiApiService) GetTransactionRuns(ctx context.Context, transactionId st
 }
 
 // Execute executes the request
-//
-//	@return []TransactionRun
+//  @return []TransactionRun
 func (a *ApiApiService) GetTransactionRunsExecute(r ApiGetTransactionRunsRequest) ([]TransactionRun, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
@@ -3703,10 +3676,10 @@ GetTransactionVersion get a transaction specific version
 
 get a transaction specific version
 
-	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-	@param transactionId
-	@param version
-	@return ApiGetTransactionVersionRequest
+ @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+ @param transactionId
+ @param version
+ @return ApiGetTransactionVersionRequest
 */
 func (a *ApiApiService) GetTransactionVersion(ctx context.Context, transactionId string, version int32) ApiGetTransactionVersionRequest {
 	return ApiGetTransactionVersionRequest{
@@ -3718,8 +3691,7 @@ func (a *ApiApiService) GetTransactionVersion(ctx context.Context, transactionId
 }
 
 // Execute executes the request
-//
-//	@return Transaction
+//  @return Transaction
 func (a *ApiApiService) GetTransactionVersionExecute(r ApiGetTransactionVersionRequest) (*Transaction, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
@@ -3811,10 +3783,10 @@ GetTransactionVersionDefinitionFile Get the transaction definition as an YAML fi
 
 Get the transaction as an YAML file
 
-	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-	@param transactionId
-	@param version
-	@return ApiGetTransactionVersionDefinitionFileRequest
+ @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+ @param transactionId
+ @param version
+ @return ApiGetTransactionVersionDefinitionFileRequest
 */
 func (a *ApiApiService) GetTransactionVersionDefinitionFile(ctx context.Context, transactionId string, version int32) ApiGetTransactionVersionDefinitionFileRequest {
 	return ApiGetTransactionVersionDefinitionFileRequest{
@@ -3826,8 +3798,7 @@ func (a *ApiApiService) GetTransactionVersionDefinitionFile(ctx context.Context,
 }
 
 // Execute executes the request
-//
-//	@return string
+//  @return string
 func (a *ApiApiService) GetTransactionVersionDefinitionFileExecute(r ApiGetTransactionVersionDefinitionFileRequest) (string, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
@@ -3952,8 +3923,8 @@ GetTransactions Get transactions
 
 get transactions
 
-	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-	@return ApiGetTransactionsRequest
+ @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+ @return ApiGetTransactionsRequest
 */
 func (a *ApiApiService) GetTransactions(ctx context.Context) ApiGetTransactionsRequest {
 	return ApiGetTransactionsRequest{
@@ -3963,8 +3934,7 @@ func (a *ApiApiService) GetTransactions(ctx context.Context) ApiGetTransactionsR
 }
 
 // Execute executes the request
-//
-//	@return []Transaction
+//  @return []Transaction
 func (a *ApiApiService) GetTransactionsExecute(r ApiGetTransactionsRequest) ([]Transaction, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
@@ -4073,8 +4043,8 @@ ImportTestRun import test and test run information
 
 import test and test run information for debugging
 
-	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-	@return ApiImportTestRunRequest
+ @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+ @return ApiImportTestRunRequest
 */
 func (a *ApiApiService) ImportTestRun(ctx context.Context) ApiImportTestRunRequest {
 	return ApiImportTestRunRequest{
@@ -4084,8 +4054,7 @@ func (a *ApiApiService) ImportTestRun(ctx context.Context) ApiImportTestRunReque
 }
 
 // Execute executes the request
-//
-//	@return ExportedTestInformation
+//  @return ExportedTestInformation
 func (a *ApiApiService) ImportTestRunExecute(r ApiImportTestRunRequest) (*ExportedTestInformation, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPost
@@ -4177,10 +4146,10 @@ RerunTestRun rerun a test run
 
 rerun a test run
 
-	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-	@param testId
-	@param runId
-	@return ApiRerunTestRunRequest
+ @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+ @param testId
+ @param runId
+ @return ApiRerunTestRunRequest
 */
 func (a *ApiApiService) RerunTestRun(ctx context.Context, testId string, runId string) ApiRerunTestRunRequest {
 	return ApiRerunTestRunRequest{
@@ -4192,8 +4161,7 @@ func (a *ApiApiService) RerunTestRun(ctx context.Context, testId string, runId s
 }
 
 // Execute executes the request
-//
-//	@return TestRun
+//  @return TestRun
 func (a *ApiApiService) RerunTestRunExecute(r ApiRerunTestRunRequest) (*TestRun, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPost
@@ -4290,9 +4258,9 @@ RunTest run test
 
 run a particular test
 
-	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-	@param testId
-	@return ApiRunTestRequest
+ @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+ @param testId
+ @return ApiRunTestRequest
 */
 func (a *ApiApiService) RunTest(ctx context.Context, testId string) ApiRunTestRequest {
 	return ApiRunTestRequest{
@@ -4303,8 +4271,7 @@ func (a *ApiApiService) RunTest(ctx context.Context, testId string) ApiRunTestRe
 }
 
 // Execute executes the request
-//
-//	@return TestRun
+//  @return TestRun
 func (a *ApiApiService) RunTestExecute(r ApiRunTestRequest) (*TestRun, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPost
@@ -4412,9 +4379,9 @@ RunTransaction run transaction
 
 run a particular transaction
 
-	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-	@param transactionId
-	@return ApiRunTransactionRequest
+ @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+ @param transactionId
+ @return ApiRunTransactionRequest
 */
 func (a *ApiApiService) RunTransaction(ctx context.Context, transactionId string) ApiRunTransactionRequest {
 	return ApiRunTransactionRequest{
@@ -4425,8 +4392,7 @@ func (a *ApiApiService) RunTransaction(ctx context.Context, transactionId string
 }
 
 // Execute executes the request
-//
-//	@return TransactionRun
+//  @return TransactionRun
 func (a *ApiApiService) RunTransactionExecute(r ApiRunTransactionRequest) (*TransactionRun, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPost
@@ -4523,8 +4489,8 @@ TestConnection Tests the config data store/exporter connection
 
 Tests the config data store/exporter connection
 
-	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-	@return ApiTestConnectionRequest
+ @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+ @return ApiTestConnectionRequest
 */
 func (a *ApiApiService) TestConnection(ctx context.Context) ApiTestConnectionRequest {
 	return ApiTestConnectionRequest{
@@ -4534,8 +4500,7 @@ func (a *ApiApiService) TestConnection(ctx context.Context) ApiTestConnectionReq
 }
 
 // Execute executes the request
-//
-//	@return TestConnectionResponse
+//  @return TestConnectionResponse
 func (a *ApiApiService) TestConnectionExecute(r ApiTestConnectionRequest) (*TestConnectionResponse, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPost
@@ -4632,9 +4597,9 @@ UpdateDataStore Update a Data Store
 
 Update a Data Store
 
-	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-	@param dataStoreId
-	@return ApiUpdateDataStoreRequest
+ @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+ @param dataStoreId
+ @return ApiUpdateDataStoreRequest
 */
 func (a *ApiApiService) UpdateDataStore(ctx context.Context, dataStoreId string) ApiUpdateDataStoreRequest {
 	return ApiUpdateDataStoreRequest{
@@ -4732,9 +4697,9 @@ UpdateEnvironment update environment
 
 update environment action
 
-	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-	@param environmentId
-	@return ApiUpdateEnvironmentRequest
+ @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+ @param environmentId
+ @return ApiUpdateEnvironmentRequest
 */
 func (a *ApiApiService) UpdateEnvironment(ctx context.Context, environmentId string) ApiUpdateEnvironmentRequest {
 	return ApiUpdateEnvironmentRequest{
@@ -4832,9 +4797,9 @@ UpdateTest update test
 
 update test action
 
-	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-	@param testId
-	@return ApiUpdateTestRequest
+ @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+ @param testId
+ @return ApiUpdateTestRequest
 */
 func (a *ApiApiService) UpdateTest(ctx context.Context, testId string) ApiUpdateTestRequest {
 	return ApiUpdateTestRequest{
@@ -4932,9 +4897,9 @@ UpdateTransaction update transaction
 
 update transaction action
 
-	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-	@param transactionId
-	@return ApiUpdateTransactionRequest
+ @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+ @param transactionId
+ @return ApiUpdateTransactionRequest
 */
 func (a *ApiApiService) UpdateTransaction(ctx context.Context, transactionId string) ApiUpdateTransactionRequest {
 	return ApiUpdateTransactionRequest{
@@ -5031,8 +4996,8 @@ UpsertDefinition Upsert a definition
 
 Upsert a definition
 
-	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-	@return ApiUpsertDefinitionRequest
+ @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+ @return ApiUpsertDefinitionRequest
 */
 func (a *ApiApiService) UpsertDefinition(ctx context.Context) ApiUpsertDefinitionRequest {
 	return ApiUpsertDefinitionRequest{
@@ -5042,8 +5007,7 @@ func (a *ApiApiService) UpsertDefinition(ctx context.Context) ApiUpsertDefinitio
 }
 
 // Execute executes the request
-//
-//	@return UpsertDefinitionResponse
+//  @return UpsertDefinitionResponse
 func (a *ApiApiService) UpsertDefinitionExecute(r ApiUpsertDefinitionRequest) (*UpsertDefinitionResponse, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPut

--- a/go.work.sum
+++ b/go.work.sum
@@ -127,6 +127,7 @@ golang.org/x/term v0.1.0/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
 golang.org/x/text v0.4.0 h1:BrVqGRd7+k1DiOgtnFvAkoQEWQvBc25ouMJM6429SFg=
 golang.org/x/text v0.4.0/go.mod h1:mrYo+phRRbMaCq/xk9113O4dZlRixOauAjOtrjsXDZ8=
 golang.org/x/tools v0.1.12/go.mod h1:hNGJHUnrk76NpqgfD5Aqm5Crs+Hm0VOH/i9J2+nxYbc=
+golang.org/x/tools v0.2.0 h1:G6AHpWxTMGY1KyEYoAQ5WTtIekUUvDNjan3ugu60JvE=
 golang.org/x/tools v0.2.0/go.mod h1:y4OqIKeOV/fWJetJ8bXPU1sEVniLMIyDAZWeHdV+NTA=
 golang.org/x/xerrors v0.0.0-20220411194840-2f41105eb62f/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20220517211312-f3a8303e98df/go.mod h1:K8+ghG5WaK9qNqU5K3HdILfMLy1f3aNYFI/wnl100a8=

--- a/server/tracedb/connection/connection.go
+++ b/server/tracedb/connection/connection.go
@@ -45,11 +45,11 @@ func (r ConnectionTestStepResult) IsSet() bool {
 	return r.OperationDescription != ""
 }
 
-func IsReachable(endpoint string, protocol Protocol) (bool, error) {
+func IsReachable(endpoint string, protocol Protocol) error {
 	if protocol == ProtocolHTTP {
 		address, err := url.Parse(endpoint)
 		if err != nil {
-			return false, err
+			return err
 		}
 
 		endpoint = strings.TrimPrefix(endpoint, "http://")
@@ -66,8 +66,8 @@ func IsReachable(endpoint string, protocol Protocol) (bool, error) {
 
 	_, err := net.DialTimeout("tcp", endpoint, 5*time.Second)
 	if err != nil {
-		return false, err
+		return err
 	}
 
-	return true, nil
+	return nil
 }

--- a/server/tracedb/connection/connection.go
+++ b/server/tracedb/connection/connection.go
@@ -39,23 +39,25 @@ func (r ConnectionTestStepResult) IsSet() bool {
 }
 
 func IsReachable(endpoint string) (bool, error) {
-	address, err := url.Parse(endpoint)
-	if err != nil {
-		return false, err
+	if strings.HasPrefix(endpoint, "http://") || strings.HasPrefix(endpoint, "https://") {
+		address, err := url.Parse(endpoint)
+		if err != nil {
+			return false, err
+		}
+
+		endpoint = strings.TrimPrefix(endpoint, "http://")
+		endpoint = strings.TrimPrefix(endpoint, "https://")
+
+		if address.Scheme == "https" && address.Port() == "" {
+			endpoint = fmt.Sprintf("%s:443", address.Hostname())
+		}
+
+		if address.Scheme == "http" && address.Port() == "" {
+			endpoint = fmt.Sprintf("%s:80", address.Hostname())
+		}
 	}
 
-	endpoint = strings.TrimPrefix(endpoint, "http://")
-	endpoint = strings.TrimPrefix(endpoint, "https://")
-
-	if address.Scheme == "https" && address.Port() == "" {
-		endpoint = fmt.Sprintf("%s:443", address.Hostname())
-	}
-
-	if address.Scheme == "http" && address.Port() == "" {
-		endpoint = fmt.Sprintf("%s:80", address.Hostname())
-	}
-
-	_, err = net.DialTimeout("tcp", endpoint, 5*time.Second)
+	_, err := net.DialTimeout("tcp", endpoint, 5*time.Second)
 	if err != nil {
 		return false, err
 	}

--- a/server/tracedb/connection/connection.go
+++ b/server/tracedb/connection/connection.go
@@ -9,7 +9,7 @@ import (
 	"time"
 )
 
-const timeoutIsReachable = 5 * time.Second
+const reachabilityTimeout = 5 * time.Second
 
 type Protocol string
 
@@ -47,7 +47,7 @@ func (r ConnectionTestStepResult) IsSet() bool {
 	return r.OperationDescription != ""
 }
 
-func IsReachable(endpoint string, protocol Protocol) error {
+func CheckReachability(endpoint string, protocol Protocol) error {
 	if protocol == ProtocolHTTP {
 		address, err := url.Parse(endpoint)
 		if err != nil {
@@ -66,7 +66,7 @@ func IsReachable(endpoint string, protocol Protocol) error {
 		}
 	}
 
-	_, err := net.DialTimeout("tcp", endpoint, timeoutIsReachable)
+	_, err := net.DialTimeout("tcp", endpoint, reachabilityTimeout)
 	if err != nil {
 		return err
 	}

--- a/server/tracedb/connection/connection.go
+++ b/server/tracedb/connection/connection.go
@@ -9,6 +9,13 @@ import (
 	"time"
 )
 
+type Protocol string
+
+var (
+	ProtocolHTTP Protocol = "http"
+	ProtocolGRPC Protocol = "grpc"
+)
+
 type ConnectionTestResult struct {
 	ConnectivityTestResult   ConnectionTestStepResult
 	AuthenticationTestResult ConnectionTestStepResult
@@ -38,8 +45,8 @@ func (r ConnectionTestStepResult) IsSet() bool {
 	return r.OperationDescription != ""
 }
 
-func IsReachable(endpoint string) (bool, error) {
-	if strings.HasPrefix(endpoint, "http://") || strings.HasPrefix(endpoint, "https://") {
+func IsReachable(endpoint string, protocol Protocol) (bool, error) {
+	if protocol == ProtocolHTTP {
 		address, err := url.Parse(endpoint)
 		if err != nil {
 			return false, err

--- a/server/tracedb/connection/connection.go
+++ b/server/tracedb/connection/connection.go
@@ -9,6 +9,8 @@ import (
 	"time"
 )
 
+const timeoutIsReachable = 5 * time.Second
+
 type Protocol string
 
 var (
@@ -64,7 +66,7 @@ func IsReachable(endpoint string, protocol Protocol) error {
 		}
 	}
 
-	_, err := net.DialTimeout("tcp", endpoint, 5*time.Second)
+	_, err := net.DialTimeout("tcp", endpoint, timeoutIsReachable)
 	if err != nil {
 		return err
 	}

--- a/server/tracedb/connection/connectivity_step.go
+++ b/server/tracedb/connection/connectivity_step.go
@@ -1,0 +1,44 @@
+package connection
+
+import (
+	"context"
+	"fmt"
+	"strings"
+)
+
+type connectivityTestStep struct {
+	endpoints []string
+}
+
+var _ TestStep = &connectivityTestStep{}
+
+func (s *connectivityTestStep) TestConnection(ctx context.Context) ConnectionTestStepResult {
+	unreachableEndpoints := make([]string, 0)
+	var connectionErr error
+	for _, endpoint := range s.endpoints {
+		reachable, err := IsReachable(endpoint)
+		if !reachable {
+			unreachableEndpoints = append(unreachableEndpoints, fmt.Sprintf(`"%s"`, endpoint))
+			connectionErr = err
+		}
+	}
+
+	if len(unreachableEndpoints) > 0 {
+		endpoints := strings.Join(unreachableEndpoints, ", ")
+		return ConnectionTestStepResult{
+			OperationDescription: fmt.Sprintf("Tracetest tried to connect to the following endpoints and failed: %s", endpoints),
+			Error:                connectionErr,
+		}
+	}
+
+	endpoints := strings.Join(s.endpoints, ", ")
+	return ConnectionTestStepResult{
+		OperationDescription: fmt.Sprintf(`Tracetest connected to "%s"`, endpoints),
+	}
+}
+
+func ConnectivityStep(endpoints ...string) TestStep {
+	return &connectivityTestStep{
+		endpoints: endpoints,
+	}
+}

--- a/server/tracedb/connection/connectivity_step.go
+++ b/server/tracedb/connection/connectivity_step.go
@@ -13,7 +13,7 @@ type connectivityTestStep struct {
 
 var _ TestStep = &connectivityTestStep{}
 
-func (s *connectivityTestStep) TestConnection(ctx context.Context) ConnectionTestStepResult {
+func (s *connectivityTestStep) TestConnection(_ context.Context) ConnectionTestStepResult {
 	unreachableEndpoints := make([]string, 0)
 	var connectionErr error
 	for _, endpoint := range s.endpoints {

--- a/server/tracedb/connection/connectivity_step.go
+++ b/server/tracedb/connection/connectivity_step.go
@@ -17,8 +17,8 @@ func (s *connectivityTestStep) TestConnection(_ context.Context) ConnectionTestS
 	unreachableEndpoints := make([]string, 0)
 	var connectionErr error
 	for _, endpoint := range s.endpoints {
-		reachable, err := IsReachable(endpoint, s.protocol)
-		if !reachable {
+		err := IsReachable(endpoint, s.protocol)
+		if err != nil {
 			unreachableEndpoints = append(unreachableEndpoints, fmt.Sprintf(`"%s"`, endpoint))
 			connectionErr = err
 		}

--- a/server/tracedb/connection/connectivity_step.go
+++ b/server/tracedb/connection/connectivity_step.go
@@ -8,6 +8,7 @@ import (
 
 type connectivityTestStep struct {
 	endpoints []string
+	protocol  Protocol
 }
 
 var _ TestStep = &connectivityTestStep{}
@@ -16,7 +17,7 @@ func (s *connectivityTestStep) TestConnection(ctx context.Context) ConnectionTes
 	unreachableEndpoints := make([]string, 0)
 	var connectionErr error
 	for _, endpoint := range s.endpoints {
-		reachable, err := IsReachable(endpoint)
+		reachable, err := IsReachable(endpoint, s.protocol)
 		if !reachable {
 			unreachableEndpoints = append(unreachableEndpoints, fmt.Sprintf(`"%s"`, endpoint))
 			connectionErr = err
@@ -37,7 +38,7 @@ func (s *connectivityTestStep) TestConnection(ctx context.Context) ConnectionTes
 	}
 }
 
-func ConnectivityStep(endpoints ...string) TestStep {
+func ConnectivityStep(protocol Protocol, endpoints ...string) TestStep {
 	return &connectivityTestStep{
 		endpoints: endpoints,
 	}

--- a/server/tracedb/connection/connectivity_step.go
+++ b/server/tracedb/connection/connectivity_step.go
@@ -19,7 +19,7 @@ func (s *connectivityTestStep) TestConnection(_ context.Context) ConnectionTestS
 	unreachableEndpoints := make([]string, 0)
 	var connectionErr error
 	for _, endpoint := range s.endpoints {
-		err := IsReachable(endpoint, s.protocol)
+		err := CheckReachability(endpoint, s.protocol)
 		if err != nil {
 			unreachableEndpoints = append(unreachableEndpoints, fmt.Sprintf(`"%s"`, endpoint))
 			connectionErr = multierror.Append(

--- a/server/tracedb/connection/options.go
+++ b/server/tracedb/connection/options.go
@@ -1,0 +1,37 @@
+package connection
+
+import "context"
+
+func WithConnectivityTest(step TestStep) TesterOption {
+	return func(t *Tester) {
+		t.connectivityTestStep = step
+	}
+}
+
+func WithAuthenticationTest(step TestStep) TesterOption {
+	return func(t *Tester) {
+		t.authenticationTestStep = step
+	}
+}
+
+func WithPollingTest(step TestStep) TesterOption {
+	return func(t *Tester) {
+		t.pollingTestStep = step
+	}
+}
+
+type functionTestStep struct {
+	fn func(ctx context.Context) (string, error)
+}
+
+func (s *functionTestStep) TestConnection(ctx context.Context) ConnectionTestStepResult {
+	str, err := s.fn(ctx)
+	return ConnectionTestStepResult{
+		OperationDescription: str,
+		Error:                err,
+	}
+}
+
+func NewTestStep(f func(ctx context.Context) (string, error)) TestStep {
+	return &functionTestStep{fn: f}
+}

--- a/server/tracedb/connection/tester.go
+++ b/server/tracedb/connection/tester.go
@@ -1,0 +1,33 @@
+package connection
+
+import "context"
+
+type TestStep interface {
+	TestConnection(ctx context.Context) ConnectionTestStepResult
+}
+
+type TesterOption func(*Tester)
+
+type Tester struct {
+	connectivityTestStep   TestStep
+	authenticationTestStep TestStep
+	pollingTestStep        TestStep
+}
+
+func NewTester(opts ...TesterOption) Tester {
+	tester := Tester{}
+
+	for _, opt := range opts {
+		opt(&tester)
+	}
+
+	return tester
+}
+
+func (t *Tester) TestConnection(ctx context.Context) ConnectionTestResult {
+	return ConnectionTestResult{
+		ConnectivityTestResult:   t.connectivityTestStep.TestConnection(ctx),
+		AuthenticationTestResult: t.authenticationTestStep.TestConnection(ctx),
+		TraceRetrievalTestResult: t.pollingTestStep.TestConnection(ctx),
+	}
+}

--- a/server/tracedb/connection/tester.go
+++ b/server/tracedb/connection/tester.go
@@ -24,25 +24,19 @@ func NewTester(opts ...TesterOption) Tester {
 	return tester
 }
 
-func (t *Tester) TestConnection(ctx context.Context) ConnectionTestResult {
-	connectivityTestResult := t.connectivityTestStep.TestConnection(ctx)
-	if connectivityTestResult.Error != nil {
-		return ConnectionTestResult{
-			ConnectivityTestResult: connectivityTestResult,
-		}
+func (t *Tester) TestConnection(ctx context.Context) res ConnectionTestResult {
+	res.ConnectivityTestResult = t.connectivityTestStep.TestConnection(ctx)
+	if res.ConnectivityTestResult.Error != nil {
+		return 
 	}
 
-	authTestResult := t.authenticationTestStep.TestConnection(ctx)
-	if authTestResult.Error != nil {
-		return ConnectionTestResult{
-			ConnectivityTestResult:   connectivityTestResult,
-			AuthenticationTestResult: authTestResult,
-		}
+	res.AuthenticationTestResult = t.authenticationTestStep.TestConnection(ctx)
+	if res.ConnectivityTestResult.Error != nil {
+		return 
 	}
 
-	return ConnectionTestResult{
-		ConnectivityTestResult:   t.connectivityTestStep.TestConnection(ctx),
-		AuthenticationTestResult: t.authenticationTestStep.TestConnection(ctx),
-		TraceRetrievalTestResult: t.pollingTestStep.TestConnection(ctx),
-	}
+	res.TraceRetrievalTestResult = t.pollingTestStep.TestConnection(ctx)
+
+	return
+}
 }

--- a/server/tracedb/connection/tester.go
+++ b/server/tracedb/connection/tester.go
@@ -24,19 +24,18 @@ func NewTester(opts ...TesterOption) Tester {
 	return tester
 }
 
-func (t *Tester) TestConnection(ctx context.Context) res ConnectionTestResult {
+func (t *Tester) TestConnection(ctx context.Context) (res ConnectionTestResult) {
 	res.ConnectivityTestResult = t.connectivityTestStep.TestConnection(ctx)
 	if res.ConnectivityTestResult.Error != nil {
-		return 
+		return
 	}
 
 	res.AuthenticationTestResult = t.authenticationTestStep.TestConnection(ctx)
 	if res.ConnectivityTestResult.Error != nil {
-		return 
+		return
 	}
 
 	res.TraceRetrievalTestResult = t.pollingTestStep.TestConnection(ctx)
 
 	return
-}
 }

--- a/server/tracedb/connection/tester.go
+++ b/server/tracedb/connection/tester.go
@@ -25,6 +25,21 @@ func NewTester(opts ...TesterOption) Tester {
 }
 
 func (t *Tester) TestConnection(ctx context.Context) ConnectionTestResult {
+	connectivityTestResult := t.connectivityTestStep.TestConnection(ctx)
+	if connectivityTestResult.Error != nil {
+		return ConnectionTestResult{
+			ConnectivityTestResult: connectivityTestResult,
+		}
+	}
+
+	authTestResult := t.authenticationTestStep.TestConnection(ctx)
+	if authTestResult.Error != nil {
+		return ConnectionTestResult{
+			ConnectivityTestResult:   connectivityTestResult,
+			AuthenticationTestResult: authTestResult,
+		}
+	}
+
 	return ConnectionTestResult{
 		ConnectivityTestResult:   t.connectivityTestStep.TestConnection(ctx),
 		AuthenticationTestResult: t.authenticationTestStep.TestConnection(ctx),

--- a/server/tracedb/connection/trace_polling_step.go
+++ b/server/tracedb/connection/trace_polling_step.go
@@ -1,0 +1,36 @@
+package connection
+
+import (
+	"context"
+	"errors"
+
+	"github.com/kubeshop/tracetest/server/id"
+	"github.com/kubeshop/tracetest/server/model"
+)
+
+type DataStore interface {
+	GetTraceByID(context.Context, string) (model.Trace, error)
+}
+
+type tracePollingTestStep struct {
+	dataStore DataStore
+}
+
+func (s *tracePollingTestStep) TestConnection(ctx context.Context) ConnectionTestStepResult {
+	_, err := s.dataStore.GetTraceByID(ctx, id.NewRandGenerator().TraceID().String())
+	if !errors.Is(err, ErrTraceNotFound) {
+		return ConnectionTestStepResult{
+			OperationDescription: "Tracetest could not get traces back from the data store",
+			Error:                err,
+		}
+	}
+
+	return ConnectionTestStepResult{
+		OperationDescription: "Traces were obtained successfully",
+		Error:                nil,
+	}
+}
+
+func TracePollingTestStep(ds DataStore) TestStep {
+	return &tracePollingTestStep{ds}
+}

--- a/server/tracedb/datasource/datasource.go
+++ b/server/tracedb/datasource/datasource.go
@@ -28,7 +28,7 @@ type DataSource interface {
 	Connect(ctx context.Context) error
 	Ready() bool
 	GetTraceByID(ctx context.Context, traceID string) (model.Trace, error)
-	TestConnection(ctx context.Context) (connection.ConnectionTestResult, error)
+	TestConnection(ctx context.Context) connection.ConnectionTestStepResult
 	Close() error
 }
 
@@ -40,8 +40,8 @@ func (dataSource *noopDataSource) GetTraceByID(ctx context.Context, traceID stri
 func (db *noopDataSource) Connect(ctx context.Context) error { return nil }
 func (db *noopDataSource) Close() error                      { return nil }
 func (db *noopDataSource) Ready() bool                       { return true }
-func (db *noopDataSource) TestConnection(ctx context.Context) (connection.ConnectionTestResult, error) {
-	return connection.ConnectionTestResult{}, nil
+func (db *noopDataSource) TestConnection(ctx context.Context) connection.ConnectionTestStepResult {
+	return connection.ConnectionTestStepResult{}
 }
 
 func New(name string, config *config.BaseClientConfig, callbacks Callbacks) DataSource {

--- a/server/tracedb/datasource/grpc.go
+++ b/server/tracedb/datasource/grpc.go
@@ -55,7 +55,7 @@ func (client *GrpcClient) TestConnection(ctx context.Context) connection.Connect
 		OperationDescription: fmt.Sprintf(`Tracetest connected to "%s"`, client.config.Endpoint),
 	}
 
-	reachable, err := connection.IsReachable(client.config.Endpoint)
+	reachable, err := connection.IsReachable(client.config.Endpoint, connection.ProtocolGRPC)
 	if !reachable {
 		return connection.ConnectionTestStepResult{
 			OperationDescription: fmt.Sprintf(`Tracetest tried to connect to "%s" and failed`, client.config.Endpoint),

--- a/server/tracedb/datasource/grpc.go
+++ b/server/tracedb/datasource/grpc.go
@@ -55,7 +55,7 @@ func (client *GrpcClient) TestConnection(ctx context.Context) connection.Connect
 		OperationDescription: fmt.Sprintf(`Tracetest connected to "%s"`, client.config.Endpoint),
 	}
 
-	err := connection.IsReachable(client.config.Endpoint, connection.ProtocolGRPC)
+	err := connection.CheckReachability(client.config.Endpoint, connection.ProtocolGRPC)
 	if err != nil {
 		return connection.ConnectionTestStepResult{
 			OperationDescription: fmt.Sprintf(`Tracetest tried to connect to "%s" and failed`, client.config.Endpoint),

--- a/server/tracedb/datasource/grpc.go
+++ b/server/tracedb/datasource/grpc.go
@@ -55,8 +55,8 @@ func (client *GrpcClient) TestConnection(ctx context.Context) connection.Connect
 		OperationDescription: fmt.Sprintf(`Tracetest connected to "%s"`, client.config.Endpoint),
 	}
 
-	reachable, err := connection.IsReachable(client.config.Endpoint, connection.ProtocolGRPC)
-	if !reachable {
+	err := connection.IsReachable(client.config.Endpoint, connection.ProtocolGRPC)
+	if err != nil {
 		return connection.ConnectionTestStepResult{
 			OperationDescription: fmt.Sprintf(`Tracetest tried to connect to "%s" and failed`, client.config.Endpoint),
 			Error:                err,

--- a/server/tracedb/datasource/grpc.go
+++ b/server/tracedb/datasource/grpc.go
@@ -50,35 +50,29 @@ func (client *GrpcClient) Connect(ctx context.Context) error {
 	return nil
 }
 
-func (client *GrpcClient) TestConnection(ctx context.Context) (connection.ConnectionTestResult, error) {
-	connectionTestResult := connection.ConnectionTestResult{
-		ConnectivityTestResult: connection.ConnectionTestStepResult{
-			OperationDescription: fmt.Sprintf(`Tracetest connected to "%s"`, client.config.Endpoint),
-		},
+func (client *GrpcClient) TestConnection(ctx context.Context) connection.ConnectionTestStepResult {
+	connectionTestResult := connection.ConnectionTestStepResult{
+		OperationDescription: fmt.Sprintf(`Tracetest connected to "%s"`, client.config.Endpoint),
 	}
 
 	reachable, err := connection.IsReachable(client.config.Endpoint)
 	if !reachable {
-		return connection.ConnectionTestResult{
-			ConnectivityTestResult: connection.ConnectionTestStepResult{
-				OperationDescription: fmt.Sprintf(`Tracetest tried to connect to "%s" and failed`, client.config.Endpoint),
-				Error:                err,
-			},
-		}, err
+		return connection.ConnectionTestStepResult{
+			OperationDescription: fmt.Sprintf(`Tracetest tried to connect to "%s" and failed`, client.config.Endpoint),
+			Error:                err,
+		}
 	}
 
 	err = client.Connect(ctx)
 	wrappedErr := errors.Unwrap(err)
 	if errors.Is(wrappedErr, connection.ErrConnectionFailed) {
-		return connection.ConnectionTestResult{
-			ConnectivityTestResult: connection.ConnectionTestStepResult{
-				OperationDescription: fmt.Sprintf(`Tracetest tried to open a gRPC connection against "%s" and failed`, client.config.Endpoint),
-				Error:                err,
-			},
-		}, err
+		return connection.ConnectionTestStepResult{
+			OperationDescription: fmt.Sprintf(`Tracetest tried to open a gRPC connection against "%s" and failed`, client.config.Endpoint),
+			Error:                err,
+		}
 	}
 
-	return connectionTestResult, nil
+	return connectionTestResult
 }
 
 func (client *GrpcClient) Close() error {

--- a/server/tracedb/datasource/http.go
+++ b/server/tracedb/datasource/http.go
@@ -73,8 +73,8 @@ func (client *HttpClient) TestConnection(ctx context.Context) connection.Connect
 		OperationDescription: fmt.Sprintf(`Tracetest connected to "%s"`, client.config.URL.String()),
 	}
 
-	reachable, err := connection.IsReachable(client.config.URL.String(), connection.ProtocolHTTP)
-	if !reachable {
+	err := connection.IsReachable(client.config.URL.String(), connection.ProtocolHTTP)
+	if err != nil {
 		return connection.ConnectionTestStepResult{
 			OperationDescription: fmt.Sprintf(`Tracetest tried to connect to "%s" and failed`, client.config.URL.String()),
 			Error:                err,

--- a/server/tracedb/datasource/http.go
+++ b/server/tracedb/datasource/http.go
@@ -68,35 +68,29 @@ func (client *HttpClient) Connect(ctx context.Context) error {
 	return err
 }
 
-func (client *HttpClient) TestConnection(ctx context.Context) (connection.ConnectionTestResult, error) {
-	connectionTestResult := connection.ConnectionTestResult{
-		ConnectivityTestResult: connection.ConnectionTestStepResult{
-			OperationDescription: fmt.Sprintf(`Tracetest connected to "%s"`, client.config.URL.String()),
-		},
+func (client *HttpClient) TestConnection(ctx context.Context) connection.ConnectionTestStepResult {
+	connectionTestResult := connection.ConnectionTestStepResult{
+		OperationDescription: fmt.Sprintf(`Tracetest connected to "%s"`, client.config.URL.String()),
 	}
 
 	reachable, err := connection.IsReachable(client.config.URL.String())
 	if !reachable {
-		return connection.ConnectionTestResult{
-			ConnectivityTestResult: connection.ConnectionTestStepResult{
-				OperationDescription: fmt.Sprintf(`Tracetest tried to connect to "%s" and failed`, client.config.URL.String()),
-				Error:                err,
-			},
-		}, err
+		return connection.ConnectionTestStepResult{
+			OperationDescription: fmt.Sprintf(`Tracetest tried to connect to "%s" and failed`, client.config.URL.String()),
+			Error:                err,
+		}
 	}
 
 	err = client.Connect(ctx)
 	wrappedErr := errors.Unwrap(err)
 	if errors.Is(wrappedErr, connection.ErrConnectionFailed) {
-		return connection.ConnectionTestResult{
-			ConnectivityTestResult: connection.ConnectionTestStepResult{
-				OperationDescription: fmt.Sprintf(`Tracetest tried to open a connection against "%s" and failed`, client.config.URL.String()),
-				Error:                err,
-			},
-		}, err
+		return connection.ConnectionTestStepResult{
+			OperationDescription: fmt.Sprintf(`Tracetest tried to open a connection against "%s" and failed`, client.config.URL.String()),
+			Error:                err,
+		}
 	}
 
-	return connectionTestResult, nil
+	return connectionTestResult
 }
 
 func (client *HttpClient) Request(ctx context.Context, path, method, body string) (*http.Response, error) {

--- a/server/tracedb/datasource/http.go
+++ b/server/tracedb/datasource/http.go
@@ -73,7 +73,7 @@ func (client *HttpClient) TestConnection(ctx context.Context) connection.Connect
 		OperationDescription: fmt.Sprintf(`Tracetest connected to "%s"`, client.config.URL.String()),
 	}
 
-	reachable, err := connection.IsReachable(client.config.URL.String())
+	reachable, err := connection.IsReachable(client.config.URL.String(), connection.ProtocolHTTP)
 	if !reachable {
 		return connection.ConnectionTestStepResult{
 			OperationDescription: fmt.Sprintf(`Tracetest tried to connect to "%s" and failed`, client.config.URL.String()),

--- a/server/tracedb/datasource/http.go
+++ b/server/tracedb/datasource/http.go
@@ -73,7 +73,7 @@ func (client *HttpClient) TestConnection(ctx context.Context) connection.Connect
 		OperationDescription: fmt.Sprintf(`Tracetest connected to "%s"`, client.config.URL.String()),
 	}
 
-	err := connection.IsReachable(client.config.URL.String(), connection.ProtocolHTTP)
+	err := connection.CheckReachability(client.config.URL.String(), connection.ProtocolHTTP)
 	if err != nil {
 		return connection.ConnectionTestStepResult{
 			OperationDescription: fmt.Sprintf(`Tracetest tried to connect to "%s" and failed`, client.config.URL.String()),

--- a/server/tracedb/elasticsearchdb.go
+++ b/server/tracedb/elasticsearchdb.go
@@ -37,7 +37,7 @@ func (db elasticsearchDB) Close() error {
 
 func (db elasticsearchDB) TestConnection(ctx context.Context) connection.ConnectionTestResult {
 	tester := connection.NewTester(
-		connection.WithConnectivityTest(connection.ConnectivityStep(db.config.Addresses...)),
+		connection.WithConnectivityTest(connection.ConnectivityStep(connection.ProtocolHTTP, db.config.Addresses...)),
 		connection.WithPollingTest(connection.TracePollingTestStep(db)),
 		connection.WithAuthenticationTest(connection.NewTestStep(func(ctx context.Context) (string, error) {
 			_, err := getClusterInfo(db.client)

--- a/server/tracedb/elasticsearchdb.go
+++ b/server/tracedb/elasticsearchdb.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"crypto/tls"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -37,66 +36,20 @@ func (db elasticsearchDB) Close() error {
 }
 
 func (db elasticsearchDB) TestConnection(ctx context.Context) connection.ConnectionTestResult {
-	addressesString := strings.Join(db.config.Addresses, ",")
-	connectionTestResult := connection.ConnectionTestResult{
-		ConnectivityTestResult: connection.ConnectionTestStepResult{
-			OperationDescription: fmt.Sprintf(`Tracetest connected to "%s"`, addressesString),
-		},
-		AuthenticationTestResult: connection.ConnectionTestStepResult{
-			OperationDescription: `Tracetest managed to authenticate with ElasticSearch`,
-		},
-		TraceRetrievalTestResult: connection.ConnectionTestStepResult{
-			OperationDescription: `Tracetest was able to search for a trace using the ElasticSearch API`,
-		},
-	}
-
-	for _, address := range db.config.Addresses {
-		reachable, err := connection.IsReachable(address)
-
-		if !reachable {
-			return connection.ConnectionTestResult{
-				ConnectivityTestResult: connection.ConnectionTestStepResult{
-					OperationDescription: fmt.Sprintf(`Tracetest tried to connect to "%s" and failed`, address),
-					Error:                err,
-				},
+	tester := connection.NewTester(
+		connection.WithConnectivityTest(connection.ConnectivityStep(db.config.Addresses...)),
+		connection.WithPollingTest(connection.TracePollingTestStep(db)),
+		connection.WithAuthenticationTest(connection.NewTestStep(func(ctx context.Context) (string, error) {
+			_, err := getClusterInfo(db.client)
+			if err != nil {
+				return "Tracetest tried to execute an OpenSearch API request but it failed due to authentication issues", err
 			}
-		}
-	}
 
-	_, err := getClusterInfo(db.client)
-	if err != nil {
-		return connection.ConnectionTestResult{
-			ConnectivityTestResult: connectionTestResult.ConnectivityTestResult,
-			AuthenticationTestResult: connection.ConnectionTestStepResult{
-				OperationDescription: `Tracetest tried to execute an ElasticSearch API request but it failed due to authentication issues`,
-				Error:                err,
-			},
-		}
-	}
+			return "Tracetest managed to authenticate with OpenSearch", nil
+		})),
+	)
 
-	_, err = db.GetTraceByID(ctx, trace.TraceID{}.String())
-	if err != nil && strings.Contains(strings.ToLower(err.Error()), "unauthorized") {
-		return connection.ConnectionTestResult{
-			ConnectivityTestResult: connectionTestResult.ConnectivityTestResult,
-			AuthenticationTestResult: connection.ConnectionTestStepResult{
-				OperationDescription: `Tracetest tried to execute an ElasticSearch API request but it failed due to authentication issues`,
-				Error:                err,
-			},
-		}
-	}
-
-	if !errors.Is(err, connection.ErrTraceNotFound) {
-		return connection.ConnectionTestResult{
-			ConnectivityTestResult:   connectionTestResult.ConnectivityTestResult,
-			AuthenticationTestResult: connectionTestResult.AuthenticationTestResult,
-			TraceRetrievalTestResult: connection.ConnectionTestStepResult{
-				OperationDescription: fmt.Sprintf(`Tracetest tried to fetch a trace from the ElasticSearch endpoint "%s" and got an error`, addressesString),
-				Error:                err,
-			},
-		}
-	}
-
-	return connectionTestResult
+	return tester.TestConnection(ctx)
 }
 
 func (db elasticsearchDB) Ready() bool {

--- a/server/tracedb/opensearchdb.go
+++ b/server/tracedb/opensearchdb.go
@@ -35,7 +35,7 @@ func (db opensearchDB) Close() error {
 
 func (db opensearchDB) TestConnection(ctx context.Context) connection.ConnectionTestResult {
 	tester := connection.NewTester(
-		connection.WithConnectivityTest(connection.ConnectivityStep(db.config.Addresses...)),
+		connection.WithConnectivityTest(connection.ConnectivityStep(connection.ProtocolHTTP, db.config.Addresses...)),
 		connection.WithPollingTest(connection.TracePollingTestStep(db)),
 		connection.WithAuthenticationTest(connection.NewTestStep(func(ctx context.Context) (string, error) {
 			_, err := db.GetTraceByID(ctx, trace.TraceID{}.String())

--- a/server/tracedb/opensearchdb.go
+++ b/server/tracedb/opensearchdb.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"crypto/tls"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -35,55 +34,20 @@ func (db opensearchDB) Close() error {
 }
 
 func (db opensearchDB) TestConnection(ctx context.Context) connection.ConnectionTestResult {
-	addressesString := strings.Join(db.config.Addresses, ",")
-	connectionTestResult := connection.ConnectionTestResult{
-		ConnectivityTestResult: connection.ConnectionTestStepResult{
-			OperationDescription: fmt.Sprintf(`Tracetest connected to "%s"`, addressesString),
-		},
-		AuthenticationTestResult: connection.ConnectionTestStepResult{
-			OperationDescription: `Tracetest managed to authenticate with OpenSearch`,
-		},
-		TraceRetrievalTestResult: connection.ConnectionTestStepResult{
-			OperationDescription: `Tracetest was able to search for a trace using the OpenSearch API`,
-		},
-	}
-
-	for _, address := range db.config.Addresses {
-		reachable, err := connection.IsReachable(address)
-
-		if !reachable {
-			return connection.ConnectionTestResult{
-				ConnectivityTestResult: connection.ConnectionTestStepResult{
-					OperationDescription: fmt.Sprintf(`Tracetest tried to connect to "%s" and failed`, address),
-					Error:                err,
-				},
+	tester := connection.NewTester(
+		connection.WithConnectivityTest(connection.ConnectivityStep(db.config.Addresses...)),
+		connection.WithPollingTest(connection.TracePollingTestStep(db)),
+		connection.WithAuthenticationTest(connection.NewTestStep(func(ctx context.Context) (string, error) {
+			_, err := db.GetTraceByID(ctx, trace.TraceID{}.String())
+			if strings.Contains(strings.ToLower(err.Error()), "unauthorized") {
+				return "Tracetest tried to execute an OpenSearch API request but it failed due to authentication issues", err
 			}
-		}
-	}
 
-	_, err := db.GetTraceByID(ctx, trace.TraceID{}.String())
-	if strings.Contains(strings.ToLower(err.Error()), "unauthorized") {
-		return connection.ConnectionTestResult{
-			ConnectivityTestResult: connectionTestResult.ConnectivityTestResult,
-			AuthenticationTestResult: connection.ConnectionTestStepResult{
-				OperationDescription: `Tracetest tried to execute an OpenSearch API request but it failed due to authentication issues`,
-				Error:                err,
-			},
-		}
-	}
+			return "Tracetest managed to authenticate with OpenSearch", nil
+		})),
+	)
 
-	if !errors.Is(err, connection.ErrTraceNotFound) {
-		return connection.ConnectionTestResult{
-			ConnectivityTestResult:   connectionTestResult.ConnectivityTestResult,
-			AuthenticationTestResult: connectionTestResult.AuthenticationTestResult,
-			TraceRetrievalTestResult: connection.ConnectionTestStepResult{
-				OperationDescription: fmt.Sprintf(`Tracetest tried to fetch a trace from the OpenSearch endpoint "%s" and got an error`, addressesString),
-				Error:                err,
-			},
-		}
-	}
-
-	return connectionTestResult
+	return tester.TestConnection(ctx)
 }
 
 func (db opensearchDB) Ready() bool {

--- a/server/tracedb/signalfxdb.go
+++ b/server/tracedb/signalfxdb.go
@@ -50,7 +50,7 @@ func (db signalfxDB) Close() error {
 func (db signalfxDB) TestConnection(ctx context.Context) connection.ConnectionTestResult {
 	url := fmt.Sprintf("%s:%s", db.getURL(), "443")
 	tester := connection.NewTester(
-		connection.WithConnectivityTest(connection.ConnectivityStep(url)),
+		connection.WithConnectivityTest(connection.ConnectivityStep(connection.ProtocolHTTP, url)),
 		connection.WithPollingTest(connection.TracePollingTestStep(db)),
 		connection.WithAuthenticationTest(connection.NewTestStep(func(ctx context.Context) (string, error) {
 			_, err := db.GetTraceByID(ctx, trace.TraceID{}.String())


### PR DESCRIPTION
This PR changes the internals of how we test the connection of each data store. Instead of having a long function with repetitive code, it uses a new `connection.Tester` which allow test steps to be chained and reused.

This is a required change to make it easier to expand our validations in the future.

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
