### PR TITLE
Adding CLI on Dockerfile path

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ COPY ./tracetest /app/tracetest
 COPY ./web/build ./html
 COPY ./server/migrations/ /app/migrations/
 
+ENV PATH="$PATH:/app"
 
 EXPOSE 11633/tcp
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ COPY ./tracetest /app/tracetest
 COPY ./web/build ./html
 COPY ./server/migrations/ /app/migrations/
 
+# Adding /app folder on $PATH to allow users to call tracetest cli on docker
 ENV PATH="$PATH:/app"
 
 EXPOSE 11633/tcp


### PR DESCRIPTION
This PR aims to add our CLI to `PATH` env, so our users can run the CLI directly from docker. This is necessary to guarantee that our integrations will not break.

## Changes

- Update Dockerfile to add CLI on `$PATH` env var

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
