### PR TITLE
fix: remove disabled state from Test Connection button

### DIFF
--- a/server/tracedb/connection/connectivity_step.go
+++ b/server/tracedb/connection/connectivity_step.go
@@ -29,6 +29,13 @@ func (s *connectivityTestStep) TestConnection(_ context.Context) ConnectionTestS
 		}
 	}
 
+	if len(s.endpoints) == 0 {
+		return ConnectionTestStepResult{
+			OperationDescription: "Tracetest tried to connect but no endpoints were provided",
+			Error:                fmt.Errorf("no endpoints provided"),
+		}
+	}
+
 	if connectionErr != nil {
 		endpoints := strings.Join(unreachableEndpoints, ", ")
 		return ConnectionTestStepResult{

--- a/server/tracedb/elasticsearchdb.go
+++ b/server/tracedb/elasticsearchdb.go
@@ -42,10 +42,10 @@ func (db elasticsearchDB) TestConnection(ctx context.Context) connection.Connect
 		connection.WithAuthenticationTest(connection.NewTestStep(func(ctx context.Context) (string, error) {
 			_, err := getClusterInfo(db.client)
 			if err != nil {
-				return "Tracetest tried to execute an OpenSearch API request but it failed due to authentication issues", err
+				return "Tracetest tried to execute an ElasticSearch API request but it failed due to authentication issues", err
 			}
 
-			return "Tracetest managed to authenticate with OpenSearch", nil
+			return "Tracetest managed to authenticate with ElasticSearch", nil
 		})),
 	)
 

--- a/web/src/components/Settings/DataStoreForm/DataStoreForm.tsx
+++ b/web/src/components/Settings/DataStoreForm/DataStoreForm.tsx
@@ -96,13 +96,7 @@ const DataStoreForm = ({
               <div />
             )}
             <S.SaveContainer>
-              <Button
-                loading={isTestConnectionLoading}
-                disabled={!isFormValid}
-                type="primary"
-                ghost
-                onClick={onTestConnection}
-              >
+              <Button loading={isTestConnectionLoading} type="primary" ghost onClick={onTestConnection}>
                 Test Connection
               </Button>
               <Button disabled={!isFormValid} loading={isLoading} type="primary" onClick={() => form.submit()}>


### PR DESCRIPTION
This PR removes the disabled state from the Test Data Store Connection button. It also includes a new validation in the server for empty endpoints.

## Changes

- remove disabled Test Connection button
- extra validation for empty endpoints

## Fixes

- fixes #2057 

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
