### PR TITLE
docs: fix examples to use provision file

### DIFF
--- a/examples/collector/docker-compose.yml
+++ b/examples/collector/docker-compose.yml
@@ -8,6 +8,10 @@ services:
             - type: bind
               source: ./tracetest-config.yaml
               target: /app/tracetest.yaml
+            - type: bind
+              source: ./tracetest-provision.yaml
+              target: /app/provision.yaml
+        command: --provisioning-file /app/provision.yaml
         ports:
             - 11633:11633
         extra_hosts:

--- a/examples/collector/tracetest-provision.yaml
+++ b/examples/collector/tracetest-provision.yaml
@@ -1,0 +1,2 @@
+dataStore:
+  type: otlp

--- a/examples/observability-driven-development-go-tracetest/bookstore/part1/tracetest/docker-compose.yaml
+++ b/examples/observability-driven-development-go-tracetest/bookstore/part1/tracetest/docker-compose.yaml
@@ -73,6 +73,10 @@ services:
             - type: bind
               source: tracetest/tracetest.yaml
               target: /app/tracetest.yaml
+            - type: bind
+              source: tracetest/tracetest-provision.yaml
+              target: /app/provision.yaml
+        command: --provisioning-file /app/provision.yaml
 networks:
     default:
         name: _default

--- a/examples/observability-driven-development-go-tracetest/bookstore/part1/tracetest/tracetest-provision.yaml
+++ b/examples/observability-driven-development-go-tracetest/bookstore/part1/tracetest/tracetest-provision.yaml
@@ -1,0 +1,6 @@
+dataStore:
+  type: jaeger
+  jaeger:
+    endpoint: jaeger:16685
+    tls:
+      insecure: true

--- a/examples/observability-driven-development-go-tracetest/bookstore/part1/tracetest/tracetest.yaml
+++ b/examples/observability-driven-development-go-tracetest/bookstore/part1/tracetest/tracetest.yaml
@@ -6,9 +6,11 @@ demo:
         otelproductcatalog: otel-productcatalogservice:3550
         pokeshopgrpc: demo-api:8082
         pokeshophttp: http://demo-api:8081
+
 poolingconfig:
     maxwaittimefortrace: 2m
     retrydelay: 3s
+
 postgres:
   host: postgres
   user: postgres
@@ -16,36 +18,12 @@ postgres:
   port: 5432
   dbname: postgres
   params: sslmode=disable
+
 server:
     telemetry:
-        applicationexporter: collector
-        datastore: jaeger
         exporter: collector
+
 telemetry:
-    datastores:
-        jaeger:
-            jaeger:
-                auth: null
-                balancername: ""
-                compression: ""
-                endpoint: jaeger:16685
-                headers: {}
-                keepalive: null
-                readbuffersize: 0
-                tls:
-                    insecure: true
-                    insecureskipverify: false
-                    servername: ""
-                    tlssetting:
-                        cafile: ""
-                        certfile: ""
-                        keyfile: ""
-                        maxversion: ""
-                        minversion: ""
-                        reloadinterval: 0s
-                waitforready: false
-                writebuffersize: 0
-            type: jaeger
     exporters:
         collector:
             exporter:

--- a/examples/observability-driven-development-go-tracetest/bookstore/part2.1/tracetest/docker-compose.yaml
+++ b/examples/observability-driven-development-go-tracetest/bookstore/part2.1/tracetest/docker-compose.yaml
@@ -61,7 +61,7 @@ services:
             interval: 1s
             retries: 60
         image: kubeshop/tracetest:latest
-    platform: linux/amd64
+        platform: linux/amd64
         networks:
             default: null
         ports:
@@ -73,6 +73,10 @@ services:
             - type: bind
               source: tracetest/tracetest.yaml
               target: /app/tracetest.yaml
