### PR TITLE
chore(cicd): split RC pipeline

### DIFF
--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -1,0 +1,91 @@
+name: Release Tracetest
+
+permissions:
+  contents: write
+
+concurrency:
+  group: "release-server"
+  cancel-in-progress: true
+
+defaults:
+  run:
+    shell: bash
+
+on:
+  push:
+    tags:
+      # this pipeline supports RC pre releases
+      - "v[0-9]+.[0-9]+.[0-9]+-rc.[0-9]+"
+jobs:
+  build-web:
+    name: build web
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Setup node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16
+          cache: npm
+          cache-dependency-path: web/package-lock.json
+      - name: Cache Build
+        id: cache-build
+        uses: actions/cache@v3
+        with:
+          path: web/build/
+          key: web-build-${{ hashFiles('web/*') }}
+      - run: cd web; npm ci
+        if: steps.cache-build.outputs.cache-hit != 'true'
+      - run: cd web; CI= npm run build
+        if: steps.cache-build.outputs.cache-hit != 'true'
+      - name: Upload assets
+        uses: actions/upload-artifact@v3
+        with:
+          name: tracetest-web
+          path: web/build/
+
+  release:
+    runs-on: ubuntu-latest
+    needs: [build-web]
+    env:
+      DOCKER_CLI_EXPERIMENTAL: "enabled"
+      GORELEASER_KEY: ${{ secrets.GORELEASER_LICENSE }}
+      GITHUB_TOKEN: ${{ secrets.CI_BOT_TOKEN }}
+      FURY_TOKEN: ${{ secrets.FURY_TOKEN }}
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - uses: docker/setup-qemu-action@v2
+      - uses: docker/setup-buildx-action@v2
+      - name: Login to DockerHub
+        uses: docker/login-action@v2
+        if: github.event_name != 'pull_request'
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Setup go
+        uses: actions/setup-go@v3
+        with:
+          go-version-file: 'go.work'
+          cache: true
+          cache-dependency-path: go.work
+
+      - uses: actions/download-artifact@v3
+        with:
+          name: tracetest-web
+          path: web/build/
+
+      # release
+      - uses: goreleaser/goreleaser-action@v4
+        if: steps.cache.outputs.cache-hit != 'true'
+        with:
+          distribution: goreleaser-pro
+          version: v1.15.2
+          args: release --clean --nightly
+        env:
+          VERSION: ${{ github.ref_name}}
+          TRACETEST_ENV: main
+          ANALYTICS_FE_KEY: ${{ secrets.ANALYTICS_FE_KEY }}
+          ANALYTICS_BE_KEY: ${{ secrets.ANALYTICS_BE_KEY }}

--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -1,4 +1,4 @@
-name: Release Tracetest
+name: Release Tracetest (RC version)
 
 permissions:
   contents: write

--- a/.github/workflows/release-version.yml
+++ b/.github/workflows/release-version.yml
@@ -15,8 +15,6 @@ on:
   push:
     tags:
       - "v[0-9]+.[0-9]+.[0-9]+"
-      # this pipeline supports RC pre releases
-      - "v[0-9]+.[0-9]+.[0-9]+-rc.[0-9]+"
 jobs:
   build-web:
     name: build web


### PR DESCRIPTION
This PR splits the RC pipeline so we have more control of what happens for this special case release. In particular at this time we don't want to deploy brew/apt/rpm/helm repositories.

## Changes

-

## Fixes

-

## Checklist

- [ ] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
