### PR TITLE
fix: postgres config retrocompatibility 

### DIFF
--- a/server/config/server.go
+++ b/server/config/server.go
@@ -79,6 +79,10 @@ func (c *Config) PostgresConnString() string {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
+	if postgresConnString := c.vp.GetString("postgresConnString"); postgresConnString != "" {
+		return postgresConnString
+	}
+
 	str := fmt.Sprintf(
 		"host=%s user=%s password=%s port=%d dbname=%s",
 		c.vp.GetString("postgres.host"),

--- a/server/config/server_test.go
+++ b/server/config/server_test.go
@@ -79,4 +79,20 @@ func TestServerConfig(t *testing.T) {
 		assert.Equal(t, true, cfg.InternalTelemetryEnabled())
 		assert.Equal(t, "otel-collector.tracetest", cfg.InternalTelemetryOtelCollectorAddress())
 	})
+
+	t.Run("postgresConnStringCompatibility", func(t *testing.T) {
+		flags := []string{
+			"--postgres.dbname", "other_dbname",
+			"--postgres.host", "localhost",
+			"--postgres.user", "user",
+			"--postgres.password", "passwd",
+			"--postgres.port", "1234",
+			"--postgres.params", "custom=params",
+			"--postgresConnString", "host=postgres user=postgres password=postgres port=5432 sslmode=disable",
+		}
+
+		cfg := configWithFlags(t, flags)
+
+		assert.Equal(t, cfg.PostgresConnString(), "host=postgres user=postgres password=postgres port=5432 sslmode=disable")
+	})
 }


### PR DESCRIPTION
This PR makes the new config retro compatible with the old configuration file format. This means that `postgresConnString` will be used if present in the config file.

## Fixes

- #1996 

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [x] added a test