+            - type: bind
+              source: tracetest/tracetest-provision.yaml
+              target: /app/provision.yaml
+        command: --provisioning-file /app/provision.yaml
 networks:
     default:
         name: _default

--- a/examples/observability-driven-development-go-tracetest/bookstore/part2.1/tracetest/tracetest-provision.yaml
+++ b/examples/observability-driven-development-go-tracetest/bookstore/part2.1/tracetest/tracetest-provision.yaml
@@ -1,0 +1,6 @@
+dataStore:
+  type: jaeger
+  jaeger:
+    endpoint: jaeger:16685
+    tls:
+      insecure: true

--- a/examples/observability-driven-development-go-tracetest/bookstore/part2.1/tracetest/tracetest.yaml
+++ b/examples/observability-driven-development-go-tracetest/bookstore/part2.1/tracetest/tracetest.yaml
@@ -9,9 +9,11 @@ demo:
         otelproductcatalog: otel-productcatalogservice:3550
         pokeshopgrpc: demo-api:8082
         pokeshophttp: http://demo-api:8081
+
 poolingconfig:
     maxwaittimefortrace: 2m
     retrydelay: 3s
+
 postgres:
   host: postgres
   user: postgres
@@ -19,36 +21,12 @@ postgres:
   port: 5432
   dbname: postgres
   params: sslmode=disable
+
 server:
     telemetry:
-        applicationexporter: collector
-        datastore: jaeger
         exporter: collector
+
 telemetry:
-    datastores:
-        jaeger:
-            jaeger:
-                auth: null
-                balancername: ""
-                compression: ""
-                endpoint: jaeger:16685
-                headers: {}
-                keepalive: null
-                readbuffersize: 0
-                tls:
-                    insecure: true
-                    insecureskipverify: false
-                    servername: ""
-                    tlssetting:
-                        cafile: ""
-                        certfile: ""
-                        keyfile: ""
-                        maxversion: ""
-                        minversion: ""
-                        reloadinterval: 0s
-                waitforready: false
-                writebuffersize: 0
-            type: jaeger
     exporters:
         collector:
             exporter:

--- a/examples/observability-driven-development-go-tracetest/bookstore/part2.2/tracetest/docker-compose.yaml
+++ b/examples/observability-driven-development-go-tracetest/bookstore/part2.2/tracetest/docker-compose.yaml
@@ -73,6 +73,10 @@ services:
             - type: bind
               source: tracetest/tracetest.yaml
               target: /app/tracetest.yaml
+            - type: bind
+              source: tracetest/tracetest-provision.yaml
+              target: /app/provision.yaml
+        command: --provisioning-file /app/provision.yaml
 networks:
     default:
         name: _default

--- a/examples/observability-driven-development-go-tracetest/bookstore/part2.2/tracetest/tracetest-provision.yaml
+++ b/examples/observability-driven-development-go-tracetest/bookstore/part2.2/tracetest/tracetest-provision.yaml
@@ -1,0 +1,6 @@
+dataStore:
+  type: jaeger
+  jaeger:
+    endpoint: jaeger:16685
+    tls:
+      insecure: true

--- a/examples/observability-driven-development-go-tracetest/bookstore/part2.2/tracetest/tracetest.yaml
+++ b/examples/observability-driven-development-go-tracetest/bookstore/part2.2/tracetest/tracetest.yaml
@@ -9,9 +9,11 @@ demo:
         otelproductcatalog: otel-productcatalogservice:3550
         pokeshopgrpc: demo-api:8082
         pokeshophttp: http://demo-api:8081
+
 poolingconfig:
     maxwaittimefortrace: 2m
     retrydelay: 3s
+
 postgres:
   host: postgres
   user: postgres
@@ -19,36 +21,14 @@ postgres:
   port: 5432
   dbname: postgres
   params: sslmode=disable
+
 server:
     telemetry:
         applicationexporter: collector
         datastore: jaeger
         exporter: collector
+
 telemetry:
