### PR TITLE
chore(server): remove duplicated call to `readConfigFile` func

### DIFF
--- a/go.work.sum
+++ b/go.work.sum
@@ -247,6 +247,7 @@ golang.org/x/sys v0.0.0-20220624220833-87e55d714810/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20220708085239-5a0f0661e09d/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220808155132-1c4a2a72c664/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.1.0 h1:g6Z6vPFA9dYBAF7DWcH6sCcOntplXsDKcliusYijMlw=
+golang.org/x/term v0.5.0/go.mod h1:jMB1sMXY+tzblOD4FWmEbocvup2/aLOaQEp7JmGp78k=
 golang.org/x/tools v0.2.0/go.mod h1:y4OqIKeOV/fWJetJ8bXPU1sEVniLMIyDAZWeHdV+NTA=
 golang.org/x/xerrors v0.0.0-20220411194840-2f41105eb62f/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20220517211312-f3a8303e98df/go.mod h1:K8+ghG5WaK9qNqU5K3HdILfMLy1f3aNYFI/wnl100a8=

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -128,12 +128,12 @@ func New(flags *pflag.FlagSet, logger logger) (*Config, error) {
 
 	configOptions.registerDefaults(vp)
 
-	warnAboutDeprecatedFields(vp, logger)
-
 	err := readConfigFile(vp)
 	if err != nil {
 		return nil, err
 	}
+
+	warnAboutDeprecatedFields(vp, logger)
 
 	oldConfig := oldConfig{}
 	err = vp.Unmarshal(&oldConfig)
@@ -188,11 +188,6 @@ func (c *Config) AnalyticsEnabled() bool {
 }
 
 func warnAboutDeprecatedFields(vp *viper.Viper, logger logger) error {
-	err := readConfigFile(vp)
-	if err != nil {
-		return err
-	}
-
 	for _, opt := range configOptions {
 		if !opt.deprecated {
 			continue


### PR DESCRIPTION
This PR removes a duplicated function call to `readConfigFile` when checking for deprecated configs

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
