### PR TITLE
feature(cli): adding resource cmd CLI validations

### DIFF
--- a/cli/actions/demo.go
+++ b/cli/actions/demo.go
@@ -133,6 +133,10 @@ func (demo demoActions) List(ctx context.Context, listArgs ListArgs) error {
 }
 
 func (demo demoActions) Export(ctx context.Context, ID string, filePath string) error {
+	if ID == "" {
+		return fmt.Errorf("you must specify a demo profile ID to be exported")
+	}
+
 	demoProfile, err := demo.get(ctx, ID)
 	if err != nil {
 		return err

--- a/cli/cmd/apply_cmd.go
+++ b/cli/cmd/apply_cmd.go
@@ -22,6 +22,12 @@ var applyCmd = &cobra.Command{
 	PreRun:  setupCommand(),
 	Args:    cobra.MinimumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
+		if definitionFile == "" {
+			cliLogger.Error("file with definition must be specified")
+			os.Exit(1)
+			return
+		}
+
 		resourceType := args[0]
 		ctx := context.Background()
 
@@ -55,6 +61,6 @@ var applyCmd = &cobra.Command{
 }
 
 func init() {
-	applyCmd.Flags().StringVar(&definitionFile, "file", "", "path to the definition file")
+	applyCmd.Flags().StringVarP(&definitionFile, "file", "f", "", "file path with name where to export the resource")
 	rootCmd.AddCommand(applyCmd)
 }

--- a/cli/cmd/delete_cmd.go
+++ b/cli/cmd/delete_cmd.go
@@ -21,6 +21,12 @@ var deleteCmd = &cobra.Command{
 	PreRun:  setupCommand(),
 	Args:    cobra.MinimumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
+		if deletedResourceID == "" {
+			cliLogger.Error("id of the resource to delete must be specified")
+			os.Exit(1)
+			return
+		}
+
 		resourceType := args[0]
 		ctx := context.Background()
 

--- a/cli/cmd/export_cmd.go
+++ b/cli/cmd/export_cmd.go
@@ -24,12 +24,6 @@ var exportCmd = &cobra.Command{
 	PreRun:  setupCommand(),
 	Args:    cobra.MinimumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
-		if exportResourceID == "" {
-			cliLogger.Error("id of the resource to export must be specified")
-			os.Exit(1)
-			return
-		}
-
 		resourceType := args[0]
 		ctx := context.Background()
 

--- a/cli/cmd/export_cmd.go
+++ b/cli/cmd/export_cmd.go
@@ -24,6 +24,12 @@ var exportCmd = &cobra.Command{
 	PreRun:  setupCommand(),
 	Args:    cobra.MinimumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
+		if exportResourceID == "" {
+			cliLogger.Error("id of the resource to export must be specified")
+			os.Exit(1)
+			return
+		}
+
 		resourceType := args[0]
 		ctx := context.Background()
 
@@ -52,6 +58,6 @@ var exportCmd = &cobra.Command{
 
 func init() {
 	exportCmd.Flags().StringVar(&exportResourceID, "id", "", "id of the resource to export")
-	exportCmd.Flags().StringVar(&exportResourceFile, "file", "resource.yaml", "file path with name where to export the resource")
+	exportCmd.Flags().StringVarP(&exportResourceFile, "file", "f", "resource.yaml", "file path with name where to export the resource")
 	rootCmd.AddCommand(exportCmd)
 }

--- a/cli/cmd/get_cmd.go
+++ b/cli/cmd/get_cmd.go
@@ -20,6 +20,12 @@ var getCmd = &cobra.Command{
 	PreRun:  setupCommand(),
 	Args:    cobra.MinimumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
+		if resourceID == "" {
+			cliLogger.Error("id of the resource to get must be specified")
+			os.Exit(1)
+			return
+		}
+
 		resourceType := args[0]
 		ctx := context.Background()
 


### PR DESCRIPTION
This PR adds CLI validations to prevent users from having invalid input when using the resources commands.

## Changes

- Updates resources commands to have validations
- Changes the file flag to match the rest of the specs

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
