### PR TITLE
chore(cicd): move demo deploy to its own pipeline

### DIFF
--- a/.github/workflows/deploy-demo.yml
+++ b/.github/workflows/deploy-demo.yml
@@ -1,0 +1,121 @@
+name: Release Tracetest Demo
+
+permissions:
+  contents: write
+
+concurrency:
+  group: "release-server"
+  cancel-in-progress: true
+
+defaults:
+  run:
+    shell: bash
+
+on:
+  push:
+    tags:
+      # this pipeline is only for final releases
+      - "v[0-9]+.[0-9]+.[0-9]+"
+jobs:
+  build-web:
+    name: build web
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Setup node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16
+          cache: npm
+          cache-dependency-path: web/package-lock.json
+      - name: Cache Build
+        id: cache-build
+        uses: actions/cache@v3
+        with:
+          path: web/build/
+          key: web-build-${{ hashFiles('web/*') }}
+      - run: cd web; npm ci
+        if: steps.cache-build.outputs.cache-hit != 'true'
+      - run: cd web; CI= npm run build
+        if: steps.cache-build.outputs.cache-hit != 'true'
+      - name: Upload assets
+        uses: actions/upload-artifact@v3
+        with:
+          name: tracetest-web
+          path: web/build/
+
+  demo-release:
+    runs-on: ubuntu-latest
+    needs: [build-web]
+    env:
+      DOCKER_CLI_EXPERIMENTAL: "enabled"
+      GORELEASER_KEY: ${{ secrets.GORELEASER_LICENSE }}
+      GITHUB_TOKEN: ${{ secrets.CI_BOT_TOKEN }}
+      FURY_TOKEN: ${{ secrets.FURY_TOKEN }}
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - uses: docker/setup-qemu-action@v2
+      - uses: docker/setup-buildx-action@v2
+      - name: Login to DockerHub
+        uses: docker/login-action@v2
+        if: github.event_name != 'pull_request'
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Setup go
+        uses: actions/setup-go@v3
+        with:
+          go-version-file: 'go.work'
+          cache: true
+          cache-dependency-path: go.work
+      - uses: actions/download-artifact@v3
+        with:
+          name: tracetest-web
+          path: web/build/
+      # release
+      - uses: goreleaser/goreleaser-action@v4
+        with:
+          distribution: goreleaser-pro
+          version: v1.15.2
+          args: release --clean --skip-announce -f .goreleaser.dev.yaml
+        env:
+          VERSION: ${{ github.ref_name}}-demo
+          TRACETEST_ENV: demo
+          ANALYTICS_FE_KEY: ${{ secrets.ANALYTICS_FE_KEY }}
+          ANALYTICS_BE_KEY: ${{ secrets.ANALYTICS_BE_KEY }}
+
+  demo-deploy:
+    if: github.event_name == 'push'
+    needs: [demo-release]
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+
+    - uses: google-github-actions/setup-gcloud@94337306dda8180d967a56932ceb4ddcf01edae7
+      with:
+        service_account_key: ${{ secrets.GKE_SA_KEY }}
+        project_id: ${{ secrets.GKE_PROJECT }}
+
+    - run: |-
+        gcloud --quiet auth configure-docker
+
+    - uses: google-github-actions/get-gke-credentials@fb08709ba27618c31c09e014e1d8364b02e5042e
+      with:
+        cluster_name: ${{ secrets.GKE_CLUSTER }}
+        location: ${{ secrets.GKE_ZONE }}
+        credentials: ${{ secrets.GKE_SA_KEY }}
+
+    - name: Deploy
+      run: |
+        TAG=${{ github.ref_name}}-demo \
+        NAME=tracetest-demo \
+        CONFIG_FILE=./k8s/tracetest.demo.yaml \
+        EXPOSE_HOST=demo.tracetest.io \
+        CERT_NAME=tracetest-demo \
+        BACKEND_CONFIG=tracetest-demo \
+        ./k8s/deploy.sh

--- a/.github/workflows/release-version.yml
+++ b/.github/workflows/release-version.yml
@@ -15,7 +15,8 @@ on:
   push:
     tags:
       - "v[0-9]+.[0-9]+.[0-9]+"
-      - "v[0-9]+.[0-9]+.[0-9]+-*"
+      # this pipeline supports RC pre releases
+      - "v[0-9]+.[0-9]+.[0-9]+-rc.[0-9]+"
 jobs:
   build-web:
     name: build web
@@ -144,81 +145,6 @@ jobs:
           SLACK_LINK_NAMES: true
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
           SLACK_FOOTER: "Kubeshop --> Tracetest"
-
-  demo-release:
-    runs-on: ubuntu-latest
-    needs: [build-web]
-    env:
-      DOCKER_CLI_EXPERIMENTAL: "enabled"
-      GORELEASER_KEY: ${{ secrets.GORELEASER_LICENSE }}
-      GITHUB_TOKEN: ${{ secrets.CI_BOT_TOKEN }}
-      FURY_TOKEN: ${{ secrets.FURY_TOKEN }}
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-      - uses: docker/setup-qemu-action@v2
-      - uses: docker/setup-buildx-action@v2
-      - name: Login to DockerHub
-        uses: docker/login-action@v2
-        if: github.event_name != 'pull_request'
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - name: Setup go
-        uses: actions/setup-go@v3
-        with:
-          go-version-file: 'go.work'
-          cache: true
-          cache-dependency-path: go.work
-      - uses: actions/download-artifact@v3
-        with:
-          name: tracetest-web
-          path: web/build/
-      # release
-      - uses: goreleaser/goreleaser-action@v4
-        with:
-          distribution: goreleaser-pro
-          version: v1.15.2
-          args: release --clean --skip-announce -f .goreleaser.dev.yaml
-        env:
-          VERSION: ${{ github.ref_name}}-demo
-          TRACETEST_ENV: demo
-          ANALYTICS_FE_KEY: ${{ secrets.ANALYTICS_FE_KEY }}
-          ANALYTICS_BE_KEY: ${{ secrets.ANALYTICS_BE_KEY }}
-
-  demo-deploy:
-    if: github.event_name == 'push'
-    needs: [release, demo-release]
-    runs-on: ubuntu-latest
-
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v3
-
-    - uses: google-github-actions/setup-gcloud@94337306dda8180d967a56932ceb4ddcf01edae7
-      with:
-        service_account_key: ${{ secrets.GKE_SA_KEY }}
-        project_id: ${{ secrets.GKE_PROJECT }}
-
-    - run: |-
-        gcloud --quiet auth configure-docker
-
-    - uses: google-github-actions/get-gke-credentials@fb08709ba27618c31c09e014e1d8364b02e5042e
-      with:
-        cluster_name: ${{ secrets.GKE_CLUSTER }}
-        location: ${{ secrets.GKE_ZONE }}
-        credentials: ${{ secrets.GKE_SA_KEY }}
-
-    - name: Deploy
-      run: |
-        TAG=${{ github.ref_name}}-demo \
-        NAME=tracetest-demo \
-        CONFIG_FILE=./k8s/tracetest.demo.yaml \
-        EXPOSE_HOST=demo.tracetest.io \
-        CERT_NAME=tracetest-demo \
-        BACKEND_CONFIG=tracetest-demo \
-        ./k8s/deploy.sh
 
 
   notify_slack_if_helm_chart_bump_fails:


### PR DESCRIPTION
This PR moves the demo deploy to its own pipeline. This is required to support RC releases without deploying them to the demo environment.