### PR TITLE
Fixing bug on TraceDB instantiation

### DIFF
--- a/server/tracedb/tracedb_test.go
+++ b/server/tracedb/tracedb_test.go
@@ -39,6 +39,46 @@ func TestCreateClient(t *testing.T) {
 			expectedType: "*tracedb.tempoTraceDB",
 		},
 		{
+			name: "ElasticSearch",
+			ds: model.DataStore{
+				Type: model.DataStoreTypeElasticAPM,
+				Values: model.DataStoreValues{
+					ElasticApm: &model.ElasticSearchDataStoreConfig{},
+				},
+			},
+			expectedType: "*tracedb.elasticsearchDB",
+		},
+		{
+			name: "OpenSearch",
+			ds: model.DataStore{
+				Type: model.DataStoreTypeOpenSearch,
+				Values: model.DataStoreValues{
+					OpenSearch: &model.ElasticSearchDataStoreConfig{},
+				},
+			},
+			expectedType: "*tracedb.opensearchDB",
+		},
+		{
+			name: "SignalFX",
+			ds: model.DataStore{
+				Type: model.DataStoreTypeSignalFX,
+				Values: model.DataStoreValues{
+					SignalFx: &model.SignalFXDataStoreConfig{},
+				},
+			},
+			expectedType: "*tracedb.signalfxDB",
+		},
+		{
+			name: "AWSXRay",
+			ds: model.DataStore{
+				Type: model.DataStoreTypeAwsXRay,
+				Values: model.DataStoreValues{
+					AwsXRay: &model.AWSXRayDataStoreConfig{},
+				},
+			},
+			expectedType: "*tracedb.awsxrayDB",
+		},
+		{
 			name:         "EmptyConfig",
 			ds:           model.DataStore{},
 			expectedType: "*tracedb.noopTraceDB",

--- a/server/tracedb/tracedb_test.go
+++ b/server/tracedb/tracedb_test.go
@@ -79,6 +79,38 @@ func TestCreateClient(t *testing.T) {
 			expectedType: "*tracedb.awsxrayDB",
 		},
 		{
+			name: "OTLP",
+			ds: model.DataStore{
+				Type:   model.DataStoreTypeOTLP,
+				Values: model.DataStoreValues{},
+			},
+			expectedType: "*tracedb.OTLPTraceDB",
+		},
+		{
+			name: "NewRelic",
+			ds: model.DataStore{
+				Type:   model.DataStoreTypeNewRelic,
+				Values: model.DataStoreValues{},
+			},
+			expectedType: "*tracedb.OTLPTraceDB",
+		},
+		{
+			name: "Lightstep",
+			ds: model.DataStore{
+				Type:   model.DataStoreTypeLighStep,
+				Values: model.DataStoreValues{},
+			},
+			expectedType: "*tracedb.OTLPTraceDB",
+		},
+		{
+			name: "DataDog",
+			ds: model.DataStore{
+				Type:   model.DataStoreTypeDataDog,
+				Values: model.DataStoreValues{},
+			},
+			expectedType: "*tracedb.OTLPTraceDB",
+		},
+		{
 			name:         "EmptyConfig",
 			ds:           model.DataStore{},
 			expectedType: "*tracedb.noopTraceDB",


### PR DESCRIPTION
This PR fixes a bug found on [#2118](https://github.com/kubeshop/tracetest/issues/2118): 
With Datadog, Lightstep, and New Relic, we can use them as a Data Store provisioning the OTLP datastore or a specific Data Store for them. However, setting up a specific Data Store crashes Tracetest on a Test run.

## Changes

- Fix Data Store instantiation

## Fixes

- #2118 

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [x] added a test
