### PR TITLE
chore(examples): fixing second batch of examples

### DIFF
--- a/examples/tracetest-aws-step-functions/infra/tracetest.tf
+++ b/examples/tracetest-aws-step-functions/infra/tracetest.tf
@@ -41,12 +41,8 @@ resource "aws_ecs_task_definition" "tracetest" {
           "value" : "${module.db.db_instance_password}"
         },
         {
-          "name" : "TRACETEST_POOLINGCONFIG_MAXWAITTIMEFORTRACE",
-          "value" : "2m"
-        },
-        {
-          "name" : "TRACETEST_POOLINGCONFIG_RETRYDELAY",
-          "value" : "5s"
+          "name" : "TRACETEST_PROVISIONING",
+          "value" : base64encode(local.provisioning),
         }
       ],
       "logConfiguration" : {

--- a/examples/tracetest-aws-step-functions/infra/variables.tf
+++ b/examples/tracetest-aws-step-functions/infra/variables.tf
@@ -25,6 +25,18 @@ locals {
   vpc_cidr = "192.168.0.0/16"
   azs      = slice(data.aws_availability_zones.available.names, 0, 3)
 
+  provisioning = <<EOF
+---
+type: PollingProfile
+spec:
+  name: default
+  strategy: periodic
+  default: true
+  periodic:
+    retryDelay: 5s
+    timeout: 2m
+  EOF
+
   tags = {
     Name    = local.name
     Example = local.name

--- a/examples/tracetest-datadog/docker-compose.yaml
+++ b/examples/tracetest-datadog/docker-compose.yaml
@@ -35,6 +35,7 @@ services:
   # Accounting service
   accountingservice:
     image: ${IMAGE_NAME}:${IMAGE_VERSION}-accountingservice
+    platform: linux/amd64
     container_name: accounting-service
     deploy:
       resources:
@@ -58,6 +59,7 @@ services:
   # AdService
   adservice:
     image: ${IMAGE_NAME}:${IMAGE_VERSION}-adservice
+    platform: linux/amd64
     container_name: ad-service
     deploy:
       resources:
@@ -81,6 +83,7 @@ services:
   # Cart service
   cartservice:
     image: ${IMAGE_NAME}:${IMAGE_VERSION}-cartservice
+    platform: linux/amd64
     container_name: cart-service
     deploy:
       resources:
@@ -104,6 +107,7 @@ services:
   # Checkout service
   checkoutservice:
     image: ${IMAGE_NAME}:${IMAGE_VERSION}-checkoutservice
+    platform: linux/amd64
     container_name: checkout-service
     deploy:
       resources:
@@ -148,6 +152,7 @@ services:
   # Currency service
   currencyservice:
     image: ${IMAGE_NAME}:${IMAGE_VERSION}-currencyservice
+    platform: linux/amd64
     container_name: currency-service
     deploy:
       resources:
@@ -167,6 +172,7 @@ services:
   # Email service
   emailservice:
     image: ${IMAGE_NAME}:${IMAGE_VERSION}-emailservice
+    platform: linux/amd64
     container_name: email-service
     deploy:
       resources:
@@ -188,6 +194,7 @@ services:
   # Feature Flag service
   featureflagservice:
     image: ${IMAGE_NAME}:${IMAGE_VERSION}-featureflagservice
+    platform: linux/amd64
     container_name: feature-flag-service
     deploy:
       resources:
@@ -215,6 +222,7 @@ services:
   # Fraud Detection service
   frauddetectionservice:
     image: ${IMAGE_NAME}:${IMAGE_VERSION}-frauddetectionservice
+    platform: linux/amd64
     container_name: frauddetection-service
     deploy:
       resources:
@@ -238,11 +246,8 @@ services:
   # Frontend
   frontend:
     image: ${IMAGE_NAME}:${IMAGE_VERSION}-frontend
+    platform: linux/amd64
     container_name: frontend
-    deploy:
-      resources:
-        limits:
-          memory: 200M
     restart: unless-stopped
     ports:
       - "${FRONTEND_PORT}"
@@ -280,6 +285,7 @@ services:
   # Payment service
   paymentservice:
     image: ${IMAGE_NAME}:${IMAGE_VERSION}-paymentservice
+    platform: linux/amd64
     container_name: payment-service
     deploy:
       resources:
@@ -302,6 +308,7 @@ services:
   # Product Catalog service
   productcatalogservice:
     image: ${IMAGE_NAME}:${IMAGE_VERSION}-productcatalogservice
+    platform: linux/amd64
     container_name: product-catalog-service
     deploy:
       resources:
@@ -325,6 +332,7 @@ services:
   # Quote service
   quoteservice:
     image: ${IMAGE_NAME}:${IMAGE_VERSION}-quoteservice
+    platform: linux/amd64
     container_name: quote-service
     deploy:
       resources:
@@ -346,6 +354,7 @@ services:
   # Recommendation service
   recommendationservice:
     image: ${IMAGE_NAME}:${IMAGE_VERSION}-recommendationservice
+    platform: linux/amd64
     container_name: recommendation-service
     deploy:
       resources:
@@ -375,6 +384,7 @@ services:
   # Shipping service
   shippingservice:
     image: ${IMAGE_NAME}:${IMAGE_VERSION}-shippingservice
+    platform: linux/amd64
     container_name: shipping-service
     deploy:
       resources:
@@ -420,6 +430,7 @@ services:
   # Kafka used by Checkout, Accounting, and Fraud Detection services
   kafka:
     image: ${IMAGE_NAME}:${IMAGE_VERSION}-kafka
+    platform: linux/amd64
     container_name: kafka
     deploy:
       resources:

--- a/examples/tracetest-datadog/http-test.yaml
+++ b/examples/tracetest-datadog/http-test.yaml
@@ -9,17 +9,18 @@ spec:
       url: http://frontend:8084/api/products
       method: GET
       headers:
-      - key: Content-Type
-        value: application/json
+        - key: Content-Type
+          value: application/json
   specs:
-  - selector: span[tracetest.span.type="general" name="Tracetest trigger"]
-    assertions:
-    - attr:tracetest.response.status   =   200
-    - attr:tracetest.span.duration  <  10ms
-  - selector: span[tracetest.span.type="rpc" name="grpc.hipstershop.ProductCatalogService/ListProducts"]
-    assertions:
-    - attr:rpc.grpc.status_code = 0
-  - selector: span[tracetest.span.type="rpc" name="hipstershop.ProductCatalogService/ListProducts"
-      rpc.system="grpc" rpc.method="ListProducts" rpc.service="hipstershop.ProductCatalogService"]
-    assertions:
-    - attr:rpc.grpc.status_code = 0
+    - selector: span[tracetest.span.type="general" name="Tracetest trigger"]
+      assertions:
+        - attr:tracetest.response.status   =   200
+        - attr:tracetest.span.duration  <  10ms
+    - selector: span[tracetest.span.type="rpc" name="grpc.hipstershop.ProductCatalogService/ListProducts"]
+      assertions:
+        - attr:rpc.grpc.status_code = 0
+    - selector:
+        span[tracetest.span.type="rpc" name="hipstershop.ProductCatalogService/ListProducts"
+        rpc.system="grpc" rpc.method="ListProducts" rpc.service="hipstershop.ProductCatalogService"]
+      assertions:
+        - attr:rpc.grpc.status_code = 0

--- a/examples/tracetest-datadog/tracetest/docker-compose.yaml
+++ b/examples/tracetest-datadog/tracetest/docker-compose.yaml
@@ -17,10 +17,10 @@ services:
       - "host.docker.internal:host-gateway"
     volumes:
       - type: bind
-        source: ./tracetest-config.yaml
+        source: ./tracetest/tracetest-config.yaml
         target: /app/tracetest.yaml
       - type: bind
-        source: ./tracetest-provision.yaml
+        source: ./tracetest/tracetest-provision.yaml
         target: /app/provisioning.yaml
     command: --provisioning-file /app/provisioning.yaml
     healthcheck:

--- a/examples/tracetest-datadog/tracetest/tracetest-config.yaml
+++ b/examples/tracetest-datadog/tracetest/tracetest-config.yaml
@@ -1,6 +1,6 @@
 ---
 postgres:
-  host: postgres
+  host: tt-postgres
   user: postgres
   password: postgres
   port: 5432

--- a/examples/tracetest-elasticapm-with-elastic-agent/docker-compose.yaml
+++ b/examples/tracetest-elasticapm-with-elastic-agent/docker-compose.yaml
@@ -167,7 +167,7 @@ services:
 
   tracetest:
     image: kubeshop/tracetest:${TAG:-latest}
-    # platform: linux/amd64
+    platform: linux/amd64
     environment:
       - ELASTICSEARCH_SSL_VERIFICATION_MODE=none
       - TRACETEST_DEV=${TRACETEST_DEV}

--- a/examples/tracetest-elasticapm-with-otel/docker-compose.yaml
+++ b/examples/tracetest-elasticapm-with-otel/docker-compose.yaml
@@ -167,7 +167,7 @@ services:
 
   tracetest:
     image: kubeshop/tracetest:${TAG:-latest}
-    # platform: linux/amd64
+    platform: linux/amd64
     environment:
       - ELASTICSEARCH_SSL_VERIFICATION_MODE=none
       - TRACETEST_DEV=${TRACETEST_DEV}

--- a/examples/tracetest-k6/docker-compose.yml
+++ b/examples/tracetest-k6/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3"
 services:
   tracetest:
     image: kubeshop/tracetest:${TAG:-latest}
-    # platform: linux/amd64
+    platform: linux/amd64
     volumes:
       - type: bind
         source: ./tracetest-config.yaml

--- a/examples/tracetest-lightstep-otel-demo/docker-compose.yaml
+++ b/examples/tracetest-lightstep-otel-demo/docker-compose.yaml
@@ -656,7 +656,7 @@ services:
     volumes:
       - type: bind
         source: ./tracetest/tracetest.config.yaml
-        target: /app/config.yaml
+        target: /app/tracetest.yaml
       - type: bind
         source: ./tracetest/tracetest-provision.yaml
         target: /app/provision.yaml

--- a/examples/tracetest-lightstep-otel-demo/tracetest/tracetest-provision.yaml
+++ b/examples/tracetest-lightstep-otel-demo/tracetest/tracetest-provision.yaml
@@ -2,7 +2,7 @@
 type: DataStore
 spec:
   name: Lightstep
-  type: lightstep
+  type: lighstep
 
 ---
 type: Demo

--- a/examples/tracetest-lightstep-otel-demo/tracetest/tracetest.config.yaml
+++ b/examples/tracetest-lightstep-otel-demo/tracetest/tracetest.config.yaml
@@ -1,23 +1,8 @@
 ---
 postgres:
-  host: postgres
+  host: tt_postgres
   user: postgres
   password: postgres
   port: 5432
   dbname: postgres
   params: sslmode=disable
-
-telemetry:
-  exporters:
-    collector:
-      serviceName: tracetest
-      sampling: 100
-      exporter:
-        type: collector
-        collector:
-          endpoint: otel-collector:4317
-
-server:
-  telemetry:
-    exporter: collector
-    applicationExporter: collector

--- a/examples/tracetest-lightstep/docker-compose.yaml
+++ b/examples/tracetest-lightstep/docker-compose.yaml
@@ -15,6 +15,7 @@ services:
   # AdService
   otel-adservice:
     image: otel/demo:v0.3.4-alpha-adservice
+    platform: linux/amd64
     environment:
       - AD_SERVICE_PORT
       - OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
@@ -26,6 +27,7 @@ services:
   # CartService
   otel-cartservice:
     image: otel/demo:v0.3.4-alpha-cartservice
+    platform: linux/amd64
     environment:
       - CART_SERVICE_PORT
       - REDIS_ADDR
@@ -39,6 +41,7 @@ services:
   # CheckoutService
   otel-checkoutservice:
     image: otel/demo:v0.3.4-alpha-checkoutservice
+    platform: linux/amd64
     environment:
       - CHECKOUT_SERVICE_PORT
       - CART_SERVICE_ADDR
@@ -61,6 +64,7 @@ services:
   # CurrencyService
   otel-currencyservice:
     image: otel/demo:v0.3.4-alpha-currencyservice
+    platform: linux/amd64
     environment:
       - CURRENCY_SERVICE_PORT
       - OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
@@ -71,6 +75,7 @@ services:
   # EmailService
   otel-emailservice:
     image: otel/demo:v0.3.4-alpha-emailservice
+    platform: linux/amd64
     environment:
       - APP_ENV=production
       - EMAIL_SERVICE_PORT
@@ -82,6 +87,7 @@ services:
   # Frontend
   otel-frontend:
     image: otel/demo:v0.3.4-alpha-frontend
+    platform: linux/amd64
     ports:
       - "${FRONTEND_PORT}:${FRONTEND_PORT}"
     environment:
@@ -112,6 +118,7 @@ services:
   # PaymentService
   otel-paymentservice:
     image: otel/demo:v0.3.4-alpha-paymentservice
+    platform: linux/amd64
     environment:
       - PAYMENT_SERVICE_PORT
       - OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
@@ -122,6 +129,7 @@ services:
   # ProductCatalogService
   otel-productcatalogservice:
     image: otel/demo:v0.3.4-alpha-productcatalogservice
+    platform: linux/amd64
     environment:
       - PRODUCT_CATALOG_SERVICE_PORT
       - FEATURE_FLAG_GRPC_SERVICE_ADDR
@@ -133,6 +141,7 @@ services:
   # RecommendationService
   otel-recommendationservice:
     image: otel/demo:v0.3.4-alpha-recommendationservice
+    platform: linux/amd64
     depends_on:
       - otel-productcatalogservice
       - otel-collector
@@ -146,6 +155,7 @@ services:
   # ShippingService
   otel-shippingservice:
     image: otel/demo:v0.3.4-alpha-shippingservice
+    platform: linux/amd64
     environment:
       - SHIPPING_SERVICE_PORT
       - OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
@@ -156,6 +166,7 @@ services:
   # FeatureFlagService
   otel-featureflagservice:
     image: otel/demo:v0.3.4-alpha-featureflagservice
+    platform: linux/amd64
     ports:
       - "${FEATURE_FLAG_GRPC_SERVICE_PORT}" # Feature Flag Service gRPC API
     environment:

--- a/examples/tracetest-lightstep/tracetest/tracetest-provision.yaml
+++ b/examples/tracetest-lightstep/tracetest/tracetest-provision.yaml
@@ -2,7 +2,7 @@
 type: DataStore
 spec:
   name: Lightstep
-  type: lightstep
+  type: lighstep
 
 ---
 type: Demo


### PR DESCRIPTION
This PR fixes the second batch of examples to use the new config features.

# 2 @xoscar 

- [x] tracetest-amazon-x-ray
- [x] tracetest-amazon-x-ray-adot
- [x] tracetest-amazon-x-ray-pokeshop
- [x] tracetest-aws-step-functions
- [x] tracetest-aws-terraform-serverless
- [x] tracetest-datadog
- [x] tracetest-elasticapm-with-elastic-agent
- [x] tracetest-elasticapm-with-otel
- [x] tracetest-jaeger
- [x] tracetest-k6
- [x] tracetest-lightstep
- [x] tracetest-lightstep-otel-demo

## Fixes

- #2169 

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
