### PR TITLE
chore: Update goreleaser

### DIFF
--- a/.github/workflows/deploy-demo.yml
+++ b/.github/workflows/deploy-demo.yml
@@ -79,7 +79,7 @@ jobs:
       - uses: goreleaser/goreleaser-action@v4
         with:
           distribution: goreleaser-pro
-          version: v1.16.1
+          version: v1.16.2
           args: release --clean --skip-announce -f .goreleaser.dev.yaml
         env:
           VERSION: ${{ github.ref_name}}-demo

--- a/.github/workflows/deploy-main.yml
+++ b/.github/workflows/deploy-main.yml
@@ -85,7 +85,7 @@ jobs:
         if: steps.cache.outputs.cache-hit != 'true'
         with:
           distribution: goreleaser-pro
-          version: v1.16.1
+          version: v1.16.2
           args: release --clean --split --nightly
         env:
           GOOS: ${{ matrix.GOOS }}
@@ -145,7 +145,7 @@ jobs:
         if: steps.cache.outputs.cache-hit != 'true'
         with:
           distribution: goreleaser-pro
-          version: v1.16.1
+          version: v1.16.2
           args: continue --merge
         env:
           VERSION: sha-${{ env.sha_short }}

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -101,7 +101,7 @@ jobs:
       uses: goreleaser/goreleaser-action@v4
       with:
         distribution: goreleaser-pro
-        version: v1.16.1
+        version: v1.16.2
         args: build --single-target --clean --snapshot
       env:
         VERSION: pr-${{ github.event.pull_request.number }}
@@ -175,7 +175,7 @@ jobs:
       - uses: goreleaser/goreleaser-action@v4
         with:
           distribution: goreleaser-pro
-          version: v1.16.1
+          version: v1.16.2
           args: release --clean --skip-announce --snapshot -f .goreleaser.dev.yaml
         env:
           VERSION: pr-${{ github.event.pull_request.number }}

--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -82,7 +82,7 @@ jobs:
         if: steps.cache.outputs.cache-hit != 'true'
         with:
           distribution: goreleaser-pro
-          version: v1.16.1
+          version: v1.16.2
           args: release --clean -f .goreleaser.rc.yaml
         env:
           VERSION: ${{ github.ref_name}}

--- a/.github/workflows/release-version.yml
+++ b/.github/workflows/release-version.yml
@@ -88,7 +88,7 @@ jobs:
         if: steps.cache.outputs.cache-hit != 'true'
         with:
           distribution: goreleaser-pro
-          version: v1.16.1
+          version: v1.16.2
           args: release --clean
         env:
           VERSION: ${{ github.ref_name}}

--- a/.goreleaser.rc.yaml
+++ b/.goreleaser.rc.yaml
@@ -107,8 +107,12 @@ docker_manifests:
   - 'kubeshop/tracetest:{{ .Env.VERSION }}-arm64'
 
 archives:
-- replacements:
-    386: i386
+- name_template: >-
+    {{ .ProjectName }}_
+    {{ .Version }}_
+    {{- title .Os }}_
+    {{- if eq .Arch "386" }}i386
+    {{- else }}{{ .Arch }}{{ end }}
 checksum:
   name_template: 'checksums.txt'
 
@@ -123,8 +127,13 @@ nfpms:
   formats:
     - deb
     - rpm
-  replacements:
-    386: i386
+  file_name_template: >-
+    {{ .ProjectName }}_
+    {{ .Version }}_
+    {{- title .Os }}_
+    {{- if eq .Arch "386" }}i386
+    {{- else }}{{ .Arch }}{{ end }}
+    {{ with .Arm }}v{{ . }}{{ end }}{{ with .Mips }}_{{ . }}{{ end }}{{ if not (eq .Amd64 "v1") }}{{ .Amd64 }}{{ end }}
   deb:
     lintian_overrides:
       - statically-linked-binary

--- a/.goreleaser.rc.yaml
+++ b/.goreleaser.rc.yaml
@@ -109,10 +109,13 @@ docker_manifests:
 archives:
 - name_template: >-
     {{ .ProjectName }}_
-    {{ .Version }}_
-    {{- title .Os }}_
+    {{- .Version }}_
+    {{- .Os }}_
     {{- if eq .Arch "386" }}i386
     {{- else }}{{ .Arch }}{{ end }}
+    {{- with .Arm }}v{{ . }}{{ end }}
+    {{- with .Mips }}_{{ . }}{{ end }}
+    {{- if not (eq .Amd64 "v1") }}{{ .Amd64 }}{{ end }}
 checksum:
   name_template: 'checksums.txt'
 
@@ -129,11 +132,13 @@ nfpms:
     - rpm
   file_name_template: >-
     {{ .ProjectName }}_
-    {{ .Version }}_
-    {{- title .Os }}_
+    {{- .Version }}_
+    {{- .Os }}_
     {{- if eq .Arch "386" }}i386
     {{- else }}{{ .Arch }}{{ end }}
