### PR TITLE
feat: make expression package return ErrExpressionResolution when resolution fails

### DIFF
--- a/server/expression/data_store.go
+++ b/server/expression/data_store.go
@@ -1,6 +1,7 @@
 package expression
 
 import (
+	"errors"
 	"fmt"
 	"strconv"
 
@@ -21,7 +22,12 @@ func (ds AttributeDataStore) Source() string {
 }
 
 func (ds AttributeDataStore) Get(name string) (string, error) {
-	return ds.Span.Attributes.Get(name), nil
+	value := ds.Span.Attributes.Get(name)
+	if value == "" {
+		return "", errors.New("attribute not found")
+	}
+
+	return value, nil
 }
 
 type MetaAttributesDataStore struct {
@@ -74,5 +80,5 @@ func (ds EnvironmentDataStore) Get(name string) (string, error) {
 		}
 	}
 
-	return "", nil
+	return "", fmt.Errorf("environment variable not found")
 }

--- a/server/expression/errors.go
+++ b/server/expression/errors.go
@@ -1,0 +1,36 @@
+package expression
+
+import (
+	"errors"
+	"fmt"
+)
+
+var ErrExpressionResolution error = errors.New("error when resolving expression")
+
+type ResourceType string
+
+var (
+	ResourceTypeAttribute           ResourceType = "attribute"
+	ResourceTypeEnvironmentVariable ResourceType = "environment variable"
+	ResourceTypeFunction            ResourceType = "function"
+	ResourceTypeArrayItem           ResourceType = "array item"
+	ResourceTypeFunctionArgument    ResourceType = "function argument"
+	ResourceTypeFilter              ResourceType = "filter"
+	ResourceTypeOperator            ResourceType = "operator"
+)
+
+type ResolutionError struct {
+	Type     ResourceType
+	Name     string
+	InnerErr error
+}
+
+func resolutionError(typ ResourceType, name string, innerErr error) error {
+	newError := fmt.Errorf(`%w: %s "%s"`, ErrExpressionResolution, typ, name)
+
+	if innerErr != nil {
+		newError = fmt.Errorf("%w: %s", newError, innerErr.Error())
+	}
+
+	return newError
+}

--- a/server/expression/executor_test.go
+++ b/server/expression/executor_test.go
@@ -7,15 +7,18 @@ import (
 	"github.com/kubeshop/tracetest/server/expression"
 	"github.com/kubeshop/tracetest/server/model"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 type executorTestCase struct {
-	Name       string
-	Query      string
-	ShouldPass bool
+	Name                 string
+	Query                string
+	ShouldPass           bool
+	ExpectedErrorMessage string
 
 	AttributeDataStore      expression.DataStore
 	MetaAttributesDataStore expression.DataStore
+	EnvironmentDataStore    expression.DataStore
 }
 
 func TestBasicExpressionExecution(t *testing.T) {
@@ -405,19 +408,71 @@ func TestResolveStatementFilterExecution(t *testing.T) {
 	executeResolveStatementTestCases(t, testCases)
 }
 
+func TestFailureCases(t *testing.T) {
+	testCases := []executorTestCase{
+		{
+			Name:                 "should_report_missing_environment_variable",
+			Query:                `env:test = "abc"`,
+			ShouldPass:           false,
+			ExpectedErrorMessage: `error when resolving expression: environment variable "test": environment variable not found`,
+
+			EnvironmentDataStore: expression.EnvironmentDataStore{
+				Values: []model.EnvironmentValue{},
+			},
+		},
+		{
+			Name:                 "should_report_missing_attribute",
+			Query:                `attr:my_attribute = "abc"`,
+			ShouldPass:           false,
+			ExpectedErrorMessage: `error when resolving expression: attribute "my_attribute": attribute not found`,
+
+			AttributeDataStore: expression.AttributeDataStore{
+				Span: model.Span{
+					Attributes: model.Attributes{
+						"attr1": "1",
+						"attr2": "2",
+					},
+				},
+			},
+		},
+		{
+			Name:                 "should_report_missing_filter",
+			Query:                `"value" | missingFilter = "abc"`,
+			ShouldPass:           false,
+			ExpectedErrorMessage: `error when resolving expression: filter "missingFilter": filter not found`,
+		},
+		{
+			Name:                 "should_report_problem_resolving_array_item",
+			Query:                `["value", env:test, "anotherValue"] | get_index 0`,
+			ShouldPass:           false,
+			ExpectedErrorMessage: `error when resolving expression: array item "index 1": error when resolving expression: environment variable "test": environment variable not found`,
+
+			EnvironmentDataStore: expression.EnvironmentDataStore{
+				Values: []model.EnvironmentValue{},
+			},
+		},
+	}
+
+	executeResolveStatementTestCases(t, testCases)
+}
+
 func executeResolveStatementTestCases(t *testing.T, testCases []executorTestCase) {
 	for _, testCase := range testCases {
 		t.Run(testCase.Name, func(t *testing.T) {
 			executor := expression.NewExecutor(
 				testCase.AttributeDataStore,
 				testCase.MetaAttributesDataStore,
+				testCase.EnvironmentDataStore,
 			)
 			left, err := executor.ResolveStatement(testCase.Query)
 			debugMessage := fmt.Sprintf("left value: %s", left)
 			if testCase.ShouldPass {
 				assert.NoError(t, err, debugMessage)
 			} else {
-				assert.Error(t, err, debugMessage)
+				require.Error(t, err, debugMessage)
+				if testCase.ExpectedErrorMessage != "" {
+					assert.Contains(t, err.Error(), testCase.ExpectedErrorMessage)
+				}
 			}
 		})
 	}

--- a/server/expression/filters.go
+++ b/server/expression/filters.go
@@ -21,7 +21,7 @@ var filterFunctions = map[string]filterFn{
 func executeFilter(input value.Value, filterName string, args []string) (value.Value, error) {
 	fn, found := filterFunctions[filterName]
 	if !found {
-		return value.Value{}, fmt.Errorf("filter %s was not found", filterName)
+		return value.Nil, resolutionError(ResourceTypeFilter, filterName, fmt.Errorf("filter not found"))
 	}
 
 	output, err := fn(input, args...)


### PR DESCRIPTION
This PR makes the expression package return a ErrExpressionResolution when an expression or statement is executed and any resolution step fails and returns some context of why it failed.

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [x] added a test
