### PR TITLE
docs: add pre scripts for start and build

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -4,7 +4,9 @@
   "private": true,
   "scripts": {
     "docusaurus": "docusaurus",
+    "prestart": "cd ../cli; make docgen;",
     "start": "docusaurus start",
+    "prebuild": "cd ../cli; make docgen;",
     "build": "docusaurus build",
     "swizzle": "docusaurus swizzle",
     "deploy": "docusaurus deploy",


### PR DESCRIPTION
This PR adds a hook to generate the CLI reference docs before running the `build` and `start` scripts.

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