-    {{ with .Arm }}v{{ . }}{{ end }}{{ with .Mips }}_{{ . }}{{ end }}{{ if not (eq .Amd64 "v1") }}{{ .Amd64 }}{{ end }}
+    {{- with .Arm }}v{{ . }}{{ end }}
+    {{- with .Mips }}_{{ . }}{{ end }}
+    {{- if not (eq .Amd64 "v1") }}{{ .Amd64 }}{{ end }}
   deb:
     lintian_overrides:
       - statically-linked-binary

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -122,7 +122,7 @@ archives:
 - name_template: >-
     {{ .ProjectName }}_
     {{ .Version }}_
-    {{- title .Os }}_
+    {{-  .Os }}_
     {{- if eq .Arch "386" }}i386
     {{- else }}{{ .Arch }}{{ end }}
 checksum:
@@ -142,7 +142,7 @@ nfpms:
   file_name_template: >-
     {{ .ProjectName }}_
     {{ .Version }}_
-    {{- title .Os }}_
+    {{- .Os }}_
     {{- if eq .Arch "386" }}i386
     {{- else }}{{ .Arch }}{{ end }}
     {{ with .Arm }}v{{ . }}{{ end }}{{ with .Mips }}_{{ . }}{{ end }}{{ if not (eq .Amd64 "v1") }}{{ .Amd64 }}{{ end }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -125,6 +125,9 @@ archives:
     {{- .Os }}_
     {{- if eq .Arch "386" }}i386
     {{- else }}{{ .Arch }}{{ end }}
+    {{- with .Arm }}v{{ . }}{{ end }}
+    {{- with .Mips }}_{{ . }}{{ end }}
+    {{- if not (eq .Amd64 "v1") }}{{ .Amd64 }}{{ end }}
 checksum:
   name_template: 'checksums.txt'
 

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -119,8 +119,12 @@ docker_manifests:
   - 'kubeshop/tracetest:{{ .Env.VERSION }}-arm64'
 
 archives:
-- replacements:
-    386: i386
+- name_template: >-
+    {{ .ProjectName }}_
+    {{ .Version }}_
+    {{- title .Os }}_
+    {{- if eq .Arch "386" }}i386
+    {{- else }}{{ .Arch }}{{ end }}
 checksum:
   name_template: 'checksums.txt'
 
@@ -135,8 +139,13 @@ nfpms:
   formats:
     - deb
     - rpm
-  replacements:
-    386: i386
+  file_name_template: >-
+    {{ .ProjectName }}_
+    {{ .Version }}_
+    {{- title .Os }}_
+    {{- if eq .Arch "386" }}i386
+    {{- else }}{{ .Arch }}{{ end }}
+    {{ with .Arm }}v{{ . }}{{ end }}{{ with .Mips }}_{{ . }}{{ end }}{{ if not (eq .Amd64 "v1") }}{{ .Amd64 }}{{ end }}
   deb:
     lintian_overrides:
       - statically-linked-binary

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -148,7 +148,9 @@ nfpms:
     {{- .Os }}_
     {{- if eq .Arch "386" }}i386
     {{- else }}{{ .Arch }}{{ end }}
-    {{ with .Arm }}v{{ . }}{{ end }}{{ with .Mips }}_{{ . }}{{ end }}{{ if not (eq .Amd64 "v1") }}{{ .Amd64 }}{{ end }}
+    {{- with .Arm }}v{{ . }}{{ end }}
+    {{- with .Mips }}_{{ . }}{{ end }}
+    {{- if not (eq .Amd64 "v1") }}{{ .Amd64 }}{{ end }}
   deb:
     lintian_overrides:
       - statically-linked-binary

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -121,8 +121,8 @@ docker_manifests:
 archives:
 - name_template: >-
     {{ .ProjectName }}_
-    {{ .Version }}_
-    {{-  .Os }}_
+    {{- .Version }}_
+    {{- .Os }}_
     {{- if eq .Arch "386" }}i386
     {{- else }}{{ .Arch }}{{ end }}
 checksum:
@@ -141,7 +141,7 @@ nfpms:
     - rpm
   file_name_template: >-
     {{ .ProjectName }}_
-    {{ .Version }}_
+    {{- .Version }}_
     {{- .Os }}_
     {{- if eq .Arch "386" }}i386
     {{- else }}{{ .Arch }}{{ end }}

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 PROJECT_ROOT=${PWD}
 
-GORELEASER_VERSION=1.16.1-pro
+GORELEASER_VERSION=1.16.2-pro
 CURRENT_GORELEASER_VERSION := $(shell goreleaser --version | head -n 1 | cut -d' ' -f3-)
 goreleaser-version:
 ifneq "$(CURRENT_GORELEASER_VERSION)" "$(GORELEASER_VERSION)"


### PR DESCRIPTION
This PR updates goreleaser. It also addresses the [deprecation notice](https://github.com/kubeshop/tracetest/actions/runs/4484739631/jobs/7885557141):

![Screenshot 2023-03-21 at 21 05 21](https://user-images.githubusercontent.com/314548/226768862-c54ff9e6-c4ff-4032-97f1-0e426b5acbc0.png)

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
