### PR TITLE
fix: add title to test run event response

### DIFF
--- a/server/http/mappings/test_run_events.go
+++ b/server/http/mappings/test_run_events.go
@@ -18,6 +18,7 @@ func (m OpenAPI) TestRunEvent(in model.TestRunEvent) openapi.TestRunEvent {
 	return openapi.TestRunEvent{
 		Type:                in.Type,
 		Stage:               string(in.Stage),
+		Title:               in.Title,
 		Description:         in.Description,
 		CreatedAt:           in.CreatedAt,
 		TestId:              string(in.TestID),


### PR DESCRIPTION
This PR makes the openapi mapping function to set the title to the event response

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
