### PR TITLE
Adding OpenAPI docs for Config Resource

### DIFF
--- a/api/config.yaml
+++ b/api/config.yaml
@@ -36,3 +36,18 @@ components:
           type: string
         error:
           type: string
+    Configuration:
+      type: object
+      description: "Represents the set of configuration common options for Tracetest."
+      properties:
+        id:
+          type: string
+          description: "ID of the configuration resource. It will be set as 'current'."
+        name:
+          type: string
+          description: "Name given for this configuration set. It will be set as 'Config'."
+        analyticsEnabled:
+          type: boolean
+          description: "Flag telling if a user allow Tracetest to send analytics about its usage."
+      required:
+        - analyticsEnabled

--- a/api/config.yaml
+++ b/api/config.yaml
@@ -42,12 +42,22 @@ components:
       properties:
         id:
           type: string
-          description: "ID of the configuration resource. It will be set as 'current'."
+          description: "ID of the configuration resource. It should always be set as 'current'."
         name:
           type: string
-          description: "Name given for this configuration set. It will be set as 'Config'."
+          description: "Name given for this configuration set. It should always be set as 'Config'."
         analyticsEnabled:
           type: boolean
           description: "Flag telling if a user allow Tracetest to send analytics about its usage."
       required:
         - analyticsEnabled
+    ConfigurationResource:
+      type: object
+      description: "Represents a coonfiguration into the Resources format."
+      properties:
+        type:
+          type: string
+          description: "Represents the type of this resource. It should always be set as 'Config'."
+        spec:
+          $ref: "#/components/schemas/Configuration"
+

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -57,6 +57,7 @@ paths:
               schema:
                 $ref: "./definition.yaml#/components/schemas/UpsertDefinitionResponse"
 
+  # Transactions
   /transactions:
     get:
       tags:
@@ -130,7 +131,6 @@ paths:
                 $ref: "./transactions.yaml#/components/schemas/Transaction"
         400:
           description: "trying to create a transaction with an already existing ID"
-
   /transactions/{transactionId}:
     get:
       tags:
@@ -190,7 +190,6 @@ paths:
       responses:
         "204":
           description: OK
-
   /transactions/{transactionId}/version/{version}:
     get:
       tags:
@@ -218,7 +217,6 @@ paths:
                 $ref: "./transactions.yaml#/components/schemas/Transaction"
         500:
           description: "problem with getting a test"
-
   /transactions/{transactionId}/version/{version}/definition.yaml:
     get:
       tags:
@@ -244,7 +242,6 @@ paths:
             application/yaml:
               schema:
                 type: string
-
   /transactions/{transactionId}/run:
     post:
       tags:
@@ -303,7 +300,6 @@ paths:
                 type: array
                 items:
                   $ref: "./transactions.yaml#/components/schemas/TransactionRun"
-
   /transactions/{transactionId}/run/{runId}:
     get:
       tags:
@@ -355,6 +351,7 @@ paths:
         404:
           description: transaction run not found
 
+  # Tests
   /tests:
     get:
       tags:
@@ -428,7 +425,6 @@ paths:
                 $ref: "./tests.yaml#/components/schemas/Test"
         400:
           description: "trying to create a test with an already existing ID"
-
   /tests/{testId}:
     get:
       tags:
@@ -586,7 +582,6 @@ paths:
             application/json:
               schema:
                 $ref: "./tests.yaml#/components/schemas/SelectedSpansResult"
-
   /tests/{testId}/run/{runId}/dry-run:
     put:
       tags:
@@ -642,7 +637,6 @@ paths:
             application/json:
               schema:
                 $ref: "./tests.yaml#/components/schemas/TestRun"
-
   /tests/{testId}/run/{runId}/junit.xml:
     get:
       tags:
@@ -668,7 +662,6 @@ paths:
             application/xml:
               schema:
                 type: string
-
   /tests/{testId}/run/{runId}/export:
     get:
       tags:
@@ -694,7 +687,6 @@ paths:
             application/json:
               schema:
                 $ref: "tests.yaml#/components/schemas/ExportedTestInformation"
-
   /tests/import:
     post:
       tags:
@@ -714,7 +706,6 @@ paths:
             application/json:
               schema:
                 $ref: "tests.yaml#/components/schemas/ExportedTestInformation"
-
   /tests/{testId}/run/{runId}:
     get:
       tags:
@@ -782,7 +773,6 @@ paths:
                 type: array
                 items:
                   $ref: "./tests.yaml#/components/schemas/TestSpecs"
-
   /tests/{testId}/version/{version}:
     get:
       tags:
@@ -810,7 +800,6 @@ paths:
                 $ref: "./tests.yaml#/components/schemas/Test"
         500:
           description: "problem with getting a test"
-
   /tests/{testId}/version/{version}/definition.yaml:
     get:
       tags:
