### PR TITLE
feature(frontend): adding live updates for analytics changes

### DIFF
--- a/web/src/models/Config.model.ts
+++ b/web/src/models/Config.model.ts
@@ -16,4 +16,18 @@ function Config({
   };
 }
 
+export type TRawLiveConfig = {
+  AnalyticsEnabled?: boolean;
+  ID: 'current';
+  Name: 'Config';
+};
+
+Config.FromLiveUpdate = ({AnalyticsEnabled: analyticsEnabled = false, Name: name, ID: id}: TRawLiveConfig): Config => {
+  return {
+    id,
+    name,
+    analyticsEnabled,
+  };
+};
+
 export default Config;


### PR DESCRIPTION
This PR adds live updates for the config resource in the front, allowing the FE to switch analytics on an off based on user input

## Changes

- Setting endpoint now listens to config live updates
- FE enables/disabled analytics based on the backend WebSocket

## Fixes

- #2125 

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
