### PR TITLE
chore(server): convert optional FlagSet param to functional option in `config.New`

### DIFF
--- a/server/cmd/root.go
+++ b/server/cmd/root.go
@@ -39,7 +39,10 @@ func init() {
 
 	cobra.OnInitialize(func() {
 		var err error
-		cfg, err = config.New(rootCmd.PersistentFlags(), config.WithLogger(log.Default()))
+		cfg, err = config.New(
+			config.WithFlagSet(rootCmd.PersistentFlags()),
+			config.WithLogger(log.Default()),
+		)
 		if err != nil {
 			fmt.Println(err.Error())
 			os.Exit(1)

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -119,15 +119,21 @@ func SetupFlags(flags *pflag.FlagSet) {
 	configOptions.registerFlags(flags)
 }
 
-type configOption func(*Config)
+type Option func(*Config)
 
-func WithLogger(l logger) configOption {
-	return func(c *Config) {
-		c.logger = l
+func WithFlagSet(flags *pflag.FlagSet) Option {
+	return func(cfg *Config) {
+		cfg.vp.BindPFlags(flags)
 	}
 }
 
-func New(flags *pflag.FlagSet, confOpts ...configOption) (*Config, error) {
+func WithLogger(l logger) Option {
+	return func(cfg *Config) {
+		cfg.logger = l
+	}
+}
+
+func New(confOpts ...Option) (*Config, error) {
 	cfg := Config{
 		vp: viper.New(),
 	}
@@ -143,10 +149,6 @@ func New(flags *pflag.FlagSet, confOpts ...configOption) (*Config, error) {
 	cfg.vp.AutomaticEnv()
 
 	configureConfigFile(cfg.vp)
-
-	if flags != nil {
-		cfg.vp.BindPFlags(flags)
-	}
 
 	configOptions.registerDefaults(cfg.vp)
 

--- a/server/config/config_test.go
+++ b/server/config/config_test.go
@@ -11,18 +11,18 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func configWithFlagsE(t *testing.T, inputFlags []string) (*config.Config, error) {
+func configWithFlagsE(t *testing.T, inputFlags []string, opts ...config.Option) (*config.Config, error) {
 	flags := pflag.NewFlagSet("fake", pflag.ExitOnError)
 	config.SetupFlags(flags)
 
 	err := flags.Parse(inputFlags)
 	require.NoError(t, err)
 
-	return config.New(flags)
+	return config.New(append(opts, config.WithFlagSet(flags))...)
 }
 
-func configWithFlags(t *testing.T, inputFlags []string) *config.Config {
-	cfg, err := configWithFlagsE(t, inputFlags)
+func configWithFlags(t *testing.T, inputFlags []string, opts ...config.Option) *config.Config {
+	cfg, err := configWithFlagsE(t, inputFlags, opts...)
 	require.NoError(t, err)
 
 	return cfg
@@ -37,7 +37,7 @@ func configWithEnv(t *testing.T, env map[string]string) *config.Config {
 		os.Setenv(k, v)
 	}
 
-	cfg, err := config.New(nil)
+	cfg, err := config.New()
 	require.NoError(t, err)
 
 	return cfg
@@ -54,7 +54,7 @@ func TestFlags(t *testing.T) {
 		err := flags.Parse([]string{"--config", "notexists.yaml"})
 		require.NoError(t, err)
 
-		cfg, err := config.New(flags)
+		cfg, err := config.New(config.WithFlagSet(flags))
 		assert.Nil(t, cfg)
 		assert.ErrorIs(t, err, os.ErrNotExist)
 	})
@@ -86,7 +86,7 @@ func TestFlags(t *testing.T) {
 
 			require.NoError(t, err)
 
-			cfg, err := config.New(nil)
+			cfg, err := config.New()
 			require.NoError(t, err)
 
 			// this one assertion is enough to guarantee we're not using the defaults
@@ -100,7 +100,7 @@ func TestFlags(t *testing.T) {
 
 			require.NoError(t, err)
 
-			cfg, err := config.New(nil)
+			cfg, err := config.New()
 			require.NoError(t, err)
 
 			// the config file would change this value to 9999, but we want to make sure

--- a/server/config/demo_test.go
+++ b/server/config/demo_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestDemoConfig(t *testing.T) {
 	t.Run("DefaultValues", func(t *testing.T) {
-		cfg, err := config.New(nil)
+		cfg, err := config.New()
 		require.NoError(t, err)
 
 		defaultEndponts := map[string]string{

--- a/server/config/deprecation_test.go
+++ b/server/config/deprecation_test.go
@@ -6,9 +6,7 @@ import (
 	"testing"
 
 	"github.com/kubeshop/tracetest/server/config"
-	"github.com/spf13/pflag"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 type logger struct {
@@ -49,21 +47,11 @@ func TestDeprecatedOptions(t *testing.T) {
 		},
 	}
 
-	configFromFlagsWithLogger := func(logger *logger, inputFlags []string) *config.Config {
-		flags := pflag.NewFlagSet("fake", pflag.ExitOnError)
-		config.SetupFlags(flags)
-		err := flags.Parse(inputFlags)
-		require.NoError(t, err)
-		cfg, err := config.New(flags, config.WithLogger(logger))
-		require.NoError(t, err)
-		return cfg
-	}
-
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
 			testCase := testCase
 			logger := newLogger()
-			configFromFlagsWithLogger(logger, testCase.flags)
+			configWithFlags(t, testCase.flags, config.WithLogger(logger))
 			assert.Equal(t, testCase.expectedMessages, logger.messages)
 		})
 	}

--- a/server/config/pooling_test.go
+++ b/server/config/pooling_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestPoolingConfig(t *testing.T) {
 	t.Run("DefaultValues", func(t *testing.T) {
-		cfg, _ := config.New(nil)
+		cfg, _ := config.New()
 
 		assert.Equal(t, 30*time.Second, cfg.PoolingMaxWaitTimeForTraceDuration())
 		assert.Equal(t, 1*time.Second, cfg.PoolingRetryDelay())

--- a/server/config/server_test.go
+++ b/server/config/server_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestServerConfig(t *testing.T) {
 	t.Run("DefaultValues", func(t *testing.T) {
-		cfg, _ := config.New(nil)
+		cfg, _ := config.New()
 
 		assert.Equal(t, "host=postgres user=postgres password=postgres port=5432 dbname=tracetest sslmode=disable", cfg.PostgresConnString())
 

--- a/server/executor/poller_executor_test.go
+++ b/server/executor/poller_executor_test.go
@@ -532,7 +532,7 @@ func getDataStoreRepositoryMock(t *testing.T) model.Repository {
 func getTracerMock(t *testing.T) trace.Tracer {
 	t.Helper()
 
-	tracer, err := tracing.NewTracer(context.TODO(), config.Must(config.New(nil)))
+	tracer, err := tracing.NewTracer(context.TODO(), config.Must(config.New()))
 	require.NoError(t, err)
 
 	return tracer

--- a/server/executor/runner_test.go
+++ b/server/executor/runner_test.go
@@ -126,7 +126,7 @@ func (f runnerFixture) assert(t *testing.T) {
 }
 
 func runnerSetup(t *testing.T) runnerFixture {
-	tr, _ := tracing.NewTracer(context.TODO(), config.Must(config.New(nil)))
+	tr, _ := tracing.NewTracer(context.TODO(), config.Must(config.New()))
 	reg := trigger.NewRegsitry(tr, tr)
 
 	me := new(mockTriggerer)
@@ -141,7 +141,7 @@ func runnerSetup(t *testing.T) runnerFixture {
 	mtp := new(mockTracePoller)
 	mtp.t = t
 
-	tracer, _ := tracing.NewTracer(context.Background(), config.Must(config.New(nil)))
+	tracer, _ := tracing.NewTracer(context.Background(), config.Must(config.New()))
 	testDB := testdb.MockRepository{}
 
 	testDB.Mock.On("DefaultDataStore", mock.Anything).Return(model.DataStore{Type: model.DataStoreTypeOTLP}, nil)

--- a/server/testmock/app.go
+++ b/server/testmock/app.go
@@ -20,7 +20,7 @@ func WithHttpPort(port int) TestingAppOption {
 }
 
 func GetTestingApp(options ...TestingAppOption) (*app.App, error) {
-	cfg, _ := config.New(nil)
+	cfg, _ := config.New()
 	for _, option := range options {
 		option(cfg)
 	}


### PR DESCRIPTION
This PR takes advantage of the new functional option pattern for configuring the `Config` object and converts the optional `flags` param to a functional option for creating a new config instance
