### PR TITLE
feat: make analytics enabled by default

### DIFF
--- a/server/config/configresource/config_resource.go
+++ b/server/config/configresource/config_resource.go
@@ -97,7 +97,7 @@ const selectQuery = `SELECT "analytics_enabled" FROM config`
 var defaultConfig = Config{
 	ID:               id.ID("current"),
 	Name:             "Config",
-	AnalyticsEnabled: false,
+	AnalyticsEnabled: true,
 }
 
 func (r *Repository) Get(ctx context.Context, i id.ID) (Config, error) {

--- a/server/config/configresource/config_resource_test.go
+++ b/server/config/configresource/config_resource_test.go
@@ -62,7 +62,7 @@ func TestIsAnalyticsEnabled(t *testing.T) {
 		)
 
 		cfg := repo.Current(context.TODO())
-		assert.False(t, cfg.IsAnalyticsEnabled())
+		assert.True(t, cfg.IsAnalyticsEnabled())
 
 	})
 
@@ -73,11 +73,11 @@ func TestIsAnalyticsEnabled(t *testing.T) {
 			testmock.MustCreateRandomMigratedDatabase(db),
 		)
 		repo.Update(context.TODO(), configresource.Config{
-			AnalyticsEnabled: true,
+			AnalyticsEnabled: false,
 		})
 
 		cfg := repo.Current(context.TODO())
-		assert.True(t, cfg.IsAnalyticsEnabled())
+		assert.False(t, cfg.IsAnalyticsEnabled())
 	})
 
 	t.Run("EnvOverride", func(t *testing.T) {
@@ -122,7 +122,7 @@ func TestConfigResource(t *testing.T) {
 			"spec": {
 				"id": "current",
 				"name": "Config",
-				"analyticsEnabled": false
+				"analyticsEnabled": true
 			}
 		}`,
 		SampleJSONUpdated: `{
@@ -130,7 +130,7 @@ func TestConfigResource(t *testing.T) {
 			"spec": {
 				"id": "current",
 				"name": "Config",
-				"analyticsEnabled": true
+				"analyticsEnabled": false
 			}
 		}`,
 	},


### PR DESCRIPTION
This PR updates the default config to have analytics enabled unless updated