-    datastores:
-        jaeger:
-            jaeger:
-                auth: null
-                balancername: ""
-                compression: ""
-                endpoint: jaeger:16685
-                headers: {}
-                keepalive: null
-                readbuffersize: 0
-                tls:
-                    insecure: true
-                    insecureskipverify: false
-                    servername: ""
-                    tlssetting:
-                        cafile: ""
-                        certfile: ""
-                        keyfile: ""
-                        maxversion: ""
-                        minversion: ""
-                        reloadinterval: 0s
-                waitforready: false
-                writebuffersize: 0
-            type: jaeger
     exporters:
         collector:
             exporter:

--- a/examples/observability-driven-development-go-tracetest/bookstore/part2.2/tracetest/tracetest.yaml
+++ b/examples/observability-driven-development-go-tracetest/bookstore/part2.2/tracetest/tracetest.yaml
@@ -24,8 +24,6 @@ postgres:
 
 server:
     telemetry:
-        applicationexporter: collector
-        datastore: jaeger
         exporter: collector
 
 telemetry:

--- a/examples/observability-driven-development-go-tracetest/bookstore/part3.1/tracetest/docker-compose.yaml
+++ b/examples/observability-driven-development-go-tracetest/bookstore/part3.1/tracetest/docker-compose.yaml
@@ -75,6 +75,10 @@ services:
             - type: bind
               source: tracetest/tracetest.yaml
               target: /app/tracetest.yaml
+            - type: bind
+              source: tracetest/tracetest-provision.yaml
+              target: /app/provision.yaml
+        command: --provisioning-file /app/provision.yaml
 networks:
     default:
         name: _default

--- a/examples/observability-driven-development-go-tracetest/bookstore/part3.1/tracetest/tracetest-provision.yaml
+++ b/examples/observability-driven-development-go-tracetest/bookstore/part3.1/tracetest/tracetest-provision.yaml
@@ -1,0 +1,6 @@
+dataStore:
+  type: jaeger
+  jaeger:
+    endpoint: jaeger:16685
+    tls:
+      insecure: true

--- a/examples/observability-driven-development-go-tracetest/bookstore/part3.1/tracetest/tracetest.yaml
+++ b/examples/observability-driven-development-go-tracetest/bookstore/part3.1/tracetest/tracetest.yaml
@@ -9,9 +9,11 @@ demo:
         otelproductcatalog: otel-productcatalogservice:3550
         pokeshopgrpc: demo-api:8082
         pokeshophttp: http://demo-api:8081
+
 poolingconfig:
     maxwaittimefortrace: 2m
     retrydelay: 3s
+
 postgres:
   host: postgres
   user: postgres
@@ -19,36 +21,14 @@ postgres:
   port: 5432
   dbname: postgres
   params: sslmode=disable
+
 server:
     telemetry:
         applicationexporter: collector
         datastore: jaeger
         exporter: collector
+
 telemetry:
-    datastores:
-        jaeger:
-            jaeger:
-                auth: null
-                balancername: ""
-                compression: ""
-                endpoint: jaeger:16685
-                headers: {}
-                keepalive: null
-                readbuffersize: 0
-                tls:
-                    insecure: true
-                    insecureskipverify: false
-                    servername: ""
-                    tlssetting:
-                        cafile: ""
-                        certfile: ""
-                        keyfile: ""
-                        maxversion: ""
-                        minversion: ""
-                        reloadinterval: 0s
-                waitforready: false
-                writebuffersize: 0
-            type: jaeger
     exporters:
         collector:
             exporter:

--- a/examples/observability-driven-development-go-tracetest/bookstore/part3.1/tracetest/tracetest.yaml
+++ b/examples/observability-driven-development-go-tracetest/bookstore/part3.1/tracetest/tracetest.yaml
@@ -24,8 +24,6 @@ postgres:
 
 server:
     telemetry:
