### PR TITLE
chore(server): improve readability of config options with nil validators

### DIFF
--- a/server/config/config.go
+++ b/server/config/config.go
@@ -35,7 +35,7 @@ type option struct {
 	key          string
 	defaultValue any
 	description  string
-	validate     func(*Config) error
+	validate     validator
 }
 
 type options []option

--- a/server/config/server.go
+++ b/server/config/server.go
@@ -5,20 +5,20 @@ import (
 )
 
 var serverOptions = options{
-	{"postgres.host", "postgres", "Postgres DB host", nil},
-	{"postgres.user", "postgres", "Postgres DB user", nil},
-	{"postgres.password", "postgres", "Postgres DB password", nil},
-	{"postgres.dbname", "tracetest", "Postgres DB database name", nil},
-	{"postgres.port", 5432, "Postgres DB port", nil},
-	{"postgres.params", "sslmode=disable", "Postgres DB connection parameters", nil},
+	{"postgres.host", "postgres", "Postgres DB host", noValidation},
+	{"postgres.user", "postgres", "Postgres DB user", noValidation},
+	{"postgres.password", "postgres", "Postgres DB password", noValidation},
+	{"postgres.dbname", "tracetest", "Postgres DB database name", noValidation},
+	{"postgres.port", 5432, "Postgres DB port", noValidation},
+	{"postgres.params", "sslmode=disable", "Postgres DB connection parameters", noValidation},
 
-	{"server.httpPort", 11633, "Tracetest server HTTP Port", nil},
-	{"server.pathPrefix", "", "Tracetest server HTTP Path prefix", nil},
+	{"server.httpPort", 11633, "Tracetest server HTTP Port", noValidation},
+	{"server.pathPrefix", "", "Tracetest server HTTP Path prefix", noValidation},
 
-	{"experimentalFeatures", []string{}, "enabled experimental features", nil},
+	{"experimentalFeatures", []string{}, "enabled experimental features", noValidation},
 
-	{"internalTelemetry.enabled", false, "enable internal telemetry (used for internal testing)", nil},
-	{"internalTelemetry.otelCollectorEndpoint", "", "internal telemetry  otel collector (used for internal testing)", nil},
+	{"internalTelemetry.enabled", false, "enable internal telemetry (used for internal testing)", noValidation},
+	{"internalTelemetry.otelCollectorEndpoint", "", "internal telemetry  otel collector (used for internal testing)", noValidation},
 }
 
 func init() {

--- a/server/config/validate.go
+++ b/server/config/validate.go
@@ -7,6 +7,12 @@ import (
 	"github.com/hashicorp/go-multierror"
 )
 
+type validator func(*Config) error
+
+var (
+	noValidation validator = nil
+)
+
 func validateDuration(key string) func(c *Config) error {
 	return func(c *Config) error {
 		input := c.vp.GetString(key)


### PR DESCRIPTION
This PR does not change any functionality. It only creates an "alias" for a nil validator, so when defining options with inline 

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
