### PR TITLE
fix: test that checks if endpoint is reachable

### DIFF
--- a/server/tracedb/connection/connectivity_step.go
+++ b/server/tracedb/connection/connectivity_step.go
@@ -55,5 +55,6 @@ func (s *connectivityTestStep) TestConnection(_ context.Context) ConnectionTestS
 func ConnectivityStep(protocol Protocol, endpoints ...string) TestStep {
 	return &connectivityTestStep{
 		endpoints: endpoints,
+		protocol:  protocol,
 	}
 }


### PR DESCRIPTION
This PR fixes the bug that @xoscar found. When testing an endpoint with a schema, the reachability would fail with "too many colons" error.

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
