### PR TITLE
Fixing block for OTLP based data stores

### DIFF
--- a/server/model/data_stores.go
+++ b/server/model/data_stores.go
@@ -98,10 +98,21 @@ var validTypes = []DataStoreType{
 	DataStoreTypeAwsXRay,
 }
 
+var otlpBasedDataStores = []DataStoreType{
+	DataStoreTypeOTLP,
+	DataStoreTypeNewRelic,
+	DataStoreTypeLighStep,
+	DataStoreTypeDataDog,
+}
+
 func (ds DataStore) Validate() error {
 	if !slices.Contains(validTypes, ds.Type) {
 		return fmt.Errorf("unsupported data store")
 	}
 
 	return nil
+}
+
+func (ds DataStore) IsOTLPBasedProvider() bool {
+	return slices.Contains(otlpBasedDataStores, ds.Type)
 }

--- a/server/otlp/server.go
+++ b/server/otlp/server.go
@@ -47,7 +47,7 @@ func (s *Server) Stop() {
 func (s Server) Export(ctx context.Context, request *pb.ExportTraceServiceRequest) (*pb.ExportTraceServiceResponse, error) {
 	ds, err := s.db.DefaultDataStore(ctx)
 
-	if err != nil || ds.Type != "otlp" {
+	if err != nil || !ds.IsOTLPBasedProvider() {
 		fmt.Println("OTLP server is not enabled. Ignoring request")
 		return &pb.ExportTraceServiceResponse{}, nil
 	}


### PR DESCRIPTION
This PR aims to allow users to setup different options to use on OTel Collector setup.

Context: https://github.com/kubeshop/tracetest/issues/2053

## Changes

- Data Store validation on internal OTLP server

## Fixes

- https://github.com/kubeshop/tracetest/issues/2053

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
