### PR TITLE
feat(server): add config analytics provision

### DIFF
--- a/server/app/app.go
+++ b/server/app/app.go
@@ -84,8 +84,8 @@ func WithProvisioningFile(path string) appOption {
 	}
 }
 
-func (app *App) provision(db model.Repository) {
-	p := provisioning.New(db)
+func (app *App) provision(db model.Repository, configDB *configresource.Repository) {
+	p := provisioning.New(db, configDB)
 
 	var err error
 
@@ -180,7 +180,7 @@ func (app *App) Start(opts ...appOption) error {
 			return err
 		}
 
-		app.provision(testDB)
+		app.provision(testDB, configRepo)
 
 	}
 

--- a/server/provisioning/config.go
+++ b/server/provisioning/config.go
@@ -1,0 +1,18 @@
+package provisioning
+
+import (
+	"github.com/kubeshop/tracetest/server/config/configresource"
+)
+
+type config struct {
+	Type             string `mapstructure:"type"`
+	AnalyticsEnabled bool   `mapstructure:"analyticsEnabled"`
+}
+
+func (cfg config) model() configresource.Config {
+	m := configresource.Config{
+		AnalyticsEnabled: cfg.AnalyticsEnabled,
+	}
+
+	return m
+}

--- a/server/provisioning/data_stores_test.go
+++ b/server/provisioning/data_stores_test.go
@@ -3,9 +3,11 @@ package provisioning_test
 import (
 	"testing"
 
+	"github.com/kubeshop/tracetest/server/config/configresource"
 	"github.com/kubeshop/tracetest/server/model"
 	"github.com/kubeshop/tracetest/server/provisioning"
 	"github.com/kubeshop/tracetest/server/testdb"
+	"github.com/kubeshop/tracetest/server/testmock"
 	"github.com/stretchr/testify/assert"
 	"go.opentelemetry.io/collector/config/configgrpc"
 	"go.opentelemetry.io/collector/config/configtls"
@@ -93,8 +95,14 @@ var cases = []struct {
 }
 
 func TestDataStore(t *testing.T) {
+	db := testmock.MustGetRawTestingDatabase()
+
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
+			configDB := configresource.NewRepository(
+				testmock.MustCreateRandomMigratedDatabase(db),
+			)
+
 			t.Run("FromFile", func(t *testing.T) {
 				c := c
 				t.Parallel()
@@ -107,7 +115,7 @@ func TestDataStore(t *testing.T) {
 				}
 
 				mockRepo := &testdb.MockRepository{}
-				provisioner := provisioning.New(mockRepo)
+				provisioner := provisioning.New(mockRepo, configDB)
 
 				mockRepo.
 					On("CreateDataStore", expectedDataStore).


### PR DESCRIPTION
The current config file value `googleAnalytics.enabled` is now ignored, since it's read from DB. We need to allow provisioning of this config. This PR adds support for the provisioning of this config.

## Changes

- Implements Config provisioning

## Fixes

- fixes #2106 

## Checklist

- [X] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
