### PR TITLE
chore: disable application exporter in demo

### DIFF
--- a/k8s/tracetest.demo.yaml
+++ b/k8s/tracetest.demo.yaml
@@ -40,5 +40,4 @@ telemetry:
 server:
   telemetry:
     exporter: collector
-    applicationExporter: collector
     dataStore: jaeger


### PR DESCRIPTION
This PR disables the application exporter config from our demo environment

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
