### PR TITLE
replace connection test result with structure from model package

### DIFF
--- a/server/executor/poller_executor_test.go
+++ b/server/executor/poller_executor_test.go
@@ -585,8 +585,8 @@ func (db *traceDBMock) GetTraceID() trace.TraceID {
 func (db *traceDBMock) Connect(ctx context.Context) error { return nil }
 func (db *traceDBMock) Close() error                      { return nil }
 func (db *traceDBMock) Ready() bool                       { return true }
-func (db *traceDBMock) TestConnection(ctx context.Context) connection.ConnectionTestResult {
-	return connection.ConnectionTestResult{}
+func (db *traceDBMock) TestConnection(ctx context.Context) model.ConnectionResult {
+	return model.ConnectionResult{}
 }
 
 type traceDBState struct {

--- a/server/http/mappings/datastore.go
+++ b/server/http/mappings/datastore.go
@@ -1,41 +1,41 @@
 package mappings
 
 import (
+	"github.com/kubeshop/tracetest/server/model"
 	"github.com/kubeshop/tracetest/server/openapi"
-	"github.com/kubeshop/tracetest/server/tracedb/connection"
 )
 
-func (m *OpenAPI) ConnectionTestResult(in connection.ConnectionTestResult) openapi.ConnectionResult {
+func (m *OpenAPI) ConnectionTestResult(in model.ConnectionResult) openapi.ConnectionResult {
 	result := openapi.ConnectionResult{}
 
-	if in.EndpointLintTestResult.IsSet() {
-		result.PortCheck = m.ConnectionTestStep(in.EndpointLintTestResult)
+	if in.PortCheck.IsSet() {
+		result.PortCheck = m.ConnectionTestStep(in.PortCheck)
 	}
 
-	if in.ConnectivityTestResult.IsSet() {
-		result.Connectivity = m.ConnectionTestStep(in.ConnectivityTestResult)
+	if in.Connectivity.IsSet() {
+		result.Connectivity = m.ConnectionTestStep(in.Connectivity)
 	}
 
-	if in.AuthenticationTestResult.IsSet() {
-		result.Authentication = m.ConnectionTestStep(in.AuthenticationTestResult)
+	if in.Authentication.IsSet() {
+		result.Authentication = m.ConnectionTestStep(in.Authentication)
 	}
 
-	if in.TraceRetrievalTestResult.IsSet() {
-		result.FetchTraces = m.ConnectionTestStep(in.TraceRetrievalTestResult)
+	if in.FetchTraces.IsSet() {
+		result.FetchTraces = m.ConnectionTestStep(in.FetchTraces)
 	}
 
 	return result
 }
 
-func (m *OpenAPI) ConnectionTestStep(in connection.ConnectionTestStepResult) openapi.ConnectionTestStep {
+func (m *OpenAPI) ConnectionTestStep(in model.ConnectionTestStep) openapi.ConnectionTestStep {
 	errMessage := ""
 	if in.Error != nil {
 		errMessage = in.Error.Error()
 	}
 
 	return openapi.ConnectionTestStep{
-		Passed:  in.Status != connection.StatusFailed,
-		Message: in.OperationDescription,
+		Passed:  in.Status != model.StatusFailed,
+		Message: in.Message,
 		Status:  string(in.Status),
 		Error:   errMessage,
 	}

--- a/server/model/connection_test_result.go
+++ b/server/model/connection_test_result.go
@@ -1,0 +1,35 @@
+package model
+
+type ConnectionResult struct {
+	PortCheck      ConnectionTestStep
+	Connectivity   ConnectionTestStep
+	Authentication ConnectionTestStep
+	FetchTraces    ConnectionTestStep
+}
+
+func (c ConnectionResult) HasSucceed() bool {
+	return c.Connectivity.HasSucceed() && c.Authentication.HasSucceed() && c.FetchTraces.HasSucceed()
+}
+
+type ConnectionTestStep struct {
+	Passed  bool
+	Status  Status
+	Message string
+	Error   error
+}
+
+func (r *ConnectionTestStep) HasSucceed() bool {
+	if r == nil {
+		return true
+	}
+
+	return r.Error == nil
+}
+
+func (r *ConnectionTestStep) IsSet() bool {
+	if r == nil {
+		return false
+	}
+
+	return r.Message != ""
+}

--- a/server/model/test_run_event.go
+++ b/server/model/test_run_event.go
@@ -1,0 +1,49 @@
+package model
+
+import "time"
+
+type (
+	Protocol string
+	Status   string
+)
+
+var (
+	ProtocolHTTP Protocol = "http"
+	ProtocolGRPC Protocol = "grpc"
+)
+
+var (
+	StatusPassed  Status = "passed"
+	StatusWarning Status = "warning"
+	StatusFailed  Status = "failed"
+)
+
+type TestRunEvent struct {
+	Type                string
+	Stage               string
+	Description         string
+	CreatedAt           time.Time
+	TestId              string
+	RunId               string
+	DataStoreConnection ConnectionResult
+	Polling             PollingInfo
+	Outputs             []OutputInfo
+}
+
+type PollingInfo struct {
+	Type                string
+	ReasonNextIteration string
+	IsComplete          bool
+	Periodic            *PeriodicPollingConfig
+}
+
+type PeriodicPollingConfig struct {
+	NumberSpans      int32
+	NumberIterations int32
+}
+
+type OutputInfo struct {
+	LogLevel   string
+	Message    string
+	OutputName string
+}

--- a/server/tracedb/awsxray.go
+++ b/server/tracedb/awsxray.go
@@ -87,10 +87,10 @@ func (db *awsxrayDB) Close() error {
 	return nil
 }
 
-func (db *awsxrayDB) TestConnection(ctx context.Context) connection.ConnectionTestResult {
+func (db *awsxrayDB) TestConnection(ctx context.Context) model.ConnectionResult {
 	url := fmt.Sprintf("xray.%s.amazonaws.com:443", db.region)
 	tester := connection.NewTester(
-		connection.WithConnectivityTest(connection.ConnectivityStep(connection.ProtocolHTTP, url)),
+		connection.WithConnectivityTest(connection.ConnectivityStep(model.ProtocolHTTP, url)),
 		connection.WithPollingTest(connection.TracePollingTestStep(db)),
 		connection.WithAuthenticationTest(connection.NewTestStep(func(ctx context.Context) (string, error) {
 			_, err := db.GetTraceByID(ctx, db.GetTraceID().String())

--- a/server/tracedb/connection/connection.go
+++ b/server/tracedb/connection/connection.go
@@ -7,32 +7,11 @@ import (
 	"net/url"
 	"strings"
 	"time"
+
+	"github.com/kubeshop/tracetest/server/model"
 )
 
 const reachabilityTimeout = 5 * time.Second
-
-type (
-	Protocol string
-	Status   string
-)
-
-var (
-	ProtocolHTTP Protocol = "http"
-	ProtocolGRPC Protocol = "grpc"
-)
-
-var (
-	StatusPassed  Status = "passed"
-	StatusWarning Status = "warning"
-	StatusFailed  Status = "failed"
-)
-
-type ConnectionTestResult struct {
-	EndpointLintTestResult   ConnectionTestStepResult
-	ConnectivityTestResult   ConnectionTestStepResult
-	AuthenticationTestResult ConnectionTestStepResult
-	TraceRetrievalTestResult ConnectionTestStepResult
-}
 
 var (
 	ErrTraceNotFound        = errors.New("trace not found")
@@ -40,26 +19,8 @@ var (
 	ErrConnectionFailed     = errors.New("could not connect to data store")
 )
 
-func (c ConnectionTestResult) HasSucceed() bool {
-	return c.AuthenticationTestResult.HasSucceed() && c.ConnectivityTestResult.HasSucceed() && c.TraceRetrievalTestResult.HasSucceed()
-}
-
-type ConnectionTestStepResult struct {
-	OperationDescription string
-	Status               Status
-	Error                error
-}
-
-func (r ConnectionTestStepResult) HasSucceed() bool {
-	return r.Error == nil
-}
-
-func (r ConnectionTestStepResult) IsSet() bool {
-	return r.OperationDescription != ""
-}
-
-func CheckReachability(endpoint string, protocol Protocol) error {
-	if protocol == ProtocolHTTP {
+func CheckReachability(endpoint string, protocol model.Protocol) error {
+	if protocol == model.ProtocolHTTP {
 		address, err := url.Parse(endpoint)
 		if err != nil {
 			return err

--- a/server/tracedb/connection/connectivity_step.go
+++ b/server/tracedb/connection/connectivity_step.go
@@ -6,16 +6,17 @@ import (
 	"strings"
 
 	"github.com/hashicorp/go-multierror"
+	"github.com/kubeshop/tracetest/server/model"
 )
 
 type connectivityTestStep struct {
 	endpoints []string
-	protocol  Protocol
+	protocol  model.Protocol
 }
 
 var _ TestStep = &connectivityTestStep{}
 
-func (s *connectivityTestStep) TestConnection(_ context.Context) ConnectionTestStepResult {
+func (s *connectivityTestStep) TestConnection(_ context.Context) model.ConnectionTestStep {
 	unreachableEndpoints := make([]string, 0)
 	var connectionErr error
 	for _, endpoint := range s.endpoints {
@@ -30,29 +31,29 @@ func (s *connectivityTestStep) TestConnection(_ context.Context) ConnectionTestS
 	}
 
 	if len(s.endpoints) == 0 {
-		return ConnectionTestStepResult{
-			OperationDescription: "Tracetest tried to connect but no endpoints were provided",
-			Error:                fmt.Errorf("no endpoints provided"),
+		return model.ConnectionTestStep{
+			Message: "Tracetest tried to connect but no endpoints were provided",
+			Error:   fmt.Errorf("no endpoints provided"),
 		}
 	}
 
 	if connectionErr != nil {
 		endpoints := strings.Join(unreachableEndpoints, ", ")
-		return ConnectionTestStepResult{
-			OperationDescription: fmt.Sprintf("Tracetest tried to connect to the following endpoints and failed: %s", endpoints),
-			Status:               StatusFailed,
-			Error:                connectionErr,
+		return model.ConnectionTestStep{
+			Message: fmt.Sprintf("Tracetest tried to connect to the following endpoints and failed: %s", endpoints),
+			Status:  model.StatusFailed,
+			Error:   connectionErr,
 		}
 	}
 
 	endpoints := strings.Join(s.endpoints, ", ")
-	return ConnectionTestStepResult{
-		OperationDescription: fmt.Sprintf(`Tracetest connected to %s`, endpoints),
-		Status:               StatusPassed,
+	return model.ConnectionTestStep{
+		Message: fmt.Sprintf(`Tracetest connected to %s`, endpoints),
+		Status:  model.StatusPassed,
 	}
 }
 
-func ConnectivityStep(protocol Protocol, endpoints ...string) TestStep {
+func ConnectivityStep(protocol model.Protocol, endpoints ...string) TestStep {
 	return &connectivityTestStep{
 		endpoints: endpoints,
 		protocol:  protocol,

--- a/server/tracedb/connection/options.go
+++ b/server/tracedb/connection/options.go
@@ -1,6 +1,10 @@
 package connection
 
-import "context"
+import (
+	"context"
+
+	"github.com/kubeshop/tracetest/server/model"
+)
 
 func WithPortLintingTest(step TestStep) TesterOption {
 	return func(t *Tester) {
@@ -30,11 +34,11 @@ type functionTestStep struct {
 	fn func(ctx context.Context) (string, error)
 }
 
-func (s *functionTestStep) TestConnection(ctx context.Context) ConnectionTestStepResult {
+func (s *functionTestStep) TestConnection(ctx context.Context) model.ConnectionTestStep {
 	str, err := s.fn(ctx)
-	return ConnectionTestStepResult{
-		OperationDescription: str,
-		Error:                err,
+	return model.ConnectionTestStep{
+		Message: str,
+		Error:   err,
 	}
 }
 

--- a/server/tracedb/connection/port_linting.go
+++ b/server/tracedb/connection/port_linting.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"regexp"
 	"strings"
+
+	"github.com/kubeshop/tracetest/server/model"
 )
 
 type portLinter struct {
@@ -23,22 +25,22 @@ func PortLinter(dataStoreName string, expectedPorts []string, endpoints ...strin
 	}
 }
 
-func (s *portLinter) TestConnection(ctx context.Context) ConnectionTestStepResult {
+func (s *portLinter) TestConnection(ctx context.Context) model.ConnectionTestStep {
 	for _, endpoint := range s.endpoints {
 		port := parsePort(endpoint)
 
 		if !sliceContains(s.expectedPorts, port) {
 			suggestedPorts := formatAvailablePortsMessage(s.expectedPorts)
-			return ConnectionTestStepResult{
-				OperationDescription: fmt.Sprintf(`For %s, port "%s" is not the default port for accessing traces programmatically. Typically, %s uses port %s. If you continue experiencing issues, you may want to verify the correct port to specify.`, s.dataStoreName, port, s.dataStoreName, suggestedPorts),
-				Status:               StatusWarning,
+			return model.ConnectionTestStep{
+				Message: fmt.Sprintf(`For %s, port "%s" is not the default port for accessing traces programmatically. Typically, %s uses port %s. If you continue experiencing issues, you may want to verify the correct port to specify.`, s.dataStoreName, port, s.dataStoreName, suggestedPorts),
+				Status:  model.StatusWarning,
 			}
 		}
 	}
 
-	return ConnectionTestStepResult{
-		OperationDescription: `You are using a commonly used port`,
-		Status:               StatusPassed,
+	return model.ConnectionTestStep{
+		Message: `You are using a commonly used port`,
+		Status:  model.StatusPassed,
 	}
 }
 

--- a/server/tracedb/connection/port_linting_test.go
+++ b/server/tracedb/connection/port_linting_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/kubeshop/tracetest/server/model"
 	"github.com/kubeshop/tracetest/server/tracedb/connection"
 	"github.com/stretchr/testify/assert"
 )
@@ -13,37 +14,37 @@ func TestPortLinter(t *testing.T) {
 		Name           string
 		Endpoints      []string
 		ExpectedPorts  []string
-		ExpectedStatus connection.Status
+		ExpectedStatus model.Status
 	}{
 		{
 			Name:           "shouldSucceedIfPortIsExpected",
 			Endpoints:      []string{"jaeger:16685"},
 			ExpectedPorts:  []string{"16685"},
-			ExpectedStatus: connection.StatusPassed,
+			ExpectedStatus: model.StatusPassed,
 		},
 		{
 			Name:           "shouldShowWarningInCaseOfDifferentPort",
 			Endpoints:      []string{"jaeger:16686"},
 			ExpectedPorts:  []string{"16685"},
-			ExpectedStatus: connection.StatusWarning,
+			ExpectedStatus: model.StatusWarning,
 		},
 		{
 			Name:           "shouldSupportSchemas",
 			Endpoints:      []string{"https://us2.endpoint:9200"},
 			ExpectedPorts:  []string{"9200"},
-			ExpectedStatus: connection.StatusPassed,
+			ExpectedStatus: model.StatusPassed,
 		},
 		{
 			Name:           "shouldSupportTwoPorts",
 			Endpoints:      []string{"https://us2.endpoint:9100"},
 			ExpectedPorts:  []string{"9200", "9250"},
-			ExpectedStatus: connection.StatusWarning,
+			ExpectedStatus: model.StatusWarning,
 		},
 		{
 			Name:           "shouldSupportTwoPorts",
 			Endpoints:      []string{"https://us2.endpoint:9100"},
 			ExpectedPorts:  []string{"9200", "9250", "9300"},
-			ExpectedStatus: connection.StatusWarning,
+			ExpectedStatus: model.StatusWarning,
 		},
 	}
 

--- a/server/tracedb/connection/tester.go
+++ b/server/tracedb/connection/tester.go
@@ -1,9 +1,13 @@
 package connection
 
-import "context"
+import (
+	"context"
+
+	"github.com/kubeshop/tracetest/server/model"
+)
 
 type TestStep interface {
-	TestConnection(ctx context.Context) ConnectionTestStepResult
+	TestConnection(ctx context.Context) model.ConnectionTestStep
 }
 
 type TesterOption func(*Tester)
@@ -25,30 +29,30 @@ func NewTester(opts ...TesterOption) Tester {
 	return tester
 }
 
-func (t *Tester) TestConnection(ctx context.Context) (res ConnectionTestResult) {
+func (t *Tester) TestConnection(ctx context.Context) (res model.ConnectionResult) {
 	if t.portLinterStep != nil {
-		res.EndpointLintTestResult = t.portLinterStep.TestConnection(ctx)
-		if res.EndpointLintTestResult.Error != nil {
-			res.EndpointLintTestResult.Status = StatusFailed
+		res.PortCheck = t.portLinterStep.TestConnection(ctx)
+		if res.PortCheck.Error != nil {
+			res.PortCheck.Status = model.StatusFailed
 			return
 		}
 	}
 
-	res.ConnectivityTestResult = t.connectivityTestStep.TestConnection(ctx)
-	if res.ConnectivityTestResult.Error != nil {
-		res.ConnectivityTestResult.Status = StatusFailed
+	res.Connectivity = t.connectivityTestStep.TestConnection(ctx)
+	if res.Connectivity.Error != nil {
+		res.Connectivity.Status = model.StatusFailed
 		return
 	}
 
-	res.AuthenticationTestResult = t.authenticationTestStep.TestConnection(ctx)
-	if res.AuthenticationTestResult.Error != nil {
-		res.AuthenticationTestResult.Status = StatusFailed
+	res.Authentication = t.authenticationTestStep.TestConnection(ctx)
+	if res.Authentication.Error != nil {
+		res.Authentication.Status = model.StatusFailed
 		return
 	}
 
-	res.TraceRetrievalTestResult = t.pollingTestStep.TestConnection(ctx)
-	if res.TraceRetrievalTestResult.Error != nil {
-		res.TraceRetrievalTestResult.Status = StatusFailed
+	res.FetchTraces = t.pollingTestStep.TestConnection(ctx)
+	if res.FetchTraces.Error != nil {
+		res.FetchTraces.Status = model.StatusFailed
 	}
 
 	return

--- a/server/tracedb/connection/trace_polling_step.go
+++ b/server/tracedb/connection/trace_polling_step.go
@@ -17,20 +17,20 @@ type tracePollingTestStep struct {
 	dataStore DataStore
 }
 
-func (s *tracePollingTestStep) TestConnection(ctx context.Context) ConnectionTestStepResult {
+func (s *tracePollingTestStep) TestConnection(ctx context.Context) model.ConnectionTestStep {
 	_, err := s.dataStore.GetTraceByID(ctx, s.dataStore.GetTraceID().String())
 	if !errors.Is(err, ErrTraceNotFound) {
-		return ConnectionTestStepResult{
-			OperationDescription: "Tracetest could not get traces back from the data store",
-			Error:                err,
-			Status:               StatusFailed,
+		return model.ConnectionTestStep{
+			Message: "Tracetest could not get traces back from the data store",
+			Error:   err,
+			Status:  model.StatusFailed,
 		}
 	}
 
-	return ConnectionTestStepResult{
-		OperationDescription: "Traces were obtained successfully",
-		Error:                nil,
-		Status:               StatusPassed,
+	return model.ConnectionTestStep{
+		Message: "Traces were obtained successfully",
+		Error:   nil,
+		Status:  model.StatusPassed,
 	}
 }
 

--- a/server/tracedb/datasource/datasource.go
+++ b/server/tracedb/datasource/datasource.go
@@ -4,7 +4,6 @@ import (
 	"context"
 
 	"github.com/kubeshop/tracetest/server/model"
-	"github.com/kubeshop/tracetest/server/tracedb/connection"
 	"google.golang.org/grpc"
 )
 
@@ -28,7 +27,7 @@ type DataSource interface {
 	Connect(ctx context.Context) error
 	Ready() bool
 	GetTraceByID(ctx context.Context, traceID string) (model.Trace, error)
-	TestConnection(ctx context.Context) connection.ConnectionTestStepResult
+	TestConnection(ctx context.Context) model.ConnectionTestStep
 	Close() error
 }
 
@@ -41,8 +40,8 @@ func (db *noopDataSource) Endpoint() string                  { return "" }
 func (db *noopDataSource) Connect(ctx context.Context) error { return nil }
 func (db *noopDataSource) Close() error                      { return nil }
 func (db *noopDataSource) Ready() bool                       { return true }
-func (db *noopDataSource) TestConnection(ctx context.Context) connection.ConnectionTestStepResult {
-	return connection.ConnectionTestStepResult{}
+func (db *noopDataSource) TestConnection(ctx context.Context) model.ConnectionTestStep {
+	return model.ConnectionTestStep{}
 }
 
 func New(name string, cfg *model.BaseClientConfig, callbacks Callbacks) DataSource {

--- a/server/tracedb/datasource/grpc.go
+++ b/server/tracedb/datasource/grpc.go
@@ -54,25 +54,25 @@ func (client *GrpcClient) Connect(ctx context.Context) error {
 	return nil
 }
 
-func (client *GrpcClient) TestConnection(ctx context.Context) connection.ConnectionTestStepResult {
-	connectionTestResult := connection.ConnectionTestStepResult{
-		OperationDescription: fmt.Sprintf(`Tracetest connected to "%s"`, client.config.Endpoint),
+func (client *GrpcClient) TestConnection(ctx context.Context) model.ConnectionTestStep {
+	connectionTestResult := model.ConnectionTestStep{
+		Message: fmt.Sprintf(`Tracetest connected to "%s"`, client.config.Endpoint),
 	}
 
-	err := connection.CheckReachability(client.config.Endpoint, connection.ProtocolGRPC)
+	err := connection.CheckReachability(client.config.Endpoint, model.ProtocolGRPC)
 	if err != nil {
-		return connection.ConnectionTestStepResult{
-			OperationDescription: fmt.Sprintf(`Tracetest tried to connect to "%s" and failed`, client.config.Endpoint),
-			Error:                err,
+		return model.ConnectionTestStep{
+			Message: fmt.Sprintf(`Tracetest tried to connect to "%s" and failed`, client.config.Endpoint),
+			Error:   err,
 		}
 	}
 
 	err = client.Connect(ctx)
 	wrappedErr := errors.Unwrap(err)
 	if errors.Is(wrappedErr, connection.ErrConnectionFailed) {
-		return connection.ConnectionTestStepResult{
-			OperationDescription: fmt.Sprintf(`Tracetest tried to open a gRPC connection against "%s" and failed`, client.config.Endpoint),
-			Error:                err,
+		return model.ConnectionTestStep{
+			Message: fmt.Sprintf(`Tracetest tried to open a gRPC connection against "%s" and failed`, client.config.Endpoint),
+			Error:   err,
 		}
 	}
 

--- a/server/tracedb/datasource/http.go
+++ b/server/tracedb/datasource/http.go
@@ -71,25 +71,25 @@ func (client *HttpClient) Connect(ctx context.Context) error {
 	return err
 }
 
-func (client *HttpClient) TestConnection(ctx context.Context) connection.ConnectionTestStepResult {
-	connectionTestResult := connection.ConnectionTestStepResult{
-		OperationDescription: fmt.Sprintf(`Tracetest connected to "%s"`, client.config.URL.String()),
+func (client *HttpClient) TestConnection(ctx context.Context) model.ConnectionTestStep {
+	connectionTestResult := model.ConnectionTestStep{
+		Message: fmt.Sprintf(`Tracetest connected to "%s"`, client.config.URL.String()),
 	}
 
-	err := connection.CheckReachability(client.config.URL.String(), connection.ProtocolHTTP)
+	err := connection.CheckReachability(client.config.URL.String(), model.ProtocolHTTP)
 	if err != nil {
-		return connection.ConnectionTestStepResult{
-			OperationDescription: fmt.Sprintf(`Tracetest tried to connect to "%s" and failed`, client.config.URL.String()),
-			Error:                err,
+		return model.ConnectionTestStep{
+			Message: fmt.Sprintf(`Tracetest tried to connect to "%s" and failed`, client.config.URL.String()),
+			Error:   err,
 		}
 	}
 
 	err = client.Connect(ctx)
 	wrappedErr := errors.Unwrap(err)
 	if errors.Is(wrappedErr, connection.ErrConnectionFailed) {
-		return connection.ConnectionTestStepResult{
-			OperationDescription: fmt.Sprintf(`Tracetest tried to open a connection against "%s" and failed`, client.config.URL.String()),
-			Error:                err,
+		return model.ConnectionTestStep{
+			Message: fmt.Sprintf(`Tracetest tried to open a connection against "%s" and failed`, client.config.URL.String()),
+			Error:   err,
 		}
 	}
 

--- a/server/tracedb/elasticsearchdb.go
+++ b/server/tracedb/elasticsearchdb.go
@@ -38,10 +38,10 @@ func (db *elasticsearchDB) Close() error {
 	return nil
 }
 
-func (db *elasticsearchDB) TestConnection(ctx context.Context) connection.ConnectionTestResult {
+func (db *elasticsearchDB) TestConnection(ctx context.Context) model.ConnectionResult {
 	tester := connection.NewTester(
 		connection.WithPortLintingTest(connection.PortLinter("ElasticSearch", elasticSearchDefaultPorts(), db.config.Addresses...)),
-		connection.WithConnectivityTest(connection.ConnectivityStep(connection.ProtocolHTTP, db.config.Addresses...)),
+		connection.WithConnectivityTest(connection.ConnectivityStep(model.ProtocolHTTP, db.config.Addresses...)),
 		connection.WithPollingTest(connection.TracePollingTestStep(db)),
 		connection.WithAuthenticationTest(connection.NewTestStep(func(ctx context.Context) (string, error) {
 			_, err := getClusterInfo(db.client)

--- a/server/tracedb/jaegerdb.go
+++ b/server/tracedb/jaegerdb.go
@@ -46,7 +46,7 @@ func (jtd *jaegerTraceDB) Connect(ctx context.Context) error {
 	return jtd.dataSource.Connect(ctx)
 }
 
-func (jtd *jaegerTraceDB) TestConnection(ctx context.Context) connection.ConnectionTestResult {
+func (jtd *jaegerTraceDB) TestConnection(ctx context.Context) model.ConnectionResult {
 	tester := connection.NewTester(
 		connection.WithPortLintingTest(connection.PortLinter("Jaeger", jaegerDefaultPorts(), jtd.dataSource.Endpoint())),
 		connection.WithConnectivityTest(jtd.dataSource),

--- a/server/tracedb/opensearchdb.go
+++ b/server/tracedb/opensearchdb.go
@@ -36,10 +36,10 @@ func (db *opensearchDB) Close() error {
 	return nil
 }
 
-func (db *opensearchDB) TestConnection(ctx context.Context) connection.ConnectionTestResult {
+func (db *opensearchDB) TestConnection(ctx context.Context) model.ConnectionResult {
 	tester := connection.NewTester(
 		connection.WithPortLintingTest(connection.PortLinter("OpenSearch", opensearchDefaultPorts(), db.config.Addresses...)),
-		connection.WithConnectivityTest(connection.ConnectivityStep(connection.ProtocolHTTP, db.config.Addresses...)),
+		connection.WithConnectivityTest(connection.ConnectivityStep(model.ProtocolHTTP, db.config.Addresses...)),
 		connection.WithPollingTest(connection.TracePollingTestStep(db)),
 		connection.WithAuthenticationTest(connection.NewTestStep(func(ctx context.Context) (string, error) {
 			_, err := db.GetTraceByID(ctx, trace.TraceID{}.String())

--- a/server/tracedb/otlp.go
+++ b/server/tracedb/otlp.go
@@ -33,8 +33,8 @@ func (tdb *OTLPTraceDB) Close() error {
 	return nil
 }
 
-func (jtd *OTLPTraceDB) TestConnection(ctx context.Context) connection.ConnectionTestResult {
-	return connection.ConnectionTestResult{}
+func (jtd *OTLPTraceDB) TestConnection(ctx context.Context) model.ConnectionResult {
+	return model.ConnectionResult{}
 }
 
 // GetTraceByID implements TraceDB

--- a/server/tracedb/signalfxdb.go
+++ b/server/tracedb/signalfxdb.go
@@ -46,10 +46,10 @@ func (db *signalfxDB) Close() error {
 	return nil
 }
 
-func (db *signalfxDB) TestConnection(ctx context.Context) connection.ConnectionTestResult {
+func (db *signalfxDB) TestConnection(ctx context.Context) model.ConnectionResult {
 	url := fmt.Sprintf("%s:%s", db.getURL(), "443")
 	tester := connection.NewTester(
-		connection.WithConnectivityTest(connection.ConnectivityStep(connection.ProtocolHTTP, url)),
+		connection.WithConnectivityTest(connection.ConnectivityStep(model.ProtocolHTTP, url)),
 		connection.WithPollingTest(connection.TracePollingTestStep(db)),
 		connection.WithAuthenticationTest(connection.NewTestStep(func(ctx context.Context) (string, error) {
 			_, err := db.GetTraceByID(ctx, trace.TraceID{}.String())

--- a/server/tracedb/tempodb.go
+++ b/server/tracedb/tempodb.go
@@ -45,7 +45,7 @@ func (tdb *tempoTraceDB) Connect(ctx context.Context) error {
 	return tdb.dataSource.Connect(ctx)
 }
 
-func (ttd *tempoTraceDB) TestConnection(ctx context.Context) connection.ConnectionTestResult {
+func (ttd *tempoTraceDB) TestConnection(ctx context.Context) model.ConnectionResult {
 	tester := connection.NewTester(
 		connection.WithPortLintingTest(connection.PortLinter("Tempo", tempoDefaultPorts(), ttd.dataSource.Endpoint())),
 		connection.WithConnectivityTest(ttd.dataSource),

--- a/server/tracedb/tracedb.go
+++ b/server/tracedb/tracedb.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/kubeshop/tracetest/server/id"
 	"github.com/kubeshop/tracetest/server/model"
-	"github.com/kubeshop/tracetest/server/tracedb/connection"
 	"go.opentelemetry.io/otel/trace"
 )
 
@@ -18,7 +17,7 @@ type TraceDB interface {
 	ShouldRetry() bool
 	GetTraceID() trace.TraceID
 	GetTraceByID(ctx context.Context, traceID string) (model.Trace, error)
-	TestConnection(ctx context.Context) connection.ConnectionTestResult
+	TestConnection(ctx context.Context) model.ConnectionResult
 	Close() error
 }
 
@@ -35,8 +34,8 @@ func (db *noopTraceDB) Connect(ctx context.Context) error { return nil }
 func (db *noopTraceDB) Close() error                      { return nil }
 func (db *noopTraceDB) ShouldRetry() bool                 { return false }
 func (db *noopTraceDB) Ready() bool                       { return true }
-func (db *noopTraceDB) TestConnection(ctx context.Context) connection.ConnectionTestResult {
-	return connection.ConnectionTestResult{}
+func (db *noopTraceDB) TestConnection(ctx context.Context) model.ConnectionResult {
+	return model.ConnectionResult{}
 }
 
 func WithFallback(fn func(ds model.DataStore) (TraceDB, error), fallbackDS model.DataStore) func(ds model.DataStore) (TraceDB, error) {


### PR DESCRIPTION
This PR adds the model for the test run event and replace the connection test structures with the one located in the model package

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
