### PR TITLE
feat: limit polling profiles to one

### DIFF
--- a/server/config/configresource/config_resource_test.go
+++ b/server/config/configresource/config_resource_test.go
@@ -134,7 +134,6 @@ func TestConfigResource(t *testing.T) {
 			}
 		}`,
 	},
-		// TODO: remove this when we support multiple profiles
 		rmtests.ExcludeOperations(
 			rmtests.OperationGetNotFound,
 			rmtests.OperationUpdateNotFound,

--- a/server/config/configresource/config_resource_test.go
+++ b/server/config/configresource/config_resource_test.go
@@ -134,6 +134,7 @@ func TestConfigResource(t *testing.T) {
 			}
 		}`,
 	},
+		// TODO: remove this when we support multiple profiles
 		rmtests.ExcludeOperations(
 			rmtests.OperationGetNotFound,
 			rmtests.OperationUpdateNotFound,

--- a/server/executor/pollingprofile/polling_profile_resource.go
+++ b/server/executor/pollingprofile/polling_profile_resource.go
@@ -176,7 +176,7 @@ func (r *Repository) Update(ctx context.Context, profile PollingProfile) (Pollin
 	profile.ID = id.ID("current")
 
 	err := r.Delete(ctx, profile.ID)
-	if err != nil {
+	if err != nil && errors.Unwrap(err) != sql.ErrNoRows {
 		return PollingProfile{}, fmt.Errorf("could not delete old profile when updating it: %w", err)
 	}
 
@@ -203,21 +203,11 @@ const (
 )
 
 func (r *Repository) Get(ctx context.Context, id id.ID) (PollingProfile, error) {
-	profile, err := r.get(ctx, getQuery, id)
-	if err != nil && errors.Unwrap(err) == sql.ErrNoRows {
-		return defaultPollingProfile, nil
-	}
-
-	return profile, err
+	return r.get(ctx, getQuery, id)
 }
 
 func (r *Repository) GetDefault(ctx context.Context) (PollingProfile, error) {
-	profile, err := r.get(ctx, getDefaultQuery)
-	if err != nil && err == sql.ErrNoRows {
-		return defaultPollingProfile, nil
-	}
-
-	return profile, err
+	return r.get(ctx, getDefaultQuery)
 }
 
 func (r *Repository) get(ctx context.Context, query string, args ...any) (PollingProfile, error) {

--- a/server/executor/pollingprofile/polling_profile_resource.go
+++ b/server/executor/pollingprofile/polling_profile_resource.go
@@ -172,9 +172,6 @@ func (r *Repository) clearDefaultFlag(ctx context.Context) error {
 }
 
 func (r *Repository) Update(ctx context.Context, profile PollingProfile) (PollingProfile, error) {
-	// TODO: remove this id override when we support multiple profiles
-	profile.ID = id.ID("current")
-
 	err := r.Delete(ctx, profile.ID)
 	if err != nil && errors.Unwrap(err) != sql.ErrNoRows {
 		return PollingProfile{}, fmt.Errorf("could not delete old profile when updating it: %w", err)

--- a/server/executor/pollingprofile/polling_profile_resource_test.go
+++ b/server/executor/pollingprofile/polling_profile_resource_test.go
@@ -98,8 +98,10 @@ func TestPollingProfileResource(t *testing.T) {
 				}
 			}
 		}`,
-	}, rmtests.ExcludeOperations(
-		rmtests.OperationGetNotFound,
-		rmtests.OperationUpdateNotFound,
-	))
+	},
+		// TODO: remove this when we support multiple profiles
+		rmtests.ExcludeOperations(
+			rmtests.OperationGetNotFound,
+			rmtests.OperationUpdateNotFound,
+		))
 }

--- a/server/executor/pollingprofile/polling_profile_resource_test.go
+++ b/server/executor/pollingprofile/polling_profile_resource_test.go
@@ -98,5 +98,8 @@ func TestPollingProfileResource(t *testing.T) {
 				}
 			}
 		}`,
-	})
+	}, rmtests.ExcludeOperations(
+		rmtests.OperationGetNotFound,
+		rmtests.OperationUpdateNotFound,
+	))
 }


### PR DESCRIPTION
This PR makes sure that there's only one polling profile for now.

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [x] added a test
