### PR TITLE
fix: correct example tests

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -218,8 +218,7 @@ jobs:
           ./scripts/wait-for-port.sh 11633
 
           ./dist/tracetest configure -g --endpoint http://localhost:11633 --analytics=false
-          ./dist/tracetest test run -d examples/${{ matrix.example_dir }}/tests/list-tests.yaml --wait-for-result
-          [[ "$?" == "0" ]] || cat /tmp/docker-log
+          ./dist/tracetest test run -d examples/${{ matrix.example_dir }}/tests/list-tests.yaml --wait-for-result || (cat /tmp/docker-log; exit 1)
 
   smoke-test-cli:
     name: CLI smoke tests

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -218,7 +218,8 @@ jobs:
           ./scripts/wait-for-port.sh 11633
 
           ./dist/tracetest configure -g --endpoint http://localhost:11633 --analytics=false
-          ./dist/tracetest test run -d examples/${{ matrix.example_dir }}/tests/list-tests.yaml --wait-for-result || cat /tmp/docker-log
+          ./dist/tracetest test run -d examples/${{ matrix.example_dir }}/tests/list-tests.yaml --wait-for-result
+          [[ "$?" == "0" ]] || cat /tmp/docker-log
 
   smoke-test-cli:
     name: CLI smoke tests

--- a/examples/collector/tests/list-tests.yaml
+++ b/examples/collector/tests/list-tests.yaml
@@ -12,6 +12,6 @@ spec:
       - key: Content-Type
         value: application/json
   specs:
-  - selector: span[name = "Tracetest trigger"]
+  - selector: span[tracetest.span.type="http" name="GET /api/tests"]
     assertions:
     - attr:tracetest.selected_spans.count = 1

--- a/examples/tracetest-jaeger/tests/list-tests.yaml
+++ b/examples/tracetest-jaeger/tests/list-tests.yaml
@@ -16,6 +16,6 @@ spec:
       address: ""
       method: ""
   specs:
-  - selector: span[name = "Tracetest trigger"]
+  - selector: span[tracetest.span.type="http" name="GET /api/tests"]
     assertions:
     - attr:tracetest.selected_spans.count = 1

--- a/examples/tracetest-opensearch/tests/list-tests.yaml
+++ b/examples/tracetest-opensearch/tests/list-tests.yaml
@@ -13,6 +13,6 @@ spec:
         - key: Content-Type
           value: application/json
   specs:
-    - selector: span[name = "Tracetest trigger"]
+    - selector: span[tracetest.span.type="http" name="GET /api/tests"]
       assertions:
         - attr:tracetest.selected_spans.count = 1

--- a/examples/tracetest-provisioning-env/tests/list-tests.yaml
+++ b/examples/tracetest-provisioning-env/tests/list-tests.yaml
@@ -16,6 +16,6 @@ spec:
       address: ""
       method: ""
   specs:
-  - selector: span[name = "Tracetest trigger"]
+  - selector: span[tracetest.span.type="http" name="GET /api/tests"]
     assertions:
     - attr:tracetest.selected_spans.count = 1

--- a/examples/tracetest-tempo/tests/list-tests.yaml
+++ b/examples/tracetest-tempo/tests/list-tests.yaml
@@ -11,11 +11,7 @@ spec:
       headers:
       - key: Content-Type
         value: application/json
-    grpc:
-      protobufFile: ""
-      address: ""
-      method: ""
   specs:
-  - selector: span[name = "Tracetest trigger"]
+  - selector: span[tracetest.span.type="http" name="GET /api/tests"]
     assertions:
     - attr:tracetest.selected_spans.count = 1


### PR DESCRIPTION
This PR fixes the example tests run for PullRequest validation. It now checks for spans that can only exists if they were fetched from the data store.

## Fixes

- #2095

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [x] added a test
