### PR TITLE
increase timeout when checking if port is available

### DIFF
--- a/scripts/wait-for-port.sh
+++ b/scripts/wait-for-port.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 PORT=$1
 
-TIME_OUT=30s
+TIME_OUT=60s
 CONDITION='nc -z -w 1 localhost '$PORT' > /dev/null 2>&1'
 IF_TRUE='echo "port '$PORT' ready"'
 IF_FALSE='echo "port '$PORT' not available, retry"'


### PR DESCRIPTION
This PR increases the timeout from 30s to 60s when checking if a port is ready.

This was done because our pipeline would fail quite frequently because the Postgres instance would take some time to start on our cluster. I expect the number of false negative fails to drop after this is merged.

## Checklist

- [ ] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
