### PR TITLE
chore(server): accept functional options in config

### DIFF
--- a/server/cmd/root.go
+++ b/server/cmd/root.go
@@ -39,7 +39,7 @@ func init() {
 
 	cobra.OnInitialize(func() {
 		var err error
-		cfg, err = config.New(rootCmd.PersistentFlags(), log.Default())
+		cfg, err = config.New(rootCmd.PersistentFlags(), config.WithLogger(log.Default()))
 		if err != nil {
 			fmt.Println(err.Error())
 			os.Exit(1)

--- a/server/config/config_test.go
+++ b/server/config/config_test.go
@@ -1,7 +1,6 @@
 package config_test
 
 import (
-	"log"
 	"os"
 	"testing"
 	"time"
@@ -19,7 +18,7 @@ func configWithFlagsE(t *testing.T, inputFlags []string) (*config.Config, error)
 	err := flags.Parse(inputFlags)
 	require.NoError(t, err)
 
-	return config.New(flags, log.Default())
+	return config.New(flags)
 }
 
 func configWithFlags(t *testing.T, inputFlags []string) *config.Config {
@@ -38,7 +37,7 @@ func configWithEnv(t *testing.T, env map[string]string) *config.Config {
 		os.Setenv(k, v)
 	}
 
-	cfg, err := config.New(nil, log.Default())
+	cfg, err := config.New(nil)
 	require.NoError(t, err)
 
 	return cfg
@@ -55,7 +54,7 @@ func TestFlags(t *testing.T) {
 		err := flags.Parse([]string{"--config", "notexists.yaml"})
 		require.NoError(t, err)
 
-		cfg, err := config.New(flags, log.Default())
+		cfg, err := config.New(flags)
 		assert.Nil(t, cfg)
 		assert.ErrorIs(t, err, os.ErrNotExist)
 	})
@@ -87,7 +86,7 @@ func TestFlags(t *testing.T) {
 
 			require.NoError(t, err)
 
-			cfg, err := config.New(nil, log.Default())
+			cfg, err := config.New(nil)
 			require.NoError(t, err)
 
 			// this one assertion is enough to guarantee we're not using the defaults
@@ -101,7 +100,7 @@ func TestFlags(t *testing.T) {
 
 			require.NoError(t, err)
 
-			cfg, err := config.New(nil, log.Default())
+			cfg, err := config.New(nil)
 			require.NoError(t, err)
 
 			// the config file would change this value to 9999, but we want to make sure

--- a/server/config/demo_test.go
+++ b/server/config/demo_test.go
@@ -1,16 +1,17 @@
 package config_test
 
 import (
-	"log"
 	"testing"
 
 	"github.com/kubeshop/tracetest/server/config"
+	"github.com/stretchr/testify/require"
 	"gotest.tools/v3/assert"
 )
 
 func TestDemoConfig(t *testing.T) {
 	t.Run("DefaultValues", func(t *testing.T) {
-		cfg, _ := config.New(nil, log.Default())
+		cfg, err := config.New(nil)
+		require.NoError(t, err)
 
 		defaultEndponts := map[string]string{
 			"PokeshopHttp":       "",

--- a/server/config/deprecation_test.go
+++ b/server/config/deprecation_test.go
@@ -54,7 +54,7 @@ func TestDeprecatedOptions(t *testing.T) {
 		config.SetupFlags(flags)
 		err := flags.Parse(inputFlags)
 		require.NoError(t, err)
-		cfg, err := config.New(flags, logger)
+		cfg, err := config.New(flags, config.WithLogger(logger))
 		require.NoError(t, err)
 		return cfg
 	}

--- a/server/config/pooling_test.go
+++ b/server/config/pooling_test.go
@@ -1,7 +1,6 @@
 package config_test
 
 import (
-	"log"
 	"testing"
 	"time"
 
@@ -11,7 +10,7 @@ import (
 
 func TestPoolingConfig(t *testing.T) {
 	t.Run("DefaultValues", func(t *testing.T) {
-		cfg, _ := config.New(nil, log.Default())
+		cfg, _ := config.New(nil)
 
 		assert.Equal(t, 30*time.Second, cfg.PoolingMaxWaitTimeForTraceDuration())
 		assert.Equal(t, 1*time.Second, cfg.PoolingRetryDelay())

--- a/server/config/server_test.go
+++ b/server/config/server_test.go
@@ -1,7 +1,6 @@
 package config_test
 
 import (
-	"log"
 	"testing"
 
 	"github.com/kubeshop/tracetest/server/config"
@@ -10,7 +9,7 @@ import (
 
 func TestServerConfig(t *testing.T) {
 	t.Run("DefaultValues", func(t *testing.T) {
-		cfg, _ := config.New(nil, log.Default())
+		cfg, _ := config.New(nil)
 
 		assert.Equal(t, "host=postgres user=postgres password=postgres port=5432 dbname=tracetest sslmode=disable", cfg.PostgresConnString())
 

--- a/server/executor/poller_executor_test.go
+++ b/server/executor/poller_executor_test.go
@@ -2,7 +2,6 @@ package executor_test
 
 import (
 	"context"
-	"log"
 	"testing"
 	"time"
 
@@ -533,7 +532,7 @@ func getDataStoreRepositoryMock(t *testing.T) model.Repository {
 func getTracerMock(t *testing.T) trace.Tracer {
 	t.Helper()
 
-	tracer, err := tracing.NewTracer(context.TODO(), config.Must(config.New(nil, log.Default())))
+	tracer, err := tracing.NewTracer(context.TODO(), config.Must(config.New(nil)))
 	require.NoError(t, err)
 
 	return tracer

--- a/server/executor/runner_test.go
+++ b/server/executor/runner_test.go
@@ -2,7 +2,6 @@ package executor_test
 
 import (
 	"context"
-	"log"
 	"math/rand"
 	"testing"
 	"time"
@@ -127,7 +126,7 @@ func (f runnerFixture) assert(t *testing.T) {
 }
 
 func runnerSetup(t *testing.T) runnerFixture {
-	tr, _ := tracing.NewTracer(context.TODO(), config.Must(config.New(nil, log.Default())))
+	tr, _ := tracing.NewTracer(context.TODO(), config.Must(config.New(nil)))
 	reg := trigger.NewRegsitry(tr, tr)
 
 	me := new(mockTriggerer)
@@ -142,7 +141,7 @@ func runnerSetup(t *testing.T) runnerFixture {
 	mtp := new(mockTracePoller)
 	mtp.t = t
 
-	tracer, _ := tracing.NewTracer(context.Background(), config.Must(config.New(nil, log.Default())))
+	tracer, _ := tracing.NewTracer(context.Background(), config.Must(config.New(nil)))
 	testDB := testdb.MockRepository{}
 
 	testDB.Mock.On("DefaultDataStore", mock.Anything).Return(model.DataStore{Type: model.DataStoreTypeOTLP}, nil)

--- a/server/testmock/app.go
+++ b/server/testmock/app.go
@@ -1,8 +1,6 @@
 package testmock
 
 import (
-	"log"
-
 	"github.com/kubeshop/tracetest/server/app"
 	"github.com/kubeshop/tracetest/server/config"
 )
@@ -22,7 +20,7 @@ func WithHttpPort(port int) TestingAppOption {
 }
 
 func GetTestingApp(options ...TestingAppOption) (*app.App, error) {
-	cfg, _ := config.New(nil, log.Default())
+	cfg, _ := config.New(nil)
 	for _, option := range options {
 		option(cfg)
 	}

--- a/server/testmock/database.go
+++ b/server/testmock/database.go
@@ -92,10 +92,15 @@ func getMainDatabaseConnection(container *gnomock.Container) (*sql.DB, error) {
 	return sql.Open("postgres", connStr)
 }
 
-func createRandomDatabaseForTest(db *sql.DB, baseDatabase string) (*sql.DB, error) {
+func randomInt() int {
 	rand.Seed(time.Now().UnixNano())
-	randomInt := rand.Int()
-	newDatabaseName := fmt.Sprintf("%s_%d", baseDatabase, randomInt)
+	min := 1
+	max := 1000000
+	return rand.Intn(max-min) + min
+}
+
+func createRandomDatabaseForTest(db *sql.DB, baseDatabase string) (*sql.DB, error) {
+	newDatabaseName := fmt.Sprintf("%s_%d%d%d", baseDatabase, randomInt(), randomInt(), randomInt())
 	_, err := db.Exec(fmt.Sprintf("CREATE DATABASE %s WITH TEMPLATE %s", newDatabaseName, baseDatabase))
 	if err != nil {
 		return nil, fmt.Errorf("could not create database %s: %w", newDatabaseName, err)


### PR DESCRIPTION
The `config` object is needs to hold reference to different repositories to gather configs from DB, so it's much easier to handle the growing amount of dependencies by using the functional options patter.

This tiny pr just updates that internally without affecting any functionality.
