### PR TITLE
feat: validate port and show warning if using a non-standard port

### DIFF
--- a/api/config.yaml
+++ b/api/config.yaml
@@ -13,6 +13,8 @@ components:
     ConnectionResult:
       type: object
       properties:
+        endpointLinting:
+          $ref: "#/components/schemas/ConnectionTestStep"
         connectivity:
           $ref: "#/components/schemas/ConnectionTestStep"
         authentication:
@@ -24,6 +26,12 @@ components:
       properties:
         passed:
           type: boolean
+        status:
+          type: string
+          enum:
+            - passed
+            - passed_with_warning
+            - failed
         message:
           type: string
         error:

--- a/api/config.yaml
+++ b/api/config.yaml
@@ -13,7 +13,7 @@ components:
     ConnectionResult:
       type: object
       properties:
-        endpointLinting:
+        portCheck:
           $ref: "#/components/schemas/ConnectionTestStep"
         connectivity:
           $ref: "#/components/schemas/ConnectionTestStep"
@@ -30,7 +30,7 @@ components:
           type: string
           enum:
             - passed
-            - passed_with_warning
+            - warning
             - failed
         message:
           type: string

--- a/cli/openapi/model_connection_result.go
+++ b/cli/openapi/model_connection_result.go
@@ -19,10 +19,10 @@ var _ MappedNullable = &ConnectionResult{}
 
 // ConnectionResult struct for ConnectionResult
 type ConnectionResult struct {
-	EndpointLinting *ConnectionTestStep `json:"endpointLinting,omitempty"`
-	Connectivity    *ConnectionTestStep `json:"connectivity,omitempty"`
-	Authentication  *ConnectionTestStep `json:"authentication,omitempty"`
-	FetchTraces     *ConnectionTestStep `json:"fetchTraces,omitempty"`
+	PortCheck      *ConnectionTestStep `json:"portCheck,omitempty"`
+	Connectivity   *ConnectionTestStep `json:"connectivity,omitempty"`
+	Authentication *ConnectionTestStep `json:"authentication,omitempty"`
+	FetchTraces    *ConnectionTestStep `json:"fetchTraces,omitempty"`
 }
 
 // NewConnectionResult instantiates a new ConnectionResult object
@@ -42,36 +42,36 @@ func NewConnectionResultWithDefaults() *ConnectionResult {
 	return &this
 }
 
