### PR TITLE
fix(docs): fix missing image

### DIFF
--- a/docs/docs/configuration/trace-polling.md
+++ b/docs/docs/configuration/trace-polling.md
@@ -29,13 +29,12 @@ flowchart TD
     P --> Q[Finish]
     L --> ES
 ```
-  
 
 ## Changing Trace Polling Settings from the UI
 
 In the Tracetest Web UI, open Settings and select Trace Polling:
 
-![Demo Settings](./img/trace-polling.png)
+![Demo Settings](./img/trace-polling-settings.png)
 
 From this trace polling page, under settings, you can adjust the speed with which the trace data store is polled when gathering the trace associated with a test run.
 


### PR DESCRIPTION
This PR fixes a missing image in our `trace-polling` docs.

## Changes

-

## Fixes

-

## Checklist

- [ ] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
