### PR TITLE
Adding defer logic to config resource

### DIFF
--- a/server/config/configresource/config_resource.go
+++ b/server/config/configresource/config_resource.go
@@ -49,6 +49,7 @@ func (r *repository) Create(ctx context.Context, cfg Config) (Config, error) {
 	if err != nil {
 		return Config{}, err
 	}
+	defer tx.Rollback()
 
 	_, err = tx.ExecContext(ctx, insertQuery,
 		cfg.ID,
@@ -57,7 +58,6 @@ func (r *repository) Create(ctx context.Context, cfg Config) (Config, error) {
 	)
 
 	if err != nil {
-		tx.Rollback()
 		return Config{}, fmt.Errorf("sql exec: %w", err)
 	}
 
@@ -85,6 +85,7 @@ func (r *repository) Update(ctx context.Context, updated Config) (Config, error)
 	if err != nil {
 		return Config{}, err
 	}
+	defer tx.Rollback()
 
 	_, err = tx.ExecContext(ctx, updateQuery,
 		cfg.ID,
@@ -93,7 +94,6 @@ func (r *repository) Update(ctx context.Context, updated Config) (Config, error)
 	)
 
 	if err != nil {
-		tx.Rollback()
 		return Config{}, fmt.Errorf("sql exec: %w", err)
 	}
 
@@ -139,11 +139,11 @@ func (r *repository) Delete(ctx context.Context, id id.ID) error {
 	if err != nil {
 		return err
 	}
+	defer tx.Rollback()
 
 	_, err = tx.ExecContext(ctx, deleteQuery, cfg.ID)
 
 	if err != nil {
-		tx.Rollback()
 		return fmt.Errorf("sql exec: %w", err)
 	}
 

--- a/server/testdb/data_stores.go
+++ b/server/testdb/data_stores.go
@@ -86,11 +86,11 @@ func (td *postgresDB) DeleteDataStore(ctx context.Context, dataStore model.DataS
 	if err != nil {
 		return fmt.Errorf("sql BeginTx: %w", err)
 	}
+	defer tx.Rollback()
 
 	_, err = tx.ExecContext(ctx, deleteFromDataStoresQuery, dataStore.ID)
 
 	if err != nil {
-		tx.Rollback()
 		return fmt.Errorf("sql error: %w", err)
 	}
 
@@ -256,12 +256,12 @@ func (td *postgresDB) insertIntoDataStores(ctx context.Context, dataStore model.
 	if err != nil {
 		return model.DataStore{}, fmt.Errorf("sql BeginTx: %w", err)
 	}
+	defer tx.Rollback()
 
 	if dataStore.IsDefault {
 		_, err = tx.ExecContext(ctx, updateAllDefaultDataStoresQuery)
 
 		if err != nil {
-			tx.Rollback()
 			return model.DataStore{}, fmt.Errorf("sql exec: %w", err)
 		}
 	}
@@ -280,7 +280,6 @@ func (td *postgresDB) insertIntoDataStores(ctx context.Context, dataStore model.
 		dataStore.CreatedAt)
 
 	if err != nil {
-		tx.Rollback()
 		return model.DataStore{}, fmt.Errorf("sql exec: %w", err)
 	}
 
@@ -297,12 +296,12 @@ func (td *postgresDB) updateIntoDataStores(ctx context.Context, dataStore model.
 	if err != nil {
 		return model.DataStore{}, fmt.Errorf("sql BeginTx: %w", err)
 	}
+	defer tx.Rollback()
 
 	if dataStore.IsDefault {
 		_, err = tx.ExecContext(ctx, updateAllDefaultDataStoresQuery)
 
 		if err != nil {
-			tx.Rollback()
 			return model.DataStore{}, fmt.Errorf("sql exec: %w", err)
 		}
 	}
@@ -322,7 +321,6 @@ func (td *postgresDB) updateIntoDataStores(ctx context.Context, dataStore model.
 		dataStore.CreatedAt)
 
 	if err != nil {
-		tx.Rollback()
 		return model.DataStore{}, fmt.Errorf("sql exec: %w", err)
 	}
 

--- a/server/testdb/environments.go
+++ b/server/testdb/environments.go
@@ -79,11 +79,11 @@ func (td *postgresDB) DeleteEnvironment(ctx context.Context, environment model.E
 	if err != nil {
 		return fmt.Errorf("sql BeginTx: %w", err)
 	}
+	defer tx.Rollback()
 
 	_, err = tx.ExecContext(ctx, deleteQuery, environment.ID)
 
 	if err != nil {
-		tx.Rollback()
 		return fmt.Errorf("sql error: %w", err)
 	}
 

--- a/server/testdb/runs.go
+++ b/server/testdb/runs.go
@@ -140,10 +140,10 @@ func (td *postgresDB) CreateRun(ctx context.Context, test model.Test, run model.
 	if err != nil {
 		return model.Run{}, fmt.Errorf("sql beginTx: %w", err)
 	}
+	defer tx.Rollback()
 
 	_, err = tx.ExecContext(ctx, replaceRunSequenceName(createSequeceQuery, test.ID))
 	if err != nil {
-		tx.Rollback()
 		return model.Run{}, fmt.Errorf("sql exec: %w", err)
 	}
 
@@ -166,7 +166,6 @@ func (td *postgresDB) CreateRun(ctx context.Context, test model.Test, run model.
 		jsonEnvironment,
 	).Scan(&runID)
 	if err != nil {
-		tx.Rollback()
 		return model.Run{}, fmt.Errorf("sql exec: %w", err)
 	}
 
@@ -287,11 +286,11 @@ func (td *postgresDB) DeleteRun(ctx context.Context, r model.Run) error {
 	if err != nil {
 		return fmt.Errorf("sql BeginTx: %w", err)
 	}
+	defer tx.Rollback()
 
 	for _, sql := range queries {
 		_, err := tx.ExecContext(ctx, sql, r.ID, r.TestID)
 		if err != nil {
-			tx.Rollback()
 			return fmt.Errorf("sql error: %w", err)
 		}
 	}
@@ -327,7 +326,7 @@ SELECT
 	"test_results",
 	"trace",
 	"outputs",
-	"last_error",	
+	"last_error",
 	"metadata",
 	"environment",
 

--- a/server/testdb/tests.go
+++ b/server/testdb/tests.go
@@ -129,11 +129,11 @@ func (td *postgresDB) DeleteTest(ctx context.Context, test model.Test) error {
 	if err != nil {
 		return fmt.Errorf("sql BeginTx: %w", err)
 	}
+	defer tx.Rollback()
 
 	for _, sql := range queries {
 		_, err := tx.ExecContext(ctx, sql, test.ID)
 		if err != nil {
-			tx.Rollback()
 			return fmt.Errorf("sql error: %w", err)
 		}
 	}


### PR DESCRIPTION
This PR aims to add a `defer` logic into every transaction that we open on `database/sql` package, following this: https://go.dev/doc/database/execute-transactions

## Changes

- Added `defer` logic to every `tx.Rollback()`

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
