### PR TITLE
fix(server): removing MinSpanCount span logic from trace poller and adding unit tests

### DIFF
--- a/server/executor/poller_executor.go
+++ b/server/executor/poller_executor.go
@@ -159,7 +159,12 @@ func (pe DefaultPollerExecutor) donePollingTraces(job *PollingRequest, traceDB t
 		return false
 	}
 
-	if len(trace.Flat) > traceDB.MinSpanCount() && len(trace.Flat) == len(job.run.Trace.Flat) {
+	haveNotCollectedSpansSinceLastPoll := len(trace.Flat) == len(job.run.Trace.Flat)
+
+	// Today we consider that we finished collecting traces
+	// if we haven't collected any new spans since our last poll
+
+	if haveNotCollectedSpansSinceLastPoll {
 		log.Printf("[PollerExecutor] Test %s Run %d: Done polling. Condition met\n", job.test.ID, job.run.ID)
 		return true
 	}

--- a/server/executor/poller_executor.go
+++ b/server/executor/poller_executor.go
@@ -160,11 +160,13 @@ func (pe DefaultPollerExecutor) donePollingTraces(job *PollingRequest, traceDB t
 	}
 
 	haveNotCollectedSpansSinceLastPoll := len(trace.Flat) == len(job.run.Trace.Flat)
+	haveCollectedSpansInTestRun := len(trace.Flat) > 0
 
 	// Today we consider that we finished collecting traces
 	// if we haven't collected any new spans since our last poll
+	// and we have collected at least one span for this test run
 
-	if haveNotCollectedSpansSinceLastPoll {
+	if haveNotCollectedSpansSinceLastPoll && haveCollectedSpansInTestRun {
 		log.Printf("[PollerExecutor] Test %s Run %d: Done polling. Condition met\n", job.test.ID, job.run.ID)
 		return true
 	}

--- a/server/executor/poller_executor_test.go
+++ b/server/executor/poller_executor_test.go
@@ -1,0 +1,380 @@
+package executor_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/kubeshop/tracetest/server/config"
+	"github.com/kubeshop/tracetest/server/executor"
+	"github.com/kubeshop/tracetest/server/id"
+	"github.com/kubeshop/tracetest/server/model"
+	"github.com/kubeshop/tracetest/server/testdb"
+	"github.com/kubeshop/tracetest/server/tracedb"
+	"github.com/kubeshop/tracetest/server/tracedb/connection"
+	"github.com/kubeshop/tracetest/server/tracing"
+	"github.com/stretchr/testify/require"
+
+	"go.opentelemetry.io/otel/trace"
+)
+
+var (
+	randomIDGenerator = id.NewRandGenerator()
+)
+
+func Test_PollerExecutor_ExecuteRequest_NoRootSpan_NoSpanCase(t *testing.T) {
+	t.Parallel()
+
+	// Scenario: Trace without spans
+	// Given the trigger execution returns 0 spans
+	// And tracetest does not send the root span
+	// When the server do the polling process
+	// Then it should stop at the second iteration
+	// And it should have no error on the process
+	// And a root span should be added to it
+
+	// Given conditions
+
+	// maxRetries=30 (inferred by the calculation: maxWaitTimeForTrace / retryDelay)
+	retryDelay := 1 * time.Second
+	maxWaitTimeForTrace := 30 * time.Second
+
+	tracePerIteration := map[int]model.Trace{
+		0: model.Trace{},
+		1: model.Trace{},
+	}
+
+	// mock external dependencies
+	updater := getRunUpdaterMock(t)
+	tracer := getTracerMock(t)
+	testDB := getDataStoreRepositoryMock(t)
+	traceDBFactory := getTraceDBMockFactory(t, tracePerIteration, &traceDBState{})
+
+	pollerExecutor := executor.NewPollerExecutor(
+		retryDelay,
+		maxWaitTimeForTrace,
+		tracer,
+		updater,
+		traceDBFactory,
+		testDB,
+	)
+
+	ctx := context.Background()
+	test := model.Test{
+		ID: id.ID("some-test"),
+		ServiceUnderTest: model.Trigger{
+			Type: model.TriggerTypeHTTP,
+		},
+	}
+
+	// When doing polling process
+	// Then validate outputs
+
+	var finished bool
+	var run model.Run
+	var err error
+
+	// first iteration
+	firstRun := model.NewRun()
+	requestForFirstIteration := executor.NewPollingRequest(ctx, test, firstRun, 0)
+
+	finished, run, err = pollerExecutor.ExecuteRequest(requestForFirstIteration)
+	require.False(t, finished)
+	require.NoError(t, err)
+	require.NotNil(t, run)
+	require.False(t, run.Trace.HasRootSpan())
+
+	// second iteration
+	secondRun := run
+	requestForSecondIteration := executor.NewPollingRequest(ctx, test, secondRun, 1)
+
+	finished, run, err = pollerExecutor.ExecuteRequest(requestForSecondIteration)
+	require.True(t, finished)
+	require.NoError(t, err)
+	require.NotNil(t, run)
+	require.True(t, run.Trace.HasRootSpan())
+}
+
+func Test_PollerExecutor_ExecuteRequest_NoRootSpan_OneSpanCase(t *testing.T) {
+	t.Parallel()
+
+	// Scenario: Trace with only 1 span
+	// Given the trigger execution returns 1 span on first iteration
+	// And tracetest does not send the root span
+	// When the server do the polling process
+	// Then it should stop at the second iteration
+	// And it should have no error on the process
+	// And a root span should be added to it
+
+	// Given conditions
+
+	// maxRetries=30 (inferred by the calculation: maxWaitTimeForTrace / retryDelay)
+	retryDelay := 1 * time.Second
+	maxWaitTimeForTrace := 30 * time.Second
+
+	trace := model.NewTrace(randomIDGenerator.TraceID().String(), []model.Span{
+		{
+			ID:        randomIDGenerator.SpanID(),
+			Name:      "HTTP API",
+			StartTime: time.Now(),
+			EndTime:   time.Now().Add(retryDelay),
+			Attributes: map[string]string{
+				"testSpan": "true",
+			},
+			Children: []*model.Span{},
+		},
+	})
+
+	// test
+	tracePerIteration := map[int]model.Trace{
+		0: trace,
+		1: trace,
+	}
+
+	// mock external dependencies
+	updater := getRunUpdaterMock(t)
+	tracer := getTracerMock(t)
+	testDB := getDataStoreRepositoryMock(t)
+	traceDBFactory := getTraceDBMockFactory(t, tracePerIteration, &traceDBState{})
+
+	pollerExecutor := executor.NewPollerExecutor(
+		retryDelay,
+		maxWaitTimeForTrace,
+		tracer,
+		updater,
+		traceDBFactory,
+		testDB,
+	)
+
+	ctx := context.Background()
+	test := model.Test{
+		ID: id.ID("some-test"),
+		ServiceUnderTest: model.Trigger{
+			Type: model.TriggerTypeHTTP,
+		},
+	}
+
+	// When doing polling process
+	// Then validate outputs
+
+	var finished bool
+	var run model.Run
+	var err error
+
+	// first iteration
+	firstRun := model.NewRun()
+	requestForFirstIteration := executor.NewPollingRequest(ctx, test, firstRun, 0)
+
+	finished, run, err = pollerExecutor.ExecuteRequest(requestForFirstIteration)
+	require.False(t, finished)
+	require.NoError(t, err)
+	require.NotNil(t, run)
+	require.False(t, run.Trace.HasRootSpan())
+
+	// second iteration
+	secondRun := run
+	requestForSecondIteration := executor.NewPollingRequest(ctx, test, secondRun, 1)
+
+	finished, run, err = pollerExecutor.ExecuteRequest(requestForSecondIteration)
+	require.True(t, finished)
+	require.NoError(t, err)
+	require.NotNil(t, run)
+	require.True(t, run.Trace.HasRootSpan())
+}
+
+func Test_PollerExecutor_ExecuteRequest_NoRootSpan_TwoSpansCase(t *testing.T) {
+	t.Parallel()
+
+	// Scenario: Trace with 2 span
+	// Given the trigger execution returns 1 span on first iteration and another one on second iteration
+	// And tracetest does not send the root span
+	// When the server do the polling process
+	// Then it should stop at the third iteration
+	// And it should have no error on the process
+	// And a root span should be added to it
+
+	// Given conditions
+
+	// maxRetries=30 (inferred by the calculation: maxWaitTimeForTrace / retryDelay)
+	retryDelay := 1 * time.Second
+	maxWaitTimeForTrace := 30 * time.Second
+
+	traceID := randomIDGenerator.TraceID().String()
+
+	firstSpan := model.Span{
+		ID:        randomIDGenerator.SpanID(),
+		Name:      "HTTP API",
+		StartTime: time.Now(),
+		EndTime:   time.Now().Add(retryDelay),
+		Attributes: map[string]string{
+			"testSpan": "true",
+		},
+		Children: []*model.Span{},
+	}
+
+	secondSpan := model.Span{
+		ID:        randomIDGenerator.SpanID(),
+		Name:      "Database query",
+		StartTime: firstSpan.EndTime,
+		EndTime:   firstSpan.EndTime.Add(retryDelay),
+		Attributes: map[string]string{
+			"testSpan":  "true",
+			"parent_id": firstSpan.ID.String(),
+		},
+		Children: []*model.Span{},
+	}
+
+	firstIterationTrace := model.NewTrace(traceID, []model.Span{firstSpan})
+	secondIterationTrace := model.NewTrace(traceID, []model.Span{firstSpan, secondSpan})
+	thirdIterationTrace := model.NewTrace(traceID, []model.Span{firstSpan, secondSpan})
+
+	// test
+	tracePerIteration := map[int]model.Trace{
+		0: firstIterationTrace,
+		1: secondIterationTrace,
+		2: thirdIterationTrace,
+	}
+
+	// mock external dependencies
+	updater := getRunUpdaterMock(t)
+	tracer := getTracerMock(t)
+	testDB := getDataStoreRepositoryMock(t)
+	traceDBFactory := getTraceDBMockFactory(t, tracePerIteration, &traceDBState{})
+
+	pollerExecutor := executor.NewPollerExecutor(
+		retryDelay,
+		maxWaitTimeForTrace,
+		tracer,
+		updater,
+		traceDBFactory,
+		testDB,
+	)
+
+	ctx := context.Background()
+	test := model.Test{
+		ID: id.ID("some-test"),
+		ServiceUnderTest: model.Trigger{
+			Type: model.TriggerTypeHTTP,
+		},
+	}
+
+	// When doing polling process
+	// Then validate outputs
+
+	var finished bool
+	var run model.Run
+	var err error
+
+	// first iteration
+	firstRun := model.NewRun()
+	requestForFirstIteration := executor.NewPollingRequest(ctx, test, firstRun, 0)
+
+	finished, run, err = pollerExecutor.ExecuteRequest(requestForFirstIteration)
+	require.False(t, finished)
+	require.NoError(t, err)
+	require.NotNil(t, run)
+	require.False(t, run.Trace.HasRootSpan())
+
+	// second iteration
+	secondRun := run
+	requestForSecondIteration := executor.NewPollingRequest(ctx, test, secondRun, 1)
+
+	finished, run, err = pollerExecutor.ExecuteRequest(requestForSecondIteration)
+	require.False(t, finished)
+	require.NoError(t, err)
+	require.NotNil(t, run)
+	require.False(t, run.Trace.HasRootSpan())
+
+	// third iteration
+	thirdRun := run
+	requestForThirdIteration := executor.NewPollingRequest(ctx, test, thirdRun, 1)
+
+	finished, run, err = pollerExecutor.ExecuteRequest(requestForThirdIteration)
+	require.True(t, finished)
+	require.NoError(t, err)
+	require.NotNil(t, run)
+	require.True(t, run.Trace.HasRootSpan())
+}
+
+// TODO: add cases where Tracetest root came along
+
+// Mocks
+
+// RunUpdater
+type runUpdaterMock struct{}
+
+func (m runUpdaterMock) Update(context.Context, model.Run) error { return nil }
+
+func getRunUpdaterMock(t *testing.T) executor.RunUpdater {
+	return runUpdaterMock{}
+}
+
+// DataStoreRepository
+type dataStoreRepositoryMock struct {
+	testdb.MockRepository
+	// ...
+}
+
+func (m dataStoreRepositoryMock) DefaultDataStore(_ context.Context) (model.DataStore, error) {
+	return model.DataStore{}, nil
+}
+
+func getDataStoreRepositoryMock(t *testing.T) model.Repository {
+	t.Helper()
+
+	mock := new(dataStoreRepositoryMock)
+	mock.T = t
+	mock.Test(t)
+
+	return mock
+}
+
+// Tracer
+func getTracerMock(t *testing.T) trace.Tracer {
+	t.Helper()
+
+	tracer, err := tracing.NewTracer(context.TODO(), config.New())
+	require.NoError(t, err)
+
+	return tracer
+}
+
+// TraceDB
+type traceDBMock struct {
+	tracePerIteration map[int]model.Trace
+	state             *traceDBState
+}
+
+func (db *traceDBMock) GetTraceByID(ctx context.Context, traceID string) (t model.Trace, err error) {
+	trace := db.tracePerIteration[db.state.currentIteration]
+	db.state.currentIteration += 1
+
+	return trace, nil
+}
+
+func (db *traceDBMock) ShouldRetry() bool {
+	return true // this provider should retry
+}
+
+// empty methods to respect TraceDB interface
+func (db *traceDBMock) Connect(ctx context.Context) error { return nil }
+func (db *traceDBMock) Close() error                      { return nil }
+func (db *traceDBMock) Ready() bool                       { return true }
+func (db *traceDBMock) TestConnection(ctx context.Context) connection.ConnectionTestResult {
+	return connection.ConnectionTestResult{}
+}
+
+type traceDBState struct {
+	currentIteration int
+}
+
+func getTraceDBMockFactory(t *testing.T, tracePerIteration map[int]model.Trace, state *traceDBState) func(model.DataStore) (tracedb.TraceDB, error) {
+	t.Helper()
+
+	return func(ds model.DataStore) (tracedb.TraceDB, error) {
+		return &traceDBMock{
+			tracePerIteration: tracePerIteration,
+			state:             state,
+		}, nil
+	}
+}

--- a/server/executor/poller_executor_test.go
+++ b/server/executor/poller_executor_test.go
@@ -50,8 +50,8 @@ func Test_PollerExecutor_ExecuteRequest_NoRootSpan_NoSpanCase(t *testing.T) {
 	// When doing polling process
 	// Then validate outputs
 	executeAndValidatePollingRequests(t, pollerExecutor, []iterationExpectedValues{
-		{finished: false, expectConnectionError: true},
-		{finished: false, expectConnectionError: true},
+		{finished: false, expectNoTraceError: true},
+		{finished: false, expectNoTraceError: true},
 	})
 
 	// it will return errors on repeated calls.
@@ -102,9 +102,9 @@ func Test_PollerExecutor_ExecuteRequest_NoRootSpan_OneSpanCase(t *testing.T) {
 	// When doing polling process
 	// Then validate outputs
 	executeAndValidatePollingRequests(t, pollerExecutor, []iterationExpectedValues{
-		{finished: false, expectConnectionError: true},
-		{finished: false, expectConnectionError: false, expectRootSpan: false},
-		{finished: true, expectConnectionError: false, expectRootSpan: true},
+		{finished: false, expectNoTraceError: true},
+		{finished: false, expectNoTraceError: false, expectRootSpan: false},
+		{finished: true, expectNoTraceError: false, expectRootSpan: true},
 	})
 }
 
@@ -168,10 +168,10 @@ func Test_PollerExecutor_ExecuteRequest_NoRootSpan_TwoSpansCase(t *testing.T) {
 	// When doing polling process
 	// Then validate outputs
 	executeAndValidatePollingRequests(t, pollerExecutor, []iterationExpectedValues{
-		{finished: false, expectConnectionError: true},
-		{finished: false, expectConnectionError: false, expectRootSpan: false},
-		{finished: false, expectConnectionError: false, expectRootSpan: false},
-		{finished: true, expectConnectionError: false, expectRootSpan: true},
+		{finished: false, expectNoTraceError: true},
+		{finished: false, expectNoTraceError: false, expectRootSpan: false},
+		{finished: false, expectNoTraceError: false, expectRootSpan: false},
+		{finished: true, expectNoTraceError: false, expectRootSpan: true},
 	})
 }
 
@@ -216,9 +216,9 @@ func Test_PollerExecutor_ExecuteRequest_WithRootSpan_NoSpanCase(t *testing.T) {
 	// When doing polling process
 	// Then validate outputs
 	executeAndValidatePollingRequests(t, pollerExecutor, []iterationExpectedValues{
-		{finished: false, expectConnectionError: true},
-		{finished: false, expectConnectionError: false, expectRootSpan: true},
-		{finished: true, expectConnectionError: false, expectRootSpan: true},
+		{finished: false, expectNoTraceError: true},
+		{finished: false, expectNoTraceError: false, expectRootSpan: true},
+		{finished: true, expectNoTraceError: false, expectRootSpan: true},
 	})
 }
 
@@ -279,9 +279,9 @@ func Test_PollerExecutor_ExecuteRequest_WithRootSpan_OneSpanCase(t *testing.T) {
 	// When doing polling process
 	// Then validate outputs
 	executeAndValidatePollingRequests(t, pollerExecutor, []iterationExpectedValues{
-		{finished: false, expectConnectionError: true},
-		{finished: false, expectConnectionError: false, expectRootSpan: true},
-		{finished: true, expectConnectionError: false, expectRootSpan: true},
+		{finished: false, expectNoTraceError: true},
+		{finished: false, expectNoTraceError: false, expectRootSpan: true},
+		{finished: true, expectNoTraceError: false, expectRootSpan: true},
 	})
 }
 
@@ -357,19 +357,19 @@ func Test_PollerExecutor_ExecuteRequest_WithRootSpan_TwoSpansCase(t *testing.T) 
 	// When doing polling process
 	// Then validate outputs
 	executeAndValidatePollingRequests(t, pollerExecutor, []iterationExpectedValues{
-		{finished: false, expectConnectionError: true},
-		{finished: false, expectConnectionError: false, expectRootSpan: true},
-		{finished: false, expectConnectionError: false, expectRootSpan: true},
-		{finished: true, expectConnectionError: false, expectRootSpan: true},
+		{finished: false, expectNoTraceError: true},
+		{finished: false, expectNoTraceError: false, expectRootSpan: true},
+		{finished: false, expectNoTraceError: false, expectRootSpan: true},
+		{finished: true, expectNoTraceError: false, expectRootSpan: true},
 	})
 }
 
 // Helper structs / functions
 
 type iterationExpectedValues struct {
-	finished              bool
-	expectConnectionError bool
-	expectRootSpan        bool
+	finished           bool
+	expectNoTraceError bool
+	expectRootSpan     bool
 }
 
 func executeAndValidatePollingRequests(t *testing.T, pollerExecutor executor.PollerExecutor, expectedValues []iterationExpectedValues) {
@@ -397,7 +397,7 @@ func executeAndValidatePollingRequests(t *testing.T, pollerExecutor executor.Pol
 			require.Falsef(t, finished, "The poller should have not finished on iteration %d", i)
 		}
 
-		if value.expectConnectionError {
+		if value.expectNoTraceError {
 			require.Errorf(t, err, "An error should have happened on iteration %d", i)
 			require.ErrorIsf(t, err, connection.ErrTraceNotFound, "An connection error should have happened on iteration %d", i)
 		} else {

--- a/server/executor/trace_poller.go
+++ b/server/executor/trace_poller.go
@@ -116,13 +116,9 @@ func (tp tracePoller) Stop() {
 func (tp tracePoller) Poll(ctx context.Context, test model.Test, run model.Run) {
 	log.Printf("[TracePoller] Test %s Run %d: Poll\n", test.ID, run.ID)
 
-	job := PollingRequest{
-		ctx:  ctx,
-		test: test,
-		run:  run,
-	}
+	job := NewPollingRequest(ctx, test, run, 0)
 
-	tp.enqueueJob(job)
+	tp.enqueueJob(*job)
 }
 
 func (tp tracePoller) enqueueJob(job PollingRequest) {

--- a/server/executor/trace_poller.go
+++ b/server/executor/trace_poller.go
@@ -75,6 +75,15 @@ type PollingRequest struct {
 	count int
 }
 
+func NewPollingRequest(ctx context.Context, test model.Test, run model.Run, count int) *PollingRequest {
+	return &PollingRequest{
+		ctx:   ctx,
+		test:  test,
+		run:   run,
+		count: count,
+	}
+}
+
 func (tp tracePoller) handleDBError(err error) {
 	if err != nil {
 		fmt.Printf("DB error when polling traces: %s\n", err.Error())

--- a/server/tracedb/tracedb.go
+++ b/server/tracedb/tracedb.go
@@ -16,8 +16,11 @@ type TraceDB interface {
 	Connect(ctx context.Context) error
 	Ready() bool
 	ShouldRetry() bool
+<<<<<<< HEAD
 	MinSpanCount() int
 	GetTraceID() trace.TraceID
+=======
+>>>>>>> 87144066 (fix(server): update polling logic to remove MinSpanCount logic)
 	GetTraceByID(ctx context.Context, traceID string) (model.Trace, error)
 	TestConnection(ctx context.Context) connection.ConnectionTestResult
 	Close() error
@@ -36,7 +39,6 @@ func (db *noopTraceDB) Connect(ctx context.Context) error { return nil }
 func (db *noopTraceDB) Close() error                      { return nil }
 func (db *noopTraceDB) ShouldRetry() bool                 { return false }
 func (db *noopTraceDB) Ready() bool                       { return true }
-func (db *noopTraceDB) MinSpanCount() int                 { return 0 }
 func (db *noopTraceDB) TestConnection(ctx context.Context) connection.ConnectionTestResult {
 	return connection.ConnectionTestResult{}
 }
@@ -101,7 +103,6 @@ func (f *traceDBFactory) New(ds model.DataStore) (tdb TraceDB, err error) {
 type realTraceDB struct{}
 
 func (db *realTraceDB) ShouldRetry() bool { return true }
-func (db *realTraceDB) MinSpanCount() int { return 0 }
 func (db *realTraceDB) GetTraceID() trace.TraceID {
 	return IDGen.TraceID()
 }

--- a/server/tracedb/tracedb.go
+++ b/server/tracedb/tracedb.go
@@ -16,11 +16,7 @@ type TraceDB interface {
 	Connect(ctx context.Context) error
 	Ready() bool
 	ShouldRetry() bool
-<<<<<<< HEAD
-	MinSpanCount() int
 	GetTraceID() trace.TraceID
-=======
->>>>>>> 87144066 (fix(server): update polling logic to remove MinSpanCount logic)
 	GetTraceByID(ctx context.Context, traceID string) (model.Trace, error)
 	TestConnection(ctx context.Context) connection.ConnectionTestResult
 	Close() error


### PR DESCRIPTION
This PR aims to update our Trace collection polling logic to remove an assumption about "Tracetest trigger" node and add unit tests to handle more cases on our poller.

I'll tackle the problem of using the "Tracetest trigger" node in another PR.

## Changes

- Updating polling logic to make the stop condition explicit
- Remove logic that considers "Tracetest trigger" span on stopping criterion

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [x] updated the docs
- [x] added a test
