### PR TITLE
Added test change to stop flaky test

### DIFF
--- a/server/integration/ensure_server_prefix_test.go
+++ b/server/integration/ensure_server_prefix_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"sync"
 	"testing"
 	"time"
 
@@ -21,9 +22,16 @@ func getTracetestApp(options ...testmock.TestingAppOption) (*app.App, error) {
 		return nil, err
 	}
 
-	go tracetestApp.Start()
+	var wg sync.WaitGroup
+	wg.Add(1)
 
-	time.Sleep(1 * time.Second)
+	go func() {
+		tracetestApp.Start()
+		time.Sleep(1 * time.Second)
+		wg.Done()
+	}()
+
+	wg.Wait()
 
 	return tracetestApp, nil
 }


### PR DESCRIPTION
This PR aims to fix a problem on TestServerPrefix when running it on OSX.

Running `make test` inside `./server` should correctly now.

## Changes

- Add one sync statement to avoid racing conditions on TestServerPrefix test (made with @mathnogueira ).

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
