### PR TITLE
fix: wait until PR environment is ready before running tests

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -319,9 +319,9 @@ jobs:
         run: |
           kubectl port-forward \
             --namespace tracetest-pr-${{ github.event.pull_request.number }} \
-            svc/tracetest-pr-${{ github.event.pull_request.number }} 11633 &
+            svc/tracetest-pr-${{ github.event.pull_request.number }} 11633:11634 &
 
-          ./scripts/wait-for-port.sh 11633
+          ./scripts/wait-for-port.sh 11634
 
       - name: Run integration tests
         run: |

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -319,7 +319,7 @@ jobs:
         run: |
           kubectl port-forward \
             --namespace tracetest-pr-${{ github.event.pull_request.number }} \
-            svc/tracetest-pr-${{ github.event.pull_request.number }} 11633:11634 &
+            svc/tracetest-pr-${{ github.event.pull_request.number }} 11634:11633 &
 
           ./scripts/wait-for-port.sh 11634
 

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -315,6 +315,14 @@ jobs:
 
           ./scripts/wait-for-port.sh 11633
 
+      - name: Connecting with PR env (port-forwarding)
+        run: |
+          kubectl port-forward \
+            --namespace tracetest-pr-${{ github.event.pull_request.number }} \
+            svc/tracetest-pr-${{ github.event.pull_request.number }} 11633 &
+
+          ./scripts/wait-for-port.sh 11633
+
       - name: Run integration tests
         run: |
           cd tracetesting


### PR DESCRIPTION
This PR fixes the PR pipeline. Lately, it's been failing because the PR environment is not ready when the integration instance starts sending requests. I was restarting the Tracetest pod in the PR namespace in order for to it start faster after failing to connect to the database.

This PR aims to allow the tests to be run after the instance is up and running.


## Checklist

- [ ] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
