### PR TITLE
Add pagination tests to resource manager

### DIFF
--- a/server/config/configresource/config_resource.go
+++ b/server/config/configresource/config_resource.go
@@ -167,6 +167,14 @@ const (
 func (r *repository) List(ctx context.Context, take, skip int, query, sortBy, sortDirection string) ([]Config, error) {
 	listQuery := baseSelect
 
+	if sortDirection == "" {
+		sortDirection = "ASC"
+	}
+
+	if sortBy != "" {
+		listQuery = fmt.Sprintf("%s SORT BY %s %s", listQuery, sortBy, sortDirection)
+	}
+
 	if take > 0 {
 		listQuery = fmt.Sprintf("%s LIMIT %d", listQuery, take)
 	}

--- a/server/config/configresource/config_resource.go
+++ b/server/config/configresource/config_resource.go
@@ -165,7 +165,17 @@ const (
 )
 
 func (r *repository) List(ctx context.Context, take, skip int, query, sortBy, sortDirection string) ([]Config, error) {
-	rows, err := r.db.QueryContext(ctx, baseSelect)
+	listQuery := baseSelect
+
+	if take > 0 {
+		listQuery = fmt.Sprintf("%s LIMIT %d", listQuery, take)
+	}
+
+	if skip > 0 {
+		listQuery = fmt.Sprintf("%s OFFSET %d", listQuery, skip)
+	}
+
+	rows, err := r.db.QueryContext(ctx, listQuery)
 	if err != nil {
 		return nil, fmt.Errorf("sql query: %w", err)
 	}

--- a/server/config/configresource/config_resource.go
+++ b/server/config/configresource/config_resource.go
@@ -171,8 +171,12 @@ func (r *repository) List(ctx context.Context, take, skip int, query, sortBy, so
 		sortDirection = "ASC"
 	}
 
+	if query != "" {
+		listQuery = fmt.Sprintf("%s WHERE %s", listQuery, query)
+	}
+
 	if sortBy != "" {
-		listQuery = fmt.Sprintf("%s SORT BY %s %s", listQuery, sortBy, sortDirection)
+		listQuery = fmt.Sprintf("%s ORDER BY %s %s", listQuery, sortBy, sortDirection)
 	}
 
 	if take > 0 {
@@ -210,9 +214,15 @@ func (r *repository) List(ctx context.Context, take, skip int, query, sortBy, so
 	return configs, nil
 }
 
-const countQuery = `SELECT COUNT(*) FROM configs`
+const baseCountQuery = `SELECT COUNT(*) FROM configs`
 
 func (r *repository) Count(ctx context.Context, query string) (int, error) {
+	countQuery := baseCountQuery
+
+	if query != "" {
+		countQuery = fmt.Sprintf("%s WHERE %s", countQuery, query)
+	}
+
 	count := 0
 
 	err := r.db.

--- a/server/config/configresource/config_resource.go
+++ b/server/config/configresource/config_resource.go
@@ -164,6 +164,10 @@ const (
 		FROM configs `
 )
 
+func (r *repository) SortingFields() []string {
+	return []string{"id", "name", "analytics_enabled"}
+}
+
 func (r *repository) List(ctx context.Context, take, skip int, query, sortBy, sortDirection string) ([]Config, error) {
 	listQuery := baseSelect
 

--- a/server/config/configresource/config_resource_test.go
+++ b/server/config/configresource/config_resource_test.go
@@ -50,8 +50,7 @@ func TestConfigResource(t *testing.T) {
 				rmtests.OperationDeleteSuccess,
 				rmtests.OperationListSuccess:
 				configRepo.Create(context.TODO(), sampleConfig)
-			case rmtests.OperationListPaginatedAscendingSuccess,
-				rmtests.OperationListPaginatedDescendingSuccess:
+			case rmtests.OperationListPaginatedSuccess:
 				configRepo.Create(context.TODO(), sampleConfig)
 				configRepo.Create(context.TODO(), secondSampleConfig)
 				configRepo.Create(context.TODO(), thirdSampleConfig)

--- a/server/config/configresource/config_resource_test.go
+++ b/server/config/configresource/config_resource_test.go
@@ -73,6 +73,6 @@ func TestConfigResource(t *testing.T) {
 				"analyticsEnabled": false
 			}
 		}`,
-		PaginationSortFields: []string{"id"},
+		PaginationSortField: "id",
 	})
 }

--- a/server/config/configresource/config_resource_test.go
+++ b/server/config/configresource/config_resource_test.go
@@ -73,6 +73,7 @@ func TestConfigResource(t *testing.T) {
 				"analyticsEnabled": false
 			}
 		}`,
-		PaginationSortField: "id",
+		SortField:        "id",
+		InvalidSortField: "invalid_field",
 	})
 }

--- a/server/config/configresource/config_resource_test.go
+++ b/server/config/configresource/config_resource_test.go
@@ -17,8 +17,18 @@ func TestConfigResource(t *testing.T) {
 	db := testmock.MustGetRawTestingDatabase()
 	sampleConfig := configresource.Config{
 		ID:               "1",
-		Name:             "test",
+		Name:             "test 1",
+		AnalyticsEnabled: false,
+	}
+	secondSampleConfig := configresource.Config{
+		ID:               "2",
+		Name:             "test 2",
 		AnalyticsEnabled: true,
+	}
+	thirdSampleConfig := configresource.Config{
+		ID:               "3",
+		Name:             "test 3",
+		AnalyticsEnabled: false,
 	}
 
 	rmtests.TestResourceType(t, rmtests.ResourceTypeTest{
@@ -40,14 +50,19 @@ func TestConfigResource(t *testing.T) {
 				rmtests.OperationDeleteSuccess,
 				rmtests.OperationListSuccess:
 				configRepo.Create(context.TODO(), sampleConfig)
+			case rmtests.OperationListPaginatedAscendingSuccess,
+				rmtests.OperationListPaginatedDescendingSuccess:
+				configRepo.Create(context.TODO(), sampleConfig)
+				configRepo.Create(context.TODO(), secondSampleConfig)
+				configRepo.Create(context.TODO(), thirdSampleConfig)
 			}
 		},
 		SampleJSON: `{
 			"type": "Config",
 			"spec": {
 				"id": "1",
-				"name": "test",
-				"analyticsEnabled": true
+				"name": "test 1",
+				"analyticsEnabled": false
 			}
 		}`,
 
@@ -56,8 +71,46 @@ func TestConfigResource(t *testing.T) {
 			"spec": {
 				"id": "1",
 				"name": "test updated",
-				"analyticsEnabled": true
+				"analyticsEnabled": false
 			}
 		}`,
+
+		SamplePaginatedAscJSON: `[
+			{
+				"type": "Config",
+				"spec": {
+					"id": "2",
+					"name": "test 2",
+					"analyticsEnabled": true
+				}
+			},
+			{
+				"type": "Config",
+				"spec": {
+					"id": "3",
+					"name": "test 3",
+					"analyticsEnabled": false
+				}
+			},
+		]`,
+
+		SamplePaginatedDescJSON: `[
+			{
+				"type": "Config",
+				"spec": {
+					"id": "1",
+					"name": "test 1",
+					"analyticsEnabled": false
+				}
+			},
+			{
+				"type": "Config",
+				"spec": {
+					"id": "2",
+					"name": "test 2",
+					"analyticsEnabled": true
+				}
+			},
+		]`,
 	})
 }

--- a/server/config/configresource/config_resource_test.go
+++ b/server/config/configresource/config_resource_test.go
@@ -65,7 +65,6 @@ func TestConfigResource(t *testing.T) {
 				"analyticsEnabled": false
 			}
 		}`,
-
 		SampleJSONUpdated: `{
 			"type": "Config",
 			"spec": {
@@ -74,43 +73,6 @@ func TestConfigResource(t *testing.T) {
 				"analyticsEnabled": false
 			}
 		}`,
-
-		SamplePaginatedAscJSON: `[
-			{
-				"type": "Config",
-				"spec": {
-					"id": "2",
-					"name": "test 2",
-					"analyticsEnabled": true
-				}
-			},
-			{
-				"type": "Config",
-				"spec": {
-					"id": "3",
-					"name": "test 3",
-					"analyticsEnabled": false
-				}
-			}
-		]`,
-
-		SamplePaginatedDescJSON: `[
-			{
-				"type": "Config",
-				"spec": {
-					"id": "2",
-					"name": "test 2",
-					"analyticsEnabled": true
-				}
-			},
-			{
-				"type": "Config",
-				"spec": {
-					"id": "1",
-					"name": "test 1",
-					"analyticsEnabled": false
-				}
-			}
-		]`,
+		PaginationSortFields: []string{"id"},
 	})
 }

--- a/server/config/configresource/config_resource_test.go
+++ b/server/config/configresource/config_resource_test.go
@@ -72,7 +72,5 @@ func TestConfigResource(t *testing.T) {
 				"analyticsEnabled": false
 			}
 		}`,
-		SortField:        "id",
-		InvalidSortField: "invalid_field",
 	})
 }

--- a/server/config/configresource/config_resource_test.go
+++ b/server/config/configresource/config_resource_test.go
@@ -91,18 +91,10 @@ func TestConfigResource(t *testing.T) {
 					"name": "test 3",
 					"analyticsEnabled": false
 				}
-			},
+			}
 		]`,
 
 		SamplePaginatedDescJSON: `[
-			{
-				"type": "Config",
-				"spec": {
-					"id": "1",
-					"name": "test 1",
-					"analyticsEnabled": false
-				}
-			},
 			{
 				"type": "Config",
 				"spec": {
@@ -111,6 +103,14 @@ func TestConfigResource(t *testing.T) {
 					"analyticsEnabled": true
 				}
 			},
+			{
+				"type": "Config",
+				"spec": {
+					"id": "1",
+					"name": "test 1",
+					"analyticsEnabled": false
+				}
+			}
 		]`,
 	})
 }

--- a/server/resourcemanager/resource_manager.go
+++ b/server/resourcemanager/resource_manager.go
@@ -32,9 +32,13 @@ type Resource[T ResourceSpec] struct {
 	Spec T      `mapstructure:"spec"`
 }
 
-type ResourceHandler[T ResourceSpec] interface {
-	SetID(T, id.ID) T
+type SortableHandler interface {
 	SortingFields() []string
+}
+
+type ResourceHandler[T ResourceSpec] interface {
+	SortableHandler
+	SetID(T, id.ID) T
 	List(_ context.Context, take, skip int, query, sortBy, sortDirection string) ([]T, error)
 	Count(_ context.Context, query string) (int, error)
 	Create(context.Context, T) (T, error)

--- a/server/resourcemanager/resource_manager.go
+++ b/server/resourcemanager/resource_manager.go
@@ -143,9 +143,6 @@ func (m *manager[T]) list(w http.ResponseWriter, r *http.Request) {
 		sortDirection,
 	)
 	if err != nil {
-		fmt.Println("---------------------------------------------------------------------------------------------------")
-		fmt.Println(err)
-		fmt.Println("---------------------------------------------------------------------------------------------------")
 		m.handleResourceHandlerError(w, "listing", err, encoder)
 		return
 	}

--- a/server/resourcemanager/resource_manager.go
+++ b/server/resourcemanager/resource_manager.go
@@ -147,6 +147,9 @@ func (m *manager[T]) list(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// TODO: the name "count" can be misleading when using pagination.
+	//       an user can paginate the request and see a different number
+	//       of records inside "item"
 	resourceList := ResourceList[T]{
 		Count: count,
 		Items: []map[string]any{},

--- a/server/resourcemanager/resource_manager.go
+++ b/server/resourcemanager/resource_manager.go
@@ -143,6 +143,9 @@ func (m *manager[T]) list(w http.ResponseWriter, r *http.Request) {
 		sortDirection,
 	)
 	if err != nil {
+		fmt.Println("---------------------------------------------------------------------------------------------------")
+		fmt.Println(err)
+		fmt.Println("---------------------------------------------------------------------------------------------------")
 		m.handleResourceHandlerError(w, "listing", err, encoder)
 		return
 	}

--- a/server/resourcemanager/resource_manager_test.go
+++ b/server/resourcemanager/resource_manager_test.go
@@ -165,7 +165,8 @@ func TestSampleResource(t *testing.T) {
 				"some_value": "the value updated"
 			}
 		}`,
-		PaginationSortField: "id",
+		SortField:        "id",
+		InvalidSortField: "invalid_field",
 	})
 }
 
@@ -215,10 +216,15 @@ func (m *sampleResourceManager) Delete(_ context.Context, id id.ID) error {
 	return args.Error(0)
 }
 
+func (m *sampleResourceManager) SortingFields() []string {
+	return []string{"id", "name", "some_value"}
+}
+
 func (m *sampleResourceManager) List(_ context.Context, take, skip int, query, sortBy, sortDirection string) ([]sampleResource, error) {
 	args := m.Called(take, skip, query, sortBy, sortDirection)
 	return args.Get(0).([]sampleResource), args.Error(1)
 }
+
 func (m *sampleResourceManager) Count(_ context.Context, query string) (int, error) {
 	args := m.Called(query)
 	return args.Int(0), args.Error(1)

--- a/server/resourcemanager/resource_manager_test.go
+++ b/server/resourcemanager/resource_manager_test.go
@@ -165,7 +165,7 @@ func TestSampleResource(t *testing.T) {
 				"some_value": "the value updated"
 			}
 		}`,
-		PaginationSortFields: []string{"id"},
+		PaginationSortField: "id",
 	})
 }
 

--- a/server/resourcemanager/resource_manager_test.go
+++ b/server/resourcemanager/resource_manager_test.go
@@ -129,19 +129,15 @@ func TestSampleResource(t *testing.T) {
 				mockManager.
 					On("List", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 					Return([]sampleResource{}, nil)
-			case rmtests.OperationListPaginatedAscendingSuccess:
+			case rmtests.OperationListPaginatedSuccess:
 				mockManager.
 					On("Count", mock.Anything).
 					Return(3, nil)
 				mockManager.
-					On("List", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+					On("List", mock.Anything, mock.Anything, mock.Anything, mock.Anything, "asc").
 					Return([]sampleResource{secondSample, thirdSample}, nil)
-			case rmtests.OperationListPaginatedDescendingSuccess:
 				mockManager.
-					On("Count", mock.Anything).
-					Return(3, nil)
-				mockManager.
-					On("List", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+					On("List", mock.Anything, mock.Anything, mock.Anything, mock.Anything, "desc").
 					Return([]sampleResource{secondSample, sample}, nil)
 			case rmtests.OperationListInternalError:
 				mockManager.

--- a/server/resourcemanager/resource_manager_test.go
+++ b/server/resourcemanager/resource_manager_test.go
@@ -161,8 +161,6 @@ func TestSampleResource(t *testing.T) {
 				"some_value": "the value updated"
 			}
 		}`,
-		SortField:        "id",
-		InvalidSortField: "invalid_field",
 	})
 }
 

