### PR TITLE
Update examples to use configuration on the new format

### DIFF
--- a/examples/collector/tracetest-config.yaml
+++ b/examples/collector/tracetest-config.yaml
@@ -35,5 +35,4 @@ telemetry:
 
 server:
   telemetry:
-    dataStore: otlp
     exporter: collector

--- a/examples/collector/tracetest-config.yaml
+++ b/examples/collector/tracetest-config.yaml
@@ -6,24 +6,7 @@ postgres:
   dbname: postgres
   params: sslmode=disable
 
-poolingConfig:
-  maxWaitTimeForTrace: 10m
-  retryDelay: 5s
-
-googleAnalytics:
-  enabled: true
-
-demo:
-  enabled: []
-
-experimentalFeatures: []
-
 telemetry:
-  dataStores:
-    otlp:
-      type: otlp
-
-
   exporters:
     collector:
       serviceName: tracetest

--- a/examples/collector/tracetest-provision.yaml
+++ b/examples/collector/tracetest-provision.yaml
@@ -9,11 +9,6 @@ spec:
     timeout: 10m
 
 ---
-type: Config
-spec:
-  analyticsEnabled: true
-
----
 type: DataStore
 spec:
   name: OpenTelemetry Collector

--- a/examples/collector/tracetest-provision.yaml
+++ b/examples/collector/tracetest-provision.yaml
@@ -1,2 +1,21 @@
-dataStore:
+---
+type: PollingProfile
+spec:
+  name: Default
+  strategy: periodic
+  default: true
+  periodic:
+    retryDelay: 5s
+    timeout: 10m
+
+---
+type: Config
+spec:
+  analyticsEnabled: true
+
+---
+type: DataStore
+spec:
+  name: OpenTelemetry Collector
   type: otlp
+  default: true

--- a/examples/collector/tracetest-provision.yaml
+++ b/examples/collector/tracetest-provision.yaml
@@ -13,4 +13,4 @@ type: DataStore
 spec:
   name: OpenTelemetry Collector
   type: otlp
-  default: true
+  isdefault: true

--- a/examples/observability-driven-development-go-tracetest/bookstore/part1/tracetest/tracetest-provision.yaml
+++ b/examples/observability-driven-development-go-tracetest/bookstore/part1/tracetest/tracetest-provision.yaml
@@ -1,9 +1,4 @@
 ---
-type: Config
-spec:
-  analyticsEnabled: true
-
----
 type: Demo
 spec:
   name: "OpenTelemetry Shop"

--- a/examples/observability-driven-development-go-tracetest/bookstore/part1/tracetest/tracetest-provision.yaml
+++ b/examples/observability-driven-development-go-tracetest/bookstore/part1/tracetest/tracetest-provision.yaml
@@ -35,7 +35,7 @@ type: DataStore
 spec:
   name: Jaeger
   type: jaeger
-  default: true
+  isdefault: true
   jaeger:
     endpoint: jaeger:16685
     tls:

--- a/examples/observability-driven-development-go-tracetest/bookstore/part1/tracetest/tracetest-provision.yaml
+++ b/examples/observability-driven-development-go-tracetest/bookstore/part1/tracetest/tracetest-provision.yaml
@@ -1,5 +1,46 @@
-dataStore:
+---
+type: Config
+spec:
+  analyticsEnabled: true
+
+---
+type: Demo
+spec:
+  name: "OpenTelemetry Shop"
+  enabled: true
+  type: otelstore
+  opentelemetryStore:
+    frontendEndpoint: http://dev-frontend:9000
+    productCatalogEndpoint: http://dev-product:8081
+    cartEndpoint: http://dev-cart:8082
+    checkoutEndpoint: http://dev-checkout:8083
+
+---
+type: Demo
+spec:
+  name: "Pokeshop"
+  enabled: true
+  type: pokeshop
+  pokeshop:
+    grpcEndpoint: demo-api:8082
+    httpEndpoint: http://demo-api:8081
+
+---
+type: PollingProfile
+spec:
+  name: Default
+  strategy: periodic
+  default: true
+  periodic:
+    retryDelay: 3s
+    timeout: 2m
+
+---
+type: DataStore
+spec:
+  name: Jaeger
   type: jaeger
+  default: true
   jaeger:
     endpoint: jaeger:16685
     tls:

--- a/examples/observability-driven-development-go-tracetest/bookstore/part1/tracetest/tracetest.yaml
+++ b/examples/observability-driven-development-go-tracetest/bookstore/part1/tracetest/tracetest.yaml
@@ -1,19 +1,3 @@
-googleAnalytics:
-  enabled: true
-
-demo:
-  endpoints:
-    otelcart: otel-cartservice:7070
-    otelcheckout: otel-checkoutservice:5050
-    otelfrontend: http://otel-frontend:8084
-    otelproductcatalog: otel-productcatalogservice:3550
-    pokeshopgrpc: demo-api:8082
-    pokeshophttp: http://demo-api:8081
-
-poolingconfig:
-  maxwaittimefortrace: 2m
-  retrydelay: 3s
-
 postgres:
   host: postgres
   user: postgres
@@ -23,8 +7,8 @@ postgres:
   params: sslmode=disable
 
 server:
-    telemetry:
-        exporter: collector
+  telemetry:
+    exporter: collector
 
 telemetry:
   exporters:

--- a/examples/observability-driven-development-go-tracetest/bookstore/part1/tracetest/tracetest.yaml
+++ b/examples/observability-driven-development-go-tracetest/bookstore/part1/tracetest/tracetest.yaml
@@ -1,15 +1,18 @@
+googleAnalytics:
+  enabled: true
+
 demo:
