### PR TITLE
feature: allowing default AWS authentication

### DIFF
--- a/api/dataStores.yaml
+++ b/api/dataStores.yaml
@@ -75,6 +75,8 @@ components:
           type: string
         sessionToken:
           type: string
+        useDefaultAuth:
+          type: boolean
     HTTPClientSettings:
       type: object
       properties:

--- a/cli/openapi/model_aws_x_ray.go
+++ b/cli/openapi/model_aws_x_ray.go
@@ -23,6 +23,7 @@ type AwsXRay struct {
 	AccessKeyId     *string `json:"accessKeyId,omitempty"`
 	SecretAccessKey *string `json:"secretAccessKey,omitempty"`
 	SessionToken    *string `json:"sessionToken,omitempty"`
+	UseDefaultAuth  *bool   `json:"useDefaultAuth,omitempty"`
 }
 
 // NewAwsXRay instantiates a new AwsXRay object
@@ -170,6 +171,38 @@ func (o *AwsXRay) SetSessionToken(v string) {
 	o.SessionToken = &v
 }
 
+// GetUseDefaultAuth returns the UseDefaultAuth field value if set, zero value otherwise.
+func (o *AwsXRay) GetUseDefaultAuth() bool {
+	if o == nil || isNil(o.UseDefaultAuth) {
+		var ret bool
+		return ret
+	}
+	return *o.UseDefaultAuth
+}
+
+// GetUseDefaultAuthOk returns a tuple with the UseDefaultAuth field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *AwsXRay) GetUseDefaultAuthOk() (*bool, bool) {
+	if o == nil || isNil(o.UseDefaultAuth) {
+		return nil, false
+	}
+	return o.UseDefaultAuth, true
+}
+
+// HasUseDefaultAuth returns a boolean if a field has been set.
+func (o *AwsXRay) HasUseDefaultAuth() bool {
+	if o != nil && !isNil(o.UseDefaultAuth) {
+		return true
+	}
+
+	return false
+}
+
+// SetUseDefaultAuth gets a reference to the given bool and assigns it to the UseDefaultAuth field.
+func (o *AwsXRay) SetUseDefaultAuth(v bool) {
+	o.UseDefaultAuth = &v
+}
+
 func (o AwsXRay) MarshalJSON() ([]byte, error) {
 	toSerialize, err := o.ToMap()
 	if err != nil {
@@ -191,6 +224,9 @@ func (o AwsXRay) ToMap() (map[string]interface{}, error) {
 	}
 	if !isNil(o.SessionToken) {
 		toSerialize["sessionToken"] = o.SessionToken
+	}
+	if !isNil(o.UseDefaultAuth) {
+		toSerialize["useDefaultAuth"] = o.UseDefaultAuth
 	}
 	return toSerialize, nil
 }

--- a/examples/tracetest-aws-step-functions/infra/main.tf
+++ b/examples/tracetest-aws-step-functions/infra/main.tf
@@ -69,6 +69,61 @@ resource "aws_iam_role" "tracetest_task_execution_role" {
   tags = local.tags
 }
 
+resource "aws_iam_role" "tracetest_task_role" {
+  name = "${local.name}_task_role"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = "sts:AssumeRole"
+        Effect = "Allow"
+        Sid    = ""
+        Principal = {
+          Service = ["ecs-tasks.amazonaws.com", "ecs.amazonaws.com"]
+        }
+      },
+    ]
+  })
+
+  tags = local.tags
+}
+
+resource "aws_iam_role_policy" "tracetest_task_x_ray_role_policy" {
+  name = "${local.name}_task_x_ray_role_policy"
+  role = aws_iam_role.tracetest_task_role.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = [
+          "xray:GetSamplingRules",
+          "xray:GetSamplingTargets",
+          "xray:GetSamplingStatisticSummaries",
+          "xray:BatchGetTraces",
+          "xray:BatchGetTraceSummaryById",
+          "xray:GetDistinctTraceGraphs",
+          "xray:GetServiceGraph",
+          "xray:GetTraceGraph",
+          "xray:GetTraceSummaries",
+          "xray:GetGroups",
+          "xray:GetGroup",
+          "xray:ListTagsForResource",
+          "xray:ListResourcePolicies",
+          "xray:GetTimeSeriesServiceStatistics",
+          "xray:GetInsightSummaries",
+          "xray:GetInsight",
+          "xray:GetInsightEvents",
+          "xray:GetInsightImpactGraph"
+        ]
+        Effect   = "Allow"
+        Resource = "*"
+      },
+    ]
+  })
+}
+
 resource "aws_iam_role_policy" "tracetest_task_execution_role_policy" {
   name = "${local.name}_task_execution_role_policy"
   role = aws_iam_role.tracetest_task_execution_role.id

--- a/examples/tracetest-aws-step-functions/infra/tracetest.tf
+++ b/examples/tracetest-aws-step-functions/infra/tracetest.tf
@@ -5,6 +5,7 @@ resource "aws_ecs_task_definition" "tracetest" {
   cpu                      = 1024
   memory                   = 2048
   execution_role_arn       = aws_iam_role.tracetest_task_execution_role.arn
+  task_role_arn            = aws_iam_role.tracetest_task_role.arn
   container_definitions = jsonencode([
     {
       "name" : "${local.name}",

--- a/examples/tracetest-aws-step-functions/infra/variables.tf
+++ b/examples/tracetest-aws-step-functions/infra/variables.tf
@@ -35,6 +35,15 @@ spec:
   periodic:
     retryDelay: 5s
     timeout: 2m
+
+---
+type: DataStore
+spec:
+  name: awsxray
+  type: awsxray
+  awsxray:
+    useDefaultAuth: true
+    region: us-west-2
   EOF
 
   tags = {

--- a/examples/tracetest-aws-step-functions/tests/exam.yaml
+++ b/examples/tracetest-aws-step-functions/tests/exam.yaml
@@ -5,7 +5,7 @@ spec:
   trigger:
     type: http
     httpRequest:
-      url: <your_api_endpoint>/exam
+      url: https://ihcjsmi526.execute-api.us-west-2.amazonaws.com/v2/exam
       method: POST
       headers:
         - key: Content-Type

--- a/examples/tracetest-aws-step-functions/tests/incident.yaml
+++ b/examples/tracetest-aws-step-functions/tests/incident.yaml
@@ -5,7 +5,7 @@ spec:
   trigger:
     type: http
     httpRequest:
-      url: <your_api_endpoint>/incident
+      url: https://ihcjsmi526.execute-api.us-west-2.amazonaws.com/v2/incident
       method: POST
       headers:
         - key: Content-Type

--- a/server/model/data_stores.go
+++ b/server/model/data_stores.go
@@ -63,6 +63,7 @@ type (
 		AccessKeyID     string
 		SecretAccessKey string
 		SessionToken    string
+		UseDefaultAuth  bool
 	}
 )
 

--- a/server/model/yaml/datastore.go
+++ b/server/model/yaml/datastore.go
@@ -61,6 +61,7 @@ type AwsXRay struct {
 	AccessKeyId     string `mapstructure:"accessKeyId"`
 	SecretAccessKey string `mapstructure:"secretAccessKey"`
 	SessionToken    string `mapstructure:"sessionToken"`
+	UseDefaultAuth  bool   `mapstructure:"useDefaultAuth"`
 }
 
 type OpenSearch struct {

--- a/server/openapi/model_aws_x_ray.go
+++ b/server/openapi/model_aws_x_ray.go
@@ -17,6 +17,8 @@ type AwsXRay struct {
 	SecretAccessKey string `json:"secretAccessKey,omitempty"`
 
 	SessionToken string `json:"sessionToken,omitempty"`
+
+	UseDefaultAuth bool `json:"useDefaultAuth,omitempty"`
 }
 
 // AssertAwsXRayRequired checks if the required fields are not zero-ed

--- a/web/src/components/Settings/DataStorePlugin/forms/AwsXRay/AwsXRay.tsx
+++ b/web/src/components/Settings/DataStorePlugin/forms/AwsXRay/AwsXRay.tsx
@@ -1,35 +1,44 @@
-import {Col, Form, Input, Row} from 'antd';
-import {SupportedDataStores} from 'types/DataStore.types';
+import {Checkbox, Col, Form, Input, Row} from 'antd';
+import {SupportedDataStores, TDraftDataStore} from 'types/DataStore.types';
 
 const AwsXRay = () => {
   const baseName = ['dataStore', SupportedDataStores.AWSXRay];
+  const form = Form.useFormInstance<TDraftDataStore>();
+  const useDefaultAuth = Form.useWatch([...baseName, 'useDefaultAuth'], form) ?? false;
 
   return (
     <>
       <Row gutter={[16, 16]}>
         <Col span={12}>
+          <Form.Item name={[...baseName, 'useDefaultAuth']} valuePropName="checked">
+            <Checkbox>Use Default AWS Authentication</Checkbox>
+          </Form.Item>
+        </Col>
+      </Row>
+      <Row gutter={[16, 16]}>
+        <Col span={12}>
           <Form.Item
             label="Access Key Id"
             name={[...baseName, 'accessKeyId']}
-            rules={[{required: true, message: 'Access Key Id is required'}]}
+            rules={[{required: !useDefaultAuth, message: 'Access Key Id is required'}]}
           >
-            <Input placeholder="Access Key Id" type="password" />
+            <Input placeholder="Access Key Id" type="password" disabled={useDefaultAuth} />
           </Form.Item>
         </Col>
         <Col span={12}>
           <Form.Item
             label="Secret Access Key"
             name={[...baseName, 'secretAccessKey']}
-            rules={[{required: true, message: 'Secret Access Key is required'}]}
+            rules={[{required: !useDefaultAuth, message: 'Secret Access Key is required'}]}
           >
-            <Input placeholder="Secret Access Key" type="password" />
+            <Input placeholder="Secret Access Key" type="password" disabled={useDefaultAuth} />
           </Form.Item>
         </Col>
       </Row>
       <Row gutter={[16, 16]}>
         <Col span={12}>
           <Form.Item label="Session Token" name={[...baseName, 'sessionToken']}>
-            <Input placeholder="Session Token" type="password" />
+            <Input placeholder="Session Token" type="password" disabled={useDefaultAuth} />
           </Form.Item>
         </Col>
         <Col span={12}>

--- a/web/src/services/DataStores/AwsXRay.service.ts
+++ b/web/src/services/DataStores/AwsXRay.service.ts
@@ -2,7 +2,9 @@ import {SupportedDataStores, TDataStoreService} from 'types/DataStore.types';
 
 const AwsXRayService = (): TDataStoreService => ({
   getRequest({
-    dataStore: {awsxray: {region = '', accessKeyId = '', secretAccessKey = '', sessionToken = ''} = {}} = {},
+    dataStore: {
+      awsxray: {region = '', accessKeyId = '', secretAccessKey = '', sessionToken = '', useDefaultAuth = false} = {},
+    } = {},
   }) {
     return Promise.resolve({
       type: SupportedDataStores.AWSXRay,
@@ -12,22 +14,25 @@ const AwsXRayService = (): TDataStoreService => ({
         accessKeyId,
         secretAccessKey,
         sessionToken,
+        useDefaultAuth,
       },
     });
   },
-  validateDraft({dataStore: {awsxray: {region = '', accessKeyId = '', secretAccessKey = ''} = {}} = {}}) {
-    if (!region || !accessKeyId || !secretAccessKey) return Promise.resolve(false);
+  validateDraft({
+    dataStore: {awsxray: {region = '', accessKeyId = '', secretAccessKey = '', useDefaultAuth = false} = {}} = {},
+  }) {
+    if (((!accessKeyId || !secretAccessKey) && !useDefaultAuth) || !region) return Promise.resolve(false);
 
     return Promise.resolve(true);
   },
   getInitialValues({defaultDataStore: {awsxray = {}} = {}}) {
-    const {region = '', secretAccessKey = '', accessKeyId = '', sessionToken = ''} = awsxray;
+    const {region = '', secretAccessKey = '', accessKeyId = '', sessionToken = '', useDefaultAuth = false} = awsxray;
 
     return {
       dataStore: {
         name: SupportedDataStores.AWSXRay,
         type: SupportedDataStores.AWSXRay,
-        awsxray: {region, secretAccessKey, accessKeyId, sessionToken},
+        awsxray: {region, secretAccessKey, accessKeyId, sessionToken, useDefaultAuth},
       },
       dataStoreType: SupportedDataStores.AWSXRay,
     };

--- a/web/src/types/Generated.types.ts
+++ b/web/src/types/Generated.types.ts
@@ -1527,6 +1527,7 @@ export interface external {
           accessKeyId?: string;
           secretAccessKey?: string;
           sessionToken?: string;
+          useDefaultAuth?: boolean;
         };
         HTTPClientSettings: {
           url?: string;


### PR DESCRIPTION
This PR adds support for the AWS authentication, enabling users to assign IAM roles to the task containers where Tracetest is running from.

## Changes

- Adds skipping static credentials based on `useDefaultAuth` flag
- Updates example to use this new technique

## Fixes

- #2006 

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