--- a/server/resourcemanager/resource_manager_test.go
+++ b/server/resourcemanager/resource_manager_test.go
@@ -106,7 +106,7 @@ func TestSampleResource(t *testing.T) {
 				mockManager.
 					On("Create", sample).
 					Return(sample, nil)
-			case rmtests.OperationCreateInteralError:
+			case rmtests.OperationCreateInternalError:
 				mockManager.
 					On("Create", sample).
 					Return(sampleResource{}, fmt.Errorf("some error"))
@@ -120,7 +120,7 @@ func TestSampleResource(t *testing.T) {
 				mockManager.
 					On("Update", sampleUpdated).
 					Return(sampleUpdated, nil)
-			case rmtests.OperationUpdateInteralError:
+			case rmtests.OperationUpdateInternalError:
 				mockManager.
 					On("Update", sampleUpdated).
 					Return(sampleResource{}, fmt.Errorf("some error"))
@@ -134,7 +134,7 @@ func TestSampleResource(t *testing.T) {
 				mockManager.
 					On("Get", sample.ID).
 					Return(sample, nil)
-			case rmtests.OperationGetInteralError:
+			case rmtests.OperationGetInternalError:
 				mockManager.
 					On("Get", sample.ID).
 					Return(sampleResource{}, fmt.Errorf("some error"))
@@ -151,7 +151,7 @@ func TestSampleResource(t *testing.T) {
 				mockManager.
 					On("Get", sample.ID).
 					Return(sampleResource{}, sql.ErrNoRows)
-			case rmtests.OperationDeleteInteralError:
+			case rmtests.OperationDeleteInternalError:
 				mockManager.
 					On("Delete", sample.ID).
 					Return(fmt.Errorf("some error"))
@@ -171,7 +171,7 @@ func TestSampleResource(t *testing.T) {
 				mockManager.
 					On("List", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 					Return([]sampleResource{}, nil)
-			case rmtests.OperationListInteralError:
+			case rmtests.OperationListInternalError:
 				mockManager.
 					On("Count", mock.Anything).
 					Return(0, fmt.Errorf("some error"))

--- a/server/resourcemanager/resource_manager_test.go
+++ b/server/resourcemanager/resource_manager_test.go
@@ -20,6 +20,18 @@ func TestSampleResource(t *testing.T) {
 		SomeValue: "the value",
 	}
 
+	secondSample := sampleResource{
+		ID:        "2",
+		Name:      "the name 2",
+		SomeValue: "the value 2",
+	}
+
+	thirdSample := sampleResource{
+		ID:        "3",
+		Name:      "the name 3",
+		SomeValue: "the value 3",
+	}
+
 	sampleUpdated := sampleResource{
 		ID:        "1",
 		Name:      "the name updated",
@@ -117,6 +129,20 @@ func TestSampleResource(t *testing.T) {
 				mockManager.
 					On("List", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 					Return([]sampleResource{}, nil)
+			case rmtests.OperationListPaginatedAscendingSuccess:
+				mockManager.
+					On("Count", mock.Anything).
+					Return(3, nil)
+				mockManager.
+					On("List", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+					Return([]sampleResource{secondSample, thirdSample}, nil)
+			case rmtests.OperationListPaginatedDescendingSuccess:
+				mockManager.
+					On("Count", mock.Anything).
+					Return(3, nil)
+				mockManager.
+					On("List", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+					Return([]sampleResource{secondSample, sample}, nil)
 			case rmtests.OperationListInternalError:
 				mockManager.
 					On("Count", mock.Anything).
@@ -139,6 +165,42 @@ func TestSampleResource(t *testing.T) {
 				"some_value": "the value updated"
 			}
 		}`,
+		SamplePaginatedAscJSON: `[
+			{
+				"type": "SampleResource",
+				"spec": {
+					"id": "2",
+					"name": "the name 2",
+					"some_value": "the value 2"
+				}
+			},
+			{
+				"type": "SampleResource",
+				"spec": {
+					"id": "3",
+					"name": "the name 3",
+					"some_value": "the value 3"
+				}
+			}
+		]`,
+		SamplePaginatedDescJSON: `[
+			{
+				"type": "SampleResource",
+				"spec": {
+					"id": "2",
+					"name": "the name 2",
+					"some_value": "the value 2"
+				}
+			},
+			{
+				"type": "SampleResource",
+				"spec": {
+					"id": "1",
+					"name": "the name",
+					"some_value": "the value"
+				}
+			}
+		]`,
 	})
 }
 

--- a/server/resourcemanager/resource_manager_test.go
+++ b/server/resourcemanager/resource_manager_test.go
@@ -165,42 +165,7 @@ func TestSampleResource(t *testing.T) {
 				"some_value": "the value updated"
 			}
 		}`,
-		SamplePaginatedAscJSON: `[
-			{
-				"type": "SampleResource",
-				"spec": {
-					"id": "2",
-					"name": "the name 2",
-					"some_value": "the value 2"
-				}
-			},
-			{
-				"type": "SampleResource",
-				"spec": {
-					"id": "3",
-					"name": "the name 3",
-					"some_value": "the value 3"
-				}
-			}
-		]`,
-		SamplePaginatedDescJSON: `[
-			{
-				"type": "SampleResource",
-				"spec": {
-					"id": "2",
-					"name": "the name 2",
-					"some_value": "the value 2"
-				}
-			},
-			{
-				"type": "SampleResource",
-				"spec": {
-					"id": "1",
-					"name": "the name",
-					"some_value": "the value"
-				}
-			}
-		]`,
+		PaginationSortFields: []string{"id"},
 	})
 }
 

--- a/server/resourcemanager/resource_manager_test.go
+++ b/server/resourcemanager/resource_manager_test.go
@@ -13,61 +13,7 @@ import (
 	"github.com/stretchr/testify/mock"
 )
 
-type sampleResource struct {
-	ID   id.ID  `mapstructure:"id"`
-	Name string `mapstructure:"name"`
-
-	SomeValue string `mapstructure:"some_value"`
-}
-
-func (sr sampleResource) HasID() bool {
-	return sr.ID.String() != ""
-}
-
-func (sr sampleResource) Validate() error {
-	return nil
-}
-
-type sampleResourceManager struct {
-	mock.Mock
-}
-
-func (m *sampleResourceManager) SetID(sr sampleResource, id id.ID) sampleResource {
-	sr.ID = id
-	return sr
-}
-
-func (m *sampleResourceManager) Create(_ context.Context, s sampleResource) (sampleResource, error) {
-	args := m.Called(s)
-	return args.Get(0).(sampleResource), args.Error(1)
-}
-
-func (m *sampleResourceManager) Update(_ context.Context, s sampleResource) (sampleResource, error) {
-	args := m.Called(s)
-	return args.Get(0).(sampleResource), args.Error(1)
-}
-
-func (m *sampleResourceManager) Get(_ context.Context, id id.ID) (sampleResource, error) {
-	args := m.Called(id)
-	return args.Get(0).(sampleResource), args.Error(1)
-}
-
-func (m *sampleResourceManager) Delete(_ context.Context, id id.ID) error {
-	args := m.Called(id)
-	return args.Error(0)
-}
-
-func (m *sampleResourceManager) List(_ context.Context, take, skip int, query, sortBy, sortDirection string) ([]sampleResource, error) {
-	args := m.Called(take, skip, query, sortBy, sortDirection)
-	return args.Get(0).([]sampleResource), args.Error(1)
-}
-func (m *sampleResourceManager) Count(_ context.Context, query string) (int, error) {
-	args := m.Called(query)
-	return args.Int(0), args.Error(1)
-}
-
 func TestSampleResource(t *testing.T) {
-
 	sample := sampleResource{
 		ID:        "1",
 		Name:      "the name",
@@ -194,4 +140,59 @@ func TestSampleResource(t *testing.T) {
 			}
 		}`,
 	})
+}
+
+// test structures and mocks
+
+type sampleResource struct {
+	ID   id.ID  `mapstructure:"id"`
+	Name string `mapstructure:"name"`
+
+	SomeValue string `mapstructure:"some_value"`
+}
+
+func (sr sampleResource) HasID() bool {
+	return sr.ID.String() != ""
+}
+
+func (sr sampleResource) Validate() error {
+	return nil
+}
+
+type sampleResourceManager struct {
+	mock.Mock
+}
+
+func (m *sampleResourceManager) SetID(sr sampleResource, id id.ID) sampleResource {
+	sr.ID = id
+	return sr
+}
+
+func (m *sampleResourceManager) Create(_ context.Context, s sampleResource) (sampleResource, error) {
+	args := m.Called(s)
+	return args.Get(0).(sampleResource), args.Error(1)
+}
+
+func (m *sampleResourceManager) Update(_ context.Context, s sampleResource) (sampleResource, error) {
+	args := m.Called(s)
+	return args.Get(0).(sampleResource), args.Error(1)
+}
+
+func (m *sampleResourceManager) Get(_ context.Context, id id.ID) (sampleResource, error) {
+	args := m.Called(id)
+	return args.Get(0).(sampleResource), args.Error(1)
+}
+
+func (m *sampleResourceManager) Delete(_ context.Context, id id.ID) error {
+	args := m.Called(id)
+	return args.Error(0)
+}
+
+func (m *sampleResourceManager) List(_ context.Context, take, skip int, query, sortBy, sortDirection string) ([]sampleResource, error) {
+	args := m.Called(take, skip, query, sortBy, sortDirection)
+	return args.Get(0).([]sampleResource), args.Error(1)
+}
+func (m *sampleResourceManager) Count(_ context.Context, query string) (int, error) {
+	args := m.Called(query)
+	return args.Int(0), args.Error(1)
 }

--- a/server/resourcemanager/testutil/common_functions.go
+++ b/server/resourcemanager/testutil/common_functions.go
@@ -1,0 +1,87 @@
+package testutil
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func removeID(input map[string]any) map[string]any {
+	out := map[string]any{}
+	out["type"] = input["type"]
+	newSpec := map[string]any{}
+	for k, v := range input["spec"].(map[string]any) {
+		if k == "id" {
+			continue
+		}
+		newSpec[k] = v
+	}
+
+	out["spec"] = newSpec
+
+	return out
+}
+
+func parseJSON(input string) map[string]any {
+	parsed := map[string]any{}
+	err := json.Unmarshal([]byte(input), &parsed)
+	if err != nil {
+		panic(err)
+	}
+
+	return parsed
+}
+
+func removeIDFromJSON(input string) string {
+
+	clean := removeID(parseJSON(input))
+
+	out, err := json.Marshal(clean)
+	if err != nil {
+		panic(err)
+	}
+	return string(out)
+}
+
+func extractID(input string) string {
+	parsed := parseJSON(input)
+	id := parsed["spec"].(map[string]any)["id"]
+	if id == nil {
+		return ""
+	}
+
+	return id.(string)
+}
+
+func responseBody(t *testing.T, resp *http.Response) string {
+	require.NotNil(t, resp.Body)
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+
+	return string(body)
+}
+
+func responseBodyJSON(t *testing.T, resp *http.Response, ct contentTypeConverter) string {
+	body := responseBody(t, resp)
+	jsonBody := ct.toJSON(string(body))
+	return jsonBody
+}
+
+func assertInternalError(t *testing.T, resp *http.Response, ct contentTypeConverter, rt ResourceTypeTest, verb string) {
+	require.Equal(t, 500, resp.StatusCode)
+
+	jsonBody := responseBodyJSON(t, resp, ct)
+
+	// hacky way to get the types we want
+	bodyValues := struct {
+		Code  int    `json:"code"`
+		Error string `json:"error"`
+	}{}
+	json.Unmarshal([]byte(jsonBody), &bodyValues)
+
+	require.Equal(t, 500, bodyValues.Code)
+	require.Contains(t, bodyValues.Error, "error "+verb+" resource "+rt.ResourceType)
+}

--- a/server/resourcemanager/testutil/common_functions.go
+++ b/server/resourcemanager/testutil/common_functions.go
@@ -7,7 +7,14 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
+	"github.com/kubeshop/tracetest/server/id"
 )
+
+func generateRandomString() string {
+	generator := id.NewRandGenerator()
+	return generator.TraceID().String()
+}
 
 func removeID(input map[string]any) map[string]any {
 	out := map[string]any{}

--- a/server/resourcemanager/testutil/common_functions.go
+++ b/server/resourcemanager/testutil/common_functions.go
@@ -70,7 +70,7 @@ func responseBodyJSON(t *testing.T, resp *http.Response, ct contentTypeConverter
 	return jsonBody
 }
 
-func assertInternalError(t *testing.T, resp *http.Response, ct contentTypeConverter, rt ResourceTypeTest, verb string) {
+func assertInternalError(t *testing.T, resp *http.Response, ct contentTypeConverter, resourceType, verb string) {
 	require.Equal(t, 500, resp.StatusCode)
 
 	jsonBody := responseBodyJSON(t, resp, ct)
@@ -83,5 +83,5 @@ func assertInternalError(t *testing.T, resp *http.Response, ct contentTypeConver
 	json.Unmarshal([]byte(jsonBody), &bodyValues)
 
 	require.Equal(t, 500, bodyValues.Code)
-	require.Contains(t, bodyValues.Error, "error "+verb+" resource "+rt.ResourceType)
+	require.Contains(t, bodyValues.Error, "error "+verb+" resource "+resourceType)
 }

--- a/server/resourcemanager/testutil/content_type.go
+++ b/server/resourcemanager/testutil/content_type.go
@@ -4,21 +4,21 @@ import (
 	"sigs.k8s.io/yaml"
 )
 
-type ContentTypeConverter struct {
+type contentTypeConverter struct {
 	name        string
 	contentType string
 	fromJSON    func(input string) string
 	toJSON      func(input string) string
 }
 
-var contentTypeJSON = ContentTypeConverter{
+var contentTypeJSON = contentTypeConverter{
 	name:        "json",
 	contentType: "application/json",
 	fromJSON:    func(jsonString string) string { return jsonString },
 	toJSON:      func(jsonString string) string { return jsonString },
 }
 
-var contentTypeYAML = ContentTypeConverter{
+var contentTypeYAML = contentTypeConverter{
 	name:        "yaml",
 	contentType: "text/yaml",
 	fromJSON: func(jsonString string) string {
@@ -37,4 +37,4 @@ var contentTypeYAML = ContentTypeConverter{
 	},
 }
 
-var contentTypeConverters = []ContentTypeConverter{contentTypeJSON, contentTypeYAML}
+var contentTypeConverters = []contentTypeConverter{contentTypeJSON, contentTypeYAML}

--- a/server/resourcemanager/testutil/contenttype.go
+++ b/server/resourcemanager/testutil/contenttype.go
@@ -1,0 +1,40 @@
+package testutil
+
+import (
+	"sigs.k8s.io/yaml"
+)
+
+type ContentTypeConverter struct {
+	name        string
+	contentType string
+	fromJSON    func(input string) string
+	toJSON      func(input string) string
+}
+
+var contentTypeJSON = ContentTypeConverter{
+	name:        "json",
+	contentType: "application/json",
+	fromJSON:    func(jsonString string) string { return jsonString },
+	toJSON:      func(jsonString string) string { return jsonString },
+}
+
+var contentTypeYAML = ContentTypeConverter{
+	name:        "yaml",
+	contentType: "text/yaml",
+	fromJSON: func(jsonString string) string {
+		y, err := yaml.JSONToYAML([]byte(jsonString))
+		if err != nil {
+			panic(err)
+		}
+		return string(y)
+	},
+	toJSON: func(yamlString string) string {
+		j, err := yaml.YAMLToJSON([]byte(yamlString))
+		if err != nil {
+			panic(err)
+		}
+		return string(j)
+	},
+}
+
+var contentTypeConverters = []ContentTypeConverter{contentTypeJSON, contentTypeYAML}

--- a/server/resourcemanager/testutil/operations.go
+++ b/server/resourcemanager/testutil/operations.go
@@ -31,6 +31,8 @@ var (
 
 		listNoResultsOperation,
 		listSuccessOperation,
+		listPaginatedAscendingSuccessOperation,
+		listPaginatedDescendingSuccessOperation,
 		// TODO: add tests for pagination etc
 	}
 

--- a/server/resourcemanager/testutil/operations.go
+++ b/server/resourcemanager/testutil/operations.go
@@ -9,10 +9,36 @@ import (
 type Operation string
 
 type operationTester struct {
+	name     Operation
+	getSteps func(*testing.T, ResourceTypeTest) []operationTesterStep
+}
+
+type operationTesterStep struct {
 	buildRequest   func(*testing.T, *httptest.Server, contentTypeConverter, ResourceTypeTest) *http.Request
 	assertResponse func(*testing.T, *http.Response, contentTypeConverter, ResourceTypeTest)
+	postAssert     func(*testing.T, contentTypeConverter, ResourceTypeTest, *httptest.Server)
+}
+
+type singleStepOperationTester struct {
 	name           Operation
-	postAssert     func(t *testing.T, ct contentTypeConverter, rt ResourceTypeTest, testServer *httptest.Server)
+	buildRequest   func(*testing.T, *httptest.Server, contentTypeConverter, ResourceTypeTest) *http.Request
+	assertResponse func(*testing.T, *http.Response, contentTypeConverter, ResourceTypeTest)
+	postAssert     func(*testing.T, contentTypeConverter, ResourceTypeTest, *httptest.Server)
+}
+
+func buildSingleStepOperation(operation singleStepOperationTester) operationTester {
+	return operationTester{
+		name: operation.name,
+		getSteps: func(t *testing.T, rt ResourceTypeTest) []operationTesterStep {
+			return []operationTesterStep{
+				{
+					buildRequest:   operation.buildRequest,
+					assertResponse: operation.assertResponse,
+					postAssert:     operation.postAssert,
+				},
+			}
+		},
+	}
 }
 
 var (

--- a/server/resourcemanager/testutil/operations.go
+++ b/server/resourcemanager/testutil/operations.go
@@ -8,37 +8,37 @@ import (
 
 type Operation string
 
-type OperationTester interface {
-	buildRequest(*testing.T, *httptest.Server, contentTypeConverter, ResourceTypeTest) *http.Request
-	assertResponse(*testing.T, *http.Response, contentTypeConverter, ResourceTypeTest)
-	name() Operation
-	postAssert(t *testing.T, ct contentTypeConverter, rt ResourceTypeTest, testServer *httptest.Server)
+type operationTester struct {
+	buildRequest   func(*testing.T, *httptest.Server, contentTypeConverter, ResourceTypeTest) *http.Request
+	assertResponse func(*testing.T, *http.Response, contentTypeConverter, ResourceTypeTest)
+	name           Operation
+	postAssert     func(t *testing.T, ct contentTypeConverter, rt ResourceTypeTest, testServer *httptest.Server)
 }
 
 var (
-	defaultOperations = []OperationTester{
-		createNoIDOperation{},
-		createSuccessOperation{},
+	defaultOperations = []operationTester{
+		createNoIDOperation,
+		createSuccessOperation,
 
-		updateNotFoundOperation{},
-		updateSuccessOperation{},
+		updateNotFoundOperation,
+		updateSuccessOperation,
 
-		getNotFoundOperation{},
-		getSuccessOperation{},
+		getNotFoundOperation,
+		getSuccessOperation,
 
-		deleteNotFoundOperation{},
-		deleteSuccessOperation{},
+		deleteNotFoundOperation,
+		deleteSuccessOperation,
 
-		listNoResultsOperation{},
-		listSuccessOperation{},
+		listNoResultsOperation,
+		listSuccessOperation,
 		// TODO: add tests for pagination etc
 	}
 
-	errorOperations = []OperationTester{
-		createInternalErrorOperation{},
-		updateInternalErrorOperation{},
-		getInternalErrorOperation{},
-		deleteInternalErrorOperation{},
-		listInternalErrorOperation{},
+	errorOperations = []operationTester{
+		createInternalErrorOperation,
+		updateInternalErrorOperation,
+		getInternalErrorOperation,
+		deleteInternalErrorOperation,
+		listInternalErrorOperation,
 	}
 )

--- a/server/resourcemanager/testutil/operations.go
+++ b/server/resourcemanager/testutil/operations.go
@@ -57,8 +57,7 @@ var (
 
 		listNoResultsOperation,
 		listSuccessOperation,
-		listPaginatedAscendingSuccessOperation,
-		listPaginatedDescendingSuccessOperation,
+		listPaginatedSuccessOperation,
 		// TODO: add tests for other operations
 	}
 

--- a/server/resourcemanager/testutil/operations.go
+++ b/server/resourcemanager/testutil/operations.go
@@ -1,16 +1,22 @@
 package testutil
 
 import (
-	"encoding/json"
-	"io"
 	"net/http"
+	"net/http/httptest"
 	"testing"
-
-	"github.com/stretchr/testify/require"
 )
 
+type Operation string
+
+type OperationTester interface {
+	buildRequest(*testing.T, *httptest.Server, contentTypeConverter, ResourceTypeTest) *http.Request
+	assertResponse(*testing.T, *http.Response, contentTypeConverter, ResourceTypeTest)
+	name() Operation
+	postAssert(t *testing.T, ct contentTypeConverter, rt ResourceTypeTest, testServer *httptest.Server)
+}
+
 var (
-	defaultOperations = []operationTester{
+	defaultOperations = []OperationTester{
 		createNoIDOperation{},
 		createSuccessOperation{},
 
@@ -28,7 +34,7 @@ var (
 		// TODO: add tests for pagination etc
 	}
 
-	errorOperations = []operationTester{
+	errorOperations = []OperationTester{
 		createInternalErrorOperation{},
 		updateInternalErrorOperation{},
 		getInternalErrorOperation{},
@@ -36,80 +42,3 @@ var (
 		listInternalErrorOperation{},
 	}
 )
-
-func removeID(input map[string]any) map[string]any {
-	out := map[string]any{}
-	out["type"] = input["type"]
-	newSpec := map[string]any{}
-	for k, v := range input["spec"].(map[string]any) {
-		if k == "id" {
-			continue
-		}
-		newSpec[k] = v
-	}
-
-	out["spec"] = newSpec
-
-	return out
-}
-
-func parseJSON(input string) map[string]any {
-	parsed := map[string]any{}
-	err := json.Unmarshal([]byte(input), &parsed)
-	if err != nil {
-		panic(err)
-	}
-
-	return parsed
-}
-
-func removeIDFromJSON(input string) string {
-
-	clean := removeID(parseJSON(input))
-
-	out, err := json.Marshal(clean)
-	if err != nil {
-		panic(err)
-	}
-	return string(out)
-}
-
-func extractID(input string) string {
-	parsed := parseJSON(input)
-	id := parsed["spec"].(map[string]any)["id"]
-	if id == nil {
-		return ""
-	}
-
-	return id.(string)
-}
-
-func responseBody(t *testing.T, resp *http.Response) string {
-	require.NotNil(t, resp.Body)
-	body, err := io.ReadAll(resp.Body)
-	require.NoError(t, err)
-
-	return string(body)
-}
-
-func responseBodyJSON(t *testing.T, resp *http.Response, ct ContentTypeConverter) string {
-	body := responseBody(t, resp)
-	jsonBody := ct.toJSON(string(body))
-	return jsonBody
-}
-
-func assertInternalError(t *testing.T, resp *http.Response, ct ContentTypeConverter, rt ResourceTypeTest, verb string) {
-	require.Equal(t, 500, resp.StatusCode)
-
-	jsonBody := responseBodyJSON(t, resp, ct)
-
-	// hacky way to get the types we want
-	bodyValues := struct {
-		Code  int    `json:"code"`
-		Error string `json:"error"`
-	}{}
-	json.Unmarshal([]byte(jsonBody), &bodyValues)
-
-	require.Equal(t, 500, bodyValues.Code)
-	require.Contains(t, bodyValues.Error, "error "+verb+" resource "+rt.ResourceType)
-}

--- a/server/resourcemanager/testutil/operations.go
+++ b/server/resourcemanager/testutil/operations.go
@@ -31,6 +31,7 @@ var (
 
 		listNoResultsOperation,
 		listSuccessOperation,
+		listWithInvalidSortFieldOperation,
 		listPaginatedAscendingSuccessOperation,
 		listPaginatedDescendingSuccessOperation,
 		// TODO: add tests for pagination etc

--- a/server/resourcemanager/testutil/operations.go
+++ b/server/resourcemanager/testutil/operations.go
@@ -31,10 +31,9 @@ var (
 
 		listNoResultsOperation,
 		listSuccessOperation,
-		listWithInvalidSortFieldOperation,
 		listPaginatedAscendingSuccessOperation,
 		listPaginatedDescendingSuccessOperation,
-		// TODO: add tests for pagination etc
+		// TODO: add tests for other operations
 	}
 
 	errorOperations = []operationTester{
@@ -43,5 +42,6 @@ var (
 		getInternalErrorOperation,
 		deleteInternalErrorOperation,
 		listInternalErrorOperation,
+		listWithInvalidSortFieldOperation,
 	}
 )

--- a/server/resourcemanager/testutil/operations.go
+++ b/server/resourcemanager/testutil/operations.go
@@ -92,13 +92,13 @@ func responseBody(t *testing.T, resp *http.Response) string {
 	return string(body)
 }
 
-func responseBodyJSON(t *testing.T, resp *http.Response, ct contentType) string {
+func responseBodyJSON(t *testing.T, resp *http.Response, ct ContentTypeConverter) string {
 	body := responseBody(t, resp)
 	jsonBody := ct.toJSON(string(body))
 	return jsonBody
 }
 
-func assertInternalError(t *testing.T, resp *http.Response, ct contentType, rt ResourceTypeTest, verb string) {
+func assertInternalError(t *testing.T, resp *http.Response, ct ContentTypeConverter, rt ResourceTypeTest, verb string) {
 	require.Equal(t, 500, resp.StatusCode)
 
 	jsonBody := responseBodyJSON(t, resp, ct)

--- a/server/resourcemanager/testutil/operations.go
+++ b/server/resourcemanager/testutil/operations.go
@@ -29,11 +29,11 @@ var (
 	}
 
 	errorOperations = []operationTester{
-		createInteralErrorOperation{},
-		updateInteralErrorOperation{},
-		getInteralErrorOperation{},
-		deleteInteralErrorOperation{},
-		listInteralErrorOperation{},
+		createInternalErrorOperation{},
+		updateInternalErrorOperation{},
+		getInternalErrorOperation{},
+		deleteInternalErrorOperation{},
+		listInternalErrorOperation{},
 	}
 )
 

--- a/server/resourcemanager/testutil/operations_create.go
+++ b/server/resourcemanager/testutil/operations_create.go
@@ -82,6 +82,6 @@ var createInternalErrorOperation = operationTester{
 		)
 	},
 	assertResponse: func(t *testing.T, resp *http.Response, ct contentTypeConverter, rt ResourceTypeTest) {
-		assertInternalError(t, resp, ct, rt, "creating")
+		assertInternalError(t, resp, ct, rt.ResourceType, "creating")
 	},
 }

--- a/server/resourcemanager/testutil/operations_create.go
+++ b/server/resourcemanager/testutil/operations_create.go
@@ -10,7 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildCreateRequest(body, rt string, ct ContentTypeConverter, testServer *httptest.Server, t *testing.T) *http.Request {
+func buildCreateRequest(body, rt string, ct contentTypeConverter, testServer *httptest.Server, t *testing.T) *http.Request {
 	input := ct.fromJSON(body)
 	url := fmt.Sprintf("%s/%s/", testServer.URL, strings.ToLower(rt))
 
@@ -23,10 +23,10 @@ const OperationCreateNoID Operation = "CreateNoID"
 
 type createNoIDOperation struct{}
 
-func (op createNoIDOperation) postAssert(t *testing.T, ct ContentTypeConverter, rt ResourceTypeTest, testServer *httptest.Server) {
+func (op createNoIDOperation) postAssert(t *testing.T, ct contentTypeConverter, rt ResourceTypeTest, testServer *httptest.Server) {
 }
 
-func (op createNoIDOperation) buildRequest(t *testing.T, testServer *httptest.Server, ct ContentTypeConverter, rt ResourceTypeTest) *http.Request {
+func (op createNoIDOperation) buildRequest(t *testing.T, testServer *httptest.Server, ct contentTypeConverter, rt ResourceTypeTest) *http.Request {
 	return buildCreateRequest(
 		removeIDFromJSON(rt.SampleJSON),
 		rt.ResourceType,
@@ -40,7 +40,7 @@ func (createNoIDOperation) name() Operation {
 	return OperationCreateNoID
 }
 
-func (createNoIDOperation) assertResponse(t *testing.T, resp *http.Response, ct ContentTypeConverter, rt ResourceTypeTest) {
+func (createNoIDOperation) assertResponse(t *testing.T, resp *http.Response, ct contentTypeConverter, rt ResourceTypeTest) {
 	require.Equal(t, 201, resp.StatusCode)
 
 	jsonBody := responseBodyJSON(t, resp, ct)
@@ -56,10 +56,10 @@ const OperationCreateSuccess Operation = "CreateSuccess"
 
 type createSuccessOperation struct{}
 
-func (op createSuccessOperation) postAssert(t *testing.T, ct ContentTypeConverter, rt ResourceTypeTest, testServer *httptest.Server) {
+func (op createSuccessOperation) postAssert(t *testing.T, ct contentTypeConverter, rt ResourceTypeTest, testServer *httptest.Server) {
 }
 
-func (op createSuccessOperation) buildRequest(t *testing.T, testServer *httptest.Server, ct ContentTypeConverter, rt ResourceTypeTest) *http.Request {
+func (op createSuccessOperation) buildRequest(t *testing.T, testServer *httptest.Server, ct contentTypeConverter, rt ResourceTypeTest) *http.Request {
 	return buildCreateRequest(
 		rt.SampleJSON,
 		rt.ResourceType,
@@ -73,7 +73,7 @@ func (createSuccessOperation) name() Operation {
 	return OperationCreateSuccess
 }
 
-func (createSuccessOperation) assertResponse(t *testing.T, resp *http.Response, ct ContentTypeConverter, rt ResourceTypeTest) {
+func (createSuccessOperation) assertResponse(t *testing.T, resp *http.Response, ct contentTypeConverter, rt ResourceTypeTest) {
 	require.Equal(t, 201, resp.StatusCode)
 
 	jsonBody := responseBodyJSON(t, resp, ct)
@@ -86,10 +86,10 @@ const OperationCreateInternalError Operation = "CreateInternalError"
 
 type createInternalErrorOperation struct{}
 
-func (op createInternalErrorOperation) postAssert(t *testing.T, ct ContentTypeConverter, rt ResourceTypeTest, testServer *httptest.Server) {
+func (op createInternalErrorOperation) postAssert(t *testing.T, ct contentTypeConverter, rt ResourceTypeTest, testServer *httptest.Server) {
 }
 
-func (op createInternalErrorOperation) buildRequest(t *testing.T, testServer *httptest.Server, ct ContentTypeConverter, rt ResourceTypeTest) *http.Request {
+func (op createInternalErrorOperation) buildRequest(t *testing.T, testServer *httptest.Server, ct contentTypeConverter, rt ResourceTypeTest) *http.Request {
 	return buildCreateRequest(
 		rt.SampleJSON,
 		rt.ResourceType,
@@ -103,6 +103,6 @@ func (createInternalErrorOperation) name() Operation {
 	return OperationCreateInternalError
 }
 
-func (createInternalErrorOperation) assertResponse(t *testing.T, resp *http.Response, ct ContentTypeConverter, rt ResourceTypeTest) {
+func (createInternalErrorOperation) assertResponse(t *testing.T, resp *http.Response, ct contentTypeConverter, rt ResourceTypeTest) {
 	assertInternalError(t, resp, ct, rt, "creating")
 }

--- a/server/resourcemanager/testutil/operations_create.go
+++ b/server/resourcemanager/testutil/operations_create.go
@@ -21,88 +21,67 @@ func buildCreateRequest(body, rt string, ct contentTypeConverter, testServer *ht
 
 const OperationCreateNoID Operation = "CreateNoID"
 
-type createNoIDOperation struct{}
+var createNoIDOperation = operationTester{
+	name: OperationCreateNoID,
+	buildRequest: func(t *testing.T, testServer *httptest.Server, ct contentTypeConverter, rt ResourceTypeTest) *http.Request {
+		return buildCreateRequest(
+			removeIDFromJSON(rt.SampleJSON),
+			rt.ResourceType,
+			ct,
+			testServer,
+			t,
+		)
+	},
+	assertResponse: func(t *testing.T, resp *http.Response, ct contentTypeConverter, rt ResourceTypeTest) {
+		require.Equal(t, 201, resp.StatusCode)
 
-func (op createNoIDOperation) postAssert(t *testing.T, ct contentTypeConverter, rt ResourceTypeTest, testServer *httptest.Server) {
-}
+		jsonBody := responseBodyJSON(t, resp, ct)
 
-func (op createNoIDOperation) buildRequest(t *testing.T, testServer *httptest.Server, ct contentTypeConverter, rt ResourceTypeTest) *http.Request {
-	return buildCreateRequest(
-		removeIDFromJSON(rt.SampleJSON),
-		rt.ResourceType,
-		ct,
-		testServer,
-		t,
-	)
-}
+		clean := removeIDFromJSON(rt.SampleJSON)
+		expected := ct.toJSON(clean)
 
-func (createNoIDOperation) name() Operation {
-	return OperationCreateNoID
-}
-
-func (createNoIDOperation) assertResponse(t *testing.T, resp *http.Response, ct contentTypeConverter, rt ResourceTypeTest) {
-	require.Equal(t, 201, resp.StatusCode)
-
-	jsonBody := responseBodyJSON(t, resp, ct)
-
-	clean := removeIDFromJSON(rt.SampleJSON)
-	expected := ct.toJSON(clean)
-
-	require.JSONEq(t, expected, removeIDFromJSON(jsonBody))
-	require.NotEmpty(t, extractID(jsonBody))
+		require.JSONEq(t, expected, removeIDFromJSON(jsonBody))
+		require.NotEmpty(t, extractID(jsonBody))
+	},
 }
 
 const OperationCreateSuccess Operation = "CreateSuccess"
 
-type createSuccessOperation struct{}
+var createSuccessOperation = operationTester{
+	name: OperationCreateSuccess,
+	buildRequest: func(t *testing.T, testServer *httptest.Server, ct contentTypeConverter, rt ResourceTypeTest) *http.Request {
+		return buildCreateRequest(
+			rt.SampleJSON,
+			rt.ResourceType,
+			ct,
+			testServer,
+			t,
+		)
+	},
+	assertResponse: func(t *testing.T, resp *http.Response, ct contentTypeConverter, rt ResourceTypeTest) {
+		require.Equal(t, 201, resp.StatusCode)
 
-func (op createSuccessOperation) postAssert(t *testing.T, ct contentTypeConverter, rt ResourceTypeTest, testServer *httptest.Server) {
-}
+		jsonBody := responseBodyJSON(t, resp, ct)
+		expected := ct.toJSON(rt.SampleJSON)
 
-func (op createSuccessOperation) buildRequest(t *testing.T, testServer *httptest.Server, ct contentTypeConverter, rt ResourceTypeTest) *http.Request {
-	return buildCreateRequest(
-		rt.SampleJSON,
-		rt.ResourceType,
-		ct,
-		testServer,
-		t,
-	)
-}
-
-func (createSuccessOperation) name() Operation {
-	return OperationCreateSuccess
-}
-
-func (createSuccessOperation) assertResponse(t *testing.T, resp *http.Response, ct contentTypeConverter, rt ResourceTypeTest) {
-	require.Equal(t, 201, resp.StatusCode)
-
-	jsonBody := responseBodyJSON(t, resp, ct)
-	expected := ct.toJSON(rt.SampleJSON)
-
-	require.JSONEq(t, expected, jsonBody)
+		require.JSONEq(t, expected, jsonBody)
+	},
 }
 
 const OperationCreateInternalError Operation = "CreateInternalError"
 
-type createInternalErrorOperation struct{}
-
-func (op createInternalErrorOperation) postAssert(t *testing.T, ct contentTypeConverter, rt ResourceTypeTest, testServer *httptest.Server) {
-}
-
-func (op createInternalErrorOperation) buildRequest(t *testing.T, testServer *httptest.Server, ct contentTypeConverter, rt ResourceTypeTest) *http.Request {
-	return buildCreateRequest(
-		rt.SampleJSON,
-		rt.ResourceType,
-		ct,
-		testServer,
-		t,
-	)
-}
-
-func (createInternalErrorOperation) name() Operation {
-	return OperationCreateInternalError
-}
-
-func (createInternalErrorOperation) assertResponse(t *testing.T, resp *http.Response, ct contentTypeConverter, rt ResourceTypeTest) {
-	assertInternalError(t, resp, ct, rt, "creating")
+var createInternalErrorOperation = operationTester{
+	name: OperationCreateInternalError,
+	buildRequest: func(t *testing.T, testServer *httptest.Server, ct contentTypeConverter, rt ResourceTypeTest) *http.Request {
+		return buildCreateRequest(
+			rt.SampleJSON,
+			rt.ResourceType,
+			ct,
+			testServer,
+			t,
+		)
+	},
+	assertResponse: func(t *testing.T, resp *http.Response, ct contentTypeConverter, rt ResourceTypeTest) {
+		assertInternalError(t, resp, ct, rt, "creating")
+	},
 }

--- a/server/resourcemanager/testutil/operations_create.go
+++ b/server/resourcemanager/testutil/operations_create.go
@@ -10,7 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildCreateRequest(body, rt string, ct contentType, testServer *httptest.Server, t *testing.T) *http.Request {
+func buildCreateRequest(body, rt string, ct ContentTypeConverter, testServer *httptest.Server, t *testing.T) *http.Request {
 	input := ct.fromJSON(body)
 	url := fmt.Sprintf("%s/%s/", testServer.URL, strings.ToLower(rt))
 
@@ -23,10 +23,10 @@ const OperationCreateNoID Operation = "CreateNoID"
 
 type createNoIDOperation struct{}
 
-func (op createNoIDOperation) postAssert(t *testing.T, ct contentType, rt ResourceTypeTest, testServer *httptest.Server) {
+func (op createNoIDOperation) postAssert(t *testing.T, ct ContentTypeConverter, rt ResourceTypeTest, testServer *httptest.Server) {
 }
 
-func (op createNoIDOperation) buildRequest(t *testing.T, testServer *httptest.Server, ct contentType, rt ResourceTypeTest) *http.Request {
+func (op createNoIDOperation) buildRequest(t *testing.T, testServer *httptest.Server, ct ContentTypeConverter, rt ResourceTypeTest) *http.Request {
 	return buildCreateRequest(
 		removeIDFromJSON(rt.SampleJSON),
 		rt.ResourceType,
@@ -40,7 +40,7 @@ func (createNoIDOperation) name() Operation {
 	return OperationCreateNoID
 }
 
-func (createNoIDOperation) assertResponse(t *testing.T, resp *http.Response, ct contentType, rt ResourceTypeTest) {
+func (createNoIDOperation) assertResponse(t *testing.T, resp *http.Response, ct ContentTypeConverter, rt ResourceTypeTest) {
 	require.Equal(t, 201, resp.StatusCode)
 
 	jsonBody := responseBodyJSON(t, resp, ct)
@@ -56,10 +56,10 @@ const OperationCreateSuccess Operation = "CreateSuccess"
 
 type createSuccessOperation struct{}
 
-func (op createSuccessOperation) postAssert(t *testing.T, ct contentType, rt ResourceTypeTest, testServer *httptest.Server) {
+func (op createSuccessOperation) postAssert(t *testing.T, ct ContentTypeConverter, rt ResourceTypeTest, testServer *httptest.Server) {
 }
 
-func (op createSuccessOperation) buildRequest(t *testing.T, testServer *httptest.Server, ct contentType, rt ResourceTypeTest) *http.Request {
+func (op createSuccessOperation) buildRequest(t *testing.T, testServer *httptest.Server, ct ContentTypeConverter, rt ResourceTypeTest) *http.Request {
 	return buildCreateRequest(
 		rt.SampleJSON,
 		rt.ResourceType,
@@ -73,7 +73,7 @@ func (createSuccessOperation) name() Operation {
 	return OperationCreateSuccess
 }
 
-func (createSuccessOperation) assertResponse(t *testing.T, resp *http.Response, ct contentType, rt ResourceTypeTest) {
+func (createSuccessOperation) assertResponse(t *testing.T, resp *http.Response, ct ContentTypeConverter, rt ResourceTypeTest) {
 	require.Equal(t, 201, resp.StatusCode)
 
 	jsonBody := responseBodyJSON(t, resp, ct)
@@ -86,10 +86,10 @@ const OperationCreateInternalError Operation = "CreateInternalError"
 
 type createInternalErrorOperation struct{}
 
-func (op createInternalErrorOperation) postAssert(t *testing.T, ct contentType, rt ResourceTypeTest, testServer *httptest.Server) {
+func (op createInternalErrorOperation) postAssert(t *testing.T, ct ContentTypeConverter, rt ResourceTypeTest, testServer *httptest.Server) {
 }
 
-func (op createInternalErrorOperation) buildRequest(t *testing.T, testServer *httptest.Server, ct contentType, rt ResourceTypeTest) *http.Request {
+func (op createInternalErrorOperation) buildRequest(t *testing.T, testServer *httptest.Server, ct ContentTypeConverter, rt ResourceTypeTest) *http.Request {
 	return buildCreateRequest(
 		rt.SampleJSON,
 		rt.ResourceType,
@@ -103,6 +103,6 @@ func (createInternalErrorOperation) name() Operation {
 	return OperationCreateInternalError
 }
 
-func (createInternalErrorOperation) assertResponse(t *testing.T, resp *http.Response, ct contentType, rt ResourceTypeTest) {
+func (createInternalErrorOperation) assertResponse(t *testing.T, resp *http.Response, ct ContentTypeConverter, rt ResourceTypeTest) {
 	assertInternalError(t, resp, ct, rt, "creating")
 }

--- a/server/resourcemanager/testutil/operations_create.go
+++ b/server/resourcemanager/testutil/operations_create.go
@@ -21,7 +21,7 @@ func buildCreateRequest(body, rt string, ct contentTypeConverter, testServer *ht
 
 const OperationCreateNoID Operation = "CreateNoID"
 
-var createNoIDOperation = operationTester{
+var createNoIDOperation = buildSingleStepOperation(singleStepOperationTester{
 	name: OperationCreateNoID,
 	buildRequest: func(t *testing.T, testServer *httptest.Server, ct contentTypeConverter, rt ResourceTypeTest) *http.Request {
 		return buildCreateRequest(
@@ -43,11 +43,11 @@ var createNoIDOperation = operationTester{
 		require.JSONEq(t, expected, removeIDFromJSON(jsonBody))
 		require.NotEmpty(t, extractID(jsonBody))
 	},
-}
+})
 
 const OperationCreateSuccess Operation = "CreateSuccess"
 
-var createSuccessOperation = operationTester{
+var createSuccessOperation = buildSingleStepOperation(singleStepOperationTester{
 	name: OperationCreateSuccess,
 	buildRequest: func(t *testing.T, testServer *httptest.Server, ct contentTypeConverter, rt ResourceTypeTest) *http.Request {
 		return buildCreateRequest(
@@ -66,11 +66,11 @@ var createSuccessOperation = operationTester{
 
 		require.JSONEq(t, expected, jsonBody)
 	},
-}
+})
 
 const OperationCreateInternalError Operation = "CreateInternalError"
 
-var createInternalErrorOperation = operationTester{
+var createInternalErrorOperation = buildSingleStepOperation(singleStepOperationTester{
 	name: OperationCreateInternalError,
 	buildRequest: func(t *testing.T, testServer *httptest.Server, ct contentTypeConverter, rt ResourceTypeTest) *http.Request {
 		return buildCreateRequest(
@@ -84,4 +84,4 @@ var createInternalErrorOperation = operationTester{
 	assertResponse: func(t *testing.T, resp *http.Response, ct contentTypeConverter, rt ResourceTypeTest) {
 		assertInternalError(t, resp, ct, rt.ResourceType, "creating")
 	},
-}
+})

--- a/server/resourcemanager/testutil/operations_create.go
+++ b/server/resourcemanager/testutil/operations_create.go
@@ -82,14 +82,14 @@ func (createSuccessOperation) assertResponse(t *testing.T, resp *http.Response, 
 	require.JSONEq(t, expected, jsonBody)
 }
 
-const OperationCreateInteralError Operation = "CreateInteralError"
+const OperationCreateInternalError Operation = "CreateInternalError"
 
-type createInteralErrorOperation struct{}
+type createInternalErrorOperation struct{}
 
-func (op createInteralErrorOperation) postAssert(t *testing.T, ct contentType, rt ResourceTypeTest, testServer *httptest.Server) {
+func (op createInternalErrorOperation) postAssert(t *testing.T, ct contentType, rt ResourceTypeTest, testServer *httptest.Server) {
 }
 
-func (op createInteralErrorOperation) buildRequest(t *testing.T, testServer *httptest.Server, ct contentType, rt ResourceTypeTest) *http.Request {
+func (op createInternalErrorOperation) buildRequest(t *testing.T, testServer *httptest.Server, ct contentType, rt ResourceTypeTest) *http.Request {
 	return buildCreateRequest(
 		rt.SampleJSON,
 		rt.ResourceType,
@@ -99,10 +99,10 @@ func (op createInteralErrorOperation) buildRequest(t *testing.T, testServer *htt
 	)
 }
 
-func (createInteralErrorOperation) name() Operation {
-	return OperationCreateInteralError
+func (createInternalErrorOperation) name() Operation {
+	return OperationCreateInternalError
 }
 
-func (createInteralErrorOperation) assertResponse(t *testing.T, resp *http.Response, ct contentType, rt ResourceTypeTest) {
+func (createInternalErrorOperation) assertResponse(t *testing.T, resp *http.Response, ct contentType, rt ResourceTypeTest) {
 	assertInternalError(t, resp, ct, rt, "creating")
 }

--- a/server/resourcemanager/testutil/operations_delete.go
+++ b/server/resourcemanager/testutil/operations_delete.go
@@ -10,7 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildDeleteRequest(rt ResourceTypeTest, ct ContentTypeConverter, testServer *httptest.Server, t *testing.T) *http.Request {
+func buildDeleteRequest(rt ResourceTypeTest, ct contentTypeConverter, testServer *httptest.Server, t *testing.T) *http.Request {
 	id := extractID(rt.SampleJSON)
 	url := fmt.Sprintf(
 		"%s/%s/%s",
@@ -28,7 +28,7 @@ const OperationDeleteSuccess Operation = "DeleteSuccess"
 
 type deleteSuccessOperation struct{}
 
-func (op deleteSuccessOperation) postAssert(t *testing.T, ct ContentTypeConverter, rt ResourceTypeTest, testServer *httptest.Server) {
+func (op deleteSuccessOperation) postAssert(t *testing.T, ct contentTypeConverter, rt ResourceTypeTest, testServer *httptest.Server) {
 	req := buildGetRequest(rt, ct, testServer, t)
 
 	resp := doRequest(t, req, ct, testServer)
@@ -36,7 +36,7 @@ func (op deleteSuccessOperation) postAssert(t *testing.T, ct ContentTypeConverte
 	(getNotFoundOperation{}).assertResponse(t, resp, ct, rt)
 }
 
-func (op deleteSuccessOperation) buildRequest(t *testing.T, testServer *httptest.Server, ct ContentTypeConverter, rt ResourceTypeTest) *http.Request {
+func (op deleteSuccessOperation) buildRequest(t *testing.T, testServer *httptest.Server, ct contentTypeConverter, rt ResourceTypeTest) *http.Request {
 	return buildDeleteRequest(rt, ct, testServer, t)
 }
 
@@ -44,7 +44,7 @@ func (deleteSuccessOperation) name() Operation {
 	return OperationDeleteSuccess
 }
 
-func (deleteSuccessOperation) assertResponse(t *testing.T, resp *http.Response, ct ContentTypeConverter, rt ResourceTypeTest) {
+func (deleteSuccessOperation) assertResponse(t *testing.T, resp *http.Response, ct contentTypeConverter, rt ResourceTypeTest) {
 	t.Helper()
 	require.Equal(t, 204, resp.StatusCode)
 	require.Empty(t, responseBody(t, resp))
@@ -54,10 +54,10 @@ const OperationDeleteNotFound Operation = "DeleteNotFound"
 
 type deleteNotFoundOperation struct{}
 
-func (op deleteNotFoundOperation) postAssert(t *testing.T, ct ContentTypeConverter, rt ResourceTypeTest, testServer *httptest.Server) {
+func (op deleteNotFoundOperation) postAssert(t *testing.T, ct contentTypeConverter, rt ResourceTypeTest, testServer *httptest.Server) {
 }
 
-func (op deleteNotFoundOperation) buildRequest(t *testing.T, testServer *httptest.Server, ct ContentTypeConverter, rt ResourceTypeTest) *http.Request {
+func (op deleteNotFoundOperation) buildRequest(t *testing.T, testServer *httptest.Server, ct contentTypeConverter, rt ResourceTypeTest) *http.Request {
 	return buildDeleteRequest(rt, ct, testServer, t)
 }
 
@@ -65,7 +65,7 @@ func (deleteNotFoundOperation) name() Operation {
 	return OperationDeleteNotFound
 }
 
-func (deleteNotFoundOperation) assertResponse(t *testing.T, resp *http.Response, ct ContentTypeConverter, rt ResourceTypeTest) {
+func (deleteNotFoundOperation) assertResponse(t *testing.T, resp *http.Response, ct contentTypeConverter, rt ResourceTypeTest) {
 	t.Helper()
 	require.Equal(t, 404, resp.StatusCode)
 }
@@ -74,10 +74,10 @@ const OperationDeleteInternalError Operation = "DeleteInternalError"
 
 type deleteInternalErrorOperation struct{}
 
-func (op deleteInternalErrorOperation) postAssert(t *testing.T, ct ContentTypeConverter, rt ResourceTypeTest, testServer *httptest.Server) {
+func (op deleteInternalErrorOperation) postAssert(t *testing.T, ct contentTypeConverter, rt ResourceTypeTest, testServer *httptest.Server) {
 }
 
-func (op deleteInternalErrorOperation) buildRequest(t *testing.T, testServer *httptest.Server, ct ContentTypeConverter, rt ResourceTypeTest) *http.Request {
+func (op deleteInternalErrorOperation) buildRequest(t *testing.T, testServer *httptest.Server, ct contentTypeConverter, rt ResourceTypeTest) *http.Request {
 	return buildDeleteRequest(rt, ct, testServer, t)
 }
 
@@ -85,6 +85,6 @@ func (deleteInternalErrorOperation) name() Operation {
 	return OperationDeleteInternalError
 }
 
-func (deleteInternalErrorOperation) assertResponse(t *testing.T, resp *http.Response, ct ContentTypeConverter, rt ResourceTypeTest) {
+func (deleteInternalErrorOperation) assertResponse(t *testing.T, resp *http.Response, ct contentTypeConverter, rt ResourceTypeTest) {
 	assertInternalError(t, resp, ct, rt, "deleting")
 }

--- a/server/resourcemanager/testutil/operations_delete.go
+++ b/server/resourcemanager/testutil/operations_delete.go
@@ -70,21 +70,21 @@ func (deleteNotFoundOperation) assertResponse(t *testing.T, resp *http.Response,
 	require.Equal(t, 404, resp.StatusCode)
 }
 
-const OperationDeleteInteralError Operation = "DeleteInteralError"
+const OperationDeleteInternalError Operation = "DeleteInternalError"
 
-type deleteInteralErrorOperation struct{}
+type deleteInternalErrorOperation struct{}
 
-func (op deleteInteralErrorOperation) postAssert(t *testing.T, ct contentType, rt ResourceTypeTest, testServer *httptest.Server) {
+func (op deleteInternalErrorOperation) postAssert(t *testing.T, ct contentType, rt ResourceTypeTest, testServer *httptest.Server) {
 }
 
-func (op deleteInteralErrorOperation) buildRequest(t *testing.T, testServer *httptest.Server, ct contentType, rt ResourceTypeTest) *http.Request {
+func (op deleteInternalErrorOperation) buildRequest(t *testing.T, testServer *httptest.Server, ct contentType, rt ResourceTypeTest) *http.Request {
 	return buildDeleteRequest(rt, ct, testServer, t)
 }
 
-func (deleteInteralErrorOperation) name() Operation {
-	return OperationDeleteInteralError
+func (deleteInternalErrorOperation) name() Operation {
+	return OperationDeleteInternalError
 }
 
-func (deleteInteralErrorOperation) assertResponse(t *testing.T, resp *http.Response, ct contentType, rt ResourceTypeTest) {
+func (deleteInternalErrorOperation) assertResponse(t *testing.T, resp *http.Response, ct contentType, rt ResourceTypeTest) {
 	assertInternalError(t, resp, ct, rt, "deleting")
 }

--- a/server/resourcemanager/testutil/operations_delete.go
+++ b/server/resourcemanager/testutil/operations_delete.go
@@ -26,65 +26,44 @@ func buildDeleteRequest(rt ResourceTypeTest, ct contentTypeConverter, testServer
 
 const OperationDeleteSuccess Operation = "DeleteSuccess"
 
-type deleteSuccessOperation struct{}
-
-func (op deleteSuccessOperation) postAssert(t *testing.T, ct contentTypeConverter, rt ResourceTypeTest, testServer *httptest.Server) {
-	req := buildGetRequest(rt, ct, testServer, t)
-
-	resp := doRequest(t, req, ct, testServer)
-
-	(getNotFoundOperation{}).assertResponse(t, resp, ct, rt)
-}
-
-func (op deleteSuccessOperation) buildRequest(t *testing.T, testServer *httptest.Server, ct contentTypeConverter, rt ResourceTypeTest) *http.Request {
-	return buildDeleteRequest(rt, ct, testServer, t)
-}
-
-func (deleteSuccessOperation) name() Operation {
-	return OperationDeleteSuccess
-}
-
-func (deleteSuccessOperation) assertResponse(t *testing.T, resp *http.Response, ct contentTypeConverter, rt ResourceTypeTest) {
-	t.Helper()
-	require.Equal(t, 204, resp.StatusCode)
-	require.Empty(t, responseBody(t, resp))
+var deleteSuccessOperation = operationTester{
+	name: OperationDeleteSuccess,
+	postAssert: func(t *testing.T, ct contentTypeConverter, rt ResourceTypeTest, testServer *httptest.Server) {
+		req := buildGetRequest(rt, ct, testServer, t)
+		resp := doRequest(t, req, ct, testServer)
+		getNotFoundOperation.assertResponse(t, resp, ct, rt)
+	},
+	buildRequest: func(t *testing.T, testServer *httptest.Server, ct contentTypeConverter, rt ResourceTypeTest) *http.Request {
+		return buildDeleteRequest(rt, ct, testServer, t)
+	},
+	assertResponse: func(t *testing.T, resp *http.Response, ct contentTypeConverter, rt ResourceTypeTest) {
+		t.Helper()
+		require.Equal(t, 204, resp.StatusCode)
+		require.Empty(t, responseBody(t, resp))
+	},
 }
 
 const OperationDeleteNotFound Operation = "DeleteNotFound"
 
-type deleteNotFoundOperation struct{}
-
-func (op deleteNotFoundOperation) postAssert(t *testing.T, ct contentTypeConverter, rt ResourceTypeTest, testServer *httptest.Server) {
-}
-
-func (op deleteNotFoundOperation) buildRequest(t *testing.T, testServer *httptest.Server, ct contentTypeConverter, rt ResourceTypeTest) *http.Request {
-	return buildDeleteRequest(rt, ct, testServer, t)
-}
-
-func (deleteNotFoundOperation) name() Operation {
-	return OperationDeleteNotFound
-}
-
-func (deleteNotFoundOperation) assertResponse(t *testing.T, resp *http.Response, ct contentTypeConverter, rt ResourceTypeTest) {
-	t.Helper()
-	require.Equal(t, 404, resp.StatusCode)
+var deleteNotFoundOperation = operationTester{
+	name: OperationDeleteNotFound,
+	buildRequest: func(t *testing.T, testServer *httptest.Server, ct contentTypeConverter, rt ResourceTypeTest) *http.Request {
+		return buildDeleteRequest(rt, ct, testServer, t)
+	},
+	assertResponse: func(t *testing.T, resp *http.Response, ct contentTypeConverter, rt ResourceTypeTest) {
+		t.Helper()
+		require.Equal(t, 404, resp.StatusCode)
+	},
 }
 
 const OperationDeleteInternalError Operation = "DeleteInternalError"
 
-type deleteInternalErrorOperation struct{}
-
-func (op deleteInternalErrorOperation) postAssert(t *testing.T, ct contentTypeConverter, rt ResourceTypeTest, testServer *httptest.Server) {
-}
-
-func (op deleteInternalErrorOperation) buildRequest(t *testing.T, testServer *httptest.Server, ct contentTypeConverter, rt ResourceTypeTest) *http.Request {
-	return buildDeleteRequest(rt, ct, testServer, t)
-}
-
-func (deleteInternalErrorOperation) name() Operation {
-	return OperationDeleteInternalError
-}
-
-func (deleteInternalErrorOperation) assertResponse(t *testing.T, resp *http.Response, ct contentTypeConverter, rt ResourceTypeTest) {
-	assertInternalError(t, resp, ct, rt, "deleting")
+var deleteInternalErrorOperation = operationTester{
+	name: OperationDeleteInternalError,
+	buildRequest: func(t *testing.T, testServer *httptest.Server, ct contentTypeConverter, rt ResourceTypeTest) *http.Request {
+		return buildDeleteRequest(rt, ct, testServer, t)
+	},
+	assertResponse: func(t *testing.T, resp *http.Response, ct contentTypeConverter, rt ResourceTypeTest) {
+		assertInternalError(t, resp, ct, rt, "deleting")
+	},
 }

--- a/server/resourcemanager/testutil/operations_delete.go
+++ b/server/resourcemanager/testutil/operations_delete.go
@@ -26,12 +26,12 @@ func buildDeleteRequest(rt ResourceTypeTest, ct contentTypeConverter, testServer
 
 const OperationDeleteSuccess Operation = "DeleteSuccess"
 
-var deleteSuccessOperation = operationTester{
+var deleteSuccessOperation = buildSingleStepOperation(singleStepOperationTester{
 	name: OperationDeleteSuccess,
 	postAssert: func(t *testing.T, ct contentTypeConverter, rt ResourceTypeTest, testServer *httptest.Server) {
 		req := buildGetRequest(rt, ct, testServer, t)
 		resp := doRequest(t, req, ct.contentType, testServer)
-		getNotFoundOperation.assertResponse(t, resp, ct, rt)
+		require.Equal(t, 404, resp.StatusCode)
 	},
 	buildRequest: func(t *testing.T, testServer *httptest.Server, ct contentTypeConverter, rt ResourceTypeTest) *http.Request {
 		return buildDeleteRequest(rt, ct, testServer, t)
@@ -41,11 +41,11 @@ var deleteSuccessOperation = operationTester{
 		require.Equal(t, 204, resp.StatusCode)
 		require.Empty(t, responseBody(t, resp))
 	},
-}
+})
 
 const OperationDeleteNotFound Operation = "DeleteNotFound"
 
-var deleteNotFoundOperation = operationTester{
+var deleteNotFoundOperation = buildSingleStepOperation(singleStepOperationTester{
 	name: OperationDeleteNotFound,
 	buildRequest: func(t *testing.T, testServer *httptest.Server, ct contentTypeConverter, rt ResourceTypeTest) *http.Request {
 		return buildDeleteRequest(rt, ct, testServer, t)
@@ -54,11 +54,11 @@ var deleteNotFoundOperation = operationTester{
 		t.Helper()
 		require.Equal(t, 404, resp.StatusCode)
 	},
-}
+})
 
 const OperationDeleteInternalError Operation = "DeleteInternalError"
 
-var deleteInternalErrorOperation = operationTester{
+var deleteInternalErrorOperation = buildSingleStepOperation(singleStepOperationTester{
 	name: OperationDeleteInternalError,
 	buildRequest: func(t *testing.T, testServer *httptest.Server, ct contentTypeConverter, rt ResourceTypeTest) *http.Request {
 		return buildDeleteRequest(rt, ct, testServer, t)
@@ -66,4 +66,4 @@ var deleteInternalErrorOperation = operationTester{
 	assertResponse: func(t *testing.T, resp *http.Response, ct contentTypeConverter, rt ResourceTypeTest) {
 		assertInternalError(t, resp, ct, rt.ResourceType, "deleting")
 	},
-}
+})

--- a/server/resourcemanager/testutil/operations_delete.go
+++ b/server/resourcemanager/testutil/operations_delete.go
@@ -30,7 +30,7 @@ var deleteSuccessOperation = operationTester{
 	name: OperationDeleteSuccess,
 	postAssert: func(t *testing.T, ct contentTypeConverter, rt ResourceTypeTest, testServer *httptest.Server) {
 		req := buildGetRequest(rt, ct, testServer, t)
-		resp := doRequest(t, req, ct, testServer)
+		resp := doRequest(t, req, ct.contentType, testServer)
 		getNotFoundOperation.assertResponse(t, resp, ct, rt)
 	},
 	buildRequest: func(t *testing.T, testServer *httptest.Server, ct contentTypeConverter, rt ResourceTypeTest) *http.Request {

--- a/server/resourcemanager/testutil/operations_delete.go
+++ b/server/resourcemanager/testutil/operations_delete.go
@@ -64,6 +64,6 @@ var deleteInternalErrorOperation = operationTester{
 		return buildDeleteRequest(rt, ct, testServer, t)
 	},
 	assertResponse: func(t *testing.T, resp *http.Response, ct contentTypeConverter, rt ResourceTypeTest) {
-		assertInternalError(t, resp, ct, rt, "deleting")
+		assertInternalError(t, resp, ct, rt.ResourceType, "deleting")
 	},
 }

--- a/server/resourcemanager/testutil/operations_delete.go
+++ b/server/resourcemanager/testutil/operations_delete.go
@@ -10,7 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildDeleteRequest(rt ResourceTypeTest, ct contentType, testServer *httptest.Server, t *testing.T) *http.Request {
+func buildDeleteRequest(rt ResourceTypeTest, ct ContentTypeConverter, testServer *httptest.Server, t *testing.T) *http.Request {
 	id := extractID(rt.SampleJSON)
 	url := fmt.Sprintf(
 		"%s/%s/%s",
@@ -28,7 +28,7 @@ const OperationDeleteSuccess Operation = "DeleteSuccess"
 
 type deleteSuccessOperation struct{}
 
-func (op deleteSuccessOperation) postAssert(t *testing.T, ct contentType, rt ResourceTypeTest, testServer *httptest.Server) {
+func (op deleteSuccessOperation) postAssert(t *testing.T, ct ContentTypeConverter, rt ResourceTypeTest, testServer *httptest.Server) {
 	req := buildGetRequest(rt, ct, testServer, t)
 
 	resp := doRequest(t, req, ct, testServer)
@@ -36,7 +36,7 @@ func (op deleteSuccessOperation) postAssert(t *testing.T, ct contentType, rt Res
 	(getNotFoundOperation{}).assertResponse(t, resp, ct, rt)
 }
 
-func (op deleteSuccessOperation) buildRequest(t *testing.T, testServer *httptest.Server, ct contentType, rt ResourceTypeTest) *http.Request {
+func (op deleteSuccessOperation) buildRequest(t *testing.T, testServer *httptest.Server, ct ContentTypeConverter, rt ResourceTypeTest) *http.Request {
 	return buildDeleteRequest(rt, ct, testServer, t)
 }
 
@@ -44,7 +44,7 @@ func (deleteSuccessOperation) name() Operation {
 	return OperationDeleteSuccess
 }
 
-func (deleteSuccessOperation) assertResponse(t *testing.T, resp *http.Response, ct contentType, rt ResourceTypeTest) {
+func (deleteSuccessOperation) assertResponse(t *testing.T, resp *http.Response, ct ContentTypeConverter, rt ResourceTypeTest) {
 	t.Helper()
 	require.Equal(t, 204, resp.StatusCode)
 	require.Empty(t, responseBody(t, resp))
@@ -54,10 +54,10 @@ const OperationDeleteNotFound Operation = "DeleteNotFound"
 
 type deleteNotFoundOperation struct{}
 
-func (op deleteNotFoundOperation) postAssert(t *testing.T, ct contentType, rt ResourceTypeTest, testServer *httptest.Server) {
+func (op deleteNotFoundOperation) postAssert(t *testing.T, ct ContentTypeConverter, rt ResourceTypeTest, testServer *httptest.Server) {
 }
 
-func (op deleteNotFoundOperation) buildRequest(t *testing.T, testServer *httptest.Server, ct contentType, rt ResourceTypeTest) *http.Request {
+func (op deleteNotFoundOperation) buildRequest(t *testing.T, testServer *httptest.Server, ct ContentTypeConverter, rt ResourceTypeTest) *http.Request {
 	return buildDeleteRequest(rt, ct, testServer, t)
 }
 
@@ -65,7 +65,7 @@ func (deleteNotFoundOperation) name() Operation {
 	return OperationDeleteNotFound
 }
 
-func (deleteNotFoundOperation) assertResponse(t *testing.T, resp *http.Response, ct contentType, rt ResourceTypeTest) {
+func (deleteNotFoundOperation) assertResponse(t *testing.T, resp *http.Response, ct ContentTypeConverter, rt ResourceTypeTest) {
 	t.Helper()
 	require.Equal(t, 404, resp.StatusCode)
 }
@@ -74,10 +74,10 @@ const OperationDeleteInternalError Operation = "DeleteInternalError"
 
 type deleteInternalErrorOperation struct{}
 
-func (op deleteInternalErrorOperation) postAssert(t *testing.T, ct contentType, rt ResourceTypeTest, testServer *httptest.Server) {
+func (op deleteInternalErrorOperation) postAssert(t *testing.T, ct ContentTypeConverter, rt ResourceTypeTest, testServer *httptest.Server) {
 }
 
-func (op deleteInternalErrorOperation) buildRequest(t *testing.T, testServer *httptest.Server, ct contentType, rt ResourceTypeTest) *http.Request {
+func (op deleteInternalErrorOperation) buildRequest(t *testing.T, testServer *httptest.Server, ct ContentTypeConverter, rt ResourceTypeTest) *http.Request {
 	return buildDeleteRequest(rt, ct, testServer, t)
 }
 
@@ -85,6 +85,6 @@ func (deleteInternalErrorOperation) name() Operation {
 	return OperationDeleteInternalError
 }
 
-func (deleteInternalErrorOperation) assertResponse(t *testing.T, resp *http.Response, ct contentType, rt ResourceTypeTest) {
+func (deleteInternalErrorOperation) assertResponse(t *testing.T, resp *http.Response, ct ContentTypeConverter, rt ResourceTypeTest) {
 	assertInternalError(t, resp, ct, rt, "deleting")
 }

--- a/server/resourcemanager/testutil/operations_get.go
+++ b/server/resourcemanager/testutil/operations_get.go
@@ -10,7 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildGetRequest(rt ResourceTypeTest, ct ContentTypeConverter, testServer *httptest.Server, t *testing.T) *http.Request {
+func buildGetRequest(rt ResourceTypeTest, ct contentTypeConverter, testServer *httptest.Server, t *testing.T) *http.Request {
 	id := extractID(rt.SampleJSON)
 	url := fmt.Sprintf(
 		"%s/%s/%s",
@@ -28,10 +28,10 @@ const OperationGetSuccess Operation = "GetSuccess"
 
 type getSuccessOperation struct{}
 
-func (op getSuccessOperation) postAssert(t *testing.T, ct ContentTypeConverter, rt ResourceTypeTest, testServer *httptest.Server) {
+func (op getSuccessOperation) postAssert(t *testing.T, ct contentTypeConverter, rt ResourceTypeTest, testServer *httptest.Server) {
 }
 
-func (op getSuccessOperation) buildRequest(t *testing.T, testServer *httptest.Server, ct ContentTypeConverter, rt ResourceTypeTest) *http.Request {
+func (op getSuccessOperation) buildRequest(t *testing.T, testServer *httptest.Server, ct contentTypeConverter, rt ResourceTypeTest) *http.Request {
 	return buildGetRequest(rt, ct, testServer, t)
 }
 
@@ -39,7 +39,7 @@ func (getSuccessOperation) name() Operation {
 	return OperationGetSuccess
 }
 
-func (getSuccessOperation) assertResponse(t *testing.T, resp *http.Response, ct ContentTypeConverter, rt ResourceTypeTest) {
+func (getSuccessOperation) assertResponse(t *testing.T, resp *http.Response, ct contentTypeConverter, rt ResourceTypeTest) {
 	t.Helper()
 	require.Equal(t, 200, resp.StatusCode)
 
@@ -54,10 +54,10 @@ const OperationGetNotFound Operation = "GetNotFound"
 
 type getNotFoundOperation struct{}
 
-func (op getNotFoundOperation) postAssert(t *testing.T, ct ContentTypeConverter, rt ResourceTypeTest, testServer *httptest.Server) {
+func (op getNotFoundOperation) postAssert(t *testing.T, ct contentTypeConverter, rt ResourceTypeTest, testServer *httptest.Server) {
 }
 
-func (op getNotFoundOperation) buildRequest(t *testing.T, testServer *httptest.Server, ct ContentTypeConverter, rt ResourceTypeTest) *http.Request {
+func (op getNotFoundOperation) buildRequest(t *testing.T, testServer *httptest.Server, ct contentTypeConverter, rt ResourceTypeTest) *http.Request {
 	return buildGetRequest(rt, ct, testServer, t)
 }
 
@@ -65,7 +65,7 @@ func (getNotFoundOperation) name() Operation {
 	return OperationGetNotFound
 }
 
-func (getNotFoundOperation) assertResponse(t *testing.T, resp *http.Response, ct ContentTypeConverter, rt ResourceTypeTest) {
+func (getNotFoundOperation) assertResponse(t *testing.T, resp *http.Response, ct contentTypeConverter, rt ResourceTypeTest) {
 	t.Helper()
 	require.Equal(t, 404, resp.StatusCode)
 }
@@ -74,10 +74,10 @@ const OperationGetInternalError Operation = "GetInternalError"
 
 type getInternalErrorOperation struct{}
 
-func (op getInternalErrorOperation) postAssert(t *testing.T, ct ContentTypeConverter, rt ResourceTypeTest, testServer *httptest.Server) {
+func (op getInternalErrorOperation) postAssert(t *testing.T, ct contentTypeConverter, rt ResourceTypeTest, testServer *httptest.Server) {
 }
 
-func (op getInternalErrorOperation) buildRequest(t *testing.T, testServer *httptest.Server, ct ContentTypeConverter, rt ResourceTypeTest) *http.Request {
+func (op getInternalErrorOperation) buildRequest(t *testing.T, testServer *httptest.Server, ct contentTypeConverter, rt ResourceTypeTest) *http.Request {
 	return buildGetRequest(rt, ct, testServer, t)
 }
 
@@ -85,6 +85,6 @@ func (getInternalErrorOperation) name() Operation {
 	return OperationGetInternalError
 }
 
-func (getInternalErrorOperation) assertResponse(t *testing.T, resp *http.Response, ct ContentTypeConverter, rt ResourceTypeTest) {
+func (getInternalErrorOperation) assertResponse(t *testing.T, resp *http.Response, ct contentTypeConverter, rt ResourceTypeTest) {
 	assertInternalError(t, resp, ct, rt, "getting")
 }

--- a/server/resourcemanager/testutil/operations_get.go
+++ b/server/resourcemanager/testutil/operations_get.go
@@ -70,21 +70,21 @@ func (getNotFoundOperation) assertResponse(t *testing.T, resp *http.Response, ct
 	require.Equal(t, 404, resp.StatusCode)
 }
 
-const OperationGetInteralError Operation = "GetInteralError"
+const OperationGetInternalError Operation = "GetInternalError"
 
-type getInteralErrorOperation struct{}
+type getInternalErrorOperation struct{}
 
-func (op getInteralErrorOperation) postAssert(t *testing.T, ct contentType, rt ResourceTypeTest, testServer *httptest.Server) {
+func (op getInternalErrorOperation) postAssert(t *testing.T, ct contentType, rt ResourceTypeTest, testServer *httptest.Server) {
 }
 
-func (op getInteralErrorOperation) buildRequest(t *testing.T, testServer *httptest.Server, ct contentType, rt ResourceTypeTest) *http.Request {
+func (op getInternalErrorOperation) buildRequest(t *testing.T, testServer *httptest.Server, ct contentType, rt ResourceTypeTest) *http.Request {
 	return buildGetRequest(rt, ct, testServer, t)
 }
 
-func (getInteralErrorOperation) name() Operation {
-	return OperationGetInteralError
+func (getInternalErrorOperation) name() Operation {
+	return OperationGetInternalError
 }
 
-func (getInteralErrorOperation) assertResponse(t *testing.T, resp *http.Response, ct contentType, rt ResourceTypeTest) {
+func (getInternalErrorOperation) assertResponse(t *testing.T, resp *http.Response, ct contentType, rt ResourceTypeTest) {
 	assertInternalError(t, resp, ct, rt, "getting")
 }

--- a/server/resourcemanager/testutil/operations_get.go
+++ b/server/resourcemanager/testutil/operations_get.go
@@ -64,6 +64,6 @@ var getInternalErrorOperation = operationTester{
 		return buildGetRequest(rt, ct, testServer, t)
 	},
 	assertResponse: func(t *testing.T, resp *http.Response, ct contentTypeConverter, rt ResourceTypeTest) {
-		assertInternalError(t, resp, ct, rt, "getting")
+		assertInternalError(t, resp, ct, rt.ResourceType, "getting")
 	},
 }

--- a/server/resourcemanager/testutil/operations_get.go
+++ b/server/resourcemanager/testutil/operations_get.go
@@ -26,7 +26,7 @@ func buildGetRequest(rt ResourceTypeTest, ct contentTypeConverter, testServer *h
 
 const OperationGetSuccess Operation = "GetSuccess"
 
-var getSuccessOperation = operationTester{
+var getSuccessOperation = buildSingleStepOperation(singleStepOperationTester{
 	name: OperationGetSuccess,
 	buildRequest: func(t *testing.T, testServer *httptest.Server, ct contentTypeConverter, rt ResourceTypeTest) *http.Request {
 		return buildGetRequest(rt, ct, testServer, t)
@@ -41,11 +41,11 @@ var getSuccessOperation = operationTester{
 
 		require.JSONEq(t, expected, jsonBody)
 	},
-}
+})
 
 const OperationGetNotFound Operation = "GetNotFound"
 
-var getNotFoundOperation = operationTester{
+var getNotFoundOperation = buildSingleStepOperation(singleStepOperationTester{
 	name: OperationGetNotFound,
 	buildRequest: func(t *testing.T, testServer *httptest.Server, ct contentTypeConverter, rt ResourceTypeTest) *http.Request {
 		return buildGetRequest(rt, ct, testServer, t)
@@ -54,11 +54,11 @@ var getNotFoundOperation = operationTester{
 		t.Helper()
 		require.Equal(t, 404, resp.StatusCode)
 	},
-}
+})
 
 const OperationGetInternalError Operation = "GetInternalError"
 
-var getInternalErrorOperation = operationTester{
+var getInternalErrorOperation = buildSingleStepOperation(singleStepOperationTester{
 	name: OperationGetInternalError,
 	buildRequest: func(t *testing.T, testServer *httptest.Server, ct contentTypeConverter, rt ResourceTypeTest) *http.Request {
 		return buildGetRequest(rt, ct, testServer, t)
@@ -66,4 +66,4 @@ var getInternalErrorOperation = operationTester{
 	assertResponse: func(t *testing.T, resp *http.Response, ct contentTypeConverter, rt ResourceTypeTest) {
 		assertInternalError(t, resp, ct, rt.ResourceType, "getting")
 	},
-}
+})

--- a/server/resourcemanager/testutil/operations_get.go
+++ b/server/resourcemanager/testutil/operations_get.go
@@ -26,65 +26,44 @@ func buildGetRequest(rt ResourceTypeTest, ct contentTypeConverter, testServer *h
 
 const OperationGetSuccess Operation = "GetSuccess"
 
-type getSuccessOperation struct{}
+var getSuccessOperation = operationTester{
+	name: OperationGetSuccess,
+	buildRequest: func(t *testing.T, testServer *httptest.Server, ct contentTypeConverter, rt ResourceTypeTest) *http.Request {
+		return buildGetRequest(rt, ct, testServer, t)
+	},
+	assertResponse: func(t *testing.T, resp *http.Response, ct contentTypeConverter, rt ResourceTypeTest) {
+		t.Helper()
+		require.Equal(t, 200, resp.StatusCode)
 
-func (op getSuccessOperation) postAssert(t *testing.T, ct contentTypeConverter, rt ResourceTypeTest, testServer *httptest.Server) {
-}
+		jsonBody := responseBodyJSON(t, resp, ct)
 
-func (op getSuccessOperation) buildRequest(t *testing.T, testServer *httptest.Server, ct contentTypeConverter, rt ResourceTypeTest) *http.Request {
-	return buildGetRequest(rt, ct, testServer, t)
-}
+		expected := ct.toJSON(rt.SampleJSON)
 
-func (getSuccessOperation) name() Operation {
-	return OperationGetSuccess
-}
-
-func (getSuccessOperation) assertResponse(t *testing.T, resp *http.Response, ct contentTypeConverter, rt ResourceTypeTest) {
-	t.Helper()
-	require.Equal(t, 200, resp.StatusCode)
-
-	jsonBody := responseBodyJSON(t, resp, ct)
-
-	expected := ct.toJSON(rt.SampleJSON)
-
-	require.JSONEq(t, expected, jsonBody)
+		require.JSONEq(t, expected, jsonBody)
+	},
 }
 
 const OperationGetNotFound Operation = "GetNotFound"
 
-type getNotFoundOperation struct{}
-
-func (op getNotFoundOperation) postAssert(t *testing.T, ct contentTypeConverter, rt ResourceTypeTest, testServer *httptest.Server) {
-}
-
-func (op getNotFoundOperation) buildRequest(t *testing.T, testServer *httptest.Server, ct contentTypeConverter, rt ResourceTypeTest) *http.Request {
-	return buildGetRequest(rt, ct, testServer, t)
-}
-
-func (getNotFoundOperation) name() Operation {
-	return OperationGetNotFound
-}
-
-func (getNotFoundOperation) assertResponse(t *testing.T, resp *http.Response, ct contentTypeConverter, rt ResourceTypeTest) {
-	t.Helper()
-	require.Equal(t, 404, resp.StatusCode)
+var getNotFoundOperation = operationTester{
+	name: OperationGetNotFound,
+	buildRequest: func(t *testing.T, testServer *httptest.Server, ct contentTypeConverter, rt ResourceTypeTest) *http.Request {
+		return buildGetRequest(rt, ct, testServer, t)
+	},
+	assertResponse: func(t *testing.T, resp *http.Response, ct contentTypeConverter, rt ResourceTypeTest) {
+		t.Helper()
+		require.Equal(t, 404, resp.StatusCode)
+	},
 }
 
 const OperationGetInternalError Operation = "GetInternalError"
 
-type getInternalErrorOperation struct{}
-
-func (op getInternalErrorOperation) postAssert(t *testing.T, ct contentTypeConverter, rt ResourceTypeTest, testServer *httptest.Server) {
-}
-
-func (op getInternalErrorOperation) buildRequest(t *testing.T, testServer *httptest.Server, ct contentTypeConverter, rt ResourceTypeTest) *http.Request {
-	return buildGetRequest(rt, ct, testServer, t)
-}
-
-func (getInternalErrorOperation) name() Operation {
-	return OperationGetInternalError
-}
-
-func (getInternalErrorOperation) assertResponse(t *testing.T, resp *http.Response, ct contentTypeConverter, rt ResourceTypeTest) {
-	assertInternalError(t, resp, ct, rt, "getting")
+var getInternalErrorOperation = operationTester{
+	name: OperationGetInternalError,
+	buildRequest: func(t *testing.T, testServer *httptest.Server, ct contentTypeConverter, rt ResourceTypeTest) *http.Request {
+		return buildGetRequest(rt, ct, testServer, t)
+	},
+	assertResponse: func(t *testing.T, resp *http.Response, ct contentTypeConverter, rt ResourceTypeTest) {
+		assertInternalError(t, resp, ct, rt, "getting")
+	},
 }

--- a/server/resourcemanager/testutil/operations_get.go
+++ b/server/resourcemanager/testutil/operations_get.go
@@ -10,7 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildGetRequest(rt ResourceTypeTest, ct contentType, testServer *httptest.Server, t *testing.T) *http.Request {
+func buildGetRequest(rt ResourceTypeTest, ct ContentTypeConverter, testServer *httptest.Server, t *testing.T) *http.Request {
 	id := extractID(rt.SampleJSON)
 	url := fmt.Sprintf(
 		"%s/%s/%s",
@@ -28,10 +28,10 @@ const OperationGetSuccess Operation = "GetSuccess"
 
 type getSuccessOperation struct{}
 
-func (op getSuccessOperation) postAssert(t *testing.T, ct contentType, rt ResourceTypeTest, testServer *httptest.Server) {
+func (op getSuccessOperation) postAssert(t *testing.T, ct ContentTypeConverter, rt ResourceTypeTest, testServer *httptest.Server) {
 }
 
-func (op getSuccessOperation) buildRequest(t *testing.T, testServer *httptest.Server, ct contentType, rt ResourceTypeTest) *http.Request {
+func (op getSuccessOperation) buildRequest(t *testing.T, testServer *httptest.Server, ct ContentTypeConverter, rt ResourceTypeTest) *http.Request {
 	return buildGetRequest(rt, ct, testServer, t)
 }
 
@@ -39,7 +39,7 @@ func (getSuccessOperation) name() Operation {
 	return OperationGetSuccess
 }
 
-func (getSuccessOperation) assertResponse(t *testing.T, resp *http.Response, ct contentType, rt ResourceTypeTest) {
+func (getSuccessOperation) assertResponse(t *testing.T, resp *http.Response, ct ContentTypeConverter, rt ResourceTypeTest) {
 	t.Helper()
 	require.Equal(t, 200, resp.StatusCode)
 
@@ -54,10 +54,10 @@ const OperationGetNotFound Operation = "GetNotFound"
 
 type getNotFoundOperation struct{}
 
-func (op getNotFoundOperation) postAssert(t *testing.T, ct contentType, rt ResourceTypeTest, testServer *httptest.Server) {
+func (op getNotFoundOperation) postAssert(t *testing.T, ct ContentTypeConverter, rt ResourceTypeTest, testServer *httptest.Server) {
 }
 
-func (op getNotFoundOperation) buildRequest(t *testing.T, testServer *httptest.Server, ct contentType, rt ResourceTypeTest) *http.Request {
+func (op getNotFoundOperation) buildRequest(t *testing.T, testServer *httptest.Server, ct ContentTypeConverter, rt ResourceTypeTest) *http.Request {
 	return buildGetRequest(rt, ct, testServer, t)
 }
 
@@ -65,7 +65,7 @@ func (getNotFoundOperation) name() Operation {
 	return OperationGetNotFound
 }
 
-func (getNotFoundOperation) assertResponse(t *testing.T, resp *http.Response, ct contentType, rt ResourceTypeTest) {
+func (getNotFoundOperation) assertResponse(t *testing.T, resp *http.Response, ct ContentTypeConverter, rt ResourceTypeTest) {
 	t.Helper()
 	require.Equal(t, 404, resp.StatusCode)
 }
@@ -74,10 +74,10 @@ const OperationGetInternalError Operation = "GetInternalError"
 
 type getInternalErrorOperation struct{}
 
-func (op getInternalErrorOperation) postAssert(t *testing.T, ct contentType, rt ResourceTypeTest, testServer *httptest.Server) {
+func (op getInternalErrorOperation) postAssert(t *testing.T, ct ContentTypeConverter, rt ResourceTypeTest, testServer *httptest.Server) {
 }
 
-func (op getInternalErrorOperation) buildRequest(t *testing.T, testServer *httptest.Server, ct contentType, rt ResourceTypeTest) *http.Request {
+func (op getInternalErrorOperation) buildRequest(t *testing.T, testServer *httptest.Server, ct ContentTypeConverter, rt ResourceTypeTest) *http.Request {
 	return buildGetRequest(rt, ct, testServer, t)
 }
 
@@ -85,6 +85,6 @@ func (getInternalErrorOperation) name() Operation {
 	return OperationGetInternalError
 }
 
-func (getInternalErrorOperation) assertResponse(t *testing.T, resp *http.Response, ct contentType, rt ResourceTypeTest) {
+func (getInternalErrorOperation) assertResponse(t *testing.T, resp *http.Response, ct ContentTypeConverter, rt ResourceTypeTest) {
 	assertInternalError(t, resp, ct, rt, "getting")
 }

--- a/server/resourcemanager/testutil/operations_list.go
+++ b/server/resourcemanager/testutil/operations_list.go
@@ -10,7 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildListRequest(rt string, ct ContentTypeConverter, testServer *httptest.Server, t *testing.T) *http.Request {
+func buildListRequest(rt string, ct contentTypeConverter, testServer *httptest.Server, t *testing.T) *http.Request {
 	url := fmt.Sprintf("%s/%s/", testServer.URL, strings.ToLower(rt))
 
 	req, err := http.NewRequest(http.MethodGet, url, nil)
@@ -22,10 +22,10 @@ const OperationListNoResults Operation = "ListNoResults"
 
 type listNoResultsOperation struct{}
 
-func (op listNoResultsOperation) postAssert(t *testing.T, ct ContentTypeConverter, rt ResourceTypeTest, testServer *httptest.Server) {
+func (op listNoResultsOperation) postAssert(t *testing.T, ct contentTypeConverter, rt ResourceTypeTest, testServer *httptest.Server) {
 }
 
-func (op listNoResultsOperation) buildRequest(t *testing.T, testServer *httptest.Server, ct ContentTypeConverter, rt ResourceTypeTest) *http.Request {
+func (op listNoResultsOperation) buildRequest(t *testing.T, testServer *httptest.Server, ct contentTypeConverter, rt ResourceTypeTest) *http.Request {
 	return buildListRequest(
 		rt.ResourceType,
 		ct,
@@ -38,7 +38,7 @@ func (listNoResultsOperation) name() Operation {
 	return OperationListNoResults
 }
 
-func (listNoResultsOperation) assertResponse(t *testing.T, resp *http.Response, ct ContentTypeConverter, rt ResourceTypeTest) {
+func (listNoResultsOperation) assertResponse(t *testing.T, resp *http.Response, ct contentTypeConverter, rt ResourceTypeTest) {
 	require.Equal(t, 200, resp.StatusCode)
 
 	jsonBody := responseBodyJSON(t, resp, ct)
@@ -55,10 +55,10 @@ const OperationListSuccess Operation = "ListSuccess"
 
 type listSuccessOperation struct{}
 
-func (op listSuccessOperation) postAssert(t *testing.T, ct ContentTypeConverter, rt ResourceTypeTest, testServer *httptest.Server) {
+func (op listSuccessOperation) postAssert(t *testing.T, ct contentTypeConverter, rt ResourceTypeTest, testServer *httptest.Server) {
 }
 
-func (op listSuccessOperation) buildRequest(t *testing.T, testServer *httptest.Server, ct ContentTypeConverter, rt ResourceTypeTest) *http.Request {
+func (op listSuccessOperation) buildRequest(t *testing.T, testServer *httptest.Server, ct contentTypeConverter, rt ResourceTypeTest) *http.Request {
 	return buildListRequest(
 		rt.ResourceType,
 		ct,
@@ -71,7 +71,7 @@ func (listSuccessOperation) name() Operation {
 	return OperationListSuccess
 }
 
-func (listSuccessOperation) assertResponse(t *testing.T, resp *http.Response, ct ContentTypeConverter, rt ResourceTypeTest) {
+func (listSuccessOperation) assertResponse(t *testing.T, resp *http.Response, ct contentTypeConverter, rt ResourceTypeTest) {
 	require.Equal(t, 200, resp.StatusCode)
 
 	jsonBody := responseBodyJSON(t, resp, ct)
@@ -88,10 +88,10 @@ const OperationListInternalError Operation = "ListInternalError"
 
 type listInternalErrorOperation struct{}
 
-func (op listInternalErrorOperation) postAssert(t *testing.T, ct ContentTypeConverter, rt ResourceTypeTest, testServer *httptest.Server) {
+func (op listInternalErrorOperation) postAssert(t *testing.T, ct contentTypeConverter, rt ResourceTypeTest, testServer *httptest.Server) {
 }
 
-func (op listInternalErrorOperation) buildRequest(t *testing.T, testServer *httptest.Server, ct ContentTypeConverter, rt ResourceTypeTest) *http.Request {
+func (op listInternalErrorOperation) buildRequest(t *testing.T, testServer *httptest.Server, ct contentTypeConverter, rt ResourceTypeTest) *http.Request {
 	return buildListRequest(
 		rt.ResourceType,
 		ct,
@@ -104,6 +104,6 @@ func (listInternalErrorOperation) name() Operation {
 	return OperationListInternalError
 }
 
-func (listInternalErrorOperation) assertResponse(t *testing.T, resp *http.Response, ct ContentTypeConverter, rt ResourceTypeTest) {
+func (listInternalErrorOperation) assertResponse(t *testing.T, resp *http.Response, ct contentTypeConverter, rt ResourceTypeTest) {
 	assertInternalError(t, resp, ct, rt, "listing")
 }

--- a/server/resourcemanager/testutil/operations_list.go
+++ b/server/resourcemanager/testutil/operations_list.go
@@ -38,7 +38,7 @@ func buildListRequest(resourceType string, paginationParams map[string]string, c
 
 const OperationListNoResults Operation = "ListNoResults"
 
-var listNoResultsOperation = operationTester{
+var listNoResultsOperation = buildSingleStepOperation(singleStepOperationTester{
 	name: OperationListNoResults,
 	buildRequest: func(t *testing.T, testServer *httptest.Server, ct contentTypeConverter, rt ResourceTypeTest) *http.Request {
 		return buildListRequest(
@@ -61,11 +61,11 @@ var listNoResultsOperation = operationTester{
 
 		require.JSONEq(t, expected, jsonBody)
 	},
-}
+})
 
 const OperationListSuccess Operation = "ListSuccess"
 
-var listSuccessOperation = operationTester{
+var listSuccessOperation = buildSingleStepOperation(singleStepOperationTester{
 	name: OperationListSuccess,
 	buildRequest: func(t *testing.T, testServer *httptest.Server, ct contentTypeConverter, rt ResourceTypeTest) *http.Request {
 		return buildListRequest(
@@ -88,11 +88,11 @@ var listSuccessOperation = operationTester{
 
 		require.JSONEq(t, expected, jsonBody)
 	},
-}
+})
 
 const OperationListWithInvalidSortField Operation = "ListWithInvalidSortField"
 
-var listWithInvalidSortFieldOperation = operationTester{
+var listWithInvalidSortFieldOperation = buildSingleStepOperation(singleStepOperationTester{
 	name: OperationListWithInvalidSortField,
 	buildRequest: func(t *testing.T, testServer *httptest.Server, ct contentTypeConverter, rt ResourceTypeTest) *http.Request {
 		invalidSortField := generateRandomString()
@@ -113,14 +113,14 @@ var listWithInvalidSortFieldOperation = operationTester{
 	assertResponse: func(t *testing.T, resp *http.Response, ct contentTypeConverter, rt ResourceTypeTest) {
 		require.Equal(t, 400, resp.StatusCode)
 	},
-}
+})
 
 // Tech debt: Even being one operation, we will split ASC and DESC in two just to keep
 // "one request per operation". In the future we can change this structure to support both tests
 // in one operationTester instance
 const OperationListPaginatedSuccess Operation = "ListPaginatedSuccess"
 
-var listPaginatedAscendingSuccessOperation = operationTester{
+var listPaginatedAscendingSuccessOperation = buildSingleStepOperation(singleStepOperationTester{
 	name: OperationListPaginatedSuccess,
 	buildRequest: func(t *testing.T, testServer *httptest.Server, ct contentTypeConverter, rt ResourceTypeTest) *http.Request {
 		return buildListRequest(
@@ -162,9 +162,9 @@ var listPaginatedAscendingSuccessOperation = operationTester{
 			prevVal = item[field]
 		}
 	},
-}
+})
 
-var listPaginatedDescendingSuccessOperation = operationTester{
+var listPaginatedDescendingSuccessOperation = buildSingleStepOperation(singleStepOperationTester{
 	name: OperationListPaginatedSuccess,
 	buildRequest: func(t *testing.T, testServer *httptest.Server, ct contentTypeConverter, rt ResourceTypeTest) *http.Request {
 		return buildListRequest(
@@ -206,11 +206,11 @@ var listPaginatedDescendingSuccessOperation = operationTester{
 			prevVal = item[field]
 		}
 	},
-}
+})
 
 const OperationListInternalError Operation = "ListInternalError"
 
-var listInternalErrorOperation = operationTester{
+var listInternalErrorOperation = buildSingleStepOperation(singleStepOperationTester{
 	name: OperationListInternalError,
 	buildRequest: func(t *testing.T, testServer *httptest.Server, ct contentTypeConverter, rt ResourceTypeTest) *http.Request {
 		return buildListRequest(
@@ -224,4 +224,4 @@ var listInternalErrorOperation = operationTester{
 	assertResponse: func(t *testing.T, resp *http.Response, ct contentTypeConverter, rt ResourceTypeTest) {
 		assertInternalError(t, resp, ct, rt.ResourceType, "listing")
 	},
-}
+})

--- a/server/resourcemanager/testutil/operations_list.go
+++ b/server/resourcemanager/testutil/operations_list.go
@@ -10,7 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildListRequest(rt string, ct contentType, testServer *httptest.Server, t *testing.T) *http.Request {
+func buildListRequest(rt string, ct ContentTypeConverter, testServer *httptest.Server, t *testing.T) *http.Request {
 	url := fmt.Sprintf("%s/%s/", testServer.URL, strings.ToLower(rt))
 
 	req, err := http.NewRequest(http.MethodGet, url, nil)
@@ -22,10 +22,10 @@ const OperationListNoResults Operation = "ListNoResults"
 
 type listNoResultsOperation struct{}
 
-func (op listNoResultsOperation) postAssert(t *testing.T, ct contentType, rt ResourceTypeTest, testServer *httptest.Server) {
+func (op listNoResultsOperation) postAssert(t *testing.T, ct ContentTypeConverter, rt ResourceTypeTest, testServer *httptest.Server) {
 }
 
-func (op listNoResultsOperation) buildRequest(t *testing.T, testServer *httptest.Server, ct contentType, rt ResourceTypeTest) *http.Request {
+func (op listNoResultsOperation) buildRequest(t *testing.T, testServer *httptest.Server, ct ContentTypeConverter, rt ResourceTypeTest) *http.Request {
 	return buildListRequest(
 		rt.ResourceType,
 		ct,
@@ -38,7 +38,7 @@ func (listNoResultsOperation) name() Operation {
 	return OperationListNoResults
 }
 
-func (listNoResultsOperation) assertResponse(t *testing.T, resp *http.Response, ct contentType, rt ResourceTypeTest) {
+func (listNoResultsOperation) assertResponse(t *testing.T, resp *http.Response, ct ContentTypeConverter, rt ResourceTypeTest) {
 	require.Equal(t, 200, resp.StatusCode)
 
 	jsonBody := responseBodyJSON(t, resp, ct)
@@ -55,10 +55,10 @@ const OperationListSuccess Operation = "ListSuccess"
 
 type listSuccessOperation struct{}
 
-func (op listSuccessOperation) postAssert(t *testing.T, ct contentType, rt ResourceTypeTest, testServer *httptest.Server) {
+func (op listSuccessOperation) postAssert(t *testing.T, ct ContentTypeConverter, rt ResourceTypeTest, testServer *httptest.Server) {
 }
 
-func (op listSuccessOperation) buildRequest(t *testing.T, testServer *httptest.Server, ct contentType, rt ResourceTypeTest) *http.Request {
+func (op listSuccessOperation) buildRequest(t *testing.T, testServer *httptest.Server, ct ContentTypeConverter, rt ResourceTypeTest) *http.Request {
 	return buildListRequest(
 		rt.ResourceType,
 		ct,
@@ -71,7 +71,7 @@ func (listSuccessOperation) name() Operation {
 	return OperationListSuccess
 }
 
-func (listSuccessOperation) assertResponse(t *testing.T, resp *http.Response, ct contentType, rt ResourceTypeTest) {
+func (listSuccessOperation) assertResponse(t *testing.T, resp *http.Response, ct ContentTypeConverter, rt ResourceTypeTest) {
 	require.Equal(t, 200, resp.StatusCode)
 
 	jsonBody := responseBodyJSON(t, resp, ct)
@@ -88,10 +88,10 @@ const OperationListInternalError Operation = "ListInternalError"
 
 type listInternalErrorOperation struct{}
 
-func (op listInternalErrorOperation) postAssert(t *testing.T, ct contentType, rt ResourceTypeTest, testServer *httptest.Server) {
+func (op listInternalErrorOperation) postAssert(t *testing.T, ct ContentTypeConverter, rt ResourceTypeTest, testServer *httptest.Server) {
 }
 
-func (op listInternalErrorOperation) buildRequest(t *testing.T, testServer *httptest.Server, ct contentType, rt ResourceTypeTest) *http.Request {
+func (op listInternalErrorOperation) buildRequest(t *testing.T, testServer *httptest.Server, ct ContentTypeConverter, rt ResourceTypeTest) *http.Request {
 	return buildListRequest(
 		rt.ResourceType,
 		ct,
@@ -104,6 +104,6 @@ func (listInternalErrorOperation) name() Operation {
 	return OperationListInternalError
 }
 
-func (listInternalErrorOperation) assertResponse(t *testing.T, resp *http.Response, ct contentType, rt ResourceTypeTest) {
+func (listInternalErrorOperation) assertResponse(t *testing.T, resp *http.Response, ct ContentTypeConverter, rt ResourceTypeTest) {
 	assertInternalError(t, resp, ct, rt, "listing")
 }

--- a/server/resourcemanager/testutil/operations_list.go
+++ b/server/resourcemanager/testutil/operations_list.go
@@ -20,90 +20,69 @@ func buildListRequest(rt string, ct contentTypeConverter, testServer *httptest.S
 
 const OperationListNoResults Operation = "ListNoResults"
 
-type listNoResultsOperation struct{}
+var listNoResultsOperation = operationTester{
+	name: OperationListNoResults,
+	buildRequest: func(t *testing.T, testServer *httptest.Server, ct contentTypeConverter, rt ResourceTypeTest) *http.Request {
+		return buildListRequest(
+			rt.ResourceType,
+			ct,
+			testServer,
+			t,
+		)
+	},
+	assertResponse: func(t *testing.T, resp *http.Response, ct contentTypeConverter, rt ResourceTypeTest) {
+		require.Equal(t, 200, resp.StatusCode)
 
-func (op listNoResultsOperation) postAssert(t *testing.T, ct contentTypeConverter, rt ResourceTypeTest, testServer *httptest.Server) {
-}
+		jsonBody := responseBodyJSON(t, resp, ct)
 
-func (op listNoResultsOperation) buildRequest(t *testing.T, testServer *httptest.Server, ct contentTypeConverter, rt ResourceTypeTest) *http.Request {
-	return buildListRequest(
-		rt.ResourceType,
-		ct,
-		testServer,
-		t,
-	)
-}
+		expected := `{
+			"count": 0,
+			"items": []
+		}`
 
-func (listNoResultsOperation) name() Operation {
-	return OperationListNoResults
-}
-
-func (listNoResultsOperation) assertResponse(t *testing.T, resp *http.Response, ct contentTypeConverter, rt ResourceTypeTest) {
-	require.Equal(t, 200, resp.StatusCode)
-
-	jsonBody := responseBodyJSON(t, resp, ct)
-
-	expected := `{
-		"count": 0,
-		"items": []
-	}`
-
-	require.JSONEq(t, expected, jsonBody)
+		require.JSONEq(t, expected, jsonBody)
+	},
 }
 
 const OperationListSuccess Operation = "ListSuccess"
 
-type listSuccessOperation struct{}
+var listSuccessOperation = operationTester{
+	name: OperationListSuccess,
+	buildRequest: func(t *testing.T, testServer *httptest.Server, ct contentTypeConverter, rt ResourceTypeTest) *http.Request {
+		return buildListRequest(
+			rt.ResourceType,
+			ct,
+			testServer,
+			t,
+		)
+	},
+	assertResponse: func(t *testing.T, resp *http.Response, ct contentTypeConverter, rt ResourceTypeTest) {
+		require.Equal(t, 200, resp.StatusCode)
 
-func (op listSuccessOperation) postAssert(t *testing.T, ct contentTypeConverter, rt ResourceTypeTest, testServer *httptest.Server) {
-}
+		jsonBody := responseBodyJSON(t, resp, ct)
 
-func (op listSuccessOperation) buildRequest(t *testing.T, testServer *httptest.Server, ct contentTypeConverter, rt ResourceTypeTest) *http.Request {
-	return buildListRequest(
-		rt.ResourceType,
-		ct,
-		testServer,
-		t,
-	)
-}
+		expected := `{
+			"count": 1,
+			"items": [` + ct.toJSON(rt.SampleJSON) + `]
+		}`
 
-func (listSuccessOperation) name() Operation {
-	return OperationListSuccess
-}
-
-func (listSuccessOperation) assertResponse(t *testing.T, resp *http.Response, ct contentTypeConverter, rt ResourceTypeTest) {
-	require.Equal(t, 200, resp.StatusCode)
-
-	jsonBody := responseBodyJSON(t, resp, ct)
-
-	expected := `{
-		"count": 1,
-		"items": [` + ct.toJSON(rt.SampleJSON) + `]
-	}`
-
-	require.JSONEq(t, expected, jsonBody)
+		require.JSONEq(t, expected, jsonBody)
+	},
 }
 
 const OperationListInternalError Operation = "ListInternalError"
 
-type listInternalErrorOperation struct{}
-
-func (op listInternalErrorOperation) postAssert(t *testing.T, ct contentTypeConverter, rt ResourceTypeTest, testServer *httptest.Server) {
-}
-
-func (op listInternalErrorOperation) buildRequest(t *testing.T, testServer *httptest.Server, ct contentTypeConverter, rt ResourceTypeTest) *http.Request {
-	return buildListRequest(
-		rt.ResourceType,
-		ct,
-		testServer,
-		t,
-	)
-}
-
-func (listInternalErrorOperation) name() Operation {
-	return OperationListInternalError
-}
-
-func (listInternalErrorOperation) assertResponse(t *testing.T, resp *http.Response, ct contentTypeConverter, rt ResourceTypeTest) {
-	assertInternalError(t, resp, ct, rt, "listing")
+var listInternalErrorOperation = operationTester{
+	name: OperationListInternalError,
+	buildRequest: func(t *testing.T, testServer *httptest.Server, ct contentTypeConverter, rt ResourceTypeTest) *http.Request {
+		return buildListRequest(
+			rt.ResourceType,
+			ct,
+			testServer,
+			t,
+		)
+	},
+	assertResponse: func(t *testing.T, resp *http.Response, ct contentTypeConverter, rt ResourceTypeTest) {
+		assertInternalError(t, resp, ct, rt, "listing")
+	},
 }

--- a/server/resourcemanager/testutil/operations_list.go
+++ b/server/resourcemanager/testutil/operations_list.go
@@ -115,7 +115,7 @@ var listPaginatedAscendingSuccessOperation = operationTester{
 		jsonBody := responseBodyJSON(t, resp, ct)
 
 		expected := `{
-			"count": 2,
+			"count": 3,
 			"items": ` + ct.toJSON(rt.SamplePaginatedAscJSON) + `
 		}`
 
@@ -148,7 +148,7 @@ var listPaginatedDescendingSuccessOperation = operationTester{
 		jsonBody := responseBodyJSON(t, resp, ct)
 
 		expected := `{
-			"count": 2,
+			"count": 3,
 			"items": ` + ct.toJSON(rt.SamplePaginatedDescJSON) + `
 		}`
 

--- a/server/resourcemanager/testutil/operations_list.go
+++ b/server/resourcemanager/testutil/operations_list.go
@@ -122,6 +122,29 @@ var listSuccessOperation = operationTester{
 	},
 }
 
+const OperationListWithInvalidSortField Operation = "ListWithInvalidSortField"
+
+var listWithInvalidSortFieldOperation = operationTester{
+	name: OperationListWithInvalidSortField,
+	buildRequest: func(t *testing.T, testServer *httptest.Server, ct contentTypeConverter, rt ResourceTypeTest) *http.Request {
+		return buildListRequest(
+			rt.ResourceType,
+			map[string]string{
+				"take":          "2",
+				"skip":          "1",
+				"sortBy":        rt.InvalidSortField,
+				"sortDirection": "asc",
+			},
+			ct,
+			testServer,
+			t,
+		)
+	},
+	assertResponse: func(t *testing.T, resp *http.Response, ct contentTypeConverter, rt ResourceTypeTest) {
+		require.Equal(t, 400, resp.StatusCode)
+	},
+}
+
 const OperationListPaginatedAscendingSuccess Operation = "ListPaginatedAscendingSuccess"
 
 var listPaginatedAscendingSuccessOperation = operationTester{
@@ -132,7 +155,7 @@ var listPaginatedAscendingSuccessOperation = operationTester{
 			map[string]string{
 				"take":          "2",
 				"skip":          "1",
-				"sortBy":        rt.PaginationSortField,
+				"sortBy":        rt.SortField,
 				"sortDirection": "asc",
 			},
 			ct,
@@ -154,7 +177,7 @@ var listPaginatedAscendingSuccessOperation = operationTester{
 		require.Equal(t, 3, parsedJsonBody.Count)
 
 		var prevVal any
-		field := rt.PaginationSortField
+		field := rt.SortField
 
 		for _, item := range parsedJsonBody.Items {
 			if prevVal == nil {
@@ -178,7 +201,7 @@ var listPaginatedDescendingSuccessOperation = operationTester{
 			map[string]string{
 				"take":          "2",
 				"skip":          "1",
-				"sortBy":        rt.PaginationSortField,
+				"sortBy":        rt.SortField,
 				"sortDirection": "desc",
 			},
 			ct,
@@ -200,7 +223,7 @@ var listPaginatedDescendingSuccessOperation = operationTester{
 		require.Equal(t, 3, parsedJsonBody.Count)
 
 		var prevVal any
-		field := rt.PaginationSortField
+		field := rt.SortField
 
 		for _, item := range parsedJsonBody.Items {
 			if prevVal == nil {

--- a/server/resourcemanager/testutil/operations_list.go
+++ b/server/resourcemanager/testutil/operations_list.go
@@ -170,6 +170,6 @@ var listInternalErrorOperation = operationTester{
 		)
 	},
 	assertResponse: func(t *testing.T, resp *http.Response, ct contentTypeConverter, rt ResourceTypeTest) {
-		assertInternalError(t, resp, ct, rt, "listing")
+		assertInternalError(t, resp, ct, rt.ResourceType, "listing")
 	},
 }

--- a/server/resourcemanager/testutil/operations_list.go
+++ b/server/resourcemanager/testutil/operations_list.go
@@ -113,10 +113,13 @@ var listWithInvalidSortFieldOperation = operationTester{
 	},
 }
 
-const OperationListPaginatedAscendingSuccess Operation = "ListPaginatedAscendingSuccess"
+// Tech debt: Even being one operation, we will split ASC and DESC in two just to keep
+// "one request per operation". In the future we can change this structure to support both tests
+// in one operationTester instance
+const OperationListPaginatedSuccess Operation = "ListPaginatedSuccess"
 
 var listPaginatedAscendingSuccessOperation = operationTester{
-	name: OperationListPaginatedAscendingSuccess,
+	name: OperationListPaginatedSuccess,
 	buildRequest: func(t *testing.T, testServer *httptest.Server, ct contentTypeConverter, rt ResourceTypeTest) *http.Request {
 		return buildListRequest(
 			rt.ResourceType,
@@ -159,10 +162,8 @@ var listPaginatedAscendingSuccessOperation = operationTester{
 	},
 }
 
-const OperationListPaginatedDescendingSuccess Operation = "ListPaginatedDescendingSuccess"
-
 var listPaginatedDescendingSuccessOperation = operationTester{
-	name: OperationListPaginatedDescendingSuccess,
+	name: OperationListPaginatedSuccess,
 	buildRequest: func(t *testing.T, testServer *httptest.Server, ct contentTypeConverter, rt ResourceTypeTest) *http.Request {
 		return buildListRequest(
 			rt.ResourceType,

--- a/server/resourcemanager/testutil/operations_list.go
+++ b/server/resourcemanager/testutil/operations_list.go
@@ -28,18 +28,6 @@ func buildQueryString(params map[string]string) string {
 	return "?" + strings.Join(formattedParams, "&")
 }
 
-func getSafeSortFields(sortFields []string) []string {
-	if sortFields == nil {
-		return []string{}
-	}
-
-	return sortFields
-}
-
-func getSortFieldsString(sortFields []string) string {
-	return strings.Join(getSafeSortFields(sortFields), ",")
-}
-
 func compareFieldsGreaterThan(first, second any) bool {
 	switch first.(type) {
 	case int:
@@ -144,7 +132,7 @@ var listPaginatedAscendingSuccessOperation = operationTester{
 			map[string]string{
 				"take":          "2",
 				"skip":          "1",
-				"sortBy":        getSortFieldsString(rt.PaginationSortFields),
+				"sortBy":        rt.PaginationSortField,
 				"sortDirection": "asc",
 			},
 			ct,
@@ -166,19 +154,16 @@ var listPaginatedAscendingSuccessOperation = operationTester{
 		require.Equal(t, 3, parsedJsonBody.Count)
 
 		var prevVal any
+		field := rt.PaginationSortField
 
-		sortFields := getSafeSortFields(rt.PaginationSortFields)
-
-		for _, field := range sortFields {
-			for _, item := range parsedJsonBody.Items {
-				if prevVal == nil {
-					prevVal = item[field]
-					continue
-				}
-				assert.True(t, compareFieldsLesserThan(prevVal, item[field]))
-
+		for _, item := range parsedJsonBody.Items {
+			if prevVal == nil {
 				prevVal = item[field]
+				continue
 			}
+			assert.True(t, compareFieldsLesserThan(prevVal, item[field]))
+
+			prevVal = item[field]
 		}
 	},
 }
@@ -193,7 +178,7 @@ var listPaginatedDescendingSuccessOperation = operationTester{
 			map[string]string{
 				"take":          "2",
 				"skip":          "1",
-				"sortBy":        getSortFieldsString(rt.PaginationSortFields),
+				"sortBy":        rt.PaginationSortField,
 				"sortDirection": "desc",
 			},
 			ct,
@@ -215,19 +200,16 @@ var listPaginatedDescendingSuccessOperation = operationTester{
 		require.Equal(t, 3, parsedJsonBody.Count)
 
 		var prevVal any
+		field := rt.PaginationSortField
 
-		sortFields := getSafeSortFields(rt.PaginationSortFields)
-
-		for _, field := range sortFields {
-			for _, item := range parsedJsonBody.Items {
-				if prevVal == nil {
-					prevVal = item[field]
-					continue
-				}
-				assert.True(t, compareFieldsGreaterThan(prevVal, item[field]))
-
+		for _, item := range parsedJsonBody.Items {
+			if prevVal == nil {
 				prevVal = item[field]
+				continue
 			}
+			assert.True(t, compareFieldsGreaterThan(prevVal, item[field]))
+
+			prevVal = item[field]
 		}
 	},
 }

--- a/server/resourcemanager/testutil/operations_list.go
+++ b/server/resourcemanager/testutil/operations_list.go
@@ -84,14 +84,14 @@ func (listSuccessOperation) assertResponse(t *testing.T, resp *http.Response, ct
 	require.JSONEq(t, expected, jsonBody)
 }
 
-const OperationListInteralError Operation = "ListInteralError"
+const OperationListInternalError Operation = "ListInternalError"
 
-type listInteralErrorOperation struct{}
+type listInternalErrorOperation struct{}
 
-func (op listInteralErrorOperation) postAssert(t *testing.T, ct contentType, rt ResourceTypeTest, testServer *httptest.Server) {
+func (op listInternalErrorOperation) postAssert(t *testing.T, ct contentType, rt ResourceTypeTest, testServer *httptest.Server) {
 }
 
-func (op listInteralErrorOperation) buildRequest(t *testing.T, testServer *httptest.Server, ct contentType, rt ResourceTypeTest) *http.Request {
+func (op listInternalErrorOperation) buildRequest(t *testing.T, testServer *httptest.Server, ct contentType, rt ResourceTypeTest) *http.Request {
 	return buildListRequest(
 		rt.ResourceType,
 		ct,
@@ -100,10 +100,10 @@ func (op listInteralErrorOperation) buildRequest(t *testing.T, testServer *httpt
 	)
 }
 
-func (listInteralErrorOperation) name() Operation {
-	return OperationListInteralError
+func (listInternalErrorOperation) name() Operation {
+	return OperationListInternalError
 }
 
-func (listInteralErrorOperation) assertResponse(t *testing.T, resp *http.Response, ct contentType, rt ResourceTypeTest) {
+func (listInternalErrorOperation) assertResponse(t *testing.T, resp *http.Response, ct contentType, rt ResourceTypeTest) {
 	assertInternalError(t, resp, ct, rt, "listing")
 }

--- a/server/resourcemanager/testutil/operations_list.go
+++ b/server/resourcemanager/testutil/operations_list.go
@@ -95,12 +95,14 @@ const OperationListWithInvalidSortField Operation = "ListWithInvalidSortField"
 var listWithInvalidSortFieldOperation = operationTester{
 	name: OperationListWithInvalidSortField,
 	buildRequest: func(t *testing.T, testServer *httptest.Server, ct contentTypeConverter, rt ResourceTypeTest) *http.Request {
+		invalidSortField := generateRandomString()
+
 		return buildListRequest(
 			rt.ResourceType,
 			map[string]string{
 				"take":          "2",
 				"skip":          "1",
-				"sortBy":        rt.InvalidSortField,
+				"sortBy":        invalidSortField,
 				"sortDirection": "asc",
 			},
 			ct,
@@ -126,7 +128,7 @@ var listPaginatedAscendingSuccessOperation = operationTester{
 			map[string]string{
 				"take":          "2",
 				"skip":          "1",
-				"sortBy":        rt.SortField,
+				"sortBy":        rt.sortFields[0],
 				"sortDirection": "asc",
 			},
 			ct,
@@ -148,7 +150,7 @@ var listPaginatedAscendingSuccessOperation = operationTester{
 		require.Equal(t, 3, parsedJsonBody.Count)
 
 		var prevVal any
-		field := rt.SortField
+		field := rt.sortFields[0]
 
 		for _, item := range parsedJsonBody.Items {
 			if prevVal == nil {
@@ -170,7 +172,7 @@ var listPaginatedDescendingSuccessOperation = operationTester{
 			map[string]string{
 				"take":          "2",
 				"skip":          "1",
-				"sortBy":        rt.SortField,
+				"sortBy":        rt.sortFields[0],
 				"sortDirection": "desc",
 			},
 			ct,
@@ -192,7 +194,7 @@ var listPaginatedDescendingSuccessOperation = operationTester{
 		require.Equal(t, 3, parsedJsonBody.Count)
 
 		var prevVal any
-		field := rt.SortField
+		field := rt.sortFields[0]
 
 		for _, item := range parsedJsonBody.Items {
 			if prevVal == nil {

--- a/server/resourcemanager/testutil/operations_update.go
+++ b/server/resourcemanager/testutil/operations_update.go
@@ -10,7 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildUpdateRequest(rt ResourceTypeTest, ct ContentTypeConverter, testServer *httptest.Server, t *testing.T) *http.Request {
+func buildUpdateRequest(rt ResourceTypeTest, ct contentTypeConverter, testServer *httptest.Server, t *testing.T) *http.Request {
 	input := ct.fromJSON(rt.SampleJSONUpdated)
 	url := fmt.Sprintf("%s/%s/", testServer.URL, strings.ToLower(rt.ResourceType))
 
@@ -23,10 +23,10 @@ const OperationUpdateSuccess Operation = "UpdateSuccess"
 
 type updateSuccessOperation struct{}
 
-func (op updateSuccessOperation) postAssert(t *testing.T, ct ContentTypeConverter, rt ResourceTypeTest, testServer *httptest.Server) {
+func (op updateSuccessOperation) postAssert(t *testing.T, ct contentTypeConverter, rt ResourceTypeTest, testServer *httptest.Server) {
 }
 
-func (op updateSuccessOperation) buildRequest(t *testing.T, testServer *httptest.Server, ct ContentTypeConverter, rt ResourceTypeTest) *http.Request {
+func (op updateSuccessOperation) buildRequest(t *testing.T, testServer *httptest.Server, ct contentTypeConverter, rt ResourceTypeTest) *http.Request {
 	return buildUpdateRequest(rt, ct, testServer, t)
 }
 
@@ -34,7 +34,7 @@ func (updateSuccessOperation) name() Operation {
 	return OperationUpdateSuccess
 }
 
-func (updateSuccessOperation) assertResponse(t *testing.T, resp *http.Response, ct ContentTypeConverter, rt ResourceTypeTest) {
+func (updateSuccessOperation) assertResponse(t *testing.T, resp *http.Response, ct contentTypeConverter, rt ResourceTypeTest) {
 	t.Helper()
 	require.Equal(t, 200, resp.StatusCode)
 
@@ -49,10 +49,10 @@ const OperationUpdateNotFound Operation = "UpdateNotFound"
 
 type updateNotFoundOperation struct{}
 
-func (op updateNotFoundOperation) postAssert(t *testing.T, ct ContentTypeConverter, rt ResourceTypeTest, testServer *httptest.Server) {
+func (op updateNotFoundOperation) postAssert(t *testing.T, ct contentTypeConverter, rt ResourceTypeTest, testServer *httptest.Server) {
 }
 
-func (op updateNotFoundOperation) buildRequest(t *testing.T, testServer *httptest.Server, ct ContentTypeConverter, rt ResourceTypeTest) *http.Request {
+func (op updateNotFoundOperation) buildRequest(t *testing.T, testServer *httptest.Server, ct contentTypeConverter, rt ResourceTypeTest) *http.Request {
 	return buildUpdateRequest(rt, ct, testServer, t)
 }
 
@@ -60,7 +60,7 @@ func (updateNotFoundOperation) name() Operation {
 	return OperationUpdateNotFound
 }
 
-func (updateNotFoundOperation) assertResponse(t *testing.T, resp *http.Response, ct ContentTypeConverter, rt ResourceTypeTest) {
+func (updateNotFoundOperation) assertResponse(t *testing.T, resp *http.Response, ct contentTypeConverter, rt ResourceTypeTest) {
 	t.Helper()
 	require.Equal(t, 404, resp.StatusCode)
 }
@@ -69,10 +69,10 @@ const OperationUpdateInternalError Operation = "UpdateInternalError"
 
 type updateInternalErrorOperation struct{}
 
-func (op updateInternalErrorOperation) postAssert(t *testing.T, ct ContentTypeConverter, rt ResourceTypeTest, testServer *httptest.Server) {
+func (op updateInternalErrorOperation) postAssert(t *testing.T, ct contentTypeConverter, rt ResourceTypeTest, testServer *httptest.Server) {
 }
 
-func (op updateInternalErrorOperation) buildRequest(t *testing.T, testServer *httptest.Server, ct ContentTypeConverter, rt ResourceTypeTest) *http.Request {
+func (op updateInternalErrorOperation) buildRequest(t *testing.T, testServer *httptest.Server, ct contentTypeConverter, rt ResourceTypeTest) *http.Request {
 	return buildUpdateRequest(rt, ct, testServer, t)
 }
 
@@ -80,6 +80,6 @@ func (updateInternalErrorOperation) name() Operation {
 	return OperationUpdateInternalError
 }
 
-func (updateInternalErrorOperation) assertResponse(t *testing.T, resp *http.Response, ct ContentTypeConverter, rt ResourceTypeTest) {
+func (updateInternalErrorOperation) assertResponse(t *testing.T, resp *http.Response, ct contentTypeConverter, rt ResourceTypeTest) {
 	assertInternalError(t, resp, ct, rt, "updating")
 }

--- a/server/resourcemanager/testutil/operations_update.go
+++ b/server/resourcemanager/testutil/operations_update.go
@@ -59,6 +59,6 @@ var updateInternalErrorOperation = operationTester{
 		return buildUpdateRequest(rt, ct, testServer, t)
 	},
 	assertResponse: func(t *testing.T, resp *http.Response, ct contentTypeConverter, rt ResourceTypeTest) {
-		assertInternalError(t, resp, ct, rt, "updating")
+		assertInternalError(t, resp, ct, rt.ResourceType, "updating")
 	},
 }

--- a/server/resourcemanager/testutil/operations_update.go
+++ b/server/resourcemanager/testutil/operations_update.go
@@ -21,65 +21,44 @@ func buildUpdateRequest(rt ResourceTypeTest, ct contentTypeConverter, testServer
 
 const OperationUpdateSuccess Operation = "UpdateSuccess"
 
-type updateSuccessOperation struct{}
+var updateSuccessOperation = operationTester{
+	name: OperationUpdateSuccess,
+	buildRequest: func(t *testing.T, testServer *httptest.Server, ct contentTypeConverter, rt ResourceTypeTest) *http.Request {
+		return buildUpdateRequest(rt, ct, testServer, t)
+	},
+	assertResponse: func(t *testing.T, resp *http.Response, ct contentTypeConverter, rt ResourceTypeTest) {
+		t.Helper()
+		require.Equal(t, 200, resp.StatusCode)
 
-func (op updateSuccessOperation) postAssert(t *testing.T, ct contentTypeConverter, rt ResourceTypeTest, testServer *httptest.Server) {
-}
+		jsonBody := responseBodyJSON(t, resp, ct)
 
-func (op updateSuccessOperation) buildRequest(t *testing.T, testServer *httptest.Server, ct contentTypeConverter, rt ResourceTypeTest) *http.Request {
-	return buildUpdateRequest(rt, ct, testServer, t)
-}
+		expected := ct.toJSON(rt.SampleJSONUpdated)
 
-func (updateSuccessOperation) name() Operation {
-	return OperationUpdateSuccess
-}
-
-func (updateSuccessOperation) assertResponse(t *testing.T, resp *http.Response, ct contentTypeConverter, rt ResourceTypeTest) {
-	t.Helper()
-	require.Equal(t, 200, resp.StatusCode)
-
-	jsonBody := responseBodyJSON(t, resp, ct)
-
-	expected := ct.toJSON(rt.SampleJSONUpdated)
-
-	require.JSONEq(t, expected, jsonBody)
+		require.JSONEq(t, expected, jsonBody)
+	},
 }
 
 const OperationUpdateNotFound Operation = "UpdateNotFound"
 
-type updateNotFoundOperation struct{}
-
-func (op updateNotFoundOperation) postAssert(t *testing.T, ct contentTypeConverter, rt ResourceTypeTest, testServer *httptest.Server) {
-}
-
-func (op updateNotFoundOperation) buildRequest(t *testing.T, testServer *httptest.Server, ct contentTypeConverter, rt ResourceTypeTest) *http.Request {
-	return buildUpdateRequest(rt, ct, testServer, t)
-}
-
-func (updateNotFoundOperation) name() Operation {
-	return OperationUpdateNotFound
-}
-
-func (updateNotFoundOperation) assertResponse(t *testing.T, resp *http.Response, ct contentTypeConverter, rt ResourceTypeTest) {
-	t.Helper()
-	require.Equal(t, 404, resp.StatusCode)
+var updateNotFoundOperation = operationTester{
+	name: OperationUpdateNotFound,
+	buildRequest: func(t *testing.T, testServer *httptest.Server, ct contentTypeConverter, rt ResourceTypeTest) *http.Request {
+		return buildUpdateRequest(rt, ct, testServer, t)
+	},
+	assertResponse: func(t *testing.T, resp *http.Response, ct contentTypeConverter, rt ResourceTypeTest) {
+		t.Helper()
+		require.Equal(t, 404, resp.StatusCode)
+	},
 }
 
 const OperationUpdateInternalError Operation = "UpdateInternalError"
 
-type updateInternalErrorOperation struct{}
-
-func (op updateInternalErrorOperation) postAssert(t *testing.T, ct contentTypeConverter, rt ResourceTypeTest, testServer *httptest.Server) {
-}
-
-func (op updateInternalErrorOperation) buildRequest(t *testing.T, testServer *httptest.Server, ct contentTypeConverter, rt ResourceTypeTest) *http.Request {
-	return buildUpdateRequest(rt, ct, testServer, t)
-}
-
-func (updateInternalErrorOperation) name() Operation {
-	return OperationUpdateInternalError
-}
-
-func (updateInternalErrorOperation) assertResponse(t *testing.T, resp *http.Response, ct contentTypeConverter, rt ResourceTypeTest) {
-	assertInternalError(t, resp, ct, rt, "updating")
+var updateInternalErrorOperation = operationTester{
+	name: OperationUpdateInternalError,
+	buildRequest: func(t *testing.T, testServer *httptest.Server, ct contentTypeConverter, rt ResourceTypeTest) *http.Request {
+		return buildUpdateRequest(rt, ct, testServer, t)
+	},
+	assertResponse: func(t *testing.T, resp *http.Response, ct contentTypeConverter, rt ResourceTypeTest) {
+		assertInternalError(t, resp, ct, rt, "updating")
+	},
 }

--- a/server/resourcemanager/testutil/operations_update.go
+++ b/server/resourcemanager/testutil/operations_update.go
@@ -10,7 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildUpdateRequest(rt ResourceTypeTest, ct contentType, testServer *httptest.Server, t *testing.T) *http.Request {
+func buildUpdateRequest(rt ResourceTypeTest, ct ContentTypeConverter, testServer *httptest.Server, t *testing.T) *http.Request {
 	input := ct.fromJSON(rt.SampleJSONUpdated)
 	url := fmt.Sprintf("%s/%s/", testServer.URL, strings.ToLower(rt.ResourceType))
 
@@ -23,10 +23,10 @@ const OperationUpdateSuccess Operation = "UpdateSuccess"
 
 type updateSuccessOperation struct{}
 
-func (op updateSuccessOperation) postAssert(t *testing.T, ct contentType, rt ResourceTypeTest, testServer *httptest.Server) {
+func (op updateSuccessOperation) postAssert(t *testing.T, ct ContentTypeConverter, rt ResourceTypeTest, testServer *httptest.Server) {
 }
 
-func (op updateSuccessOperation) buildRequest(t *testing.T, testServer *httptest.Server, ct contentType, rt ResourceTypeTest) *http.Request {
+func (op updateSuccessOperation) buildRequest(t *testing.T, testServer *httptest.Server, ct ContentTypeConverter, rt ResourceTypeTest) *http.Request {
 	return buildUpdateRequest(rt, ct, testServer, t)
 }
 
@@ -34,7 +34,7 @@ func (updateSuccessOperation) name() Operation {
 	return OperationUpdateSuccess
 }
 
-func (updateSuccessOperation) assertResponse(t *testing.T, resp *http.Response, ct contentType, rt ResourceTypeTest) {
+func (updateSuccessOperation) assertResponse(t *testing.T, resp *http.Response, ct ContentTypeConverter, rt ResourceTypeTest) {
 	t.Helper()
 	require.Equal(t, 200, resp.StatusCode)
 
@@ -49,10 +49,10 @@ const OperationUpdateNotFound Operation = "UpdateNotFound"
 
 type updateNotFoundOperation struct{}
 
-func (op updateNotFoundOperation) postAssert(t *testing.T, ct contentType, rt ResourceTypeTest, testServer *httptest.Server) {
+func (op updateNotFoundOperation) postAssert(t *testing.T, ct ContentTypeConverter, rt ResourceTypeTest, testServer *httptest.Server) {
 }
 
-func (op updateNotFoundOperation) buildRequest(t *testing.T, testServer *httptest.Server, ct contentType, rt ResourceTypeTest) *http.Request {
+func (op updateNotFoundOperation) buildRequest(t *testing.T, testServer *httptest.Server, ct ContentTypeConverter, rt ResourceTypeTest) *http.Request {
 	return buildUpdateRequest(rt, ct, testServer, t)
 }
 
@@ -60,7 +60,7 @@ func (updateNotFoundOperation) name() Operation {
 	return OperationUpdateNotFound
 }
 
-func (updateNotFoundOperation) assertResponse(t *testing.T, resp *http.Response, ct contentType, rt ResourceTypeTest) {
+func (updateNotFoundOperation) assertResponse(t *testing.T, resp *http.Response, ct ContentTypeConverter, rt ResourceTypeTest) {
 	t.Helper()
 	require.Equal(t, 404, resp.StatusCode)
 }
@@ -69,10 +69,10 @@ const OperationUpdateInternalError Operation = "UpdateInternalError"
 
 type updateInternalErrorOperation struct{}
 
-func (op updateInternalErrorOperation) postAssert(t *testing.T, ct contentType, rt ResourceTypeTest, testServer *httptest.Server) {
+func (op updateInternalErrorOperation) postAssert(t *testing.T, ct ContentTypeConverter, rt ResourceTypeTest, testServer *httptest.Server) {
 }
 
-func (op updateInternalErrorOperation) buildRequest(t *testing.T, testServer *httptest.Server, ct contentType, rt ResourceTypeTest) *http.Request {
+func (op updateInternalErrorOperation) buildRequest(t *testing.T, testServer *httptest.Server, ct ContentTypeConverter, rt ResourceTypeTest) *http.Request {
 	return buildUpdateRequest(rt, ct, testServer, t)
 }
 
@@ -80,6 +80,6 @@ func (updateInternalErrorOperation) name() Operation {
 	return OperationUpdateInternalError
 }
 
-func (updateInternalErrorOperation) assertResponse(t *testing.T, resp *http.Response, ct contentType, rt ResourceTypeTest) {
+func (updateInternalErrorOperation) assertResponse(t *testing.T, resp *http.Response, ct ContentTypeConverter, rt ResourceTypeTest) {
 	assertInternalError(t, resp, ct, rt, "updating")
 }

--- a/server/resourcemanager/testutil/operations_update.go
+++ b/server/resourcemanager/testutil/operations_update.go
@@ -65,21 +65,21 @@ func (updateNotFoundOperation) assertResponse(t *testing.T, resp *http.Response,
 	require.Equal(t, 404, resp.StatusCode)
 }
 
-const OperationUpdateInteralError Operation = "UpdateInteralError"
+const OperationUpdateInternalError Operation = "UpdateInternalError"
 
-type updateInteralErrorOperation struct{}
+type updateInternalErrorOperation struct{}
 
-func (op updateInteralErrorOperation) postAssert(t *testing.T, ct contentType, rt ResourceTypeTest, testServer *httptest.Server) {
+func (op updateInternalErrorOperation) postAssert(t *testing.T, ct contentType, rt ResourceTypeTest, testServer *httptest.Server) {
 }
 
-func (op updateInteralErrorOperation) buildRequest(t *testing.T, testServer *httptest.Server, ct contentType, rt ResourceTypeTest) *http.Request {
+func (op updateInternalErrorOperation) buildRequest(t *testing.T, testServer *httptest.Server, ct contentType, rt ResourceTypeTest) *http.Request {
 	return buildUpdateRequest(rt, ct, testServer, t)
 }
 
-func (updateInteralErrorOperation) name() Operation {
-	return OperationUpdateInteralError
+func (updateInternalErrorOperation) name() Operation {
+	return OperationUpdateInternalError
 }
 
-func (updateInteralErrorOperation) assertResponse(t *testing.T, resp *http.Response, ct contentType, rt ResourceTypeTest) {
+func (updateInternalErrorOperation) assertResponse(t *testing.T, resp *http.Response, ct contentType, rt ResourceTypeTest) {
 	assertInternalError(t, resp, ct, rt, "updating")
 }

--- a/server/resourcemanager/testutil/operations_update.go
+++ b/server/resourcemanager/testutil/operations_update.go
@@ -21,7 +21,7 @@ func buildUpdateRequest(rt ResourceTypeTest, ct contentTypeConverter, testServer
 
 const OperationUpdateSuccess Operation = "UpdateSuccess"
 
-var updateSuccessOperation = operationTester{
+var updateSuccessOperation = buildSingleStepOperation(singleStepOperationTester{
 	name: OperationUpdateSuccess,
 	buildRequest: func(t *testing.T, testServer *httptest.Server, ct contentTypeConverter, rt ResourceTypeTest) *http.Request {
 		return buildUpdateRequest(rt, ct, testServer, t)
@@ -36,11 +36,11 @@ var updateSuccessOperation = operationTester{
 
 		require.JSONEq(t, expected, jsonBody)
 	},
-}
+})
 
 const OperationUpdateNotFound Operation = "UpdateNotFound"
 
-var updateNotFoundOperation = operationTester{
+var updateNotFoundOperation = buildSingleStepOperation(singleStepOperationTester{
 	name: OperationUpdateNotFound,
 	buildRequest: func(t *testing.T, testServer *httptest.Server, ct contentTypeConverter, rt ResourceTypeTest) *http.Request {
 		return buildUpdateRequest(rt, ct, testServer, t)
@@ -49,11 +49,11 @@ var updateNotFoundOperation = operationTester{
 		t.Helper()
 		require.Equal(t, 404, resp.StatusCode)
 	},
-}
+})
 
 const OperationUpdateInternalError Operation = "UpdateInternalError"
 
-var updateInternalErrorOperation = operationTester{
+var updateInternalErrorOperation = buildSingleStepOperation(singleStepOperationTester{
 	name: OperationUpdateInternalError,
 	buildRequest: func(t *testing.T, testServer *httptest.Server, ct contentTypeConverter, rt ResourceTypeTest) *http.Request {
 		return buildUpdateRequest(rt, ct, testServer, t)
@@ -61,4 +61,4 @@ var updateInternalErrorOperation = operationTester{
 	assertResponse: func(t *testing.T, resp *http.Response, ct contentTypeConverter, rt ResourceTypeTest) {
 		assertInternalError(t, resp, ct, rt.ResourceType, "updating")
 	},
-}
+})

--- a/server/resourcemanager/testutil/test_resource.go
+++ b/server/resourcemanager/testutil/test_resource.go
@@ -15,9 +15,10 @@ type ResourceTypeTest struct {
 	RegisterManagerFn func(*mux.Router) any
 	Prepare           func(t *testing.T, operation Operation, bridge any)
 
-	SampleJSON          string
-	SampleJSONUpdated   string
-	PaginationSortField string
+	SampleJSON        string
+	SampleJSONUpdated string
+	SortField         string
+	InvalidSortField  string
 }
 
 func TestResourceType(t *testing.T, rt ResourceTypeTest) {

--- a/server/resourcemanager/testutil/test_resource.go
+++ b/server/resourcemanager/testutil/test_resource.go
@@ -15,8 +15,10 @@ type ResourceTypeTest struct {
 	RegisterManagerFn func(*mux.Router) any
 	Prepare           func(t *testing.T, operation Operation, bridge any)
 
-	SampleJSON        string
-	SampleJSONUpdated string
+	SampleJSON              string
+	SampleJSONUpdated       string
+	SamplePaginatedAscJSON  string
+	SamplePaginatedDescJSON string
 }
 
 func TestResourceType(t *testing.T, rt ResourceTypeTest) {

--- a/server/resourcemanager/testutil/test_resource.go
+++ b/server/resourcemanager/testutil/test_resource.go
@@ -15,10 +15,9 @@ type ResourceTypeTest struct {
 	RegisterManagerFn func(*mux.Router) any
 	Prepare           func(t *testing.T, operation Operation, bridge any)
 
-	SampleJSON              string
-	SampleJSONUpdated       string
-	SamplePaginatedAscJSON  string
-	SamplePaginatedDescJSON string
+	SampleJSON           string
+	SampleJSONUpdated    string
+	PaginationSortFields []string
 }
 
 func TestResourceType(t *testing.T, rt ResourceTypeTest) {
@@ -74,7 +73,7 @@ func testOperationForContentType(t *testing.T, op operationTester, ct contentTyp
 	}
 
 	req := op.buildRequest(t, testServer, ct, rt)
-	resp := doRequest(t, req, ct, testServer)
+	resp := doRequest(t, req, ct.contentType, testServer)
 
 	op.assertResponse(t, resp, ct, rt)
 	assert.Equal(t, ct.contentType, resp.Header.Get("Content-Type"))
@@ -83,8 +82,8 @@ func testOperationForContentType(t *testing.T, op operationTester, ct contentTyp
 	}
 }
 
-func doRequest(t *testing.T, req *http.Request, ct contentTypeConverter, testServer *httptest.Server) *http.Response {
-	req.Header.Set("Content-Type", ct.contentType)
+func doRequest(t *testing.T, req *http.Request, contentType string, testServer *httptest.Server) *http.Response {
+	req.Header.Set("Content-Type", contentType)
 	resp, err := testServer.Client().Do(req)
 	require.NoError(t, err)
 

--- a/server/resourcemanager/testutil/test_resource.go
+++ b/server/resourcemanager/testutil/test_resource.go
@@ -8,6 +8,8 @@ import (
 	"github.com/gorilla/mux"
 	"github.com/stretchr/testify/require"
 	"gotest.tools/v3/assert"
+
+	rm "github.com/kubeshop/tracetest/server/resourcemanager"
 )
 
 type ResourceTypeTest struct {
@@ -17,8 +19,9 @@ type ResourceTypeTest struct {
 
 	SampleJSON        string
 	SampleJSONUpdated string
-	SortField         string
-	InvalidSortField  string
+
+	// private files
+	sortFields []string
 }
 
 func TestResourceType(t *testing.T, rt ResourceTypeTest) {
@@ -72,6 +75,9 @@ func testOperationForContentType(t *testing.T, op operationTester, ct contentTyp
 	if rt.Prepare != nil {
 		rt.Prepare(t, op.name, testBridge)
 	}
+
+	sortableHandler := testBridge.(rm.SortableHandler)
+	rt.sortFields = sortableHandler.SortingFields()
 
 	req := op.buildRequest(t, testServer, ct, rt)
 	resp := doRequest(t, req, ct.contentType, testServer)

--- a/server/resourcemanager/testutil/test_resource.go
+++ b/server/resourcemanager/testutil/test_resource.go
@@ -15,9 +15,9 @@ type ResourceTypeTest struct {
 	RegisterManagerFn func(*mux.Router) any
 	Prepare           func(t *testing.T, operation Operation, bridge any)
 
-	SampleJSON           string
-	SampleJSONUpdated    string
-	PaginationSortFields []string
+	SampleJSON          string
+	SampleJSONUpdated   string
+	PaginationSortField string
 }
 
 func TestResourceType(t *testing.T, rt ResourceTypeTest) {


### PR DESCRIPTION
This PR aims to add pagination tests to Resource Manager and update the tests for the first resource to consider that

## Changes

- Refactor resource manager tests to simplify the readability of each operation
- Added tests for resource manager
- Added pagination capabilities for config_resource
- Added pagination tests for config_resource

## Fixes

- https://github.com/kubeshop/tracetest/issues/2060

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [x] added a test