-    endpoints:
-        otelcart: otel-cartservice:7070
-        otelcheckout: otel-checkoutservice:5050
-        otelfrontend: http://otel-frontend:8084
-        otelproductcatalog: otel-productcatalogservice:3550
-        pokeshopgrpc: demo-api:8082
-        pokeshophttp: http://demo-api:8081
+  endpoints:
+    otelcart: otel-cartservice:7070
+    otelcheckout: otel-checkoutservice:5050
+    otelfrontend: http://otel-frontend:8084
+    otelproductcatalog: otel-productcatalogservice:3550
+    pokeshopgrpc: demo-api:8082
+    pokeshophttp: http://demo-api:8081
 
 poolingconfig:
-    maxwaittimefortrace: 2m
-    retrydelay: 3s
+  maxwaittimefortrace: 2m
+  retrydelay: 3s
 
 postgres:
   host: postgres
@@ -24,11 +27,11 @@ server:
         exporter: collector
 
 telemetry:
-    exporters:
+  exporters:
+    collector:
+      exporter:
         collector:
-            exporter:
-                collector:
-                    endpoint: otel-collector:4317
-                type: collector
-            sampling: 100
-            servicename: tracetest
+          endpoint: otel-collector:4317
+        type: collector
+      sampling: 100
+      servicename: tracetest

--- a/examples/observability-driven-development-go-tracetest/bookstore/part2.1/tracetest/tracetest-provision.yaml
+++ b/examples/observability-driven-development-go-tracetest/bookstore/part2.1/tracetest/tracetest-provision.yaml
@@ -1,9 +1,4 @@
 ---
-type: Config
-spec:
-  analyticsEnabled: true
-
----
 type: Demo
 spec:
   name: "OpenTelemetry Shop"

--- a/examples/observability-driven-development-go-tracetest/bookstore/part2.1/tracetest/tracetest-provision.yaml
+++ b/examples/observability-driven-development-go-tracetest/bookstore/part2.1/tracetest/tracetest-provision.yaml
@@ -35,7 +35,7 @@ type: DataStore
 spec:
   name: Jaeger
   type: jaeger
-  default: true
+  isdefault: true
   jaeger:
     endpoint: jaeger:16685
     tls:

--- a/examples/observability-driven-development-go-tracetest/bookstore/part2.1/tracetest/tracetest-provision.yaml
+++ b/examples/observability-driven-development-go-tracetest/bookstore/part2.1/tracetest/tracetest-provision.yaml
@@ -1,5 +1,46 @@
-dataStore:
+---
+type: Config
+spec:
+  analyticsEnabled: true
+
+---
+type: Demo
+spec:
+  name: "OpenTelemetry Shop"
+  enabled: true
+  type: otelstore
+  opentelemetryStore:
+    frontendEndpoint: http://dev-frontend:9000
+    productCatalogEndpoint: http://dev-product:8081
+    cartEndpoint: http://dev-cart:8082
+    checkoutEndpoint: http://dev-checkout:8083
+
+---
+type: Demo
+spec:
+  name: "Pokeshop"
+  enabled: true
+  type: pokeshop
+  pokeshop:
+    grpcEndpoint: demo-api:8082
+    httpEndpoint: http://demo-api:8081
+
+---
+type: PollingProfile
+spec:
+  name: Default
+  strategy: periodic
+  default: true
+  periodic:
+    retryDelay: 3s
+    timeout: 2m
+
+---
+type: DataStore
+spec:
+  name: Jaeger
   type: jaeger
+  default: true
   jaeger:
     endpoint: jaeger:16685
     tls:

--- a/examples/observability-driven-development-go-tracetest/bookstore/part2.1/tracetest/tracetest.yaml
+++ b/examples/observability-driven-development-go-tracetest/bookstore/part2.1/tracetest/tracetest.yaml
@@ -1,19 +1,3 @@
-googleAnalytics:
-  enabled: true
-
-demo:
-    endpoints:
-        otelcart: otel-cartservice:7070
-        otelcheckout: otel-checkoutservice:5050
-        otelfrontend: http://otel-frontend:8084
-        otelproductcatalog: otel-productcatalogservice:3550
-        pokeshopgrpc: demo-api:8082
-        pokeshophttp: http://demo-api:8081
-
-poolingconfig:
-    maxwaittimefortrace: 2m
-    retrydelay: 3s
-
 postgres:
   host: postgres
   user: postgres
@@ -23,15 +7,15 @@ postgres:
   params: sslmode=disable
 
 server:
-    telemetry:
-        exporter: collector
+  telemetry:
+    exporter: collector
 
 telemetry:
-    exporters:
+  exporters:
+    collector:
+      exporter:
         collector:
-            exporter:
-                collector:
-                    endpoint: otel-collector:4317
-                type: collector
-            sampling: 100
-            servicename: tracetest
+          endpoint: otel-collector:4317
+        type: collector
+      sampling: 100
+      servicename: tracetest

--- a/examples/observability-driven-development-go-tracetest/bookstore/part2.1/tracetest/tracetest.yaml
+++ b/examples/observability-driven-development-go-tracetest/bookstore/part2.1/tracetest/tracetest.yaml
@@ -1,5 +1,5 @@
 googleAnalytics:
-  enabled: false
+  enabled: true
 
 demo:
     endpoints:

--- a/examples/observability-driven-development-go-tracetest/bookstore/part2.2/tracetest/tracetest-provision.yaml
+++ b/examples/observability-driven-development-go-tracetest/bookstore/part2.2/tracetest/tracetest-provision.yaml
@@ -1,9 +1,4 @@
 ---
-type: Config
-spec:
-  analyticsEnabled: true
-
----
 type: Demo
 spec:
   name: "OpenTelemetry Shop"

--- a/examples/observability-driven-development-go-tracetest/bookstore/part2.2/tracetest/tracetest-provision.yaml
+++ b/examples/observability-driven-development-go-tracetest/bookstore/part2.2/tracetest/tracetest-provision.yaml
@@ -35,7 +35,7 @@ type: DataStore
 spec:
   name: Jaeger
   type: jaeger
-  default: true
+  isdefault: true
   jaeger:
     endpoint: jaeger:16685
     tls:

--- a/examples/observability-driven-development-go-tracetest/bookstore/part2.2/tracetest/tracetest-provision.yaml
+++ b/examples/observability-driven-development-go-tracetest/bookstore/part2.2/tracetest/tracetest-provision.yaml
@@ -1,5 +1,46 @@
-dataStore:
+---
+type: Config
+spec:
+  analyticsEnabled: true
+
+---
+type: Demo
+spec:
+  name: "OpenTelemetry Shop"
+  enabled: true
+  type: otelstore
+  opentelemetryStore:
+    frontendEndpoint: http://dev-frontend:9000
+    productCatalogEndpoint: http://dev-product:8081
+    cartEndpoint: http://dev-cart:8082
+    checkoutEndpoint: http://dev-checkout:8083
+
+---
+type: Demo
+spec:
+  name: "Pokeshop"
+  enabled: true
+  type: pokeshop
+  pokeshop:
+    grpcEndpoint: demo-api:8082
+    httpEndpoint: http://demo-api:8081
+
+---
+type: PollingProfile
+spec:
+  name: Default
+  strategy: periodic
+  default: true
+  periodic:
+    retryDelay: 3s
+    timeout: 2m
+
+---
+type: DataStore
+spec:
+  name: Jaeger
   type: jaeger
+  default: true
   jaeger:
     endpoint: jaeger:16685
     tls:

--- a/examples/observability-driven-development-go-tracetest/bookstore/part2.2/tracetest/tracetest.yaml
+++ b/examples/observability-driven-development-go-tracetest/bookstore/part2.2/tracetest/tracetest.yaml
@@ -1,19 +1,3 @@
-googleAnalytics:
-  enabled: true
-
-demo:
-    endpoints:
-        otelcart: otel-cartservice:7070
-        otelcheckout: otel-checkoutservice:5050
-        otelfrontend: http://otel-frontend:8084
-        otelproductcatalog: otel-productcatalogservice:3550
-        pokeshopgrpc: demo-api:8082
-        pokeshophttp: http://demo-api:8081
-
-poolingconfig:
-    maxwaittimefortrace: 2m
-    retrydelay: 3s
-
 postgres:
   host: postgres
   user: postgres
@@ -23,15 +7,15 @@ postgres:
   params: sslmode=disable
 
 server:
-    telemetry:
-        exporter: collector
+  telemetry:
+    exporter: collector
 
 telemetry:
-    exporters:
+  exporters:
+    collector:
+      exporter:
         collector:
-            exporter:
-                collector:
-                    endpoint: otel-collector:4317
-                type: collector
-            sampling: 100
-            servicename: tracetest
+          endpoint: otel-collector:4317
+        type: collector
+      sampling: 100
+      servicename: tracetest

--- a/examples/observability-driven-development-go-tracetest/bookstore/part2.2/tracetest/tracetest.yaml
+++ b/examples/observability-driven-development-go-tracetest/bookstore/part2.2/tracetest/tracetest.yaml
@@ -1,5 +1,5 @@
 googleAnalytics:
-  enabled: false
+  enabled: true
 
 demo:
     endpoints:

--- a/examples/observability-driven-development-go-tracetest/bookstore/part3.1/tracetest/tracetest-provision.yaml
+++ b/examples/observability-driven-development-go-tracetest/bookstore/part3.1/tracetest/tracetest-provision.yaml
@@ -1,9 +1,4 @@
 ---
-type: Config
-spec:
-  analyticsEnabled: true
-
----
 type: Demo
 spec:
   name: "OpenTelemetry Shop"

--- a/examples/observability-driven-development-go-tracetest/bookstore/part3.1/tracetest/tracetest-provision.yaml
+++ b/examples/observability-driven-development-go-tracetest/bookstore/part3.1/tracetest/tracetest-provision.yaml
@@ -35,7 +35,7 @@ type: DataStore
 spec:
   name: Jaeger
   type: jaeger
-  default: true
+  isdefault: true
   jaeger:
     endpoint: jaeger:16685
     tls:

--- a/examples/observability-driven-development-go-tracetest/bookstore/part3.1/tracetest/tracetest-provision.yaml
+++ b/examples/observability-driven-development-go-tracetest/bookstore/part3.1/tracetest/tracetest-provision.yaml
@@ -1,5 +1,46 @@
-dataStore:
+---
+type: Config
+spec:
+  analyticsEnabled: true
+
+---
+type: Demo
+spec:
+  name: "OpenTelemetry Shop"
+  enabled: true
+  type: otelstore
+  opentelemetryStore:
+    frontendEndpoint: http://dev-frontend:9000
+    productCatalogEndpoint: http://dev-product:8081
+    cartEndpoint: http://dev-cart:8082
+    checkoutEndpoint: http://dev-checkout:8083
+
+---
+type: Demo
+spec:
+  name: "Pokeshop"
+  enabled: true
+  type: pokeshop
+  pokeshop:
+    grpcEndpoint: demo-api:8082
+    httpEndpoint: http://demo-api:8081
+
+---
+type: PollingProfile
+spec:
+  name: Default
+  strategy: periodic
+  default: true
+  periodic:
+    retryDelay: 3s
+    timeout: 2m
+
+---
+type: DataStore
+spec:
+  name: Jaeger
   type: jaeger
+  default: true
   jaeger:
     endpoint: jaeger:16685
     tls:

--- a/examples/observability-driven-development-go-tracetest/bookstore/part3.1/tracetest/tracetest.yaml
+++ b/examples/observability-driven-development-go-tracetest/bookstore/part3.1/tracetest/tracetest.yaml
@@ -1,19 +1,3 @@
-googleAnalytics:
-  enabled: true
-
-demo:
-    endpoints:
-        otelcart: otel-cartservice:7070
-        otelcheckout: otel-checkoutservice:5050
-        otelfrontend: http://otel-frontend:8084
-        otelproductcatalog: otel-productcatalogservice:3550
-        pokeshopgrpc: demo-api:8082
-        pokeshophttp: http://demo-api:8081
-
-poolingconfig:
-    maxwaittimefortrace: 2m
-    retrydelay: 3s
-
 postgres:
   host: postgres
   user: postgres
