### PR TITLE
feat: add endpoint to list events from a test run

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -863,7 +863,7 @@ paths:
         - in: path
           name: runId
           schema:
-            type: string
+            type: integer
           required: true
       summary: "get events from a test run"
       description: "get events from a test run"

--- a/api/testEvents.yaml
+++ b/api/testEvents.yaml
@@ -22,7 +22,7 @@ components:
         testId:
           type: string
         runId:
-          type: string
+          type: integer
         dataStoreConnection:
           $ref: "./config.yaml#/components/schemas/ConnectionResult"
         polling:

--- a/cli/openapi/api_api.go
+++ b/cli/openapi/api_api.go
@@ -2742,7 +2742,7 @@ type ApiGetTestRunEventsRequest struct {
 	ctx        context.Context
 	ApiService *ApiApiService
 	testId     string
-	runId      string
+	runId      int32
 }
 
 func (r ApiGetTestRunEventsRequest) Execute() ([]TestRunEvent, *http.Response, error) {
@@ -2759,7 +2759,7 @@ get events from a test run
  @param runId
  @return ApiGetTestRunEventsRequest
 */
-func (a *ApiApiService) GetTestRunEvents(ctx context.Context, testId string, runId string) ApiGetTestRunEventsRequest {
+func (a *ApiApiService) GetTestRunEvents(ctx context.Context, testId string, runId int32) ApiGetTestRunEventsRequest {
 	return ApiGetTestRunEventsRequest{
 		ApiService: a,
 		ctx:        ctx,

--- a/cli/openapi/model_test_run_event.go
+++ b/cli/openapi/model_test_run_event.go
@@ -26,7 +26,7 @@ type TestRunEvent struct {
 	Description         *string           `json:"description,omitempty"`
 	CreatedAt           *time.Time        `json:"createdAt,omitempty"`
 	TestId              *string           `json:"testId,omitempty"`
-	RunId               *string           `json:"runId,omitempty"`
+	RunId               *int32            `json:"runId,omitempty"`
 	DataStoreConnection *ConnectionResult `json:"dataStoreConnection,omitempty"`
 	Polling             *PollingInfo      `json:"polling,omitempty"`
 	Outputs             []OutputInfo      `json:"outputs,omitempty"`
@@ -242,9 +242,9 @@ func (o *TestRunEvent) SetTestId(v string) {
 }
 
 // GetRunId returns the RunId field value if set, zero value otherwise.
-func (o *TestRunEvent) GetRunId() string {
+func (o *TestRunEvent) GetRunId() int32 {
 	if o == nil || isNil(o.RunId) {
-		var ret string
+		var ret int32
 		return ret
 	}
 	return *o.RunId
@@ -252,7 +252,7 @@ func (o *TestRunEvent) GetRunId() string {
 
 // GetRunIdOk returns a tuple with the RunId field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *TestRunEvent) GetRunIdOk() (*string, bool) {
+func (o *TestRunEvent) GetRunIdOk() (*int32, bool) {
 	if o == nil || isNil(o.RunId) {
 		return nil, false
 	}
@@ -268,8 +268,8 @@ func (o *TestRunEvent) HasRunId() bool {
 	return false
 }
 
-// SetRunId gets a reference to the given string and assigns it to the RunId field.
-func (o *TestRunEvent) SetRunId(v string) {
+// SetRunId gets a reference to the given int32 and assigns it to the RunId field.
+func (o *TestRunEvent) SetRunId(v int32) {
 	o.RunId = &v
 }
 

--- a/server/http/controller.go
+++ b/server/http/controller.go
@@ -184,8 +184,13 @@ func (c *controller) GetTestRun(ctx context.Context, testID, runID string) (open
 	return openapi.Response(200, c.mappers.Out.Run(&run)), nil
 }
 
-func (*controller) GetTestRunEvents(context.Context, string, string) (openapi.ImplResponse, error) {
-	return openapi.Response(http.StatusOK, []openapi.TestRunEvent{}), nil
+func (c *controller) GetTestRunEvents(ctx context.Context, testID string, runID int32) (openapi.ImplResponse, error) {
+	events, err := c.testDB.GetTestRunEvents(ctx, id.ID(testID), int(runID))
+	if err != nil {
+		return openapi.Response(http.StatusInternalServerError, nil), err
+	}
+
+	return openapi.Response(http.StatusOK, c.mappers.Out.TestRunEvents(events)), nil
 }
 
 func (c *controller) DeleteTestRun(ctx context.Context, testID, runID string) (openapi.ImplResponse, error) {

--- a/server/http/mappings/test_run_events.go
+++ b/server/http/mappings/test_run_events.go
@@ -1,0 +1,64 @@
+package mappings
+
+import (
+	"github.com/kubeshop/tracetest/server/model"
+	"github.com/kubeshop/tracetest/server/openapi"
+)
+
+func (m OpenAPI) TestRunEvents(in []model.TestRunEvent) []openapi.TestRunEvent {
+	out := make([]openapi.TestRunEvent, 0, len(in))
+	for _, event := range in {
+		out = append(out, m.TestRunEvent(event))
+	}
+
+	return out
+}
+
+func (m OpenAPI) TestRunEvent(in model.TestRunEvent) openapi.TestRunEvent {
+	return openapi.TestRunEvent{
+		Type:                in.Type,
+		Stage:               string(in.Stage),
+		Description:         in.Description,
+		CreatedAt:           in.CreatedAt,
+		TestId:              string(in.TestID),
+		RunId:               int32(in.RunID),
+		DataStoreConnection: m.ConnectionTestResult(in.DataStoreConnection),
+		Polling:             m.PollingInfo(in.Polling),
+		Outputs:             m.OutputsInfo(in.Outputs),
+	}
+}
+
+func (m OpenAPI) PollingInfo(in model.PollingInfo) openapi.PollingInfo {
+	return openapi.PollingInfo{
+		Type:                string(in.Type),
+		ReasonNextIteration: in.ReasonNextIteration,
+		IsComplete:          in.IsComplete,
+		Periodic:            m.PeriodicPollingInfo(in.Periodic),
+	}
+}
+
+func (m OpenAPI) PeriodicPollingInfo(in *model.PeriodicPollingConfig) openapi.PollingInfoPeriodic {
+	if in == nil {
+		return openapi.PollingInfoPeriodic{}
+	}
+
+	return openapi.PollingInfoPeriodic{
+		NumberSpans:      int32(in.NumberSpans),
+		NumberIterations: int32(in.NumberIterations),
+	}
+}
+
+func (m OpenAPI) OutputsInfo(in []model.OutputInfo) []openapi.OutputInfo {
+	out := make([]openapi.OutputInfo, 0, len(in))
+	for _, output := range in {
+		newOutput := openapi.OutputInfo{
+			LogLevel:   string(output.LogLevel),
+			Message:    output.Message,
+			OutputName: output.OutputName,
+		}
+
+		out = append(out, newOutput)
+	}
+
+	return out
+}

--- a/server/openapi/api.go
+++ b/server/openapi/api.go
@@ -116,7 +116,7 @@ type ApiApiServicer interface {
 	GetTest(context.Context, string) (ImplResponse, error)
 	GetTestResultSelectedSpans(context.Context, string, string, string) (ImplResponse, error)
 	GetTestRun(context.Context, string, string) (ImplResponse, error)
-	GetTestRunEvents(context.Context, string, string) (ImplResponse, error)
+	GetTestRunEvents(context.Context, string, int32) (ImplResponse, error)
 	GetTestRuns(context.Context, string, int32, int32) (ImplResponse, error)
 	GetTestSpecs(context.Context, string) (ImplResponse, error)
 	GetTestVersion(context.Context, string, int32) (ImplResponse, error)

--- a/server/openapi/api_api.go
+++ b/server/openapi/api_api.go
@@ -858,7 +858,11 @@ func (c *ApiApiController) GetTestRunEvents(w http.ResponseWriter, r *http.Reque
 	params := mux.Vars(r)
 	testIdParam := params["testId"]
 
-	runIdParam := params["runId"]
+	runIdParam, err := parseInt32Parameter(params["runId"], true)
+	if err != nil {
+		c.errorHandler(w, r, &ParsingError{Err: err}, nil)
+		return
+	}
 
 	result, err := c.service.GetTestRunEvents(r.Context(), testIdParam, runIdParam)
 	// If an error occurred, encode the error with the status code

--- a/server/openapi/model_test_run_event.go
+++ b/server/openapi/model_test_run_event.go
@@ -26,7 +26,7 @@ type TestRunEvent struct {
 
 	TestId string `json:"testId,omitempty"`
 
-	RunId string `json:"runId,omitempty"`
+	RunId int32 `json:"runId,omitempty"`
 
 	DataStoreConnection ConnectionResult `json:"dataStoreConnection,omitempty"`
 

--- a/web/src/types/Generated.types.ts
+++ b/web/src/types/Generated.types.ts
@@ -818,7 +818,7 @@ export interface operations {
     parameters: {
       path: {
         testId: string;
-        runId: string;
+        runId: number;
       };
     };
     responses: {
@@ -1802,7 +1802,7 @@ export interface external {
           /** Format: date-time */
           createdAt?: string;
           testId?: string;
-          runId?: string;
+          runId?: number;
           dataStoreConnection?: external["config.yaml"]["components"]["schemas"]["ConnectionResult"];
           polling?: external["testEvents.yaml"]["components"]["schemas"]["PollingInfo"];
           outputs?: external["testEvents.yaml"]["components"]["schemas"]["OutputInfo"][];


### PR DESCRIPTION
This PR adds the endpoint to get events from a test run: `GET /api/tests/:testID/run/:runID/events`

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
