### PR TITLE
fix(docs): fix deployment page to match new config file

### DIFF
--- a/docs/docs/deployment/docker.md
+++ b/docs/docs/deployment/docker.md
@@ -26,18 +26,22 @@ How do you want to run TraceTest? [type to search]:
 Select `Using Docker Compose` and follow the instructions.
 
 **Tools required (installed if missing)**:
+
 - Docker
 - Docker Compose
 
 **Requirements**:
+
 - Jaeger or other compatible backend. If missing, the installer will help you configure one.
 - OpenTelemetry Collector. If missing, the installer will help you configure one.
 - A `docker-compose.yaml` (configurable) file in the project directory. If missing, the installer will create an empty file.
 
 **Optionals**:
+
 - [PokeShop demo app](https://github.com/kubeshop/pokeshop/). A sample microservice app to test your Tracetest installation.
 
 **Result**:
+
 - `tracetest/` directory (configurable) with a `docker-compose.yaml` and other config files.
 - [Jaeger](https://www.jaegertracing.io/) instance, if selected.
 - [OpenTelemetry Collector](https://opentelemetry.io/docs/collector/), if selected.
@@ -48,7 +52,7 @@ Select `Using Docker Compose` and follow the instructions.
 In the folder where you ran `tracetest server install`, run this command to start the Tracetest cluster:
 
 ```bash
-docker compose -f docker-compose.yaml -f tracetest/docker-compose.yaml up
+docker compose -f tracetest/docker-compose.yaml up -d
 ```
 
 ```bash title="Condensed expected output from the Tracetest container:"

--- a/docs/docs/deployment/overview.md
+++ b/docs/docs/deployment/overview.md
@@ -8,6 +8,7 @@ This section contains a general overview of deploying a Tracetest in production.
 As shown in the diagram below, a typical production Tracetest deployment consists of Postgres, an OpenTelemetry Colletor and a [trace data store](../configuration/overview). But, if you do not want to use a trace data store, you can rely entirely on OpenTelemetry Collector.
 
 <!-- Add graph for Tracetest cluster -->
+
 ```mermaid
 flowchart TD
     A(("Tracetest"))
@@ -31,10 +32,10 @@ OpenTelemetry Collector ingests traces from your distributed system and forwards
 
 A trace data store is used to store traces. Tracetest will fetch trace data from the trace data store when running tests.
 
-Tracetest can be configured via a configuration file.
+Tracetest can be configured via a configuration file:
 
 ```yaml
-# tracetest.config.yaml
+# tracetest.yaml
 
 postgres:
   host: postgres
@@ -43,42 +44,6 @@ postgres:
   port: 5432
   dbname: postgres
   params: sslmode=disable
-
-poolingConfig:
-  maxWaitTimeForTrace: 10m
-  retryDelay: 5s
-
-googleAnalytics:
-  enabled: true
-
-demo:
-  enabled: []
-
-experimentalFeatures: []
-
-telemetry:
-  dataStores:
-    jaeger:
-      type: jaeger
-      jaeger:
-        endpoint: jaeger:16685
-        tls:
-          insecure: true
-
-  exporters:
-    collector:
-      serviceName: tracetest
-      sampling: 100 # 100%
-      exporter:
-        type: collector
-        collector:
-          endpoint: otel-collector:4317
-
-server:
-  telemetry:
-    dataStore: jaeger
-    exporter: collector
-    applicationExporter: collector
 ```
 
 Read more in the [configuration docs](../configuration/overview.md).


### PR DESCRIPTION
This PR fixes a config file in the deployment overview page (docs).

## Changes

- Fix docs

## Fixes

- related #2237 

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
