### PR TITLE
feat: emit unreachable host events for http and grpc triggers

### DIFF
--- a/server/executor/runner.go
+++ b/server/executor/runner.go
@@ -288,9 +288,14 @@ func (r persistentRunner) emitUnreachableEndpointEvent(job execReq, err error) {
 }
 
 func isConnectionError(err error) bool {
-	// check if root cause is a dial error
 	for err != nil {
+		// a dial error means we couldn't open a TCP connection (either host is not available or DNS doesn't exist)
 		if strings.HasPrefix(err.Error(), "dial ") {
+			return true
+		}
+
+		// it means a trigger timeout
+		if errors.Is(err, context.DeadlineExceeded) {
 			return true
 		}
 

--- a/server/executor/runner.go
+++ b/server/executor/runner.go
@@ -2,7 +2,9 @@ package executor
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/kubeshop/tracetest/server/executor/trigger"
 	"github.com/kubeshop/tracetest/server/expression"
@@ -229,6 +231,10 @@ func (r persistentRunner) processExecQueue(job execReq) {
 	response, err := triggerer.Trigger(job.ctx, resolvedTest, triggerOptions)
 	run = r.handleExecutionResult(run, response, err)
 	if err != nil {
+		if isConnectionError(err) {
+			r.emitUnreachableEndpointEvent(job, err)
+		}
+
 		emitErr := r.eventEmitter.Emit(job.ctx, events.TriggerExecutionError(job.run.TestID, job.run.ID, err))
 		if emitErr != nil {
 			r.handleError(job.run, emitErr)
@@ -264,4 +270,32 @@ func (r persistentRunner) handleExecutionResult(run model.Run, response trigger.
 	}
 
 	return run.SuccessfullyTriggered()
+}
+
+func (r persistentRunner) emitUnreachableEndpointEvent(job execReq, err error) {
+	var event model.TestRunEvent
+	switch job.test.ServiceUnderTest.Type {
+	case model.TriggerTypeHTTP:
+		event = events.TriggerHTTPUnreachableHostError(job.run.TestID, job.run.ID, err)
+	case model.TriggerTypeGRPC:
+		event = events.TriggergRPCUnreachableHostError(job.run.TestID, job.run.ID, err)
+	}
+
+	emitErr := r.eventEmitter.Emit(job.ctx, event)
+	if emitErr != nil {
+		r.handleError(job.run, emitErr)
+	}
+}
+
+func isConnectionError(err error) bool {
+	// check if root cause is a dial error
+	for err != nil {
+		if strings.HasPrefix(err.Error(), "dial ") {
+			return true
+		}
+
+		err = errors.Unwrap(err)
+	}
+
+	return false
 }

--- a/server/model/events/events.go
+++ b/server/model/events/events.go
@@ -113,14 +113,14 @@ func TriggerExecutionError(testID id.ID, runID int, err error) model.TestRunEven
 	}
 }
 
-func TriggerHTTPUnreachableHostError(testID id.ID, runID int) model.TestRunEvent {
+func TriggerHTTPUnreachableHostError(testID id.ID, runID int, err error) model.TestRunEvent {
 	return model.TestRunEvent{
 		TestID:              testID,
 		RunID:               runID,
 		Stage:               model.StageTrigger,
 		Type:                "HTTP_UNREACHABLE_HOST_ERROR",
 		Title:               "Tracetest could not reach the defined host in the trigger",
-		Description:         "Tracetest could not reach the defined host in the trigger",
+		Description:         fmt.Sprintf("Tracetest could not reach the defined host in the trigger: %s", err.Error()),
 		CreatedAt:           time.Now(),
 		DataStoreConnection: model.ConnectionResult{},
 		Polling:             model.PollingInfo{},
@@ -143,14 +143,14 @@ func TriggerDockerComposeHostMismatchError(testID id.ID, runID int) model.TestRu
 	}
 }
 
-func TriggergRPCUnreachableHostError(testID id.ID, runID int) model.TestRunEvent {
+func TriggergRPCUnreachableHostError(testID id.ID, runID int, err error) model.TestRunEvent {
 	return model.TestRunEvent{
 		TestID:              testID,
 		RunID:               runID,
 		Stage:               model.StageTrigger,
 		Type:                "GRPC_UNREACHABLE_HOST_ERROR",
 		Title:               "Tracetest could not reach the defined host in the trigger",
-		Description:         "Tracetest could not reach the defined host in the trigger",
+		Description:         fmt.Sprintf("Tracetest could not reach the defined host in the trigger: %s", err.Error()),
 		CreatedAt:           time.Now(),
 		DataStoreConnection: model.ConnectionResult{},
 		Polling:             model.PollingInfo{},


### PR DESCRIPTION
This PR adds events when trying to triggering http and grpc endpoints but they are unreachable

![image](https://user-images.githubusercontent.com/2704737/229206946-45f72319-fdcb-4b2c-9945-b3bbb47faa18.png)


## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
