### PR TITLE
fix(frontend): rename publish button to save

### DIFF
--- a/web/src/components/TestActions/TestActions.tsx
+++ b/web/src/components/TestActions/TestActions.tsx
@@ -37,7 +37,7 @@ const TestActions = () => {
           publish();
         }}
       >
-        Publish
+        Save
       </Button>
     </S.Container>
   );

--- a/web/src/providers/TestSpecs/hooks/useTestSpecsCrud.ts
+++ b/web/src/providers/TestSpecs/hooks/useTestSpecsCrud.ts
@@ -74,7 +74,7 @@ const useTestSpecsCrud = ({runId, testId, test, isDraftMode, assertionResults}: 
 
     showNotification({
       type: 'success',
-      title: 'Your test has been published successfully',
+      title: 'Your test has been saved successfully',
       description: 'A new test run has been generated.',
     });
 


### PR DESCRIPTION
This PR renames the `Publish` button to `Save`.

## Changes

- Rename publish button

## Fixes

- fixes #2236 

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Screenshot

![2023-03-23 12 38 18](https://user-images.githubusercontent.com/3879892/227294746-250477ea-455f-4998-a727-d86e5deb24e1.gif)