### PR TITLE
ci: set merge gate interval to 30s instead of 10 (default)

### DIFF
--- a/.github/workflows/merge-gate.yaml
+++ b/.github/workflows/merge-gate.yaml
@@ -12,6 +12,7 @@ jobs:
           token: '${{ secrets.GITHUB_TOKEN }}'
           # Ignore the job we're running on lest we create an infinite loop
           ignored_checks: 'wait-for-green'
+          check_interval: 20
       - name: Fail if checks have failed
         if: steps.wait-for-green.outputs.success != 'true'
         run: echo "Status checks failed with status ${{ steps.wait-for-green.outputs.success }}!" && exit 1

--- a/.github/workflows/merge-gate.yaml
+++ b/.github/workflows/merge-gate.yaml
@@ -12,7 +12,7 @@ jobs:
           token: '${{ secrets.GITHUB_TOKEN }}'
           # Ignore the job we're running on lest we create an infinite loop
           ignored_checks: 'wait-for-green'
-          check_interval: 20
+          check_interval: 30
       - name: Fail if checks have failed
         if: steps.wait-for-green.outputs.success != 'true'
         run: echo "Status checks failed with status ${{ steps.wait-for-green.outputs.success }}!" && exit 1


### PR DESCRIPTION
This PR changes the check interval of the merge gate step of our CI. Instead of 10s, we use 30s now to prevent the `API rate exceeded` error from GitHub API.

## Checklist

- [ ] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