@@ -23,15 +7,15 @@ postgres:
   params: sslmode=disable
 
 server:
-    telemetry:
-        exporter: collector
+  telemetry:
+    exporter: collector
 
 telemetry:
-    exporters:
+  exporters:
+    collector:
+      exporter:
         collector:
-            exporter:
-                collector:
-                    endpoint: otel-collector:4317
-                type: collector
-            sampling: 100
-            servicename: tracetest
+          endpoint: otel-collector:4317
+        type: collector
+      sampling: 100
+      servicename: tracetest

--- a/examples/observability-driven-development-go-tracetest/bookstore/part3.1/tracetest/tracetest.yaml
+++ b/examples/observability-driven-development-go-tracetest/bookstore/part3.1/tracetest/tracetest.yaml
@@ -1,5 +1,5 @@
 googleAnalytics:
-  enabled: false
+  enabled: true
 
 demo:
     endpoints:

--- a/examples/observability-driven-development-go-tracetest/bookstore/part3.2/tracetest/tracetest-provision.yaml
+++ b/examples/observability-driven-development-go-tracetest/bookstore/part3.2/tracetest/tracetest-provision.yaml
@@ -1,9 +1,4 @@
 ---
-type: Config
-spec:
-  analyticsEnabled: true
-
----
 type: Demo
 spec:
   name: "OpenTelemetry Shop"

--- a/examples/observability-driven-development-go-tracetest/bookstore/part3.2/tracetest/tracetest-provision.yaml
+++ b/examples/observability-driven-development-go-tracetest/bookstore/part3.2/tracetest/tracetest-provision.yaml
@@ -35,7 +35,7 @@ type: DataStore
 spec:
   name: Jaeger
   type: jaeger
-  default: true
+  isdefault: true
   jaeger:
     endpoint: jaeger:16685
     tls:

--- a/examples/observability-driven-development-go-tracetest/bookstore/part3.2/tracetest/tracetest-provision.yaml
+++ b/examples/observability-driven-development-go-tracetest/bookstore/part3.2/tracetest/tracetest-provision.yaml
@@ -1,5 +1,46 @@
-dataStore:
+---
+type: Config
+spec:
+  analyticsEnabled: true
+
+---
+type: Demo
+spec:
+  name: "OpenTelemetry Shop"
+  enabled: true
+  type: otelstore
+  opentelemetryStore:
+    frontendEndpoint: http://dev-frontend:9000
+    productCatalogEndpoint: http://dev-product:8081
+    cartEndpoint: http://dev-cart:8082
+    checkoutEndpoint: http://dev-checkout:8083
+
+---
+type: Demo
+spec:
+  name: "Pokeshop"
+  enabled: true
+  type: pokeshop
+  pokeshop:
+    grpcEndpoint: demo-api:8082
+    httpEndpoint: http://demo-api:8081
+
+---
+type: PollingProfile
+spec:
+  name: Default
+  strategy: periodic
+  default: true
+  periodic:
+    retryDelay: 3s
+    timeout: 2m
+
+---
+type: DataStore
+spec:
+  name: Jaeger
   type: jaeger
+  default: true
   jaeger:
     endpoint: jaeger:16685
     tls:

--- a/examples/observability-driven-development-go-tracetest/bookstore/part3.2/tracetest/tracetest.yaml
+++ b/examples/observability-driven-development-go-tracetest/bookstore/part3.2/tracetest/tracetest.yaml
@@ -1,19 +1,3 @@
-googleAnalytics:
-  enabled: true
-
-demo:
-    endpoints:
-        otelcart: otel-cartservice:7070
-        otelcheckout: otel-checkoutservice:5050
-        otelfrontend: http://otel-frontend:8084
-        otelproductcatalog: otel-productcatalogservice:3550
-        pokeshopgrpc: demo-api:8082
-        pokeshophttp: http://demo-api:8081
-
-poolingconfig:
-    maxwaittimefortrace: 2m
-    retrydelay: 3s
-
 postgres:
   host: postgres
   user: postgres
@@ -23,15 +7,15 @@ postgres:
   params: sslmode=disable
 
 server:
-    telemetry:
-        exporter: collector
+  telemetry:
+    exporter: collector
 
 telemetry:
-    exporters:
+  exporters:
+    collector:
+      exporter:
         collector:
-            exporter:
-                collector:
-                    endpoint: otel-collector:4317
-                type: collector
-            sampling: 100
-            servicename: tracetest
+          endpoint: otel-collector:4317
+        type: collector
+      sampling: 100
+      servicename: tracetest

--- a/examples/observability-driven-development-go-tracetest/bookstore/part3.2/tracetest/tracetest.yaml
+++ b/examples/observability-driven-development-go-tracetest/bookstore/part3.2/tracetest/tracetest.yaml
@@ -1,5 +1,5 @@
 googleAnalytics:
-  enabled: false
+  enabled: true
 
 demo:
     endpoints:

--- a/examples/quick-start-datadog-nodejs/tracetest/tracetest-provision.yaml
+++ b/examples/quick-start-datadog-nodejs/tracetest/tracetest-provision.yaml
@@ -3,4 +3,4 @@ type: DataStore
 spec:
   name: Datadog
   type: datadog
-  default: true
+  isdefault: true

--- a/examples/quick-start-datadog-nodejs/tracetest/tracetest-provision.yaml
+++ b/examples/quick-start-datadog-nodejs/tracetest/tracetest-provision.yaml
@@ -1,2 +1,6 @@
-dataStore:
+---
+type: DataStore
+spec:
+  name: Datadog
   type: datadog
+  default: true

