### PR TITLE
feat(frontend): integrate pollingprofile settings with API

### DIFF
--- a/web/src/components/Settings/Polling/PollingForm.tsx
+++ b/web/src/components/Settings/Polling/PollingForm.tsx
@@ -3,6 +3,7 @@ import {Button, Col, Form, Input, Row} from 'antd';
 import {rawToResource, TRawPolling} from 'models/Polling.model';
 import {useSettings} from 'providers/Settings/Settings.provider';
 import {useSettingsValues} from 'providers/SettingsValues/SettingsValues.provider';
+import {useEffect} from 'react';
 import * as S from '../common/Settings.styled';
 
 const FORM_ID = 'polling';
@@ -11,6 +12,10 @@ const PollingForm = () => {
   const [form] = Form.useForm<TRawPolling>();
   const {isLoading, onSubmit} = useSettings();
   const {polling} = useSettingsValues();
+
+  useEffect(() => {
+    form.resetFields();
+  }, [form, polling]);
 
   const handleOnSubmit = (values: TRawPolling) => {
     onSubmit(rawToResource(values));
@@ -25,11 +30,16 @@ const PollingForm = () => {
       name={FORM_ID}
       onFinish={handleOnSubmit}
     >
+      <Form.Item hidden name="default" />
+      <Form.Item hidden name="id" />
+      <Form.Item hidden name="name" />
+      <Form.Item hidden name="strategy" />
+
       <Row gutter={[16, 16]}>
         <Col span={12}>
           <Form.Item
             label="Max wait time for trace"
-            name="maxWaitTimeForTrace"
+            name={['periodic', 'timeout']}
             rules={[{required: true, message: 'Max wait time for trace is required'}]}
           >
             <Input placeholder="10s" />
@@ -38,7 +48,7 @@ const PollingForm = () => {
         <Col span={12}>
           <Form.Item
             label="Retry delay"
-            name="retryDelay"
+            name={['periodic', 'retryDelay']}
             rules={[{required: true, message: 'Retry delay is required'}]}
           >
             <Input placeholder="500ms" />

--- a/web/src/models/Polling.model.ts
+++ b/web/src/models/Polling.model.ts
@@ -1,28 +1,40 @@
 import {EResourceType, TListResponse, TResource} from 'types/Settings.types';
 
 export type TRawPolling = {
+  default: boolean;
   id: string;
-  maxWaitTimeForTrace: string;
   name: string;
-  retryDelay: string;
+  periodic: {
+    retryDelay: string;
+    timeout: string;
+  };
+  strategy: string;
 };
 
 type Polling = {
+  default: boolean;
   id: string;
-  maxWaitTimeForTrace: string;
   name: string;
-  retryDelay: string;
+  periodic: {
+    retryDelay: string;
+    timeout: string;
+  };
+  strategy: string;
 };
 
 function Polling(rawPollings?: TListResponse<TRawPolling>): Polling {
   const items = rawPollings?.items ?? [];
-  const polling = items?.[0];
+  const polling = items.find(item => item?.spec?.default ?? false);
 
   return {
+    default: true,
     id: polling?.spec?.id ?? '',
-    maxWaitTimeForTrace: polling?.spec?.maxWaitTimeForTrace ?? '',
-    name: polling?.spec?.name ?? '',
-    retryDelay: polling?.spec?.retryDelay ?? '',
+    name: polling?.spec?.name ?? 'periodic',
+    periodic: {
+      retryDelay: polling?.spec?.periodic?.retryDelay ?? '',
+      timeout: polling?.spec?.periodic?.timeout ?? '',
+    },
+    strategy: polling?.spec?.strategy ?? 'periodic',
   };
 }
 

--- a/web/src/pages/Settings/Content.tsx
+++ b/web/src/pages/Settings/Content.tsx
@@ -2,7 +2,7 @@ import {Tabs} from 'antd';
 import Analytics from 'components/Settings/Analytics';
 import DataStore from 'components/Settings/DataStore';
 // import Demo from 'components/Settings/Demo';
-// import Polling from 'components/Settings/Polling';
+import Polling from 'components/Settings/Polling';
 import * as S from './Settings.styled';
 
 const TabsKeys = {
@@ -26,10 +26,10 @@ const Content = () => (
         <Tabs.TabPane key={TabsKeys.Analytics} tab="Analytics">
           <Analytics />
         </Tabs.TabPane>
-        {/* <Tabs.TabPane key={TabsKeys.Polling} tab="Trace Polling">
+        <Tabs.TabPane key={TabsKeys.Polling} tab="Trace Polling">
           <Polling />
         </Tabs.TabPane>
-         <Tabs.TabPane key={TabsKeys.Demo} tab="Demo">
+        {/* <Tabs.TabPane key={TabsKeys.Demo} tab="Demo">
           <Demo />
         </Tabs.TabPane> */}
       </Tabs>

--- a/web/src/types/Settings.types.ts
+++ b/web/src/types/Settings.types.ts
@@ -13,7 +13,7 @@ export type TResource<T> = {
 
 export enum EResourceType {
   Config = 'Config',
-  Polling = 'Polling',
+  Polling = 'PollingProfile',
 }
 
 export type TSpec = TRawConfig | TRawPolling;


### PR DESCRIPTION
This PR integrates polling profile settings with the resources API.

## Changes

- Integrate web UI with resources API

## Fixes

- #2100 

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