-// GetEndpointLinting returns the EndpointLinting field value if set, zero value otherwise.
-func (o *ConnectionResult) GetEndpointLinting() ConnectionTestStep {
-	if o == nil || isNil(o.EndpointLinting) {
+// GetPortCheck returns the PortCheck field value if set, zero value otherwise.
+func (o *ConnectionResult) GetPortCheck() ConnectionTestStep {
+	if o == nil || isNil(o.PortCheck) {
 		var ret ConnectionTestStep
 		return ret
 	}
-	return *o.EndpointLinting
+	return *o.PortCheck
 }
 
-// GetEndpointLintingOk returns a tuple with the EndpointLinting field value if set, nil otherwise
+// GetPortCheckOk returns a tuple with the PortCheck field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *ConnectionResult) GetEndpointLintingOk() (*ConnectionTestStep, bool) {
-	if o == nil || isNil(o.EndpointLinting) {
+func (o *ConnectionResult) GetPortCheckOk() (*ConnectionTestStep, bool) {
+	if o == nil || isNil(o.PortCheck) {
 		return nil, false
 	}
-	return o.EndpointLinting, true
+	return o.PortCheck, true
 }
 
-// HasEndpointLinting returns a boolean if a field has been set.
-func (o *ConnectionResult) HasEndpointLinting() bool {
-	if o != nil && !isNil(o.EndpointLinting) {
+// HasPortCheck returns a boolean if a field has been set.
+func (o *ConnectionResult) HasPortCheck() bool {
+	if o != nil && !isNil(o.PortCheck) {
 		return true
 	}
 
 	return false
 }
 
-// SetEndpointLinting gets a reference to the given ConnectionTestStep and assigns it to the EndpointLinting field.
-func (o *ConnectionResult) SetEndpointLinting(v ConnectionTestStep) {
-	o.EndpointLinting = &v
+// SetPortCheck gets a reference to the given ConnectionTestStep and assigns it to the PortCheck field.
+func (o *ConnectionResult) SetPortCheck(v ConnectionTestStep) {
+	o.PortCheck = &v
 }
 
 // GetConnectivity returns the Connectivity field value if set, zero value otherwise.
@@ -180,8 +180,8 @@ func (o ConnectionResult) MarshalJSON() ([]byte, error) {
 
 func (o ConnectionResult) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	if !isNil(o.EndpointLinting) {
-		toSerialize["endpointLinting"] = o.EndpointLinting
+	if !isNil(o.PortCheck) {
+		toSerialize["portCheck"] = o.PortCheck
 	}
 	if !isNil(o.Connectivity) {
 		toSerialize["connectivity"] = o.Connectivity

--- a/cli/openapi/model_connection_result.go
+++ b/cli/openapi/model_connection_result.go
@@ -19,9 +19,10 @@ var _ MappedNullable = &ConnectionResult{}
 
 // ConnectionResult struct for ConnectionResult
 type ConnectionResult struct {
-	Connectivity   *ConnectionTestStep `json:"connectivity,omitempty"`
-	Authentication *ConnectionTestStep `json:"authentication,omitempty"`
-	FetchTraces    *ConnectionTestStep `json:"fetchTraces,omitempty"`
+	EndpointLinting *ConnectionTestStep `json:"endpointLinting,omitempty"`
+	Connectivity    *ConnectionTestStep `json:"connectivity,omitempty"`
+	Authentication  *ConnectionTestStep `json:"authentication,omitempty"`
+	FetchTraces     *ConnectionTestStep `json:"fetchTraces,omitempty"`
 }
 
 // NewConnectionResult instantiates a new ConnectionResult object
@@ -39,6 +40,38 @@ func NewConnectionResult() *ConnectionResult {
 func NewConnectionResultWithDefaults() *ConnectionResult {
 	this := ConnectionResult{}
 	return &this
+}
+
+// GetEndpointLinting returns the EndpointLinting field value if set, zero value otherwise.
+func (o *ConnectionResult) GetEndpointLinting() ConnectionTestStep {
+	if o == nil || isNil(o.EndpointLinting) {
+		var ret ConnectionTestStep
+		return ret
+	}
+	return *o.EndpointLinting
+}
+
+// GetEndpointLintingOk returns a tuple with the EndpointLinting field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *ConnectionResult) GetEndpointLintingOk() (*ConnectionTestStep, bool) {
+	if o == nil || isNil(o.EndpointLinting) {
+		return nil, false
+	}
+	return o.EndpointLinting, true
+}
+
+// HasEndpointLinting returns a boolean if a field has been set.
+func (o *ConnectionResult) HasEndpointLinting() bool {
+	if o != nil && !isNil(o.EndpointLinting) {
+		return true
+	}
+
+	return false
+}
+
+// SetEndpointLinting gets a reference to the given ConnectionTestStep and assigns it to the EndpointLinting field.
+func (o *ConnectionResult) SetEndpointLinting(v ConnectionTestStep) {
+	o.EndpointLinting = &v
 }
 
 // GetConnectivity returns the Connectivity field value if set, zero value otherwise.
@@ -147,6 +180,9 @@ func (o ConnectionResult) MarshalJSON() ([]byte, error) {
 
 func (o ConnectionResult) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
+	if !isNil(o.EndpointLinting) {
+		toSerialize["endpointLinting"] = o.EndpointLinting
+	}
 	if !isNil(o.Connectivity) {
 		toSerialize["connectivity"] = o.Connectivity
 	}

--- a/cli/openapi/model_connection_test_step.go
+++ b/cli/openapi/model_connection_test_step.go
@@ -20,6 +20,7 @@ var _ MappedNullable = &ConnectionTestStep{}
 // ConnectionTestStep struct for ConnectionTestStep
 type ConnectionTestStep struct {
 	Passed  *bool   `json:"passed,omitempty"`
+	Status  *string `json:"status,omitempty"`
 	Message *string `json:"message,omitempty"`
 	Error   *string `json:"error,omitempty"`
 }
@@ -71,6 +72,38 @@ func (o *ConnectionTestStep) HasPassed() bool {
 // SetPassed gets a reference to the given bool and assigns it to the Passed field.
 func (o *ConnectionTestStep) SetPassed(v bool) {
 	o.Passed = &v
+}
+
+// GetStatus returns the Status field value if set, zero value otherwise.
+func (o *ConnectionTestStep) GetStatus() string {
+	if o == nil || isNil(o.Status) {
+		var ret string
+		return ret
+	}
+	return *o.Status
+}
+
+// GetStatusOk returns a tuple with the Status field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *ConnectionTestStep) GetStatusOk() (*string, bool) {
+	if o == nil || isNil(o.Status) {
+		return nil, false
+	}
+	return o.Status, true
+}
+
+// HasStatus returns a boolean if a field has been set.
+func (o *ConnectionTestStep) HasStatus() bool {
+	if o != nil && !isNil(o.Status) {
+		return true
+	}
+
+	return false
+}
+
+// SetStatus gets a reference to the given string and assigns it to the Status field.
+func (o *ConnectionTestStep) SetStatus(v string) {
+	o.Status = &v
 }
 
 // GetMessage returns the Message field value if set, zero value otherwise.
@@ -149,6 +182,9 @@ func (o ConnectionTestStep) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	if !isNil(o.Passed) {
 		toSerialize["passed"] = o.Passed
+	}
+	if !isNil(o.Status) {
+		toSerialize["status"] = o.Status
 	}
 	if !isNil(o.Message) {
 		toSerialize["message"] = o.Message

--- a/go.work.sum
+++ b/go.work.sum
@@ -170,7 +170,6 @@ github.com/fsnotify/fsnotify v1.5.4/go.mod h1:OVB6XrOHzAwXMpEM7uPOzcehqUV2UqJxmV
 github.com/go-kit/log v0.2.1/go.mod h1:NwTd00d/i8cPZ3xOwwiv2PO5MOcx78fFErGNcVmBjv0=
 github.com/go-ole/go-ole v1.2.6/go.mod h1:pprOEPIfldk/42T2oK7lQ4v4JSDwmV0As9GaiUsvbm0=
 github.com/go-redis/redis v6.15.9+incompatible h1:K0pv1D7EQUjfyoMql+r/jZqCLizCGKFlFgcHWWmHQjg=
-github.com/google/go-cmp v0.5.8/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/googleapis/enterprise-certificate-proxy v0.0.0-20220520183353-fd19c99a87aa/go.mod h1:17drOmN3MwGY7t0e+Ei9b45FFGA3fBs3x36SsCg1hq8=
 github.com/googleapis/enterprise-certificate-proxy v0.1.0/go.mod h1:17drOmN3MwGY7t0e+Ei9b45FFGA3fBs3x36SsCg1hq8=
 github.com/googleapis/gax-go/v2 v2.2.0/go.mod h1:as02EH8zWkzwUoLbBaFeQ+arQaj/OthfcblKl4IGNaM=
@@ -202,14 +201,11 @@ github.com/tklauser/numcpus v0.4.0/go.mod h1:1+UI3pD8NW14VMwdgJNJ1ESk2UnwhAnz5hM
 github.com/yusufpapurcu/wmi v1.2.2/go.mod h1:SBZ9tNy3G9/m5Oi98Zks0QjeHVDvuK0qfxQmPyzfmi0=
 go.etcd.io/etcd/client/v2 v2.305.4/go.mod h1:Ud+VUwIi9/uQHOMA+4ekToJ12lTxlv0zB/+DHwTGEbU=
 go.opentelemetry.io/collector/semconv v0.60.0/go.mod h1:aRkHuJ/OshtDFYluKEtnG5nkKTsy1HZuvZVHmakx+Vo=
-go.opentelemetry.io/contrib v0.20.0 h1:ubFQUn0VCZ0gPwIoJfBJVpeBlyRMxu8Mm/huKWYd9p0=
 go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.34.0/go.mod h1:fk1+icoN47ytLSgkoWHLJrtVTSQ+HgmkNgPTKrk/Nsc=
 go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.34.0/go.mod h1:548ZsYzmT4PL4zWKRd8q/N4z0Wxzn/ZxUE+lkEpwWQA=
-go.opentelemetry.io/contrib/propagators/b3 v1.9.0 h1:Lzb9zU98jCE2kyfCjWfSSsiQoGtvBL+COxvUBf7FNhU=
 go.opentelemetry.io/contrib/propagators/b3 v1.9.0/go.mod h1:fyx3gFXn+4w5uWTTiqaI8oBNBW/6w9Ow5zxXf7NGixU=
 go.opentelemetry.io/contrib/zpages v0.34.0/go.mod h1:zuVCe4eoOREH+liRJLCtGITqL3NiUvkdr6U/4j9iQRg=
 go.opentelemetry.io/otel v1.9.0/go.mod h1:np4EoPGzoPs3O67xUVNoPPcmSvsfOxNlNA4F4AC+0Eo=
-go.opentelemetry.io/otel/exporters/otlp v0.20.0 h1:PTNgq9MRmQqqJY0REVbZFvwkYOA85vbdQU/nVfxDyqg=
 go.opentelemetry.io/otel/exporters/prometheus v0.31.0/go.mod h1:QarXIB8L79IwIPoNgG3A6zNvBgVmcppeFogV1d8612s=
 go.opentelemetry.io/otel/metric v0.31.0/go.mod h1:ohmwj9KTSIeBnDBm/ZwH2PSZxZzoOaG2xZeekTRzL5A=
 go.opentelemetry.io/otel/sdk v1.9.0/go.mod h1:AEZc8nt5bd2F7BC24J5R0mrjYnpEgYHyTcM/vrSple4=
@@ -247,7 +243,6 @@ golang.org/x/sys v0.0.0-20220610221304-9f5ed59c137d/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20220624220833-87e55d714810/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220708085239-5a0f0661e09d/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220808155132-1c4a2a72c664/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/term v0.1.0 h1:g6Z6vPFA9dYBAF7DWcH6sCcOntplXsDKcliusYijMlw=
 golang.org/x/tools v0.2.0/go.mod h1:y4OqIKeOV/fWJetJ8bXPU1sEVniLMIyDAZWeHdV+NTA=
 golang.org/x/xerrors v0.0.0-20220411194840-2f41105eb62f/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20220517211312-f3a8303e98df/go.mod h1:K8+ghG5WaK9qNqU5K3HdILfMLy1f3aNYFI/wnl100a8=
@@ -288,5 +283,4 @@ google.golang.org/genproto v0.0.0-20220624142145-8cd45d7dbd1f/go.mod h1:KEWEmljW
 google.golang.org/grpc v1.46.0/go.mod h1:vN9eftEi1UMyUsIF80+uQXhHjbXYbm0uXoFCACuMGWk=
 google.golang.org/grpc v1.46.2/go.mod h1:vN9eftEi1UMyUsIF80+uQXhHjbXYbm0uXoFCACuMGWk=
 google.golang.org/grpc v1.48.0/go.mod h1:vN9eftEi1UMyUsIF80+uQXhHjbXYbm0uXoFCACuMGWk=
-gotest.tools v2.2.0+incompatible h1:VsBPFP1AI068pPrMxtb/S8Zkgf9xEmTLJjfM+P5UIEo=
 gotest.tools/v3 v3.3.0/go.mod h1:Mcr9QNxkg0uMvy/YElmo4SpXgJKWgQvYrT7Kw5RzJ1A=

--- a/server/http/mappings/datastore.go
+++ b/server/http/mappings/datastore.go
@@ -9,7 +9,7 @@ func (m *OpenAPI) ConnectionTestResult(in connection.ConnectionTestResult) opena
 	result := openapi.ConnectionResult{}
 
 	if in.EndpointLintTestResult.IsSet() {
-		result.EndpointLinting = m.ConnectionTestStep(in.EndpointLintTestResult)
+		result.PortCheck = m.ConnectionTestStep(in.EndpointLintTestResult)
 	}
 
 	if in.ConnectivityTestResult.IsSet() {

--- a/server/http/mappings/datastore.go
+++ b/server/http/mappings/datastore.go
@@ -8,6 +8,10 @@ import (
 func (m *OpenAPI) ConnectionTestResult(in connection.ConnectionTestResult) openapi.ConnectionResult {
 	result := openapi.ConnectionResult{}
 
+	if in.EndpointLintTestResult.IsSet() {
+		result.EndpointLinting = m.ConnectionTestStep(in.EndpointLintTestResult)
+	}
+
 	if in.ConnectivityTestResult.IsSet() {
 		result.Connectivity = m.ConnectionTestStep(in.ConnectivityTestResult)
 	}
@@ -30,8 +34,9 @@ func (m *OpenAPI) ConnectionTestStep(in connection.ConnectionTestStepResult) ope
 	}
 
 	return openapi.ConnectionTestStep{
-		Passed:  in.Error == nil,
+		Passed:  in.Status != connection.StatusFailed,
 		Message: in.OperationDescription,
+		Status:  string(in.Status),
 		Error:   errMessage,
 	}
 }

--- a/server/openapi/model_connection_result.go
+++ b/server/openapi/model_connection_result.go
@@ -10,6 +10,8 @@
 package openapi
 
 type ConnectionResult struct {
+	EndpointLinting ConnectionTestStep `json:"endpointLinting,omitempty"`
+
 	Connectivity ConnectionTestStep `json:"connectivity,omitempty"`
 
 	Authentication ConnectionTestStep `json:"authentication,omitempty"`
@@ -19,6 +21,9 @@ type ConnectionResult struct {
 
 // AssertConnectionResultRequired checks if the required fields are not zero-ed
 func AssertConnectionResultRequired(obj ConnectionResult) error {
+	if err := AssertConnectionTestStepRequired(obj.EndpointLinting); err != nil {
+		return err
+	}
 	if err := AssertConnectionTestStepRequired(obj.Connectivity); err != nil {
 		return err
 	}

--- a/server/openapi/model_connection_result.go
+++ b/server/openapi/model_connection_result.go
@@ -10,7 +10,7 @@
 package openapi
 
 type ConnectionResult struct {
-	EndpointLinting ConnectionTestStep `json:"endpointLinting,omitempty"`
+	PortCheck ConnectionTestStep `json:"portCheck,omitempty"`
 
 	Connectivity ConnectionTestStep `json:"connectivity,omitempty"`
 
@@ -21,7 +21,7 @@ type ConnectionResult struct {
 
 // AssertConnectionResultRequired checks if the required fields are not zero-ed
 func AssertConnectionResultRequired(obj ConnectionResult) error {
-	if err := AssertConnectionTestStepRequired(obj.EndpointLinting); err != nil {
+	if err := AssertConnectionTestStepRequired(obj.PortCheck); err != nil {
 		return err
 	}
 	if err := AssertConnectionTestStepRequired(obj.Connectivity); err != nil {

--- a/server/openapi/model_connection_test_step.go
+++ b/server/openapi/model_connection_test_step.go
@@ -12,6 +12,8 @@ package openapi
 type ConnectionTestStep struct {
 	Passed bool `json:"passed,omitempty"`
 
+	Status string `json:"status,omitempty"`
+
 	Message string `json:"message,omitempty"`
 
 	Error string `json:"error,omitempty"`

--- a/server/tracedb/connection/connection.go
+++ b/server/tracedb/connection/connection.go
@@ -11,14 +11,24 @@ import (
 
 const reachabilityTimeout = 5 * time.Second
 
-type Protocol string
+type (
+	Protocol string
+	Status   string
+)
 
 var (
 	ProtocolHTTP Protocol = "http"
 	ProtocolGRPC Protocol = "grpc"
 )
 
+var (
+	StatusPassed  Status = "passed"
+	StatusWarning Status = "passed_with_warning"
+	StatusFailed  Status = "failed"
+)
+
 type ConnectionTestResult struct {
+	EndpointLintTestResult   ConnectionTestStepResult
 	ConnectivityTestResult   ConnectionTestStepResult
 	AuthenticationTestResult ConnectionTestStepResult
 	TraceRetrievalTestResult ConnectionTestStepResult
@@ -36,6 +46,7 @@ func (c ConnectionTestResult) HasSucceed() bool {
 
 type ConnectionTestStepResult struct {
 	OperationDescription string
+	Status               Status
 	Error                error
 }
 

--- a/server/tracedb/connection/connection.go
+++ b/server/tracedb/connection/connection.go
@@ -23,7 +23,7 @@ var (
 
 var (
 	StatusPassed  Status = "passed"
-	StatusWarning Status = "passed_with_warning"
+	StatusWarning Status = "warning"
 	StatusFailed  Status = "failed"
 )
 

--- a/server/tracedb/connection/connectivity_step.go
+++ b/server/tracedb/connection/connectivity_step.go
@@ -33,6 +33,7 @@ func (s *connectivityTestStep) TestConnection(_ context.Context) ConnectionTestS
 		endpoints := strings.Join(unreachableEndpoints, ", ")
 		return ConnectionTestStepResult{
 			OperationDescription: fmt.Sprintf("Tracetest tried to connect to the following endpoints and failed: %s", endpoints),
+			Status:               StatusFailed,
 			Error:                connectionErr,
 		}
 	}
@@ -40,6 +41,7 @@ func (s *connectivityTestStep) TestConnection(_ context.Context) ConnectionTestS
 	endpoints := strings.Join(s.endpoints, ", ")
 	return ConnectionTestStepResult{
 		OperationDescription: fmt.Sprintf(`Tracetest connected to %s`, endpoints),
+		Status:               StatusPassed,
 	}
 }
 

--- a/server/tracedb/connection/options.go
+++ b/server/tracedb/connection/options.go
@@ -2,6 +2,12 @@ package connection
 
 import "context"
 
+func WithPortLintingTest(step TestStep) TesterOption {
+	return func(t *Tester) {
+		t.portLinterStep = step
+	}
+}
+
 func WithConnectivityTest(step TestStep) TesterOption {
 	return func(t *Tester) {
 		t.connectivityTestStep = step

--- a/server/tracedb/connection/port_linting.go
+++ b/server/tracedb/connection/port_linting.go
@@ -1,0 +1,68 @@
+package connection
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+type portLinter struct {
+	endpoints     []string
+	expectedPorts []string
+}
+
+var _ TestStep = &portLinter{}
+
+func PortLinter(expectedPorts []string, endpoints ...string) TestStep {
+	return &portLinter{
+		endpoints:     endpoints,
+		expectedPorts: expectedPorts,
+	}
+}
+
+func (s *portLinter) TestConnection(ctx context.Context) ConnectionTestStepResult {
+	for _, endpoint := range s.endpoints {
+		port := parsePort(endpoint)
+
+		if !sliceContains(s.expectedPorts, port) {
+			suggestedPorts := strings.Join(s.expectedPorts, ", ")
+			return ConnectionTestStepResult{
+				OperationDescription: fmt.Sprintf(`port "%s" is not used frequently for connecting to this data store. Consider using %s instead if you experience problems connecting to it`, port, suggestedPorts),
+				Status:               StatusWarning,
+			}
+		}
+	}
+
+	return ConnectionTestStepResult{
+		OperationDescription: `You are using a commonly used port`,
+		Status:               StatusPassed,
+	}
+}
+
+func sliceContains(slice []string, value string) bool {
+	for _, item := range slice {
+		if item == value {
+			return true
+		}
+	}
+
+	return false
+}
+
+var extractPortRegex = regexp.MustCompile("([0-9]+).*")
+
+func parsePort(url string) string {
+	index := strings.LastIndex(url, ":")
+	if index < 0 {
+		return ""
+	}
+
+	substring := url[index+1:]
+	regexGroups := extractPortRegex.FindStringSubmatch(substring)
+	if len(regexGroups) < 2 {
+		return ""
+	}
+
+	return regexGroups[1]
+}

--- a/server/tracedb/connection/port_linting_test.go
+++ b/server/tracedb/connection/port_linting_test.go
@@ -1,0 +1,45 @@
+package connection_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/kubeshop/tracetest/server/tracedb/connection"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPortLinter(t *testing.T) {
+	testCases := []struct {
+		Name           string
+		Endpoints      []string
+		ExpectedPorts  []string
+		ExpectedStatus connection.Status
+	}{
+		{
+			Name:           "shouldSucceedIfPortIsExpected",
+			Endpoints:      []string{"jaeger:16685"},
+			ExpectedPorts:  []string{"16685"},
+			ExpectedStatus: connection.StatusPassed,
+		},
+		{
+			Name:           "shouldShowWarningInCaseOfDifferentPort",
+			Endpoints:      []string{"jaeger:16686"},
+			ExpectedPorts:  []string{"16685"},
+			ExpectedStatus: connection.StatusWarning,
+		},
+		{
+			Name:           "shouldSupportSchemas",
+			Endpoints:      []string{"https://us2.endpoint:9200"},
+			ExpectedPorts:  []string{"9200"},
+			ExpectedStatus: connection.StatusPassed,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.Name, func(t *testing.T) {
+			linter := connection.PortLinter(testCase.ExpectedPorts, testCase.Endpoints...)
+			result := linter.TestConnection(context.Background())
+			assert.Equal(t, testCase.ExpectedStatus, result.Status)
+		})
+	}
+}

--- a/server/tracedb/connection/tester.go
+++ b/server/tracedb/connection/tester.go
@@ -9,6 +9,7 @@ type TestStep interface {
 type TesterOption func(*Tester)
 
 type Tester struct {
+	portLinterStep         TestStep
 	connectivityTestStep   TestStep
 	authenticationTestStep TestStep
 	pollingTestStep        TestStep
@@ -25,17 +26,30 @@ func NewTester(opts ...TesterOption) Tester {
 }
 
 func (t *Tester) TestConnection(ctx context.Context) (res ConnectionTestResult) {
+	if t.portLinterStep != nil {
+		res.EndpointLintTestResult = t.portLinterStep.TestConnection(ctx)
+		if res.EndpointLintTestResult.Error != nil {
+			res.EndpointLintTestResult.Status = StatusFailed
+			return
+		}
+	}
+
 	res.ConnectivityTestResult = t.connectivityTestStep.TestConnection(ctx)
 	if res.ConnectivityTestResult.Error != nil {
+		res.ConnectivityTestResult.Status = StatusFailed
 		return
 	}
 
 	res.AuthenticationTestResult = t.authenticationTestStep.TestConnection(ctx)
-	if res.ConnectivityTestResult.Error != nil {
+	if res.AuthenticationTestResult.Error != nil {
+		res.AuthenticationTestResult.Status = StatusFailed
 		return
 	}
 
 	res.TraceRetrievalTestResult = t.pollingTestStep.TestConnection(ctx)
+	if res.TraceRetrievalTestResult.Error != nil {
+		res.TraceRetrievalTestResult.Status = StatusFailed
+	}
 
 	return
 }

--- a/server/tracedb/connection/trace_polling_step.go
+++ b/server/tracedb/connection/trace_polling_step.go
@@ -23,12 +23,14 @@ func (s *tracePollingTestStep) TestConnection(ctx context.Context) ConnectionTes
 		return ConnectionTestStepResult{
 			OperationDescription: "Tracetest could not get traces back from the data store",
 			Error:                err,
+			Status:               StatusFailed,
 		}
 	}
 
 	return ConnectionTestStepResult{
 		OperationDescription: "Traces were obtained successfully",
 		Error:                nil,
+		Status:               StatusPassed,
 	}
 }
 

--- a/server/tracedb/datasource/datasource.go
+++ b/server/tracedb/datasource/datasource.go
@@ -24,6 +24,7 @@ type Callbacks struct {
 }
 
 type DataSource interface {
+	Endpoint() string
 	Connect(ctx context.Context) error
 	Ready() bool
 	GetTraceByID(ctx context.Context, traceID string) (model.Trace, error)
@@ -36,6 +37,7 @@ type noopDataSource struct{}
 func (dataSource *noopDataSource) GetTraceByID(ctx context.Context, traceID string) (t model.Trace, err error) {
 	return model.Trace{}, nil
 }
+func (db *noopDataSource) Endpoint() string                  { return "" }
 func (db *noopDataSource) Connect(ctx context.Context) error { return nil }
 func (db *noopDataSource) Close() error                      { return nil }
 func (db *noopDataSource) Ready() bool                       { return true }

--- a/server/tracedb/datasource/grpc.go
+++ b/server/tracedb/datasource/grpc.go
@@ -35,6 +35,10 @@ func (client *GrpcClient) GetTraceByID(ctx context.Context, traceID string) (mod
 	return client.callback(ctx, traceID, client.conn)
 }
 
+func (client *GrpcClient) Endpoint() string {
+	return client.config.Endpoint
+}
+
 func (client *GrpcClient) Connect(ctx context.Context) error {
 	opts, err := client.config.ToDialOptions(nil, componenttest.NewNopTelemetrySettings())
 	if err != nil {

--- a/server/tracedb/datasource/http.go
+++ b/server/tracedb/datasource/http.go
@@ -61,6 +61,10 @@ func (client *HttpClient) GetTraceByID(ctx context.Context, traceID string) (mod
 	return client.callback(ctx, traceID, client)
 }
 
+func (client *HttpClient) Endpoint() string {
+	return client.config.Host
+}
+
 func (client *HttpClient) Connect(ctx context.Context) error {
 	_, err := client.client.Transport.RoundTrip(client.config)
 

--- a/server/tracedb/elasticsearchdb.go
+++ b/server/tracedb/elasticsearchdb.go
@@ -36,6 +36,7 @@ func (db *elasticsearchDB) Close() error {
 
 func (db *elasticsearchDB) TestConnection(ctx context.Context) connection.ConnectionTestResult {
 	tester := connection.NewTester(
+		connection.WithPortLintingTest(connection.PortLinter([]string{"9200"}, db.config.Addresses...)),
 		connection.WithConnectivityTest(connection.ConnectivityStep(connection.ProtocolHTTP, db.config.Addresses...)),
 		connection.WithPollingTest(connection.TracePollingTestStep(db)),
 		connection.WithAuthenticationTest(connection.NewTestStep(func(ctx context.Context) (string, error) {

--- a/server/tracedb/elasticsearchdb.go
+++ b/server/tracedb/elasticsearchdb.go
@@ -19,6 +19,10 @@ import (
 	"go.opentelemetry.io/otel/trace"
 )
 
+func elasticSearchDefaultPorts() []string {
+	return []string{"9200"}
+}
+
 type elasticsearchDB struct {
 	realTraceDB
 	config *model.ElasticSearchDataStoreConfig
@@ -36,7 +40,7 @@ func (db *elasticsearchDB) Close() error {
 
 func (db *elasticsearchDB) TestConnection(ctx context.Context) connection.ConnectionTestResult {
 	tester := connection.NewTester(
-		connection.WithPortLintingTest(connection.PortLinter([]string{"9200"}, db.config.Addresses...)),
+		connection.WithPortLintingTest(connection.PortLinter(elasticSearchDefaultPorts(), db.config.Addresses...)),
 		connection.WithConnectivityTest(connection.ConnectivityStep(connection.ProtocolHTTP, db.config.Addresses...)),
 		connection.WithPollingTest(connection.TracePollingTestStep(db)),
 		connection.WithAuthenticationTest(connection.NewTestStep(func(ctx context.Context) (string, error) {

--- a/server/tracedb/jaegerdb.go
+++ b/server/tracedb/jaegerdb.go
@@ -18,6 +18,10 @@ import (
 	"google.golang.org/grpc/status"
 )
 
+func jaegerDefaultPorts() []string {
+	return []string{"16685"}
+}
+
 type jaegerTraceDB struct {
 	realTraceDB
 	dataSource datasource.DataSource
@@ -44,7 +48,7 @@ func (jtd *jaegerTraceDB) Connect(ctx context.Context) error {
 
 func (jtd *jaegerTraceDB) TestConnection(ctx context.Context) connection.ConnectionTestResult {
 	tester := connection.NewTester(
-		connection.WithPortLintingTest(connection.PortLinter([]string{"16685"}, jtd.dataSource.Endpoint())),
+		connection.WithPortLintingTest(connection.PortLinter(jaegerDefaultPorts(), jtd.dataSource.Endpoint())),
 		connection.WithConnectivityTest(jtd.dataSource),
 		connection.WithPollingTest(connection.TracePollingTestStep(jtd)),
 		connection.WithAuthenticationTest(connection.NewTestStep(func(ctx context.Context) (string, error) {

--- a/server/tracedb/jaegerdb.go
+++ b/server/tracedb/jaegerdb.go
@@ -44,6 +44,7 @@ func (jtd *jaegerTraceDB) Connect(ctx context.Context) error {
 
 func (jtd *jaegerTraceDB) TestConnection(ctx context.Context) connection.ConnectionTestResult {
 	tester := connection.NewTester(
+		connection.WithPortLintingTest(connection.PortLinter([]string{"16685"}, jtd.dataSource.Endpoint())),
 		connection.WithConnectivityTest(jtd.dataSource),
 		connection.WithPollingTest(connection.TracePollingTestStep(jtd)),
 		connection.WithAuthenticationTest(connection.NewTestStep(func(ctx context.Context) (string, error) {

--- a/server/tracedb/opensearchdb.go
+++ b/server/tracedb/opensearchdb.go
@@ -17,6 +17,10 @@ import (
 	"go.opentelemetry.io/otel/trace"
 )
 
+func opensearchDefaultPorts() []string {
+	return []string{"9200", "9250"}
+}
+
 type opensearchDB struct {
 	realTraceDB
 	config *model.ElasticSearchDataStoreConfig
@@ -34,7 +38,7 @@ func (db *opensearchDB) Close() error {
 
 func (db *opensearchDB) TestConnection(ctx context.Context) connection.ConnectionTestResult {
 	tester := connection.NewTester(
-		connection.WithPortLintingTest(connection.PortLinter([]string{"9200", "9250"}, db.config.Addresses...)),
+		connection.WithPortLintingTest(connection.PortLinter(opensearchDefaultPorts(), db.config.Addresses...)),
 		connection.WithConnectivityTest(connection.ConnectivityStep(connection.ProtocolHTTP, db.config.Addresses...)),
 		connection.WithPollingTest(connection.TracePollingTestStep(db)),
 		connection.WithAuthenticationTest(connection.NewTestStep(func(ctx context.Context) (string, error) {

--- a/server/tracedb/opensearchdb.go
+++ b/server/tracedb/opensearchdb.go
@@ -34,6 +34,7 @@ func (db *opensearchDB) Close() error {
 
 func (db *opensearchDB) TestConnection(ctx context.Context) connection.ConnectionTestResult {
 	tester := connection.NewTester(
+		connection.WithPortLintingTest(connection.PortLinter([]string{"9200", "9250"}, db.config.Addresses...)),
 		connection.WithConnectivityTest(connection.ConnectivityStep(connection.ProtocolHTTP, db.config.Addresses...)),
 		connection.WithPollingTest(connection.TracePollingTestStep(db)),
 		connection.WithAuthenticationTest(connection.NewTestStep(func(ctx context.Context) (string, error) {

--- a/server/tracedb/tempodb.go
+++ b/server/tracedb/tempodb.go
@@ -43,6 +43,7 @@ func (tdb *tempoTraceDB) Connect(ctx context.Context) error {
 
 func (ttd *tempoTraceDB) TestConnection(ctx context.Context) connection.ConnectionTestResult {
 	tester := connection.NewTester(
+		connection.WithPortLintingTest(connection.PortLinter([]string{"9095"}, ttd.dataSource.Endpoint())),
 		connection.WithConnectivityTest(ttd.dataSource),
 		connection.WithPollingTest(connection.TracePollingTestStep(ttd)),
 		connection.WithAuthenticationTest(connection.NewTestStep(func(ctx context.Context) (string, error) {

--- a/server/tracedb/tempodb.go
+++ b/server/tracedb/tempodb.go
@@ -21,6 +21,10 @@ import (
 	"google.golang.org/grpc/status"
 )
 
+func tempoDefaultPorts() []string {
+	return []string{"9095"}
+}
+
 type tempoTraceDB struct {
 	realTraceDB
 	dataSource datasource.DataSource
@@ -43,7 +47,7 @@ func (tdb *tempoTraceDB) Connect(ctx context.Context) error {
 
 func (ttd *tempoTraceDB) TestConnection(ctx context.Context) connection.ConnectionTestResult {
 	tester := connection.NewTester(
-		connection.WithPortLintingTest(connection.PortLinter([]string{"9095"}, ttd.dataSource.Endpoint())),
+		connection.WithPortLintingTest(connection.PortLinter(tempoDefaultPorts(), ttd.dataSource.Endpoint())),
 		connection.WithConnectivityTest(ttd.dataSource),
 		connection.WithPollingTest(connection.TracePollingTestStep(ttd)),
 		connection.WithAuthenticationTest(connection.NewTestStep(func(ctx context.Context) (string, error) {

--- a/web/src/components/TestConnectionNotification/TestConnectionNotification.styled.ts
+++ b/web/src/components/TestConnectionNotification/TestConnectionNotification.styled.ts
@@ -12,7 +12,7 @@ export const FailedCheckIcon = styled(MinusCircleFilled)`
   margin-top: 3px;
 `;
 
-export const WarningCheckICon = styled(WarningFilled)`
+export const WarningCheckIcon = styled(WarningFilled)`
   color: ${({theme}) => theme.color.warningYellow};
   margin-top: 3px;
 `;

--- a/web/src/components/TestConnectionNotification/TestConnectionNotification.styled.ts
+++ b/web/src/components/TestConnectionNotification/TestConnectionNotification.styled.ts
@@ -1,4 +1,4 @@
-import {CheckCircleFilled, MinusCircleFilled} from '@ant-design/icons';
+import {CheckCircleFilled, MinusCircleFilled, WarningFilled} from '@ant-design/icons';
 import styled from 'styled-components';
 import {Typography} from 'antd';
 
@@ -9,6 +9,11 @@ export const SuccessCheckIcon = styled(CheckCircleFilled)`
 
 export const FailedCheckIcon = styled(MinusCircleFilled)`
   color: ${({theme}) => theme.color.error};
+  margin-top: 3px;
+`;
+
+export const WarningCheckICon = styled(WarningFilled)`
+  color: ${({theme}) => theme.color.warningYellow};
   margin-top: 3px;
 `;
 

--- a/web/src/components/TestConnectionNotification/TestConnectionNotification.tsx
+++ b/web/src/components/TestConnectionNotification/TestConnectionNotification.tsx
@@ -6,9 +6,10 @@ interface IProps {
   result: TConnectionResult;
 }
 
-const TestConnectionNotification = ({result: {authentication, connectivity, fetchTraces}}: IProps) => {
+const TestConnectionNotification = ({result: {endpointLinting, authentication, connectivity, fetchTraces}}: IProps) => {
   return (
     <S.Container>
+      <TestConnectionStep step={endpointLinting} title="Port checking" />
       <TestConnectionStep step={connectivity} title="Connectivity" />
       <TestConnectionStep step={authentication} title="Authentication" />
       <TestConnectionStep step={fetchTraces} title="Fetch traces" />

--- a/web/src/components/TestConnectionNotification/TestConnectionNotification.tsx
+++ b/web/src/components/TestConnectionNotification/TestConnectionNotification.tsx
@@ -6,10 +6,10 @@ interface IProps {
   result: TConnectionResult;
 }
 
-const TestConnectionNotification = ({result: {endpointLinting, authentication, connectivity, fetchTraces}}: IProps) => {
+const TestConnectionNotification = ({result: {portCheck, authentication, connectivity, fetchTraces}}: IProps) => {
   return (
     <S.Container>
-      <TestConnectionStep step={endpointLinting} title="Port checking" />
+      <TestConnectionStep step={portCheck} title="Port checking" />
       <TestConnectionStep step={connectivity} title="Connectivity" />
       <TestConnectionStep step={authentication} title="Authentication" />
       <TestConnectionStep step={fetchTraces} title="Fetch traces" />

--- a/web/src/components/TestConnectionNotification/TestConnectionStep.tsx
+++ b/web/src/components/TestConnectionNotification/TestConnectionStep.tsx
@@ -7,12 +7,14 @@ interface IProps {
   title: string;
 }
 
+const iconMap = {
+  passed: <S.SuccessCheckIcon />,
+  failed: <S.FailedCheckIcon />,
+  warning: <S.WarningCheckICon />,
+};
+
 const TestConnectionStep = ({step: {message, error: err, status}, title}: IProps) => {
-  const iconMap = {
-    'passed': <S.SuccessCheckIcon />,
-    'failed': <S.FailedCheckIcon />,
-    'passed_with_warning': <S.WarningCheckICon />,
-  };
+
 
   const icon = iconMap[status];
 

--- a/web/src/components/TestConnectionNotification/TestConnectionStep.tsx
+++ b/web/src/components/TestConnectionNotification/TestConnectionStep.tsx
@@ -7,10 +7,18 @@ interface IProps {
   title: string;
 }
 
-const TestConnectionStep = ({step: {message, error: err, passed}, title}: IProps) => {
+const TestConnectionStep = ({step: {message, error: err, status}, title}: IProps) => {
+  const iconMap = {
+    'passed': <S.SuccessCheckIcon />,
+    'failed': <S.FailedCheckIcon />,
+    'passed_with_warning': <S.WarningCheckICon />,
+  };
+
+  const icon = iconMap[status];
+
   return message || err ? (
     <S.StepContainer>
-      {passed ? <S.SuccessCheckIcon /> : <S.FailedCheckIcon />}
+      {icon}
       <div>
         <S.Title level={3}>{title}</S.Title>
         <Typography.Text>{message}</Typography.Text>

--- a/web/src/components/TestConnectionNotification/TestConnectionStep.tsx
+++ b/web/src/components/TestConnectionNotification/TestConnectionStep.tsx
@@ -10,7 +10,7 @@ interface IProps {
 const iconMap = {
   passed: <S.SuccessCheckIcon />,
   failed: <S.FailedCheckIcon />,
-  warning: <S.WarningCheckICon />,
+  warning: <S.WarningCheckIcon />,
 };
 
 const TestConnectionStep = ({step: {message, error: err, status}, title}: IProps) => {

--- a/web/src/models/ConnectionResult.model.ts
+++ b/web/src/models/ConnectionResult.model.ts
@@ -6,6 +6,7 @@ type ConnectionResult = Model<
   TRawConnectionResult,
   {
     allPassed: boolean;
+    endpointLinting: ConnectionTestStep;
     authentication: ConnectionTestStep;
     connectivity: ConnectionTestStep;
     fetchTraces: ConnectionTestStep;
@@ -13,16 +14,19 @@ type ConnectionResult = Model<
 >;
 
 const ConnectionResult = ({
+  endpointLinting: rawEndpointLinting = {},
   authentication: rawAuthentication = {},
   connectivity: rawConnectivity = {},
   fetchTraces: rawFetchTraces = {},
 }: TRawConnectionResult): ConnectionResult => {
+  const endpointLinting = ConnectionTestStep(rawEndpointLinting);
   const authentication = ConnectionTestStep(rawAuthentication);
   const connectivity = ConnectionTestStep(rawConnectivity);
   const fetchTraces = ConnectionTestStep(rawFetchTraces);
 
   return {
-    allPassed: authentication.passed && connectivity.passed && fetchTraces.passed,
+    allPassed: endpointLinting.status && authentication.passed && connectivity.passed && fetchTraces.passed,
+    endpointLinting,
     authentication,
     connectivity,
     fetchTraces,

--- a/web/src/models/ConnectionResult.model.ts
+++ b/web/src/models/ConnectionResult.model.ts
@@ -6,7 +6,7 @@ type ConnectionResult = Model<
   TRawConnectionResult,
   {
     allPassed: boolean;
-    endpointLinting: ConnectionTestStep;
+    portCheck: ConnectionTestStep;
     authentication: ConnectionTestStep;
     connectivity: ConnectionTestStep;
     fetchTraces: ConnectionTestStep;
@@ -14,19 +14,19 @@ type ConnectionResult = Model<
 >;
 
 const ConnectionResult = ({
-  endpointLinting: rawEndpointLinting = {},
+  portCheck: rawPortCheck = {},
   authentication: rawAuthentication = {},
   connectivity: rawConnectivity = {},
   fetchTraces: rawFetchTraces = {},
 }: TRawConnectionResult): ConnectionResult => {
-  const endpointLinting = ConnectionTestStep(rawEndpointLinting);
+  const portCheck = ConnectionTestStep(rawPortCheck);
   const authentication = ConnectionTestStep(rawAuthentication);
   const connectivity = ConnectionTestStep(rawConnectivity);
   const fetchTraces = ConnectionTestStep(rawFetchTraces);
 
   return {
-    allPassed: endpointLinting.status && authentication.passed && connectivity.passed && fetchTraces.passed,
-    endpointLinting,
+    allPassed: portCheck.status && authentication.passed && connectivity.passed && fetchTraces.passed,
+    portCheck,
     authentication,
     connectivity,
     fetchTraces,

--- a/web/src/models/ConnectionResultStep.model.ts
+++ b/web/src/models/ConnectionResultStep.model.ts
@@ -5,10 +5,12 @@ type ConnectionTestStep = Model<TRawConnectionTestStep, {}>;
 
 const ConnectionTestStep = ({
   passed = false,
+  status = 'passed',
   error = '',
   message = '',
 }: TRawConnectionTestStep): ConnectionTestStep => ({
   passed,
+  status,
   error,
   message,
 });

--- a/web/src/types/Config.types.ts
+++ b/web/src/types/Config.types.ts
@@ -45,7 +45,7 @@ export type TConnectionResult = Model<
   TRawConnectionResult,
   {
     allPassed: boolean;
-    endpointLinting: ConnectionTestStep;
+    portCheck: ConnectionTestStep;
     authentication: ConnectionTestStep;
     connectivity: ConnectionTestStep;
     fetchTraces: ConnectionTestStep;

--- a/web/src/types/Config.types.ts
+++ b/web/src/types/Config.types.ts
@@ -45,6 +45,7 @@ export type TConnectionResult = Model<
   TRawConnectionResult,
   {
     allPassed: boolean;
+    endpointLinting: ConnectionTestStep;
     authentication: ConnectionTestStep;
     connectivity: ConnectionTestStep;
     fetchTraces: ConnectionTestStep;

--- a/web/src/types/Generated.types.ts
+++ b/web/src/types/Generated.types.ts
@@ -1057,7 +1057,7 @@ export interface external {
           steps?: external["config.yaml"]["components"]["schemas"]["ConnectionResult"][];
         };
         ConnectionResult: {
-          endpointLinting?: external["config.yaml"]["components"]["schemas"]["ConnectionTestStep"];
+          portCheck?: external["config.yaml"]["components"]["schemas"]["ConnectionTestStep"];
           connectivity?: external["config.yaml"]["components"]["schemas"]["ConnectionTestStep"];
           authentication?: external["config.yaml"]["components"]["schemas"]["ConnectionTestStep"];
           fetchTraces?: external["config.yaml"]["components"]["schemas"]["ConnectionTestStep"];
@@ -1065,7 +1065,7 @@ export interface external {
         ConnectionTestStep: {
           passed?: boolean;
           /** @enum {string} */
-          status?: "passed" | "passed_with_warning" | "failed";
+          status?: "passed" | "warning" | "failed";
           message?: string;
           error?: string;
         };

--- a/web/src/types/Generated.types.ts
+++ b/web/src/types/Generated.types.ts
@@ -1057,12 +1057,15 @@ export interface external {
           steps?: external["config.yaml"]["components"]["schemas"]["ConnectionResult"][];
         };
         ConnectionResult: {
+          endpointLinting?: external["config.yaml"]["components"]["schemas"]["ConnectionTestStep"];
           connectivity?: external["config.yaml"]["components"]["schemas"]["ConnectionTestStep"];
           authentication?: external["config.yaml"]["components"]["schemas"]["ConnectionTestStep"];
           fetchTraces?: external["config.yaml"]["components"]["schemas"]["ConnectionTestStep"];
         };
         ConnectionTestStep: {
           passed?: boolean;
+          /** @enum {string} */
+          status?: "passed" | "passed_with_warning" | "failed";
           message?: string;
           error?: string;
         };


### PR DESCRIPTION
This PR adds a step to the data store test which validates the used port. If it's not a standard port, show a warning to the user and point to the correct port.

![image](https://user-images.githubusercontent.com/2704737/221919256-f964769d-713f-4778-a5e0-f96a85bb3ba1.png)


## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [x] added a test

Loom: https://www.loom.com/share/7105d6d5268c411a84665d896eb3cf4e