--- a/examples/quick-start-datadog-nodejs/tracetest/tracetest.config.yaml
+++ b/examples/quick-start-datadog-nodejs/tracetest/tracetest.config.yaml
@@ -1,4 +1,3 @@
----
 postgres:
   host: postgres
   user: postgres
@@ -6,15 +5,6 @@ postgres:
   port: 5432
   dbname: postgres
   params: sslmode=disable
-
-poolingConfig:
-  maxWaitTimeForTrace: 30s
-  retryDelay: 500ms
-
-experimentalFeatures: []
-
-googleAnalytics:
-  enabled: false
 
 telemetry:
   exporters:

--- a/examples/quick-start-go/tracetest/tracetest-provision.yaml
+++ b/examples/quick-start-go/tracetest/tracetest-provision.yaml
@@ -3,4 +3,4 @@ type: DataStore
 spec:
   name: OpenTelemetry Collector
   type: otlp
-  default: true
+  isdefault: true

--- a/examples/quick-start-go/tracetest/tracetest-provision.yaml
+++ b/examples/quick-start-go/tracetest/tracetest-provision.yaml
@@ -1,2 +1,6 @@
-dataStore:
+---
+type: DataStore
+spec:
+  name: OpenTelemetry Collector
   type: otlp
+  default: true

--- a/examples/quick-start-go/tracetest/tracetest.config.yaml
+++ b/examples/quick-start-go/tracetest/tracetest.config.yaml
@@ -1,4 +1,3 @@
----
 postgres:
   host: postgres
   user: postgres
@@ -6,13 +5,6 @@ postgres:
   port: 5432
   dbname: postgres
   params: sslmode=disable
-
-poolingConfig:
-  maxWaitTimeForTrace: 10s
-  retryDelay: 1s
-
-googleAnalytics:
-  enabled: true
 
 telemetry:
   exporters:

--- a/examples/quick-start-jaeger-nodejs/tracetest/tracetest-provision.yaml
+++ b/examples/quick-start-jaeger-nodejs/tracetest/tracetest-provision.yaml
@@ -1,5 +1,19 @@
-dataStore:
+---
+type: PollingProfile
+spec:
+  name: Default
+  strategy: periodic
+  default: true
+  periodic:
+    retryDelay: 5s
+    timeout: 10m
+
+---
+type: DataStore
+spec:
+  name: Jaeger
   type: jaeger
+  default: true
   jaeger:
     endpoint: jaeger:16685
     tls:

--- a/examples/quick-start-jaeger-nodejs/tracetest/tracetest-provision.yaml
+++ b/examples/quick-start-jaeger-nodejs/tracetest/tracetest-provision.yaml
@@ -13,7 +13,7 @@ type: DataStore
 spec:
   name: Jaeger
   type: jaeger
-  default: true
+  isdefault: true
   jaeger:
     endpoint: jaeger:16685
     tls:

--- a/examples/quick-start-jaeger-nodejs/tracetest/tracetest.config.yaml
+++ b/examples/quick-start-jaeger-nodejs/tracetest/tracetest.config.yaml
@@ -5,15 +5,3 @@ postgres:
   port: 5432
   dbname: postgres
   params: sslmode=disable
-
-poolingConfig:
-  maxWaitTimeForTrace: 10m
-  retryDelay: 5s
-
-googleAnalytics:
-  enabled: true
-
-demo:
-  enabled: []
-
-experimentalFeatures: []

--- a/examples/quick-start-net-core/tracetest-config.yaml
+++ b/examples/quick-start-net-core/tracetest-config.yaml
@@ -5,15 +5,3 @@ postgres:
   port: 5432
   dbname: postgres
   params: sslmode=disable
-
-poolingConfig:
-  maxWaitTimeForTrace: 10m
-  retryDelay: 5s
-
-googleAnalytics:
-  enabled: true
-
-demo:
-  enabled: []
-
-experimentalFeatures: []

--- a/examples/quick-start-net-core/tracetest-provision.yaml
+++ b/examples/quick-start-net-core/tracetest-provision.yaml
@@ -1,5 +1,19 @@
-dataStore:
+---
+type: PollingProfile
+spec:
+  name: Default
+  strategy: periodic
+  default: true
+  periodic:
+    retryDelay: 5s
+    timeout: 10m
+
+---
+type: DataStore
+spec:
+  name: Jaeger
   type: jaeger
+  default: true
   jaeger:
     endpoint: jaeger:16685
     tls:

--- a/examples/quick-start-net-core/tracetest-provision.yaml
+++ b/examples/quick-start-net-core/tracetest-provision.yaml
@@ -13,7 +13,7 @@ type: DataStore
 spec:
   name: Jaeger
   type: jaeger
-  default: true
+  isdefault: true
   jaeger:
     endpoint: jaeger:16685
     tls:

--- a/examples/quick-start-nodejs-manual-instrumentation/tracetest/tracetest-config.yaml
+++ b/examples/quick-start-nodejs-manual-instrumentation/tracetest/tracetest-config.yaml
@@ -5,15 +5,3 @@ postgres:
   port: 5432
   dbname: postgres
   params: sslmode=disable
-
-poolingConfig:
-  maxWaitTimeForTrace: 10m
-  retryDelay: 5s
-
-googleAnalytics:
-  enabled: true
-
-demo:
-  enabled: []
-
-experimentalFeatures: []

--- a/examples/quick-start-nodejs-manual-instrumentation/tracetest/tracetest-provision.yaml
+++ b/examples/quick-start-nodejs-manual-instrumentation/tracetest/tracetest-provision.yaml
@@ -1,2 +1,16 @@
-dataStore:
+---
+type: PollingProfile
+spec:
+  name: Default
+  strategy: periodic
+  default: true
+  periodic:
+    retryDelay: 5s
+    timeout: 10m
+
+---
+type: DataStore
+spec:
+  name: OpenTelemetry Collector
   type: otlp
+  default: true