@@ -911,7 +900,6 @@ paths:
                 $ref: "./environments.yaml#/components/schemas/Environment"
         400:
           description: "trying to create a environment with an already existing ID"
-
   /environments/{environmentId}:
     get:
       tags:
@@ -971,7 +959,6 @@ paths:
       responses:
         "204":
           description: OK
-
   /environments/{environmentId}/definition.yaml:
     get:
       tags:
@@ -993,7 +980,7 @@ paths:
               schema:
                 type: string
 
-  # expressions
+  # Expressions
   /expressions/resolve:
     post:
       tags:
@@ -1014,6 +1001,7 @@ paths:
               schema:
                 $ref: "./expressions.yaml#/components/schemas/ResolveResponseInfo"
 
+  # Resources (Tests, Transactions)
   /resources:
     get:
       tags:
@@ -1066,6 +1054,7 @@ paths:
                 items:
                   $ref: "./resources.yaml#/components/schemas/Resource"
 
+  # Configuration
   /config/connection:
     post:
       tags:
@@ -1085,6 +1074,65 @@ paths:
             application/json:
               schema:
                 $ref: "./config.yaml#/components/schemas/TestConnectionResponse"
+  /config/{id}:
+    get:
+      tags:
+        - api
+      parameters:
+        - in: path
+          name: id
+          schema:
+            type: string
+          required: true
+          description: "ID of the configuration resource used on Tracetest. It should be set as 'current'."
+      summary: "Get Tracetest configuration"
+      description: "Get Tracetest configuration"
+      operationId: getConfiguration
+      responses:
+        200:
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                $ref: "./config.yaml#/components/schemas/Configuration"
+            text/yaml:
+              schema:
+                $ref: "./config.yaml#/components/schemas/Configuration"
+        500:
+          description: "problem with getting a configuration"
+    put:
+      tags:
+        - api
+      parameters:
+        - in: path
+          name: id
+          schema:
+            type: string
+          required: true
+          description: "ID of the configuration resource used on Tracetest. It should be set as 'current'."
+      summary: "Update Tracetest configuration"
+      description: "Update Tracetest configuration"
+      operationId: updateConfiguration
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "./config.yaml#/components/schemas/Configuration"
+          text/yaml:
+            schema:
+              $ref: "./config.yaml#/components/schemas/Configuration"
+      responses:
+        200:
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                $ref: "./config.yaml#/components/schemas/Configuration"
+            text/yaml:
+              schema:
+                $ref: "./config.yaml#/components/schemas/Configuration"
+        500:
+          description: "problem with updating configuration"
 
   # Data Stores
   /datastores:
@@ -1160,7 +1208,6 @@ paths:
                 $ref: "./dataStores.yaml#/components/schemas/DataStore"
         400:
           description: "trying to create a data store with an already existing ID"
-
   /datastores/{dataStoreId}:
     get:
       tags:
@@ -1220,7 +1267,6 @@ paths:
       responses:
         "204":
           description: OK
-
   /datastores/{dataStoreId}/definition.yaml:
     get:
       tags:

--- a/server/resourcemanager/resource_manager.go
+++ b/server/resourcemanager/resource_manager.go
@@ -116,7 +116,7 @@ func (m *manager[T]) RegisterRoutes(r *mux.Router) *mux.Router {
 		subrouter.HandleFunc("/", m.create).Methods(http.MethodPost).Name(fmt.Sprintf("%s.Create", m.resourceType))
 	}
 	if slices.Contains(enabledOps, OperationUpdate) {
-		subrouter.HandleFunc("/", m.update).Methods(http.MethodPut).Name(fmt.Sprintf("%s.Update", m.resourceType))
+		subrouter.HandleFunc("/{id}", m.update).Methods(http.MethodPut).Name(fmt.Sprintf("%s.Update", m.resourceType))
 	}
 
 	if slices.Contains(enabledOps, OperationGet) {

--- a/server/resourcemanager/testutil/operations_update.go
+++ b/server/resourcemanager/testutil/operations_update.go
@@ -12,8 +12,10 @@ import (
 )
 
 func buildUpdateRequest(rt ResourceTypeTest, ct contentTypeConverter, testServer *httptest.Server, t *testing.T) *http.Request {
+	id := extractID(rt.SampleJSON)
 	input := ct.fromJSON(rt.SampleJSONUpdated)
-	url := fmt.Sprintf("%s/%s/", testServer.URL, strings.ToLower(rt.ResourceType))
+
+	url := fmt.Sprintf("%s/%s/%s", testServer.URL, strings.ToLower(rt.ResourceType), id)
 
 	req, err := http.NewRequest(http.MethodPut, url, strings.NewReader(input))
 	require.NoError(t, err)


### PR DESCRIPTION
This PR adds the API resource definition for the `Config` resource

## Changes

- Updated OpenAPI definition to have `/config/{id}` endpoints
- Added configuration resource definition

## Fixes

- (partially) #2063

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [x] updated the docs
- [ ] added a test