-        applicationexporter: collector
-        datastore: jaeger
         exporter: collector
 
 telemetry:

--- a/examples/observability-driven-development-go-tracetest/bookstore/part3.2/tracetest/docker-compose.yaml
+++ b/examples/observability-driven-development-go-tracetest/bookstore/part3.2/tracetest/docker-compose.yaml
@@ -75,6 +75,10 @@ services:
             - type: bind
               source: tracetest/tracetest.yaml
               target: /app/tracetest.yaml
+            - type: bind
+              source: tracetest/tracetest-provision.yaml
+              target: /app/provision.yaml
+        command: --provisioning-file /app/provision.yaml
 networks:
     default:
         name: _default

--- a/examples/observability-driven-development-go-tracetest/bookstore/part3.2/tracetest/tracetest-provision.yaml
+++ b/examples/observability-driven-development-go-tracetest/bookstore/part3.2/tracetest/tracetest-provision.yaml
@@ -1,0 +1,6 @@
+dataStore:
+  type: jaeger
+  jaeger:
+    endpoint: jaeger:16685
+    tls:
+      insecure: true

--- a/examples/observability-driven-development-go-tracetest/bookstore/part3.2/tracetest/tracetest.yaml
+++ b/examples/observability-driven-development-go-tracetest/bookstore/part3.2/tracetest/tracetest.yaml
@@ -9,9 +9,11 @@ demo:
         otelproductcatalog: otel-productcatalogservice:3550
         pokeshopgrpc: demo-api:8082
         pokeshophttp: http://demo-api:8081
+
 poolingconfig:
     maxwaittimefortrace: 2m
     retrydelay: 3s
+
 postgres:
   host: postgres
   user: postgres
@@ -19,36 +21,12 @@ postgres:
   port: 5432
   dbname: postgres
   params: sslmode=disable
+
 server:
     telemetry:
-        applicationexporter: collector
-        datastore: jaeger
         exporter: collector
+
 telemetry:
-    datastores:
-        jaeger:
-            jaeger:
-                auth: null
-                balancername: ""
-                compression: ""
-                endpoint: jaeger:16685
-                headers: {}
-                keepalive: null
-                readbuffersize: 0
-                tls:
-                    insecure: true
-                    insecureskipverify: false
-                    servername: ""
-                    tlssetting:
-                        cafile: ""
-                        certfile: ""
-                        keyfile: ""
-                        maxversion: ""
-                        minversion: ""
-                        reloadinterval: 0s
-                waitforready: false
-                writebuffersize: 0
-            type: jaeger
     exporters:
         collector:
             exporter:

--- a/examples/quick-start-datadog-nodejs/tracetest/docker-compose.yaml
+++ b/examples/quick-start-datadog-nodejs/tracetest/docker-compose.yaml
@@ -12,6 +12,10 @@ services:
       - type: bind
         source: ./tracetest/tracetest.config.yaml
         target: /app/tracetest.yaml
+      - type: bind
+        source: tracetest/tracetest-provision.yaml
+        target: /app/provision.yaml
+    command: --provisioning-file /app/provision.yaml
     healthcheck:
       test: ["CMD", "wget", "--spider", "localhost:11633"]
       interval: 1s

--- a/examples/quick-start-datadog-nodejs/tracetest/tracetest-provision.yaml
+++ b/examples/quick-start-datadog-nodejs/tracetest/tracetest-provision.yaml
@@ -1,0 +1,2 @@
+dataStore:
+  type: datadog

--- a/examples/quick-start-datadog-nodejs/tracetest/tracetest.config.yaml
+++ b/examples/quick-start-datadog-nodejs/tracetest/tracetest.config.yaml
@@ -17,10 +17,6 @@ googleAnalytics:
   enabled: false
 
 telemetry:
-  dataStores:
-    otlp:
-      type: otlp
-
   exporters:
     collector:
       serviceName: tracetest