--- a/examples/quick-start-nodejs-manual-instrumentation/tracetest/tracetest-provision.yaml
+++ b/examples/quick-start-nodejs-manual-instrumentation/tracetest/tracetest-provision.yaml
@@ -13,4 +13,4 @@ type: DataStore
 spec:
   name: OpenTelemetry Collector
   type: otlp
-  default: true
+  isdefault: true

--- a/examples/quick-start-nodejs/tracetest/tracetest-config.yaml
+++ b/examples/quick-start-nodejs/tracetest/tracetest-config.yaml
@@ -5,15 +5,3 @@ postgres:
   port: 5432
   dbname: postgres
   params: sslmode=disable
-
-poolingConfig:
-  maxWaitTimeForTrace: 10m
-  retryDelay: 5s
-
-googleAnalytics:
-  enabled: true
-
-demo:
-  enabled: []
-
-experimentalFeatures: []

--- a/examples/quick-start-nodejs/tracetest/tracetest-provision.yaml
+++ b/examples/quick-start-nodejs/tracetest/tracetest-provision.yaml
@@ -1,2 +1,16 @@
-dataStore:
+---
+type: PollingProfile
+spec:
+  name: Default
+  strategy: periodic
+  default: true
+  periodic:
+    retryDelay: 5s
+    timeout: 10m
+
+---
+type: DataStore
+spec:
+  name: OpenTelemetry Collector
   type: otlp
+  default: true

--- a/examples/quick-start-nodejs/tracetest/tracetest-provision.yaml
+++ b/examples/quick-start-nodejs/tracetest/tracetest-provision.yaml
@@ -13,4 +13,4 @@ type: DataStore
 spec:
   name: OpenTelemetry Collector
   type: otlp
-  default: true
+  isdefault: true

--- a/examples/quick-start-opensearch-nodejs/tracetest/tracetest-config.yaml
+++ b/examples/quick-start-opensearch-nodejs/tracetest/tracetest-config.yaml
@@ -9,11 +9,3 @@ postgres:
 poolingConfig:
   maxWaitTimeForTrace: 10m
   retryDelay: 5s
-
-googleAnalytics:
-  enabled: true
-
-demo:
-  enabled: []
-
-experimentalFeatures: []

--- a/examples/quick-start-opensearch-nodejs/tracetest/tracetest-provision.yaml
+++ b/examples/quick-start-opensearch-nodejs/tracetest/tracetest-provision.yaml
@@ -1,4 +1,17 @@
-dataStore:
+---
+type: PollingProfile
+spec:
+  name: Default
+  strategy: periodic
+  default: true
+  periodic:
+    retryDelay: 5s
+    timeout: 10m
+
+---
+type: DataStore
+spec:
+  name: OpenSearch
   type: opensearch
   opensearch:
     addresses:

--- a/examples/quick-start-python/tracetest/tracetest-config.yaml
+++ b/examples/quick-start-python/tracetest/tracetest-config.yaml
@@ -5,10 +5,3 @@ postgres:
   port: 5432
   dbname: postgres
   params: sslmode=disable
-
-poolingConfig:
-  maxWaitTimeForTrace: 10s
-  retryDelay: 1s
-
-googleAnalytics:
-  enabled: true

--- a/examples/quick-start-python/tracetest/tracetest-provision.yaml
+++ b/examples/quick-start-python/tracetest/tracetest-provision.yaml
@@ -3,4 +3,4 @@ type: DataStore
 spec:
   name: OpenTelemetry Collector
   type: otlp
-  default: true
+  isdefault: true

--- a/examples/quick-start-python/tracetest/tracetest-provision.yaml
+++ b/examples/quick-start-python/tracetest/tracetest-provision.yaml
@@ -1,2 +1,6 @@
-dataStore:
+---
+type: DataStore
+spec:
+  name: OpenTelemetry Collector
   type: otlp
+  default: true

--- a/examples/quick-start-tempo-nodejs/tracetest/tracetest-config.yaml
+++ b/examples/quick-start-tempo-nodejs/tracetest/tracetest-config.yaml
@@ -9,6 +9,3 @@ postgres:
 poolingConfig:
   maxWaitTimeForTrace: 10m
   retryDelay: 5s
-
-googleAnalytics:
-  enabled: true

--- a/examples/quick-start-tempo-nodejs/tracetest/tracetest-provision.yaml
+++ b/examples/quick-start-tempo-nodejs/tracetest/tracetest-provision.yaml
@@ -1,4 +1,17 @@
-dataStore:
+---
+type: PollingProfile
+spec:
+  name: Default
+  strategy: periodic
+  default: true
+  periodic:
+    retryDelay: 5s
+    timeout: 10m
+
+---
+type: DataStore
+spec:
+  name: Tempo
   type: tempo
   tempo:
     grpc:

--- a/examples/tracetest-new-relic-otel-demo/tracetest/tracetest-provision.yaml
+++ b/examples/tracetest-new-relic-otel-demo/tracetest/tracetest-provision.yaml
@@ -1,2 +1,18 @@
-dataStore:
-  type: otlp
+---
+type: DataStore
+spec:
+  name: New Relic
+  type: newrelic
+  default: true
+
+---
+type: Demo
+spec:
+  name: "OpenTelemetry Shop"
+  enabled: true
+  type: otelstore
+  opentelemetryStore:
+    frontendEndpoint: http://frontend:8084
+    productCatalogEndpoint: productcatalogservice:3550
+    cartEndpoint: cartservice:7070
+    checkoutEndpoint: checkoutservice:5050

--- a/examples/tracetest-new-relic-otel-demo/tracetest/tracetest-provision.yaml
+++ b/examples/tracetest-new-relic-otel-demo/tracetest/tracetest-provision.yaml
@@ -3,7 +3,7 @@ type: DataStore
 spec:
   name: New Relic
   type: newrelic
-  default: true
+  isdefault: true
 
 ---
 type: Demo

