### PR TITLE
docs(fix): add cli redirect

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -140,6 +140,10 @@ const config = {
             from: ['/cli/test-definition-file' /*, '/docs/legacyDocFrom2016'*/],
           },
           {
+            to: '/cli/configuring-your-cli/',
+            from: ['/cli/command-line-tool' /*, '/docs/legacyDocFrom2016'*/],
+          },
+          {
             to: '/ci-cd-automation/github-actions-pipeline',
             from: ['/ci-cd-automation/ci-cd-best-practices' /*, '/docs/legacyDocFrom2016'*/],
           },


### PR DESCRIPTION
This PR adds a redirect to the a CLI page that was removed.

## Changes

-

## Fixes

-

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [x] updated the docs
- [ ] added a test
