### PR TITLE
feat(frontend): add discord link to menu

### DIFF
--- a/web/src/components/Header/Menu.tsx
+++ b/web/src/components/Header/Menu.tsx
@@ -1,6 +1,6 @@
 import {useLocation} from 'react-router-dom';
 
-import {DOCUMENTATION_URL, GITHUB_URL} from 'constants/Common.constants';
+import {DISCORD_URL, DOCUMENTATION_URL, GITHUB_URL} from 'constants/Common.constants';
 import {useGuidedTour} from 'providers/GuidedTour/GuidedTour.provider';
 import Env from 'utils/Env';
 import * as S from './Header.styled';
@@ -33,6 +33,14 @@ const Menu = () => {
               label: (
                 <a data-cy="documentation-link" href={DOCUMENTATION_URL} target="_blank">
                   Documentation
+                </a>
+              ),
+            },
+            {
+              key: 'discord',
+              label: (
+                <a data-cy="discord-link" href={DISCORD_URL} target="_blank">
+                  Discord
                 </a>
               ),
             },


### PR DESCRIPTION
This PR adds a link to our `discord` server under the `help` menu icon.

## Changes

- New discord link in menu

## Fixes

- fixes #2018 

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Screenshot

<img width="1624" alt="Screenshot 2023-02-22 at 15 01 53" src="https://user-images.githubusercontent.com/3879892/220746283-81181a34-f1bc-411c-9e0c-6644071f2a49.png">