--- a/examples/tracetest-new-relic-otel-demo/tracetest/tracetest.config.yaml
+++ b/examples/tracetest-new-relic-otel-demo/tracetest/tracetest.config.yaml
@@ -1,4 +1,3 @@
----
 postgres:
   host: tt_postgres
   user: postgres
@@ -6,23 +5,6 @@ postgres:
   port: 5432
   dbname: postgres
   params: sslmode=disable
-
-poolingConfig:
-  maxWaitTimeForTrace: 30s
-  retryDelay: 500ms
-
-demo:
-  enabled: [otel]
-  endpoints:
-    otelFrontend: http://frontend:8080
-    otelProductCatalog: productcatalogservice:3550
-    otelCart: cartservice:7070
-    otelCheckout: checkoutservice:5050
-
-experimentalFeatures: []
-
-googleAnalytics:
-  enabled: true
 
 telemetry:
   exporters:

--- a/examples/tracetest-new-relic/tracetest/tracetest-provision.yaml
+++ b/examples/tracetest-new-relic/tracetest/tracetest-provision.yaml
@@ -1,2 +1,18 @@
-dataStore:
-  type: otlp
+---
+type: DataStore
+spec:
+  name: New Relic
+  type: newrelic
+  default: true
+
+---
+type: Demo
+spec:
+  name: "OpenTelemetry Shop"
+  enabled: true
+  type: otelstore
+  opentelemetryStore:
+    frontendEndpoint: http://otel-frontend:8084
+    productCatalogEndpoint: otel-productcatalogservice:3550
+    cartEndpoint: otel-cartservice:7070
+    checkoutEndpoint: otel-checkoutservice:5050

--- a/examples/tracetest-new-relic/tracetest/tracetest-provision.yaml
+++ b/examples/tracetest-new-relic/tracetest/tracetest-provision.yaml
@@ -3,7 +3,7 @@ type: DataStore
 spec:
   name: New Relic
   type: newrelic
-  default: true
+  isdefault: true
 
 ---
 type: Demo

--- a/examples/tracetest-new-relic/tracetest/tracetest.config.yaml
+++ b/examples/tracetest-new-relic/tracetest/tracetest.config.yaml
@@ -1,4 +1,3 @@
----
 postgres:
   host: postgres
   user: postgres
@@ -7,10 +6,6 @@ postgres:
   dbname: postgres
   params: sslmode=disable
 
-poolingConfig:
-  maxWaitTimeForTrace: 30s
-  retryDelay: 500ms
-
 demo:
   enabled: [otel]
   endpoints:
@@ -18,11 +13,6 @@ demo:
     otelProductCatalog: otel-productcatalogservice:3550
     otelCart: otel-cartservice:7070
     otelCheckout: otel-checkoutservice:5050
-
-experimentalFeatures: []
-
-googleAnalytics:
-  enabled: true
 
 telemetry:
   exporters:

--- a/examples/tracetest-no-tracing/tracetest-config.yaml
+++ b/examples/tracetest-no-tracing/tracetest-config.yaml
@@ -5,15 +5,3 @@ postgres:
   port: 5432
   dbname: postgres
   params: sslmode=disable
-
-poolingConfig:
-  maxWaitTimeForTrace: 10m
-  retryDelay: 5s
-
-googleAnalytics:
-  enabled: false
-
-demo:
-  enabled: []
-
-experimentalFeatures: []

--- a/examples/tracetest-open-telemetry-store-demo/tracetest-config.yaml
+++ b/examples/tracetest-open-telemetry-store-demo/tracetest-config.yaml
@@ -6,20 +6,6 @@ postgres:
   dbname: postgres
   params: sslmode=disable
 
-poolingConfig:
-  maxWaitTimeForTrace: 10m
-  retryDelay: 5s
-
-googleAnalytics:
-  enabled: false
-
-demo:
-  enabled: [otel]
-  endpoints:
-    otelFrontend: http://frontend:8080
-
-experimentalFeatures: []
-
 telemetry:
   exporters:
     collector:

--- a/examples/tracetest-open-telemetry-store-demo/tracetest-provision.yaml
+++ b/examples/tracetest-open-telemetry-store-demo/tracetest-provision.yaml
@@ -1,4 +1,26 @@
-dataStore:
+---
+type: PollingProfile
+spec:
+  name: Default
+  strategy: periodic
+  default: true
+  periodic:
+    retryDelay: 5s
+    timeout: 10m
+
+---
+type: Demo
+spec:
+  name: "OpenTelemetry Shop"
+  enabled: true
+  type: otelstore
+  opentelemetryStore:
+    frontendEndpoint: http://frontend:8080
+
+---
+type: DataStore
+spec:
+  name: Jaeger
   type: jaeger
   jaeger:
     endpoint: jaeger:16685

--- a/examples/tracetest-opensearch/tracetest-config.yaml
+++ b/examples/tracetest-opensearch/tracetest-config.yaml
@@ -6,18 +6,6 @@ postgres:
   dbname: postgres
   params: sslmode=disable
 
-poolingConfig:
-  maxWaitTimeForTrace: 10m
-  retryDelay: 5s
-
-googleAnalytics:
-  enabled: true
-
-demo:
-  enabled: []
-
-experimentalFeatures: []
-
 telemetry:
   exporters:
     collector:

--- a/examples/tracetest-provisioning-env/docker-compose.yml
+++ b/examples/tracetest-provisioning-env/docker-compose.yml
@@ -24,8 +24,8 @@ services:
             retries: 60
         environment:
             TRACETEST_DEV: ${TRACETEST_DEV}
