### PR TITLE
fix(frontend): fix postman trigger validation

### DIFF
--- a/web/src/components/CreateTestPlugins/Postman/steps/UploadCollection/UploadCollection.tsx
+++ b/web/src/components/CreateTestPlugins/Postman/steps/UploadCollection/UploadCollection.tsx
@@ -37,18 +37,9 @@ const UploadCollection = () => {
     onRefreshData();
   }, [onRefreshData]);
 
-  const onValidateUrlChange = useCallback(async () => {
-    try {
-      await form.validateFields();
-      onIsFormValid(true);
-    } catch (err) {
-      onIsFormValid(false);
-    }
-  }, [form, onIsFormValid]);
-
   useEffect(() => {
-    onValidateUrlChange();
-  }, [currentUrl, onValidateUrlChange]);
+    onValidate(null, form.getFieldsValue());
+  }, [currentUrl, form, onValidate]);
 
   return (
     <Step.Step>

--- a/web/src/components/CreateTestPlugins/Postman/steps/UploadCollection/UploadCollectionForm.tsx
+++ b/web/src/components/CreateTestPlugins/Postman/steps/UploadCollection/UploadCollectionForm.tsx
@@ -13,52 +13,50 @@ interface IProps {
   form: TDraftTestForm<IPostmanValues>;
 }
 
-const UploadCollectionForm = ({form}: IProps) => {
-  return (
-    <S.FieldsContainer>
-      <Row gutter={12}>
-        <Col span={18}>
-          <Form.Item name="requests" hidden>
-            <Input type="hidden" />
-          </Form.Item>
-          <Form.Item name="variables" hidden>
-            <Input type="hidden" />
-          </Form.Item>
-          <CollectionFileField form={form} />
-        </Col>
-      </Row>
-      <Row gutter={12}>
-        <Col span={18}>
-          <EnvFileField form={form} />
-        </Col>
-      </Row>
-      <Row gutter={12}>
-        <Col span={18}>
-          <SelectTestFromCollection form={form} />
-        </Col>
-      </Row>
-      <Row gutter={12}>
-        <Col span={18}>
-          <RequestDetailsUrlInput />
-        </Col>
-      </Row>
-      <Row gutter={12}>
-        <Col span={18}>
-          <RequestDetailsHeadersInput />
-        </Col>
-      </Row>
-      <Row gutter={12}>
-        <Col span={18}>
-          <RequestDetailsAuthInput />
-        </Col>
-      </Row>
-      <Row gutter={12}>
-        <Col span={18}>
-          <BodyField body={Form.useWatch('body', form)} setBody={body => form.setFieldsValue({body})} />
-        </Col>
-      </Row>
-    </S.FieldsContainer>
-  );
-};
+const UploadCollectionForm = ({form}: IProps) => (
+  <S.FieldsContainer>
+    <Row gutter={12}>
+      <Col span={18}>
+        <Form.Item name="requests" hidden>
+          <Input type="hidden" />
+        </Form.Item>
+        <Form.Item name="variables" hidden>
+          <Input type="hidden" />
+        </Form.Item>
+        <CollectionFileField form={form} />
+      </Col>
+    </Row>
+    <Row gutter={12}>
+      <Col span={18}>
+        <EnvFileField form={form} />
+      </Col>
+    </Row>
+    <Row gutter={12}>
+      <Col span={18}>
+        <SelectTestFromCollection form={form} />
+      </Col>
+    </Row>
+    <Row gutter={12}>
+      <Col span={18}>
+        <RequestDetailsUrlInput />
+      </Col>
+    </Row>
+    <Row gutter={12}>
+      <Col span={18}>
+        <RequestDetailsHeadersInput />
+      </Col>
+    </Row>
+    <Row gutter={12}>
+      <Col span={18}>
+        <RequestDetailsAuthInput />
+      </Col>
+    </Row>
+    <Row gutter={12}>
+      <Col span={18}>
+        <BodyField body={Form.useWatch('body', form)} setBody={body => form.setFieldsValue({body})} />
+      </Col>
+    </Row>
+  </S.FieldsContainer>
+);
 
 export default UploadCollectionForm;

--- a/web/src/components/CreateTestPlugins/Postman/steps/UploadCollection/fields/CollectionFileField.tsx
+++ b/web/src/components/CreateTestPlugins/Postman/steps/UploadCollection/fields/CollectionFileField.tsx
@@ -10,7 +10,7 @@ interface IProps {
 
 export const CollectionFileField = ({form}: IProps): React.ReactElement => (
   <Form.Item
-    rules={[{required: true, message: 'Please enter a request url'}]}
+    rules={[{required: true, message: 'No file selected yet'}]}
     name="collectionFile"
     label="Upload Postman Collection"
   >

--- a/web/src/components/CreateTestPlugins/Postman/steps/UploadCollection/fields/SelectTestFromCollection.tsx
+++ b/web/src/components/CreateTestPlugins/Postman/steps/UploadCollection/fields/SelectTestFromCollection.tsx
@@ -13,7 +13,7 @@ export const SelectTestFromCollection = ({form}: IProps) => {
   const variables = useWatch<any[]>('variables');
   return (
     <Form.Item
-      rules={[{required: true, message: 'Please enter a request url'}]}
+      rules={[{required: true, message: 'No test selected yet'}]}
       name="collectionTest"
       label="Select test from Postman Collection"
     >

--- a/web/src/services/Triggers/Postman.service.tsx
+++ b/web/src/services/Triggers/Postman.service.tsx
@@ -40,9 +40,7 @@ const Postman = (): IPostmanTriggerService => ({
   async validateDraft(draft) {
     const {collectionTest} = draft as IPostmanValues;
 
-    const isValid = Validator.required(collectionTest) && Validator.required(collectionTest);
-
-    return isValid && HttpService.validateDraft(draft);
+    return Validator.required(collectionTest) && HttpService.validateDraft(draft);
   },
   valuesFromRequest(requests, variables, identifier) {
     const request = requests.find(({id}) => identifier === id);


### PR DESCRIPTION
This PR fixes some wrong error messages in the `Postman Trigger` form. It also removes the error messages the first time you see the screen, the messages only appear when you are interacting with the input if needed.

## Changes

- fix postman trigger validation

## Fixes

- fixes #2023 
- fixes #1971  

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Screenshot

![2023-02-22 13 17 20](https://user-images.githubusercontent.com/3879892/220721170-6296e9cd-b689-4112-9620-73921143b772.gif)