### PR TITLE
add cli cmd folder to trigger docusaurus workflow

### DIFF
--- a/.github/workflows/docusaurus.yml
+++ b/.github/workflows/docusaurus.yml
@@ -5,8 +5,9 @@ on:
     branches:
       - main
     paths:
-      - "docs/**"
       - "api/*"
+      - "cli/**"
+      - "docs/**"
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/.github/workflows/docusaurus.yml
+++ b/.github/workflows/docusaurus.yml
@@ -6,7 +6,7 @@ on:
       - main
     paths:
       - "api/*"
-      - "cli/**"
+      - "cli/cmd/*"
       - "docs/**"
 
   # Allows you to run this workflow manually from the Actions tab


### PR DESCRIPTION
This PR makes the documentation be built when a command in the CLI is updated. This is important because we now generate the CLI reference using cobra

## Checklist

- [ ] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