-            # base64 encoded jaeger datastore
-            TRACETEST_PROVISIONING: "ZGF0YVN0b3JlOgogIHR5cGU6IGphZWdlcgogIGphZWdlcjoKICAgIGVuZHBvaW50OiBqYWVnZXI6MTY2ODUKICAgIHRsczoKICAgICAgaW5zZWN1cmU6IHRydWU="
+            # contents of `tracetest-provision.yaml` encoded as base64
+            TRACETEST_PROVISIONING: "LS0tCnR5cGU6IFBvbGxpbmdQcm9maWxlCnNwZWM6CiAgbmFtZTogRGVmYXVsdAogIHN0cmF0ZWd5OiBwZXJpb2RpYwogIGRlZmF1bHQ6IHRydWUKICBwZXJpb2RpYzoKICAgIHJldHJ5RGVsYXk6IDVzCiAgICB0aW1lb3V0OiAxMG0KCi0tLQp0eXBlOiBEYXRhU3RvcmUKc3BlYzoKICBuYW1lOiBKYWVnZXIKICB0eXBlOiBqYWVnZXIKICBkZWZhdWx0OiB0cnVlCiAgamFlZ2VyOgogICAgZW5kcG9pbnQ6IGphZWdlcjoxNjY4NQogICAgdGxzOgogICAgICBpbnNlY3VyZTogdHJ1ZQo="
 
     postgres:
         image: postgres:14

--- a/examples/tracetest-provisioning-env/tracetest-config.yaml
+++ b/examples/tracetest-provisioning-env/tracetest-config.yaml
@@ -6,18 +6,6 @@ postgres:
   dbname: postgres
   params: sslmode=disable
 
-poolingConfig:
-  maxWaitTimeForTrace: 10m
-  retryDelay: 5s
-
-googleAnalytics:
-  enabled: true
-
-demo:
-  enabled: []
-
-experimentalFeatures: []
-
 telemetry:
   exporters:
     collector:

--- a/examples/tracetest-provisioning-env/tracetest-provision.yaml
+++ b/examples/tracetest-provisioning-env/tracetest-provision.yaml
@@ -13,7 +13,7 @@ type: DataStore
 spec:
   name: Jaeger
   type: jaeger
-  default: true
+  isdefault: true
   jaeger:
     endpoint: jaeger:16685
     tls:

--- a/examples/tracetest-provisioning-env/tracetest-provision.yaml
+++ b/examples/tracetest-provisioning-env/tracetest-provision.yaml
@@ -11,9 +11,10 @@ spec:
 ---
 type: DataStore
 spec:
-  name: OpenSearch
-  type: opensearch
-  opensearch:
-    addresses:
-      - http://opensearch:9200
-    index: traces
+  name: Jaeger
+  type: jaeger
+  default: true
+  jaeger:
+    endpoint: jaeger:16685
+    tls:
+      insecure: true

--- a/examples/tracetest-signalfx/tracetest-config.yaml
+++ b/examples/tracetest-signalfx/tracetest-config.yaml
@@ -6,18 +6,6 @@ postgres:
   dbname: postgres
   params: sslmode=disable
 
-poolingConfig:
-  maxWaitTimeForTrace: 10m
-  retryDelay: 5s
-
-googleAnalytics:
-  enabled: true
-
-demo:
-  enabled: []
-
-experimentalFeatures: []
-
 telemetry:
   exporters:
     collector:

--- a/examples/tracetest-signalfx/tracetest-provision.yaml
+++ b/examples/tracetest-signalfx/tracetest-provision.yaml
@@ -1,5 +1,18 @@
-dataStore:
+---
+type: PollingProfile
+spec:
+  name: Default
+  strategy: periodic
+  default: true
+  periodic:
+    retryDelay: 5s
+    timeout: 10m
+
+---
+type: DataStore
+spec:
+  name: SignalFX
   type: signalfx
   signalfx:
-    token: <YOUR_TOKEN> # UPDATE THIS
-    realm: us1 # UPDATE THIS IF NEEDED
+    token: <YOUR_TOKEN> # Add SignalFX token
+    realm: us1 # Update this value if needed

--- a/examples/tracetest-tempo/tracetest-config.yaml
+++ b/examples/tracetest-tempo/tracetest-config.yaml
@@ -6,18 +6,6 @@ postgres:
   dbname: postgres
   params: sslmode=disable
 
-poolingConfig:
-  maxWaitTimeForTrace: 10m
-  retryDelay: 5s
-
-googleAnalytics:
-  enabled: true
-
-demo:
-  enabled: []
-
-experimentalFeatures: []
-
 telemetry:
   exporters:
     collector:

--- a/examples/tracetest-tempo/tracetest-provision.yaml
+++ b/examples/tracetest-tempo/tracetest-provision.yaml
@@ -1,4 +1,17 @@
-dataStore:
+---
+type: PollingProfile
+spec:
+  name: Default
+  strategy: periodic
+  default: true
+  periodic:
+    retryDelay: 5s
+    timeout: 10m
+
+---
+type: DataStore
+spec:
+  name: Tempo
   type: tempo
   tempo:
     type: grpc


### PR DESCRIPTION
This PR aims to update Tracetest configuration on each example to support the new provisioning / resource format.

## Changes

Examples updated for Part 1:

- [ ] collector
- [ ] observability-driven-development-go-tracetest
- [ ] quick-start-datadog-nodejs
- [ ] quick-start-go
- [ ] quick-start-jaeger-nodejs
- [ ] quick-start-net-core
- [ ] quick-start-nodejs
- [ ] quick-start-nodejs-manual-instrumentation
- [ ] quick-start-opensearch-nodejs
- [ ] quick-start-python
- [ ] quick-start-tempo-nodejs

Examples updated for Part 3:

- [ ] tracetest-new-relic
- [ ] tracetest-new-relic-otel-demo
- [ ] tracetest-no-tracing
- [ ] tracetest-open-telemetry-store-demo
- [ ] tracetest-opensearch
- [ ] tracetest-otel-demo
- [ ] tracetest-provisioning-env
- [ ] tracetest-signalfx
- [ ] tracetest-tempo

## Fixes

- (partially) #2169

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [x] updated the docs
- [ ] added a test
