### PR TITLE
fix(server): force extension on config file lookup

### DIFF
--- a/go.work.sum
+++ b/go.work.sum
@@ -163,6 +163,7 @@ github.com/aws/aws-sdk-go-v2/service/sts v1.18.3/go.mod h1:b+psTJn33Q4qGoDaM7ZiO
 github.com/aws/smithy-go v1.13.5/go.mod h1:Tg+OJXh4MB2R/uN61Ko2f6hTZwB/ZYGOtib8J3gBHzA=
 github.com/benbjohnson/clock v1.3.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/cenkalti/backoff v2.2.1+incompatible h1:tNowT99t7UNflLxfYYSlKYsBpXdEet03Pg2g16Swow4=
+github.com/creack/pty v1.1.11 h1:07n33Z8lZxZ2qwegKbObQohDhXDQxiMMz1NOUGYlesw=
 github.com/felixge/httpsnoop v1.0.3 h1:s/nj+GCswXYzN5v2DpNMuMQYe+0DDwt5WVCU6CWBdXk=
 github.com/felixge/httpsnoop v1.0.3/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/frankban/quicktest v1.14.3/go.mod h1:mgiwOwqx65TmIk1wJ6Q7wvnVMocbUorkibMOrVTHZps=
@@ -170,6 +171,7 @@ github.com/fsnotify/fsnotify v1.5.4/go.mod h1:OVB6XrOHzAwXMpEM7uPOzcehqUV2UqJxmV
 github.com/go-kit/log v0.2.1/go.mod h1:NwTd00d/i8cPZ3xOwwiv2PO5MOcx78fFErGNcVmBjv0=
 github.com/go-ole/go-ole v1.2.6/go.mod h1:pprOEPIfldk/42T2oK7lQ4v4JSDwmV0As9GaiUsvbm0=
 github.com/go-redis/redis v6.15.9+incompatible h1:K0pv1D7EQUjfyoMql+r/jZqCLizCGKFlFgcHWWmHQjg=
+github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da h1:oI5xCqsCo564l8iNU+DwB5epxmsaqB+rhGL0m5jtYqE=
 github.com/googleapis/enterprise-certificate-proxy v0.0.0-20220520183353-fd19c99a87aa/go.mod h1:17drOmN3MwGY7t0e+Ei9b45FFGA3fBs3x36SsCg1hq8=
 github.com/googleapis/enterprise-certificate-proxy v0.1.0/go.mod h1:17drOmN3MwGY7t0e+Ei9b45FFGA3fBs3x36SsCg1hq8=
 github.com/googleapis/gax-go/v2 v2.2.0/go.mod h1:as02EH8zWkzwUoLbBaFeQ+arQaj/OthfcblKl4IGNaM=
