### PR TITLE
chore(cicd): use separated goreleaser settigns for RC

### DIFF
--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -83,7 +83,7 @@ jobs:
         with:
           distribution: goreleaser-pro
           version: v1.16.1
-          args: release --clean --nightly
+          args: release --clean -f .goreleaser.rc.yaml
         env:
           VERSION: ${{ github.ref_name}}
           TRACETEST_ENV: main

--- a/.goreleaser.rc.yaml
+++ b/.goreleaser.rc.yaml
@@ -1,0 +1,130 @@
+# yaml-language-server: $schema=https://goreleaser.com/static/schema-pro.json
+project_name: tracetest
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - '^docs:'
+      - '^test:'
+release:
+  # discussion_category_name: General
+  draft: false
+  prerelease: "true"
+before:
+  hooks:
+    - dir: ./server
+      cmd: go mod tidy
+    - dir: ./cli
+      cmd: go mod tidy
+env:
+  - VERSION={{ if index .Env "VERSION"  }}{{ .Env.VERSION }}{{ else }}dev{{ end }}
+  - TRACETEST_ENV={{ if index .Env "TRACETEST_ENV"  }}{{ .Env.TRACETEST_ENV }}{{ else }}dev{{ end }}
+  - ANALYTICS_BE_KEY={{ if index .Env "ANALYTICS_BE_KEY"  }}{{ .Env.ANALYTICS_BE_KEY }}{{ else }}{{ end }}
+  - ANALYTICS_FE_KEY={{ if index .Env "ANALYTICS_FE_KEY"  }}{{ .Env.ANALYTICS_FE_KEY }}{{ else }}{{ end }}
+builds:
+  - id: server
+    binary: tracetest-server
+    main: ./server/main.go
+    ldflags:
+    - -X github.com/kubeshop/tracetest/server/app.Version={{ .Env.VERSION }}
+    - -X github.com/kubeshop/tracetest/server/app.Env={{ .Env.TRACETEST_ENV }}
+    - -X github.com/kubeshop/tracetest/server/analytics.SecretKey={{ .Env.ANALYTICS_BE_KEY }}
+    - -X github.com/kubeshop/tracetest/server/analytics.FrontendKey={{ .Env.ANALYTICS_FE_KEY }}
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - windows
+      - darwin
+    goarch:
+    - "386"
+    - amd64
+    - arm
+    - arm64
+    goarm:
+    - "7"
+
+  - id: cli
+    binary: tracetest
+    main: ./cli/main.go
+    ldflags:
+    - -X github.com/kubeshop/tracetest/cli/config.Version={{ .Env.VERSION }}
+    - -X github.com/kubeshop/tracetest/cli/config.Env={{ .Env.TRACETEST_ENV }}
+    - -X github.com/kubeshop/tracetest/cli/analytics.SecretKey={{ .Env.ANALYTICS_BE_KEY }}
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - windows
+      - darwin
+    goarch:
+    - "386"
+    - amd64
+    - arm
+    - arm64
+    goarm:
+    - "7"
+
+dockers:
+- image_templates:
+  - 'kubeshop/tracetest:{{ .Env.VERSION }}-amd64'
+  extra_files:
+    - web/build
+    - server/migrations
+  build_flag_templates:
+  - "--pull"
+  - "--label=org.opencontainers.image.created={{.Date}}"
+  - "--label=org.opencontainers.image.name={{.ProjectName}}"
+  - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+  - "--label=org.opencontainers.image.version={{.Version}}"
+  - "--label=org.opencontainers.image.source={{.GitURL}}"
+  - "--platform=linux/amd64"
+  goos: linux
+  goarch: amd64
+  use: buildx
+
+- image_templates:
+  - 'kubeshop/tracetest:{{ .Env.VERSION }}-arm64'
+  extra_files:
+    - web/build
+    - server/migrations
+  build_flag_templates:
+  - "--pull"
+  - "--label=org.opencontainers.image.created={{.Date}}"
+  - "--label=org.opencontainers.image.name={{.ProjectName}}"
+  - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+  - "--label=org.opencontainers.image.version={{.Version}}"
+  - "--label=org.opencontainers.image.source={{.GitURL}}"
+  - "--platform=linux/arm64/v8"
+  goos: linux
+  goarch: arm64
+  use: buildx
+
+docker_manifests:
+- name_template: 'kubeshop/tracetest:{{ .Env.VERSION }}'
+  image_templates:
+  - 'kubeshop/tracetest:{{ .Env.VERSION }}-amd64'
+  - 'kubeshop/tracetest:{{ .Env.VERSION }}-arm64'
+
+archives:
+- replacements:
+    386: i386
+checksum:
+  name_template: 'checksums.txt'
+
+universal_binaries:
+- replace: true
+
+nfpms:
+- vendor: Kubeshop
+  homepage: https://tracetest.kubeshop.io/
+  maintainer: Sebastian Choren <sebastian@kubeshop.io>
+  license: MIT
+  formats:
+    - deb
+    - rpm
+  replacements:
+    386: i386
+  deb:
+    lintian_overrides:
+      - statically-linked-binary


### PR DESCRIPTION
our current RC approach is not working correctly. Since we introduced the `nightly` flag to avoid publishing brew/linux binaries, goreleaser does not create a release in GH, nor does it use the correct versioning for files. It uses the `nightly` settings: reuses the `latest` release, and all files are labeled `latest`. This behaviour is great for keeping the last commit in `main` built and ready to test, but RCs needs to be kept in history. This approach doesn't allow that.

This PR creates a goreleaser setting specific for RC. It's essentially the same as prod but forces the `prereleas` flag to true, and removes all references to brew/linux repos. It will only create correctly tagged docker images, a GH release tagged as `pre-release`, and attached to it all the binaries, labeled correctly