### PR TITLE
fix: validate if server returns 404 error on inexisting id in demo and polling profile

### DIFF
--- a/cli/actions/demo.go
+++ b/cli/actions/demo.go
@@ -100,6 +100,10 @@ func (demo demoActions) update(ctx context.Context, file file.File, ID string) e
 	}
 
 	defer resp.Body.Close()
+	if resp.StatusCode == http.StatusNotFound {
+		return fmt.Errorf("demo id doesn't exist on server. Remove it from the definition file and try again")
+	}
+
 	if resp.StatusCode == http.StatusUnprocessableEntity {
 		// validation error
 		body, err := ioutil.ReadAll(resp.Body)

--- a/cli/actions/polling.go
+++ b/cli/actions/polling.go
@@ -100,6 +100,10 @@ func (polling pollingActions) update(ctx context.Context, file file.File, ID str
 	}
 
 	defer resp.Body.Close()
+	if resp.StatusCode == http.StatusNotFound {
+		return fmt.Errorf("polling profile id doesn't exist on server. Remove it from the definition file and try again")
+	}
+
 	if resp.StatusCode == http.StatusUnprocessableEntity {
 		// validation error
 		body, err := ioutil.ReadAll(resp.Body)


### PR DESCRIPTION
This PR fixes the error which makes the CLI erase the content from the demo definition file if it has an id that doesn't exist on the server.

The same patch was applied to polling profile resources.

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