@@ -247,7 +249,6 @@ golang.org/x/sys v0.0.0-20220624220833-87e55d714810/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20220708085239-5a0f0661e09d/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220808155132-1c4a2a72c664/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.1.0 h1:g6Z6vPFA9dYBAF7DWcH6sCcOntplXsDKcliusYijMlw=
-golang.org/x/term v0.5.0/go.mod h1:jMB1sMXY+tzblOD4FWmEbocvup2/aLOaQEp7JmGp78k=
 golang.org/x/tools v0.2.0/go.mod h1:y4OqIKeOV/fWJetJ8bXPU1sEVniLMIyDAZWeHdV+NTA=
 golang.org/x/xerrors v0.0.0-20220411194840-2f41105eb62f/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20220517211312-f3a8303e98df/go.mod h1:K8+ghG5WaK9qNqU5K3HdILfMLy1f3aNYFI/wnl100a8=

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -76,8 +76,7 @@ func (opts options) registerFlags(flags *pflag.FlagSet) {
 var configOptions options
 
 func configureConfigFile(vp *viper.Viper) {
-	vp.SetConfigName("tracetest")
-	vp.SetConfigType("yaml")
+	vp.SetConfigName("tracetest.yaml")
 	vp.AddConfigPath("/etc/tracetest")
 	vp.AddConfigPath("$HOME/.tracetest")
 	vp.AddConfigPath(".")
@@ -85,7 +84,7 @@ func configureConfigFile(vp *viper.Viper) {
 
 var ErrConfigFileNotFound = errors.New("config file not found")
 
-func readConfigFile(vp *viper.Viper) error {
+func loadConfig(vp *viper.Viper, logger logger) error {
 	if confFile := vp.GetString("config"); confFile != "" {
 		// if --config is passed, and the file does not exists
 		// it will trigger a "no such file or directory" error
@@ -95,6 +94,7 @@ func readConfigFile(vp *viper.Viper) error {
 	}
 
 	err := vp.ReadInConfig()
+	logger.Println("Config file used: ", vp.ConfigFileUsed())
 	if err == nil {
 		return nil
 	}
@@ -128,7 +128,7 @@ func New(flags *pflag.FlagSet, logger logger) (*Config, error) {
 
 	configOptions.registerDefaults(vp)
 
-	err := readConfigFile(vp)
+	err := loadConfig(vp, logger)
 	if err != nil {
 		return nil, err
 	}

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -76,7 +76,9 @@ func (opts options) registerFlags(flags *pflag.FlagSet) {
 var configOptions options
 
 func configureConfigFile(vp *viper.Viper) {
-	vp.SetConfigName("tracetest.yaml")
+	vp.SetConfigName("tracetest")
+	// intentionally removed this line, because it allows to have config files without extensions
+	// vp.SetConfigType("yaml")
 	vp.AddConfigPath("/etc/tracetest")
 	vp.AddConfigPath("$HOME/.tracetest")
 	vp.AddConfigPath(".")

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -94,7 +94,9 @@ func loadConfig(vp *viper.Viper, logger logger) error {
 	}
 
 	err := vp.ReadInConfig()
-	logger.Println("Config file used: ", vp.ConfigFileUsed())
+	if path := vp.ConfigFileUsed(); path != "" {
+		logger.Println("Config file used: ", path)
+	}
 	if err == nil {
 		return nil
 	}

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -128,6 +128,8 @@ func New(flags *pflag.FlagSet, logger logger) (*Config, error) {
 
 	configOptions.registerDefaults(vp)
 
+	warnAboutDeprecatedFields(vp, logger)
+
 	err := loadConfig(vp, logger)
 	if err != nil {
 		return nil, err

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -130,8 +130,6 @@ func New(flags *pflag.FlagSet, logger logger) (*Config, error) {
 
 	configOptions.registerDefaults(vp)
 
-	warnAboutDeprecatedFields(vp, logger)
-
 	err := loadConfig(vp, logger)
 	if err != nil {
 		return nil, err

--- a/server/config/config_test.go
+++ b/server/config/config_test.go
@@ -74,4 +74,46 @@ func TestFlags(t *testing.T) {
 		assert.Equal(t, 3*time.Second, cfg.PoolingRetryDelay())
 	})
 
+	t.Run("ConfigFileDefault", func(t *testing.T) {
+		t.Parallel()
+
+		t.Run("OK", func(t *testing.T) {
+			// copy an example config file to the default location
+			err := copyFile("./testdata/basic.yaml", "./tracetest.yaml")
+			defer os.Remove("./tracetest.yaml")
+
+			require.NoError(t, err)
+
+			cfg, err := config.New(nil, log.Default())
+			require.NoError(t, err)
+
+			// this one assertion is enough to guarantee we're not using the defaults
+			assert.Equal(t, 9999, cfg.ServerPort())
+		})
+
+		t.Run("MustHaveExtension", func(t *testing.T) {
+			// copy an example config file to the default location
+			err := copyFile("./testdata/basic.yaml", "./tracetest")
+			defer os.Remove("./tracetest")
+
+			require.NoError(t, err)
+
+			cfg, err := config.New(nil, log.Default())
+			require.NoError(t, err)
+
+			// the config file would change this value to 9999, but we want to make sure
+			// the file is NOT being read, since it doesn't have the .yaml extension
+			assert.Equal(t, 11633, cfg.ServerPort())
+		})
+	})
+
+}
+
+func copyFile(in, out string) error {
+	b, err := os.ReadFile(in)
+	if err != nil {
+		return err
+	}
+
+	return os.WriteFile(out, b, 0644)
 }

--- a/server/config/config_test.go
+++ b/server/config/config_test.go
@@ -77,6 +77,9 @@ func TestFlags(t *testing.T) {
 	t.Run("ConfigFileDefault", func(t *testing.T) {
 		t.Parallel()
 
+		// These tests are not great, since they rely on file writing and removing.
+		// Becase of this, the tests cannot be run in parallel because they might interfer with each other.
+
 		t.Run("OK", func(t *testing.T) {
 			// copy an example config file to the default location
 			err := copyFile("./testdata/basic.yaml", "./tracetest.yaml")

--- a/server/config/deprecation_test.go
+++ b/server/config/deprecation_test.go
@@ -2,6 +2,7 @@ package config_test
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/kubeshop/tracetest/server/config"
@@ -21,7 +22,13 @@ func newLogger() *logger {
 }
 
 func (l *logger) Println(in ...any) {
-	l.messages = append(l.messages, fmt.Sprintf("%s", in...))
+	str := fmt.Sprint(in...)
+
+	// ignore config file messages
+	if strings.HasPrefix(str, "Config file used:") {
+		return
+	}
+	l.messages = append(l.messages, str)
 }
 
 func TestDeprecatedOptions(t *testing.T) {


### PR DESCRIPTION
The server was accepting a config file with a name matching the expected config name but without the extension as a valid config file. This caused that in docker, where we have the cli binary in `/app/tracetest`, the server was trying to read said binary as a config file, obviously failing.


## Changes

- enforce config file with extension to avoid collisions.

## Fixes

- #2071

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
