### PR TITLE
fix(frontend): fix links in test run tabs

### DIFF
--- a/web/src/components/RunDetailLayout/RunDetailLayout.styled.ts
+++ b/web/src/components/RunDetailLayout/RunDetailLayout.styled.ts
@@ -47,7 +47,7 @@ export const ContainerHeader = styled.div`
 
   .ant-tabs-tab {
     font-weight: 600;
-    padding: 5px 16px;
+    padding: 0;
     margin: 7px 0;
     border: ${({theme}) => `1px solid ${theme.color.borderLight}`};
     border-right: none;
@@ -122,6 +122,7 @@ export const Title = styled(Typography.Title).attrs({ellipsis: true, level: 2})`
 export const TabLink = styled(Link)<{$isActive: boolean}>`
   && {
     color: ${({theme, $isActive}) => $isActive && theme.color.white};
+    padding: 5px 16px;
 
     &:hover,
     &:visited,


### PR DESCRIPTION
This PR fixes an small issue where the links in the `test run` tabs (trigger, trace, test) were not clickable in the white space.

## Changes

- fix css styles in tab links

## Fixes

-

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Screenshots

### Prev

![2023-03-24 10 35 16](https://user-images.githubusercontent.com/3879892/227572783-1335d048-7a02-464f-be38-142de0cd490f.gif)

### Now

![2023-03-24 10 36 03](https://user-images.githubusercontent.com/3879892/227572798-9e1d61a7-3c0a-46c3-a447-dadfb2eb98f9.gif)