@@ -32,6 +28,4 @@ telemetry:
 
 server:
   telemetry:
-    dataStore: otlp
     exporter: collector
-    applicationExporter: collector

--- a/examples/quick-start-go/tracetest/docker-compose.yaml
+++ b/examples/quick-start-go/tracetest/docker-compose.yaml
@@ -5,7 +5,13 @@ services:
     image: kubeshop/tracetest:latest
     platform: linux/amd64
     volumes:
-      - ./tracetest/tracetest.config.yaml:/app/config.yaml
+      - type: bind
+        source: ./tracetest/tracetest.config.yaml
+        target: /app/tracetest.yaml
+      - type: bind
+        source: tracetest/tracetest-provision.yaml
+        target: /app/provision.yaml
+    command: --provisioning-file /app/provision.yaml
     ports:
       - 11633:11633
     depends_on:

--- a/examples/quick-start-go/tracetest/tracetest-provision.yaml
+++ b/examples/quick-start-go/tracetest/tracetest-provision.yaml
@@ -1,0 +1,2 @@
+dataStore:
+  type: otlp

--- a/examples/quick-start-go/tracetest/tracetest.config.yaml
+++ b/examples/quick-start-go/tracetest/tracetest.config.yaml
@@ -1,4 +1,11 @@
-postgresConnString: "host=postgres user=postgres password=postgres port=5432 sslmode=disable"
+---
+postgres:
+  host: postgres
+  user: postgres
+  password: postgres
+  port: 5432
+  dbname: postgres
+  params: sslmode=disable
 
 poolingConfig:
   maxWaitTimeForTrace: 10s
@@ -8,9 +15,6 @@ googleAnalytics:
   enabled: true
 
 telemetry:
-  dataStores:
-    otlp:
-      type: otlp
   exporters:
     collector:
       serviceName: tracetest
@@ -22,6 +26,4 @@ telemetry:
 
 server:
   telemetry:
-    dataStore: otlp
     exporter: collector
-    applicationExporter: collector

--- a/examples/quick-start-jaeger-nodejs/tracetest/docker-compose.yaml
+++ b/examples/quick-start-jaeger-nodejs/tracetest/docker-compose.yaml
@@ -4,7 +4,13 @@ services:
     image: kubeshop/tracetest:${TAG:-latest}
     platform: linux/amd64
     volumes:
-      - ./tracetest/tracetest.config.yaml:/app/config.yaml
+      - type: bind
+        source: ./tracetest/tracetest.config.yaml
+        target: /app/tracetest.yaml
+      - type: bind
+        source: tracetest/tracetest-provision.yaml
+        target: /app/provision.yaml
+    command: --provisioning-file /app/provision.yaml
     ports:
       - 11633:11633
     depends_on:

--- a/examples/quick-start-jaeger-nodejs/tracetest/tracetest-provision.yaml
+++ b/examples/quick-start-jaeger-nodejs/tracetest/tracetest-provision.yaml
@@ -1,0 +1,6 @@
+dataStore:
+  type: jaeger
+  jaeger:
+    endpoint: jaeger:16685
+    tls:
+      insecure: true

--- a/examples/quick-start-jaeger-nodejs/tracetest/tracetest.config.yaml
+++ b/examples/quick-start-jaeger-nodejs/tracetest/tracetest.config.yaml
@@ -17,16 +17,3 @@ demo:
   enabled: []
 
 experimentalFeatures: []
-
-telemetry:
-  dataStores:
-    jaeger:
-      type: jaeger
-      jaeger:
-        endpoint: jaeger:16685
-        tls:
-          insecure: true
-
-server:
-  telemetry:
-    dataStore: jaeger


### PR DESCRIPTION
This PR changes the following examples to use the provision file

* collector
* observability-driven-development-go-tracetest
* quick-start-datadog-nodejs
* quick-start-go
* quick-start-jaeger-nodejs

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
