### PR TITLE
feat(sever): for test runs, split the failed state into more descriptive statuses

### DIFF
--- a/api/tests.yaml
+++ b/api/tests.yaml
@@ -128,7 +128,9 @@ components:
               AWAITING_TRACE,
               AWAITING_TEST_RESULTS,
               FINISHED,
-              FAILED,
+              TRIGGER_FAILED,
+              TRACE_FAILED,
+              ASSERTION_FAILED,
             ]
           description: Current execution state
         lastErrorState:

--- a/cli/actions/run_test_action.go
+++ b/cli/actions/run_test_action.go
@@ -19,6 +19,7 @@ import (
 	"github.com/kubeshop/tracetest/cli/formatters"
 	"github.com/kubeshop/tracetest/cli/openapi"
 	"github.com/kubeshop/tracetest/cli/ui"
+	"github.com/kubeshop/tracetest/cli/utils"
 	"github.com/kubeshop/tracetest/server/model/yaml"
 	"go.uber.org/zap"
 )
@@ -440,7 +441,7 @@ func (a runTestAction) transactionRun(ctx context.Context, transaction openapi.T
 	fmt.Print(formattedOutput)
 
 	if params.WaitForResult {
-		if tro.Run.GetState() == "FAILED" {
+		if utils.RunStateIsFailed(tro.Run.GetState()) {
 			// It failed, so we have to return an error status
 			os.Exit(1)
 		}
@@ -579,7 +580,7 @@ func (a runTestAction) isTestReady(ctx context.Context, testID, testRunId string
 		return &openapi.TestRun{}, fmt.Errorf("could not execute GetTestRun request: %w", err)
 	}
 
-	if *run.State == "FAILED" || *run.State == "FINISHED" {
+	if utils.RunStateIsFinished(run.GetState()) {
 		return run, nil
 	}
 
@@ -598,7 +599,7 @@ func (a runTestAction) isTransactionReady(ctx context.Context, transactionID, tr
 		return nil, fmt.Errorf("could not execute GetTestRun request: %w", err)
 	}
 
-	if *run.State == "FAILED" || *run.State == "FINISHED" {
+	if utils.RunStateIsFinished(run.GetState()) {
 		return run, nil
 	}
 

--- a/cli/formatters/test_run.go
+++ b/cli/formatters/test_run.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/kubeshop/tracetest/cli/config"
 	"github.com/kubeshop/tracetest/cli/openapi"
+	"github.com/kubeshop/tracetest/cli/utils"
 	"github.com/pterm/pterm"
 )
 
@@ -77,7 +78,7 @@ func (f testRun) json(output TestRunOutput) string {
 }
 
 func (f testRun) pretty(output TestRunOutput) string {
-	if output.Run.State != nil && *output.Run.State == "FAILED" {
+	if utils.RunStateIsFailed(output.Run.GetState()) {
 		return f.getColoredText(false, f.formatMessage("Failed to execute test: %s", *output.Run.LastErrorState))
 	}
 

--- a/cli/formatters/transaction_run.go
+++ b/cli/formatters/transaction_run.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/kubeshop/tracetest/cli/config"
 	"github.com/kubeshop/tracetest/cli/openapi"
+	"github.com/kubeshop/tracetest/cli/utils"
 	"github.com/pterm/pterm"
 )
 
@@ -78,7 +79,7 @@ func (f transactionRun) json(output TransactionRunOutput) string {
 }
 
 func (f transactionRun) pretty(output TransactionRunOutput) string {
-	if output.Run.GetState() == "FAILED" {
+	if utils.RunStateIsFailed(output.Run.GetState()) {
 		errorMessage := ""
 		if len(output.Run.Steps) > 0 {
 			lastStep := output.Run.Steps[len(output.Run.Steps)-1]

--- a/cli/openapi/api_api.go
+++ b/cli/openapi/api_api.go
@@ -42,8 +42,8 @@ CreateDataStore Create a new Data Store
 
 Create a new Data Store
 
- @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @return ApiCreateDataStoreRequest
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@return ApiCreateDataStoreRequest
 */
 func (a *ApiApiService) CreateDataStore(ctx context.Context) ApiCreateDataStoreRequest {
 	return ApiCreateDataStoreRequest{
@@ -53,7 +53,8 @@ func (a *ApiApiService) CreateDataStore(ctx context.Context) ApiCreateDataStoreR
 }
 
 // Execute executes the request
-//  @return DataStore
+//
+//	@return DataStore
 func (a *ApiApiService) CreateDataStoreExecute(r ApiCreateDataStoreRequest) (*DataStore, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPost
@@ -149,8 +150,8 @@ CreateEnvironment Create new environment
 
 Create new environment action
 
- @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @return ApiCreateEnvironmentRequest
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@return ApiCreateEnvironmentRequest
 */
 func (a *ApiApiService) CreateEnvironment(ctx context.Context) ApiCreateEnvironmentRequest {
 	return ApiCreateEnvironmentRequest{
@@ -160,7 +161,8 @@ func (a *ApiApiService) CreateEnvironment(ctx context.Context) ApiCreateEnvironm
 }
 
 // Execute executes the request
-//  @return Environment
+//
+//	@return Environment
 func (a *ApiApiService) CreateEnvironmentExecute(r ApiCreateEnvironmentRequest) (*Environment, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPost
@@ -256,8 +258,8 @@ CreateTest Create new test
 
 Create new test action
 
- @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @return ApiCreateTestRequest
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@return ApiCreateTestRequest
 */
 func (a *ApiApiService) CreateTest(ctx context.Context) ApiCreateTestRequest {
 	return ApiCreateTestRequest{
@@ -267,7 +269,8 @@ func (a *ApiApiService) CreateTest(ctx context.Context) ApiCreateTestRequest {
 }
 
 // Execute executes the request
-//  @return Test
+//
+//	@return Test
 func (a *ApiApiService) CreateTestExecute(r ApiCreateTestRequest) (*Test, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPost
@@ -363,8 +366,8 @@ CreateTransaction Create new transaction
 
 Create new transaction
 
- @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @return ApiCreateTransactionRequest
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@return ApiCreateTransactionRequest
 */
 func (a *ApiApiService) CreateTransaction(ctx context.Context) ApiCreateTransactionRequest {
 	return ApiCreateTransactionRequest{
@@ -374,7 +377,8 @@ func (a *ApiApiService) CreateTransaction(ctx context.Context) ApiCreateTransact
 }
 
 // Execute executes the request
-//  @return Transaction
+//
+//	@return Transaction
 func (a *ApiApiService) CreateTransactionExecute(r ApiCreateTransactionRequest) (*Transaction, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPost
@@ -465,9 +469,9 @@ DeleteDataStore Delete a Data Store
 
 Delete a Data Store
 
- @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @param dataStoreId
- @return ApiDeleteDataStoreRequest
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param dataStoreId
+	@return ApiDeleteDataStoreRequest
 */
 func (a *ApiApiService) DeleteDataStore(ctx context.Context, dataStoreId string) ApiDeleteDataStoreRequest {
 	return ApiDeleteDataStoreRequest{
@@ -557,9 +561,9 @@ DeleteEnvironment delete a environment
 
 delete a environment
 
- @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @param environmentId
- @return ApiDeleteEnvironmentRequest
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param environmentId
+	@return ApiDeleteEnvironmentRequest
 */
 func (a *ApiApiService) DeleteEnvironment(ctx context.Context, environmentId string) ApiDeleteEnvironmentRequest {
 	return ApiDeleteEnvironmentRequest{
@@ -649,9 +653,9 @@ DeleteTest delete a test
 
 delete a test
 
- @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @param testId
- @return ApiDeleteTestRequest
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param testId
+	@return ApiDeleteTestRequest
 */
 func (a *ApiApiService) DeleteTest(ctx context.Context, testId string) ApiDeleteTestRequest {
 	return ApiDeleteTestRequest{
@@ -742,10 +746,10 @@ DeleteTestRun delete a test run
 
 delete a test run
 
- @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @param testId
- @param runId
- @return ApiDeleteTestRunRequest
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param testId
+	@param runId
+	@return ApiDeleteTestRunRequest
 */
 func (a *ApiApiService) DeleteTestRun(ctx context.Context, testId string, runId string) ApiDeleteTestRunRequest {
 	return ApiDeleteTestRunRequest{
@@ -837,9 +841,9 @@ DeleteTransaction delete a transaction
 
 delete a transaction
 
- @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @param transactionId
- @return ApiDeleteTransactionRequest
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param transactionId
+	@return ApiDeleteTransactionRequest
 */
 func (a *ApiApiService) DeleteTransaction(ctx context.Context, transactionId string) ApiDeleteTransactionRequest {
 	return ApiDeleteTransactionRequest{
@@ -930,10 +934,10 @@ DeleteTransactionRun Delete a specific run from a particular transaction
 
 Delete a specific run from a particular transaction
 
- @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @param transactionId
- @param runId
- @return ApiDeleteTransactionRunRequest
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param transactionId
+	@param runId
+	@return ApiDeleteTransactionRunRequest
 */
 func (a *ApiApiService) DeleteTransactionRun(ctx context.Context, transactionId string, runId int32) ApiDeleteTransactionRunRequest {
 	return ApiDeleteTransactionRunRequest{
@@ -1032,10 +1036,10 @@ DryRunAssertion run given assertions against the traces from the given run witho
 
 use this method to test a definition against an actual trace without creating a new version or persisting anything
 
- @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @param testId
- @param runId
- @return ApiDryRunAssertionRequest
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param testId
+	@param runId
+	@return ApiDryRunAssertionRequest
 */
 func (a *ApiApiService) DryRunAssertion(ctx context.Context, testId string, runId string) ApiDryRunAssertionRequest {
 	return ApiDryRunAssertionRequest{
@@ -1047,7 +1051,8 @@ func (a *ApiApiService) DryRunAssertion(ctx context.Context, testId string, runI
 }
 
 // Execute executes the request
-//  @return AssertionResults
+//
+//	@return AssertionResults
 func (a *ApiApiService) DryRunAssertionExecute(r ApiDryRunAssertionRequest) (*AssertionResults, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPut
@@ -1145,8 +1150,8 @@ ExecuteDefinition Execute a definition
 
 Execute a definition
 
- @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @return ApiExecuteDefinitionRequest
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@return ApiExecuteDefinitionRequest
 */
 func (a *ApiApiService) ExecuteDefinition(ctx context.Context) ApiExecuteDefinitionRequest {
 	return ApiExecuteDefinitionRequest{
@@ -1156,7 +1161,8 @@ func (a *ApiApiService) ExecuteDefinition(ctx context.Context) ApiExecuteDefinit
 }
 
 // Execute executes the request
-//  @return ExecuteDefinitionResponse
+//
+//	@return ExecuteDefinitionResponse
 func (a *ApiApiService) ExecuteDefinitionExecute(r ApiExecuteDefinitionRequest) (*ExecuteDefinitionResponse, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPost
@@ -1248,10 +1254,10 @@ ExportTestRun export test and test run information
 
 export test and test run information for debugging
 
- @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @param testId
- @param runId
- @return ApiExportTestRunRequest
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param testId
+	@param runId
+	@return ApiExportTestRunRequest
 */
 func (a *ApiApiService) ExportTestRun(ctx context.Context, testId string, runId string) ApiExportTestRunRequest {
 	return ApiExportTestRunRequest{
@@ -1263,7 +1269,8 @@ func (a *ApiApiService) ExportTestRun(ctx context.Context, testId string, runId 
 }
 
 // Execute executes the request
-//  @return ExportedTestInformation
+//
+//	@return ExportedTestInformation
 func (a *ApiApiService) ExportTestRunExecute(r ApiExportTestRunRequest) (*ExportedTestInformation, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
@@ -1359,8 +1366,8 @@ ExpressionResolve resolves an expression and returns the result string
 
 resolves an expression and returns the result string
 
- @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @return ApiExpressionResolveRequest
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@return ApiExpressionResolveRequest
 */
 func (a *ApiApiService) ExpressionResolve(ctx context.Context) ApiExpressionResolveRequest {
 	return ApiExpressionResolveRequest{
@@ -1370,7 +1377,8 @@ func (a *ApiApiService) ExpressionResolve(ctx context.Context) ApiExpressionReso
 }
 
 // Execute executes the request
-//  @return ResolveResponseInfo
+//
+//	@return ResolveResponseInfo
 func (a *ApiApiService) ExpressionResolveExecute(r ApiExpressionResolveRequest) (*ResolveResponseInfo, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPost
@@ -1461,9 +1469,9 @@ GetDataStore Get a Data Store
 
 Get a Data Store
 
- @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @param dataStoreId
- @return ApiGetDataStoreRequest
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param dataStoreId
+	@return ApiGetDataStoreRequest
 */
 func (a *ApiApiService) GetDataStore(ctx context.Context, dataStoreId string) ApiGetDataStoreRequest {
 	return ApiGetDataStoreRequest{
@@ -1474,7 +1482,8 @@ func (a *ApiApiService) GetDataStore(ctx context.Context, dataStoreId string) Ap
 }
 
 // Execute executes the request
-//  @return DataStore
+//
+//	@return DataStore
 func (a *ApiApiService) GetDataStoreExecute(r ApiGetDataStoreRequest) (*DataStore, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
@@ -1564,9 +1573,9 @@ GetDataStoreDefinitionFile Get the data store definition as an YAML file
 
 Get the data store as an YAML file
 
- @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @param dataStoreId
- @return ApiGetDataStoreDefinitionFileRequest
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param dataStoreId
+	@return ApiGetDataStoreDefinitionFileRequest
 */
 func (a *ApiApiService) GetDataStoreDefinitionFile(ctx context.Context, dataStoreId string) ApiGetDataStoreDefinitionFileRequest {
 	return ApiGetDataStoreDefinitionFileRequest{
@@ -1577,7 +1586,8 @@ func (a *ApiApiService) GetDataStoreDefinitionFile(ctx context.Context, dataStor
 }
 
 // Execute executes the request
-//  @return string
+//
+//	@return string
 func (a *ApiApiService) GetDataStoreDefinitionFileExecute(r ApiGetDataStoreDefinitionFileRequest) (string, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
@@ -1701,8 +1711,8 @@ GetDataStores Get all Data Stores
 
 Get all Data Stores
 
- @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @return ApiGetDataStoresRequest
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@return ApiGetDataStoresRequest
 */
 func (a *ApiApiService) GetDataStores(ctx context.Context) ApiGetDataStoresRequest {
 	return ApiGetDataStoresRequest{
@@ -1712,7 +1722,8 @@ func (a *ApiApiService) GetDataStores(ctx context.Context) ApiGetDataStoresReque
 }
 
 // Execute executes the request
-//  @return []DataStore
+//
+//	@return []DataStore
 func (a *ApiApiService) GetDataStoresExecute(r ApiGetDataStoresRequest) ([]DataStore, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
@@ -1816,9 +1827,9 @@ GetEnvironment get environment
 
 get environment
 
- @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @param environmentId
- @return ApiGetEnvironmentRequest
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param environmentId
+	@return ApiGetEnvironmentRequest
 */
 func (a *ApiApiService) GetEnvironment(ctx context.Context, environmentId string) ApiGetEnvironmentRequest {
 	return ApiGetEnvironmentRequest{
@@ -1829,7 +1840,8 @@ func (a *ApiApiService) GetEnvironment(ctx context.Context, environmentId string
 }
 
 // Execute executes the request
-//  @return Environment
+//
+//	@return Environment
 func (a *ApiApiService) GetEnvironmentExecute(r ApiGetEnvironmentRequest) (*Environment, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
@@ -1919,9 +1931,9 @@ GetEnvironmentDefinitionFile Get the environment definition as an YAML file
 
 Get the environment as an YAML file
 
- @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @param environmentId
- @return ApiGetEnvironmentDefinitionFileRequest
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param environmentId
+	@return ApiGetEnvironmentDefinitionFileRequest
 */
 func (a *ApiApiService) GetEnvironmentDefinitionFile(ctx context.Context, environmentId string) ApiGetEnvironmentDefinitionFileRequest {
 	return ApiGetEnvironmentDefinitionFileRequest{
@@ -1932,7 +1944,8 @@ func (a *ApiApiService) GetEnvironmentDefinitionFile(ctx context.Context, enviro
 }
 
 // Execute executes the request
-//  @return string
+//
+//	@return string
 func (a *ApiApiService) GetEnvironmentDefinitionFileExecute(r ApiGetEnvironmentDefinitionFileRequest) (string, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
@@ -2056,8 +2069,8 @@ GetEnvironments Get Environments
 
 Get Environments
 
- @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @return ApiGetEnvironmentsRequest
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@return ApiGetEnvironmentsRequest
 */
 func (a *ApiApiService) GetEnvironments(ctx context.Context) ApiGetEnvironmentsRequest {
 	return ApiGetEnvironmentsRequest{
@@ -2067,7 +2080,8 @@ func (a *ApiApiService) GetEnvironments(ctx context.Context) ApiGetEnvironmentsR
 }
 
 // Execute executes the request
-//  @return []Environment
+//
+//	@return []Environment
 func (a *ApiApiService) GetEnvironmentsExecute(r ApiGetEnvironmentsRequest) ([]Environment, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
@@ -2205,8 +2219,8 @@ GetResources Get resources
 
 get resources
 
- @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @return ApiGetResourcesRequest
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@return ApiGetResourcesRequest
 */
 func (a *ApiApiService) GetResources(ctx context.Context) ApiGetResourcesRequest {
 	return ApiGetResourcesRequest{
@@ -2216,7 +2230,8 @@ func (a *ApiApiService) GetResources(ctx context.Context) ApiGetResourcesRequest
 }
 
 // Execute executes the request
-//  @return []Resource
+//
+//	@return []Resource
 func (a *ApiApiService) GetResourcesExecute(r ApiGetResourcesRequest) ([]Resource, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
@@ -2321,10 +2336,10 @@ GetRunResultJUnit get test run results in JUnit xml format
 
 get test run results in JUnit xml format
 
- @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @param testId
- @param runId
- @return ApiGetRunResultJUnitRequest
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param testId
+	@param runId
+	@return ApiGetRunResultJUnitRequest
 */
 func (a *ApiApiService) GetRunResultJUnit(ctx context.Context, testId string, runId string) ApiGetRunResultJUnitRequest {
 	return ApiGetRunResultJUnitRequest{
@@ -2336,7 +2351,8 @@ func (a *ApiApiService) GetRunResultJUnit(ctx context.Context, testId string, ru
 }
 
 // Execute executes the request
-//  @return string
+//
+//	@return string
 func (a *ApiApiService) GetRunResultJUnitExecute(r ApiGetRunResultJUnitRequest) (string, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
@@ -2427,9 +2443,9 @@ GetTest get test
 
 get test
 
- @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @param testId
- @return ApiGetTestRequest
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param testId
+	@return ApiGetTestRequest
 */
 func (a *ApiApiService) GetTest(ctx context.Context, testId string) ApiGetTestRequest {
 	return ApiGetTestRequest{
@@ -2440,7 +2456,8 @@ func (a *ApiApiService) GetTest(ctx context.Context, testId string) ApiGetTestRe
 }
 
 // Execute executes the request
-//  @return Test
+//
+//	@return Test
 func (a *ApiApiService) GetTestExecute(r ApiGetTestRequest) (*Test, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
@@ -2537,10 +2554,10 @@ GetTestResultSelectedSpans retrieve spans that will be selected by selector
 
 get the spans ids that would be selected by a specific selector query
 
- @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @param testId
- @param runId
- @return ApiGetTestResultSelectedSpansRequest
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param testId
+	@param runId
+	@return ApiGetTestResultSelectedSpansRequest
 */
 func (a *ApiApiService) GetTestResultSelectedSpans(ctx context.Context, testId string, runId string) ApiGetTestResultSelectedSpansRequest {
 	return ApiGetTestResultSelectedSpansRequest{
@@ -2552,7 +2569,8 @@ func (a *ApiApiService) GetTestResultSelectedSpans(ctx context.Context, testId s
 }
 
 // Execute executes the request
-//  @return SelectedSpansResult
+//
+//	@return SelectedSpansResult
 func (a *ApiApiService) GetTestResultSelectedSpansExecute(r ApiGetTestResultSelectedSpansRequest) (*SelectedSpansResult, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
@@ -2647,10 +2665,10 @@ GetTestRun get test Run
 
 get a particular test Run
 
- @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @param testId
- @param runId
- @return ApiGetTestRunRequest
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param testId
+	@param runId
+	@return ApiGetTestRunRequest
 */
 func (a *ApiApiService) GetTestRun(ctx context.Context, testId string, runId string) ApiGetTestRunRequest {
 	return ApiGetTestRunRequest{
@@ -2662,7 +2680,8 @@ func (a *ApiApiService) GetTestRun(ctx context.Context, testId string, runId str
 }
 
 // Execute executes the request
-//  @return TestRun
+//
+//	@return TestRun
 func (a *ApiApiService) GetTestRunExecute(r ApiGetTestRunRequest) (*TestRun, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
@@ -2754,10 +2773,10 @@ GetTestRunEvents get events from a test run
 
 get events from a test run
 
- @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @param testId
- @param runId
- @return ApiGetTestRunEventsRequest
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param testId
+	@param runId
+	@return ApiGetTestRunEventsRequest
 */
 func (a *ApiApiService) GetTestRunEvents(ctx context.Context, testId string, runId int32) ApiGetTestRunEventsRequest {
 	return ApiGetTestRunEventsRequest{
@@ -2769,7 +2788,8 @@ func (a *ApiApiService) GetTestRunEvents(ctx context.Context, testId string, run
 }
 
 // Execute executes the request
-//  @return []TestRunEvent
+//
+//	@return []TestRunEvent
 func (a *ApiApiService) GetTestRunEventsExecute(r ApiGetTestRunEventsRequest) ([]TestRunEvent, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
@@ -2874,9 +2894,9 @@ GetTestRuns get the runs for a test
 
 get the runs from a particular test
 
- @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @param testId
- @return ApiGetTestRunsRequest
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param testId
+	@return ApiGetTestRunsRequest
 */
 func (a *ApiApiService) GetTestRuns(ctx context.Context, testId string) ApiGetTestRunsRequest {
 	return ApiGetTestRunsRequest{
@@ -2887,7 +2907,8 @@ func (a *ApiApiService) GetTestRuns(ctx context.Context, testId string) ApiGetTe
 }
 
 // Execute executes the request
-//  @return []TestRun
+//
+//	@return []TestRun
 func (a *ApiApiService) GetTestRunsExecute(r ApiGetTestRunsRequest) ([]TestRun, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
@@ -2983,9 +3004,9 @@ GetTestSpecs Get definition for a test
 
 Gets definition for a test
 
- @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @param testId
- @return ApiGetTestSpecsRequest
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param testId
+	@return ApiGetTestSpecsRequest
 */
 func (a *ApiApiService) GetTestSpecs(ctx context.Context, testId string) ApiGetTestSpecsRequest {
 	return ApiGetTestSpecsRequest{
@@ -2996,7 +3017,8 @@ func (a *ApiApiService) GetTestSpecs(ctx context.Context, testId string) ApiGetT
 }
 
 // Execute executes the request
-//  @return []TestSpecs
+//
+//	@return []TestSpecs
 func (a *ApiApiService) GetTestSpecsExecute(r ApiGetTestSpecsRequest) ([]TestSpecs, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
@@ -3087,10 +3109,10 @@ GetTestVersion get a test specific version
 
 get a test specific version
 
- @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @param testId
- @param version
- @return ApiGetTestVersionRequest
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param testId
+	@param version
+	@return ApiGetTestVersionRequest
 */
 func (a *ApiApiService) GetTestVersion(ctx context.Context, testId string, version int32) ApiGetTestVersionRequest {
 	return ApiGetTestVersionRequest{
@@ -3102,7 +3124,8 @@ func (a *ApiApiService) GetTestVersion(ctx context.Context, testId string, versi
 }
 
 // Execute executes the request
-//  @return Test
+//
+//	@return Test
 func (a *ApiApiService) GetTestVersionExecute(r ApiGetTestVersionRequest) (*Test, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
@@ -3194,10 +3217,10 @@ GetTestVersionDefinitionFile Get the test definition as an YAML file
 
 Get the test definition as an YAML file
 
- @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @param testId
- @param version
- @return ApiGetTestVersionDefinitionFileRequest
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param testId
+	@param version
+	@return ApiGetTestVersionDefinitionFileRequest
 */
 func (a *ApiApiService) GetTestVersionDefinitionFile(ctx context.Context, testId string, version int32) ApiGetTestVersionDefinitionFileRequest {
 	return ApiGetTestVersionDefinitionFileRequest{
@@ -3209,7 +3232,8 @@ func (a *ApiApiService) GetTestVersionDefinitionFile(ctx context.Context, testId
 }
 
 // Execute executes the request
-//  @return string
+//
+//	@return string
 func (a *ApiApiService) GetTestVersionDefinitionFileExecute(r ApiGetTestVersionDefinitionFileRequest) (string, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
@@ -3334,8 +3358,8 @@ GetTests Get tests
 
 get tests
 
- @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @return ApiGetTestsRequest
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@return ApiGetTestsRequest
 */
 func (a *ApiApiService) GetTests(ctx context.Context) ApiGetTestsRequest {
 	return ApiGetTestsRequest{
@@ -3345,7 +3369,8 @@ func (a *ApiApiService) GetTests(ctx context.Context) ApiGetTestsRequest {
 }
 
 // Execute executes the request
-//  @return []Test
+//
+//	@return []Test
 func (a *ApiApiService) GetTestsExecute(r ApiGetTestsRequest) ([]Test, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
@@ -3449,9 +3474,9 @@ GetTransaction get transaction
 
 get transaction
 
- @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @param transactionId
- @return ApiGetTransactionRequest
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param transactionId
+	@return ApiGetTransactionRequest
 */
 func (a *ApiApiService) GetTransaction(ctx context.Context, transactionId string) ApiGetTransactionRequest {
 	return ApiGetTransactionRequest{
@@ -3462,7 +3487,8 @@ func (a *ApiApiService) GetTransaction(ctx context.Context, transactionId string
 }
 
 // Execute executes the request
-//  @return Transaction
+//
+//	@return Transaction
 func (a *ApiApiService) GetTransactionExecute(r ApiGetTransactionRequest) (*Transaction, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
@@ -3553,10 +3579,10 @@ GetTransactionRun Get a specific run from a particular transaction
 
 Get a specific run from a particular transaction
 
- @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @param transactionId
- @param runId
- @return ApiGetTransactionRunRequest
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param transactionId
+	@param runId
+	@return ApiGetTransactionRunRequest
 */
 func (a *ApiApiService) GetTransactionRun(ctx context.Context, transactionId string, runId int32) ApiGetTransactionRunRequest {
 	return ApiGetTransactionRunRequest{
@@ -3568,7 +3594,8 @@ func (a *ApiApiService) GetTransactionRun(ctx context.Context, transactionId str
 }
 
 // Execute executes the request
-//  @return TransactionRun
+//
+//	@return TransactionRun
 func (a *ApiApiService) GetTransactionRunExecute(r ApiGetTransactionRunRequest) (*TransactionRun, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
@@ -3673,9 +3700,9 @@ GetTransactionRuns Get all runs from a particular transaction
 
 Get all runs from a particular transaction
 
- @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @param transactionId
- @return ApiGetTransactionRunsRequest
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param transactionId
+	@return ApiGetTransactionRunsRequest
 */
 func (a *ApiApiService) GetTransactionRuns(ctx context.Context, transactionId string) ApiGetTransactionRunsRequest {
 	return ApiGetTransactionRunsRequest{
@@ -3686,7 +3713,8 @@ func (a *ApiApiService) GetTransactionRuns(ctx context.Context, transactionId st
 }
 
 // Execute executes the request
-//  @return []TransactionRun
+//
+//	@return []TransactionRun
 func (a *ApiApiService) GetTransactionRunsExecute(r ApiGetTransactionRunsRequest) ([]TransactionRun, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
@@ -3783,10 +3811,10 @@ GetTransactionVersion get a transaction specific version
 
 get a transaction specific version
 
- @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @param transactionId
- @param version
- @return ApiGetTransactionVersionRequest
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param transactionId
+	@param version
+	@return ApiGetTransactionVersionRequest
 */
 func (a *ApiApiService) GetTransactionVersion(ctx context.Context, transactionId string, version int32) ApiGetTransactionVersionRequest {
 	return ApiGetTransactionVersionRequest{
@@ -3798,7 +3826,8 @@ func (a *ApiApiService) GetTransactionVersion(ctx context.Context, transactionId
 }
 
 // Execute executes the request
-//  @return Transaction
+//
+//	@return Transaction
 func (a *ApiApiService) GetTransactionVersionExecute(r ApiGetTransactionVersionRequest) (*Transaction, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
@@ -3890,10 +3919,10 @@ GetTransactionVersionDefinitionFile Get the transaction definition as an YAML fi
 
 Get the transaction as an YAML file
 
- @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @param transactionId
- @param version
- @return ApiGetTransactionVersionDefinitionFileRequest
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param transactionId
+	@param version
+	@return ApiGetTransactionVersionDefinitionFileRequest
 */
 func (a *ApiApiService) GetTransactionVersionDefinitionFile(ctx context.Context, transactionId string, version int32) ApiGetTransactionVersionDefinitionFileRequest {
 	return ApiGetTransactionVersionDefinitionFileRequest{
@@ -3905,7 +3934,8 @@ func (a *ApiApiService) GetTransactionVersionDefinitionFile(ctx context.Context,
 }
 
 // Execute executes the request
-//  @return string
+//
+//	@return string
 func (a *ApiApiService) GetTransactionVersionDefinitionFileExecute(r ApiGetTransactionVersionDefinitionFileRequest) (string, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
@@ -4030,8 +4060,8 @@ GetTransactions Get transactions
 
 get transactions
 
- @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @return ApiGetTransactionsRequest
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@return ApiGetTransactionsRequest
 */
 func (a *ApiApiService) GetTransactions(ctx context.Context) ApiGetTransactionsRequest {
 	return ApiGetTransactionsRequest{
@@ -4041,7 +4071,8 @@ func (a *ApiApiService) GetTransactions(ctx context.Context) ApiGetTransactionsR
 }
 
 // Execute executes the request
-//  @return []Transaction
+//
+//	@return []Transaction
 func (a *ApiApiService) GetTransactionsExecute(r ApiGetTransactionsRequest) ([]Transaction, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
@@ -4150,8 +4181,8 @@ ImportTestRun import test and test run information
 
 import test and test run information for debugging
 
- @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @return ApiImportTestRunRequest
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@return ApiImportTestRunRequest
 */
 func (a *ApiApiService) ImportTestRun(ctx context.Context) ApiImportTestRunRequest {
 	return ApiImportTestRunRequest{
@@ -4161,7 +4192,8 @@ func (a *ApiApiService) ImportTestRun(ctx context.Context) ApiImportTestRunReque
 }
 
 // Execute executes the request
-//  @return ExportedTestInformation
+//
+//	@return ExportedTestInformation
 func (a *ApiApiService) ImportTestRunExecute(r ApiImportTestRunRequest) (*ExportedTestInformation, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPost
@@ -4253,10 +4285,10 @@ RerunTestRun rerun a test run
 
 rerun a test run
 
- @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @param testId
- @param runId
- @return ApiRerunTestRunRequest
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param testId
+	@param runId
+	@return ApiRerunTestRunRequest
 */
 func (a *ApiApiService) RerunTestRun(ctx context.Context, testId string, runId string) ApiRerunTestRunRequest {
 	return ApiRerunTestRunRequest{
@@ -4268,7 +4300,8 @@ func (a *ApiApiService) RerunTestRun(ctx context.Context, testId string, runId s
 }
 
 // Execute executes the request
-//  @return TestRun
+//
+//	@return TestRun
 func (a *ApiApiService) RerunTestRunExecute(r ApiRerunTestRunRequest) (*TestRun, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPost
@@ -4365,9 +4398,9 @@ RunTest run test
 
 run a particular test
 
- @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @param testId
- @return ApiRunTestRequest
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param testId
+	@return ApiRunTestRequest
 */
 func (a *ApiApiService) RunTest(ctx context.Context, testId string) ApiRunTestRequest {
 	return ApiRunTestRequest{
@@ -4378,7 +4411,8 @@ func (a *ApiApiService) RunTest(ctx context.Context, testId string) ApiRunTestRe
 }
 
 // Execute executes the request
-//  @return TestRun
+//
+//	@return TestRun
 func (a *ApiApiService) RunTestExecute(r ApiRunTestRequest) (*TestRun, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPost
@@ -4486,9 +4520,9 @@ RunTransaction run transaction
 
 run a particular transaction
 
- @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @param transactionId
- @return ApiRunTransactionRequest
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param transactionId
+	@return ApiRunTransactionRequest
 */
 func (a *ApiApiService) RunTransaction(ctx context.Context, transactionId string) ApiRunTransactionRequest {
 	return ApiRunTransactionRequest{
@@ -4499,7 +4533,8 @@ func (a *ApiApiService) RunTransaction(ctx context.Context, transactionId string
 }
 
 // Execute executes the request
-//  @return TransactionRun
+//
+//	@return TransactionRun
 func (a *ApiApiService) RunTransactionExecute(r ApiRunTransactionRequest) (*TransactionRun, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPost
@@ -4592,10 +4627,10 @@ StopTestRun stops the execution of a test run
 
 stops the execution of a test run
 
- @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @param testId
- @param runId
- @return ApiStopTestRunRequest
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param testId
+	@param runId
+	@return ApiStopTestRunRequest
 */
 func (a *ApiApiService) StopTestRun(ctx context.Context, testId string, runId string) ApiStopTestRunRequest {
 	return ApiStopTestRunRequest{
@@ -4692,8 +4727,8 @@ TestConnection Tests the config data store/exporter connection
 
 Tests the config data store/exporter connection
 
- @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @return ApiTestConnectionRequest
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@return ApiTestConnectionRequest
 */
 func (a *ApiApiService) TestConnection(ctx context.Context) ApiTestConnectionRequest {
 	return ApiTestConnectionRequest{
@@ -4703,7 +4738,8 @@ func (a *ApiApiService) TestConnection(ctx context.Context) ApiTestConnectionReq
 }
 
 // Execute executes the request
-//  @return TestConnectionResponse
+//
+//	@return TestConnectionResponse
 func (a *ApiApiService) TestConnectionExecute(r ApiTestConnectionRequest) (*TestConnectionResponse, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPost
@@ -4800,9 +4836,9 @@ UpdateDataStore Update a Data Store
 
 Update a Data Store
 
- @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @param dataStoreId
- @return ApiUpdateDataStoreRequest
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param dataStoreId
+	@return ApiUpdateDataStoreRequest
 */
 func (a *ApiApiService) UpdateDataStore(ctx context.Context, dataStoreId string) ApiUpdateDataStoreRequest {
 	return ApiUpdateDataStoreRequest{
@@ -4900,9 +4936,9 @@ UpdateEnvironment update environment
 
 update environment action
 
- @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @param environmentId
- @return ApiUpdateEnvironmentRequest
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param environmentId
+	@return ApiUpdateEnvironmentRequest
 */
 func (a *ApiApiService) UpdateEnvironment(ctx context.Context, environmentId string) ApiUpdateEnvironmentRequest {
 	return ApiUpdateEnvironmentRequest{
@@ -5000,9 +5036,9 @@ UpdateTest update test
 
 update test action
 
- @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @param testId
- @return ApiUpdateTestRequest
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param testId
+	@return ApiUpdateTestRequest
 */
 func (a *ApiApiService) UpdateTest(ctx context.Context, testId string) ApiUpdateTestRequest {
 	return ApiUpdateTestRequest{
@@ -5100,9 +5136,9 @@ UpdateTransaction update transaction
 
 update transaction action
 
- @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @param transactionId
- @return ApiUpdateTransactionRequest
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param transactionId
+	@return ApiUpdateTransactionRequest
 */
 func (a *ApiApiService) UpdateTransaction(ctx context.Context, transactionId string) ApiUpdateTransactionRequest {
 	return ApiUpdateTransactionRequest{
@@ -5199,8 +5235,8 @@ UpsertDefinition Upsert a definition
 
 Upsert a definition
 
- @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @return ApiUpsertDefinitionRequest
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@return ApiUpsertDefinitionRequest
 */
 func (a *ApiApiService) UpsertDefinition(ctx context.Context) ApiUpsertDefinitionRequest {
 	return ApiUpsertDefinitionRequest{
@@ -5210,7 +5246,8 @@ func (a *ApiApiService) UpsertDefinition(ctx context.Context) ApiUpsertDefinitio
 }
 
 // Execute executes the request
-//  @return UpsertDefinitionResponse
+//
+//	@return UpsertDefinitionResponse
 func (a *ApiApiService) UpsertDefinitionExecute(r ApiUpsertDefinitionRequest) (*UpsertDefinitionResponse, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPut

--- a/cli/openapi/api_resource_api.go
+++ b/cli/openapi/api_resource_api.go
@@ -42,8 +42,8 @@ CreateDemo Create a Demonstration setting
 
 Create a demonstration used on Tracetest as quick start examples.
 
- @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @return ApiCreateDemoRequest
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@return ApiCreateDemoRequest
 */
 func (a *ResourceApiApiService) CreateDemo(ctx context.Context) ApiCreateDemoRequest {
 	return ApiCreateDemoRequest{
@@ -53,7 +53,8 @@ func (a *ResourceApiApiService) CreateDemo(ctx context.Context) ApiCreateDemoReq
 }
 
 // Execute executes the request
-//  @return Demo
+//
+//	@return Demo
 func (a *ResourceApiApiService) CreateDemoExecute(r ApiCreateDemoRequest) (*Demo, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPost
@@ -149,8 +150,8 @@ CreatePollingProfile Create a Polling Profile
 
 Create a polling profile used on Tracetest to configure how to fetch traces in a test.
 
- @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @return ApiCreatePollingProfileRequest
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@return ApiCreatePollingProfileRequest
 */
 func (a *ResourceApiApiService) CreatePollingProfile(ctx context.Context) ApiCreatePollingProfileRequest {
 	return ApiCreatePollingProfileRequest{
@@ -160,7 +161,8 @@ func (a *ResourceApiApiService) CreatePollingProfile(ctx context.Context) ApiCre
 }
 
 // Execute executes the request
-//  @return PollingProfile
+//
+//	@return PollingProfile
 func (a *ResourceApiApiService) CreatePollingProfileExecute(r ApiCreatePollingProfileRequest) (*PollingProfile, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPost
@@ -251,9 +253,9 @@ DeleteDemo Delete a Demonstration setting
 
 Delete a demonstration used on Tracetest as quick start examples.
 
- @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @param demoId ID of a demonstration used on Tracetest as quick start examples.
- @return ApiDeleteDemoRequest
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param demoId ID of a demonstration used on Tracetest as quick start examples.
+	@return ApiDeleteDemoRequest
 */
 func (a *ResourceApiApiService) DeleteDemo(ctx context.Context, demoId string) ApiDeleteDemoRequest {
 	return ApiDeleteDemoRequest{
@@ -343,9 +345,9 @@ DeletePollingProfile Delete a Polling Profile
 
 Delete a polling profile used on Tracetest to configure how to fetch traces in a test.
 
- @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @param pollingProfileId ID of a polling profile used on Tracetest to configure how to fetch traces in a test.
- @return ApiDeletePollingProfileRequest
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param pollingProfileId ID of a polling profile used on Tracetest to configure how to fetch traces in a test.
+	@return ApiDeletePollingProfileRequest
 */
 func (a *ResourceApiApiService) DeletePollingProfile(ctx context.Context, pollingProfileId string) ApiDeletePollingProfileRequest {
 	return ApiDeletePollingProfileRequest{
@@ -435,9 +437,9 @@ GetConfiguration Get Tracetest configuration
 
 Get Tracetest configuration
 
- @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @param configId ID of the configuration resource used on Tracetest. It should be set as 'current'.
- @return ApiGetConfigurationRequest
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param configId ID of the configuration resource used on Tracetest. It should be set as 'current'.
+	@return ApiGetConfigurationRequest
 */
 func (a *ResourceApiApiService) GetConfiguration(ctx context.Context, configId string) ApiGetConfigurationRequest {
 	return ApiGetConfigurationRequest{
@@ -448,7 +450,8 @@ func (a *ResourceApiApiService) GetConfiguration(ctx context.Context, configId s
 }
 
 // Execute executes the request
-//  @return ConfigurationResource
+//
+//	@return ConfigurationResource
 func (a *ResourceApiApiService) GetConfigurationExecute(r ApiGetConfigurationRequest) (*ConfigurationResource, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
@@ -538,9 +541,9 @@ GetDemo Get Demonstration setting
 
 Get a demonstration used on Tracetest as quick start examples.
 
- @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @param demoId ID of a demonstration used on Tracetest as quick start examples.
- @return ApiGetDemoRequest
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param demoId ID of a demonstration used on Tracetest as quick start examples.
+	@return ApiGetDemoRequest
 */
 func (a *ResourceApiApiService) GetDemo(ctx context.Context, demoId string) ApiGetDemoRequest {
 	return ApiGetDemoRequest{
@@ -551,7 +554,8 @@ func (a *ResourceApiApiService) GetDemo(ctx context.Context, demoId string) ApiG
 }
 
 // Execute executes the request
-//  @return Demo
+//
+//	@return Demo
 func (a *ResourceApiApiService) GetDemoExecute(r ApiGetDemoRequest) (*Demo, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
@@ -641,9 +645,9 @@ GetPollingProfile Get Polling Profile
 
 Get a polling profile used on Tracetest to configure how to fetch traces in a test.
 
- @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @param pollingProfileId ID of a polling profile used on Tracetest to configure how to fetch traces in a test.
- @return ApiGetPollingProfileRequest
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param pollingProfileId ID of a polling profile used on Tracetest to configure how to fetch traces in a test.
+	@return ApiGetPollingProfileRequest
 */
 func (a *ResourceApiApiService) GetPollingProfile(ctx context.Context, pollingProfileId string) ApiGetPollingProfileRequest {
 	return ApiGetPollingProfileRequest{
@@ -654,7 +658,8 @@ func (a *ResourceApiApiService) GetPollingProfile(ctx context.Context, pollingPr
 }
 
 // Execute executes the request
-//  @return PollingProfile
+//
+//	@return PollingProfile
 func (a *ResourceApiApiService) GetPollingProfileExecute(r ApiGetPollingProfileRequest) (*PollingProfile, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
@@ -771,8 +776,8 @@ ListDemos List Demonstrations
 
 List demonstrations used on Tracetest as quick start examples.
 
- @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @return ApiListDemosRequest
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@return ApiListDemosRequest
 */
 func (a *ResourceApiApiService) ListDemos(ctx context.Context) ApiListDemosRequest {
 	return ApiListDemosRequest{
@@ -782,7 +787,8 @@ func (a *ResourceApiApiService) ListDemos(ctx context.Context) ApiListDemosReque
 }
 
 // Execute executes the request
-//  @return []Demo
+//
+//	@return []Demo
 func (a *ResourceApiApiService) ListDemosExecute(r ApiListDemosRequest) ([]Demo, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
@@ -910,8 +916,8 @@ ListPollingProfiles List Polling Profiles
 
 List polling profiles used on Tracetest to configure how to fetch traces in a test.
 
- @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @return ApiListPollingProfilesRequest
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@return ApiListPollingProfilesRequest
 */
 func (a *ResourceApiApiService) ListPollingProfiles(ctx context.Context) ApiListPollingProfilesRequest {
 	return ApiListPollingProfilesRequest{
@@ -921,7 +927,8 @@ func (a *ResourceApiApiService) ListPollingProfiles(ctx context.Context) ApiList
 }
 
 // Execute executes the request
-//  @return ListPollingProfiles200Response
+//
+//	@return ListPollingProfiles200Response
 func (a *ResourceApiApiService) ListPollingProfilesExecute(r ApiListPollingProfilesRequest) (*ListPollingProfiles200Response, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
@@ -1028,9 +1035,9 @@ UpdateConfiguration Update Tracetest configuration
 
 Update Tracetest configuration
 
- @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @param configId ID of the configuration resource used on Tracetest. It should be set as 'current'.
- @return ApiUpdateConfigurationRequest
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param configId ID of the configuration resource used on Tracetest. It should be set as 'current'.
+	@return ApiUpdateConfigurationRequest
 */
 func (a *ResourceApiApiService) UpdateConfiguration(ctx context.Context, configId string) ApiUpdateConfigurationRequest {
 	return ApiUpdateConfigurationRequest{
@@ -1041,7 +1048,8 @@ func (a *ResourceApiApiService) UpdateConfiguration(ctx context.Context, configI
 }
 
 // Execute executes the request
-//  @return ConfigurationResource
+//
+//	@return ConfigurationResource
 func (a *ResourceApiApiService) UpdateConfigurationExecute(r ApiUpdateConfigurationRequest) (*ConfigurationResource, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPut
@@ -1139,9 +1147,9 @@ UpdateDemo Update a Demonstration setting
 
 Update a demonstration used on Tracetest as quick start examples.
 
- @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @param demoId ID of a demonstration used on Tracetest as quick start examples.
- @return ApiUpdateDemoRequest
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param demoId ID of a demonstration used on Tracetest as quick start examples.
+	@return ApiUpdateDemoRequest
 */
 func (a *ResourceApiApiService) UpdateDemo(ctx context.Context, demoId string) ApiUpdateDemoRequest {
 	return ApiUpdateDemoRequest{
@@ -1152,7 +1160,8 @@ func (a *ResourceApiApiService) UpdateDemo(ctx context.Context, demoId string) A
 }
 
 // Execute executes the request
-//  @return Demo
+//
+//	@return Demo
 func (a *ResourceApiApiService) UpdateDemoExecute(r ApiUpdateDemoRequest) (*Demo, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPut
@@ -1250,9 +1259,9 @@ UpdatePollingProfile Update a Polling Profile
 
 Update a polling profile used on Tracetest to configure how to fetch traces in a test.
 
- @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @param pollingProfileId ID of a polling profile used on Tracetest to configure how to fetch traces in a test.
- @return ApiUpdatePollingProfileRequest
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param pollingProfileId ID of a polling profile used on Tracetest to configure how to fetch traces in a test.
+	@return ApiUpdatePollingProfileRequest
 */
 func (a *ResourceApiApiService) UpdatePollingProfile(ctx context.Context, pollingProfileId string) ApiUpdatePollingProfileRequest {
 	return ApiUpdatePollingProfileRequest{
@@ -1263,7 +1272,8 @@ func (a *ResourceApiApiService) UpdatePollingProfile(ctx context.Context, pollin
 }
 
 // Execute executes the request
-//  @return PollingProfile
+//
+//	@return PollingProfile
 func (a *ResourceApiApiService) UpdatePollingProfileExecute(r ApiUpdatePollingProfileRequest) (*PollingProfile, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPut

--- a/cli/utils/run_state.go
+++ b/cli/utils/run_state.go
@@ -1,0 +1,12 @@
+package utils
+
+func RunStateIsFinished(state string) bool {
+	return RunStateIsFailed(state) || state == "FINISHED"
+}
+
+func RunStateIsFailed(state string) bool {
+	return state == "TRIGGER_FAILED" ||
+		state == "TRACE_FAILED" ||
+		state == "ASSERTION_FAILED" ||
+		state == "FAILED" // this one is for backwards compatibility
+}

--- a/server/executor/assertion_runner.go
+++ b/server/executor/assertion_runner.go
@@ -121,7 +121,7 @@ func (e *defaultAssertionRunner) runAssertionsAndUpdateResult(ctx context.Contex
 			log.Printf("[AssertionRunner] Test %s Run %d: fail to emit TestSpecsRunError event: %s\n", request.Test.ID, request.Run.ID, anotherErr.Error())
 		}
 
-		return model.Run{}, e.updater.Update(ctx, run.Failed(err))
+		return model.Run{}, e.updater.Update(ctx, run.AssertionFailed(err))
 	}
 	log.Printf("[AssertionRunner] Test %s Run %d: Success. pass: %d, fail: %d\n", request.Test.ID, request.Run.ID, run.Pass, run.Fail)
 

--- a/server/executor/runner.go
+++ b/server/executor/runner.go
@@ -272,7 +272,7 @@ func (r persistentRunner) processExecQueue(job execReq) {
 func (r persistentRunner) handleExecutionResult(run model.Run, response trigger.Response, err error) model.Run {
 	run = run.TriggerCompleted(response.Result)
 	if err != nil {
-		return run.Failed(err)
+		return run.TriggerFailed(err)
 	}
 
 	return run.SuccessfullyTriggered()

--- a/server/executor/trace_poller.go
+++ b/server/executor/trace_poller.go
@@ -173,7 +173,7 @@ func (tp tracePoller) handleTraceDBError(job PollingRequest, err error) {
 		fmt.Println("[TracePoller] Unknown error", err)
 	}
 
-	tp.handleDBError(tp.updater.Update(job.ctx, run.Failed(err)))
+	tp.handleDBError(tp.updater.Update(job.ctx, run.TraceFailed(err)))
 
 	tp.subscriptionManager.PublishUpdate(subscription.Message{
 		ResourceID: run.TransactionStepResourceID(),

--- a/server/executor/transaction_runner_test.go
+++ b/server/executor/transaction_runner_test.go
@@ -35,7 +35,7 @@ func (r *fakeTestRunner) Run(ctx context.Context, test model.Test, metadata mode
 		time.Sleep(100 * time.Millisecond) // simulate some real work
 
 		if r.returnErr {
-			newRun.State = model.RunStateFailed
+			newRun.State = model.RunStateTriggerFailed
 			newRun.LastError = fmt.Errorf("failed to do something")
 		} else {
 			newRun.State = model.RunStateFinished
@@ -87,7 +87,7 @@ func TestTransactionRunner(t *testing.T) {
 		runTransactionRunnerTest(t, true, func(t *testing.T, actual model.TransactionRun) {
 			assert.Equal(t, model.TransactionRunStateFailed, actual.State)
 			require.Len(t, actual.Steps, 1)
-			assert.Equal(t, model.RunStateFailed, actual.Steps[0].State)
+			assert.Equal(t, model.RunStateTriggerFailed, actual.Steps[0].State)
 		})
 	})
 

--- a/server/model/json_test.go
+++ b/server/model/json_test.go
@@ -87,7 +87,7 @@ func TestRunEncoding(t *testing.T) {
 				ID:                 1,
 				TraceID:            tid,
 				SpanID:             sid,
-				State:              model.RunStateFailed,
+				State:              model.RunStateTriggerFailed,
 				LastError:          errors.New("some error"),
 				CreatedAt:          t1,
 				ServiceTriggeredAt: t1,

--- a/server/model/run.go
+++ b/server/model/run.go
@@ -121,8 +121,20 @@ func (r Run) Finish() Run {
 	return r
 }
 
-func (r Run) Failed(err error) Run {
-	r.State = RunStateFailed
+func (r Run) TriggerFailed(err error) Run {
+	r.State = RunStateTriggerFailed
+	r.LastError = err
+	return r.Finish()
+}
+
+func (r Run) TraceFailed(err error) Run {
+	r.State = RunStateTraceFailed
+	r.LastError = err
+	return r.Finish()
+}
+
+func (r Run) AssertionFailed(err error) Run {
+	r.State = RunStateAssertionFailed
 	r.LastError = err
 	return r.Finish()
 }

--- a/server/model/tests.go
+++ b/server/model/tests.go
@@ -180,13 +180,20 @@ const (
 	RunStateCreated             RunState = "CREATED"
 	RunStateExecuting           RunState = "EXECUTING"
 	RunStateAwaitingTrace       RunState = "AWAITING_TRACE"
-	RunStateFailed              RunState = "FAILED"
+	RunStateTriggerFailed       RunState = "TRIGGER_FAILED"
+	RunStateTraceFailed         RunState = "TRACE_FAILED"
+	RunStateAssertionFailed     RunState = "ASSERTION_FAILED"
 	RunStateFinished            RunState = "FINISHED"
 	RunStateAwaitingTestResults RunState = "AWAITING_TEST_RESULTS"
 )
 
 func (rs RunState) IsFinal() bool {
-	return rs == RunStateFailed || rs == RunStateFinished
+	return rs.IsError() || rs == RunStateFinished
+}
+
+func (rs RunState) IsError() bool {
+	return rs == RunStateTriggerFailed ||
+		rs == RunStateTraceFailed
 }
 
 func (r Run) ResultsCount() (pass, fail int) {

--- a/web/src/components/EditTest/EditTest.tsx
+++ b/web/src/components/EditTest/EditTest.tsx
@@ -2,10 +2,10 @@ import {Button, Form} from 'antd';
 import EditTestForm from 'components/EditTestForm';
 import {TriggerTypeToPlugin} from 'constants/Plugins.constants';
 import useValidateTestDraft from 'hooks/useValidateTestDraft';
+import {isRunStateFinished} from 'models/TestRun.model';
 import {useTest} from 'providers/Test/Test.provider';
 import {useCallback, useState} from 'react';
 import {TDraftTest} from 'types/Test.types';
-import {TestState} from 'constants/TestRun.constants';
 import {useTestRun} from 'providers/TestRun/TestRun.provider';
 import TestRunAnalyticsService from 'services/Analytics/TestRunAnalytics.service';
 import Test from 'models/Test.model';
@@ -32,7 +32,7 @@ const EditTest = ({test}: IProps) => {
   );
 
   const {run} = useTestRun();
-  const stateIsFinished = ([TestState.FINISHED, TestState.FAILED] as string[]).includes(run.state);
+  const stateIsFinished = isRunStateFinished(run.state);
 
   return (
     <S.Wrapper data-cy="edit-test-form">

--- a/web/src/components/RunCard/TestRunCard.tsx
+++ b/web/src/components/RunCard/TestRunCard.tsx
@@ -2,8 +2,7 @@ import {Tooltip} from 'antd';
 import {Link} from 'react-router-dom';
 import RunActionsMenu from 'components/RunActionsMenu';
 import TestState from 'components/TestState';
-import {TestState as TestStateEnum} from 'constants/TestRun.constants';
-import TestRun from 'models/TestRun.model';
+import TestRun, {isRunStateFailed, isRunStateFinished} from 'models/TestRun.model';
 import Date from 'utils/Date';
 import * as S from './RunCard.styled';
 
@@ -14,10 +13,10 @@ interface IProps {
 }
 
 function getIcon(state: TestRun['state'], failedAssertions: number) {
-  if (state !== TestStateEnum.FAILED && state !== TestStateEnum.FINISHED) {
+  if (!isRunStateFinished(state)) {
     return null;
   }
-  if (state === TestStateEnum.FAILED || failedAssertions > 0) {
+  if (isRunStateFailed(state) || failedAssertions > 0) {
     return <S.IconFail />;
   }
   return <S.IconSuccess />;
@@ -58,9 +57,7 @@ const TestRunCard = ({
               <S.Text>{Date.getTimeAgo(createdAt)}</S.Text>
             </Tooltip>
 
-            {(state === TestStateEnum.FAILED || state === TestStateEnum.FINISHED) && (
-              <S.Text>&nbsp;• {executionTime}s</S.Text>
-            )}
+            {isRunStateFinished(state) && <S.Text>&nbsp;• {executionTime}s</S.Text>}
 
             {metadataName && (
               <a href={metadataUrl} target="_blank" onClick={event => event.stopPropagation()}>
@@ -73,13 +70,13 @@ const TestRunCard = ({
 
         {!!transactionId && !!transactionRunId && <S.Text>Part of transaction</S.Text>}
 
-        {state !== TestStateEnum.FAILED && state !== TestStateEnum.FINISHED && (
+        {!isRunStateFinished(state) && (
           <div data-cy={`test-run-result-status-${runId}`}>
             <TestState testState={state} />
           </div>
         )}
 
-        {(state === TestStateEnum.FAILED || state === TestStateEnum.FINISHED) && (
+        {isRunStateFinished(state) && (
           <S.Row>
             <Tooltip title="Passed assertions">
               <S.HeaderDetail>

--- a/web/src/components/RunCard/TransactionRunCard.tsx
+++ b/web/src/components/RunCard/TransactionRunCard.tsx
@@ -4,7 +4,6 @@ import TestState from 'components/TestState';
 import TransactionRunActionsMenu from 'components/TransactionRunActionsMenu';
 import {TestState as TestStateEnum} from 'constants/TestRun.constants';
 import TransactionRun from 'models/TransactionRun.model';
-import TestRun from 'models/TestRun.model';
 import Date from 'utils/Date';
 import * as S from './RunCard.styled';
 
@@ -14,7 +13,7 @@ interface IProps {
   transactionId: string;
 }
 
-function getIcon(state: TestRun['state'], fail: number) {
+function getIcon(state: TransactionRun['state'], fail: number) {
   if (state !== TestStateEnum.FAILED && state !== TestStateEnum.FINISHED) {
     return null;
   }

--- a/web/src/components/RunDetailLayout/Info.tsx
+++ b/web/src/components/RunDetailLayout/Info.tsx
@@ -2,7 +2,7 @@ import {Button, Popover, Typography} from 'antd';
 import {InfoCircleOutlined} from '@ant-design/icons';
 import {useTheme} from 'styled-components';
 
-import {TestState} from 'constants/TestRun.constants';
+import {isRunStateFinished} from 'models/TestRun.model';
 import TestAnalyticsService from 'services/Analytics/TestAnalytics.service';
 import {TTestRunState} from 'types/TestRun.types';
 import Date from 'utils/Date';
@@ -30,9 +30,7 @@ const Info = ({date, executionTime, state, totalSpans, traceId}: IProps) => {
       </div>
       <div>
         <Typography.Text strong>Execution time: </Typography.Text>
-        <Typography.Text>
-          {state === TestState.FAILED || state === TestState.FINISHED ? `${executionTime}s` : '-'}
-        </Typography.Text>
+        <Typography.Text>{isRunStateFinished(state) ? `${executionTime}s` : '-'}</Typography.Text>
       </div>
       <div>
         <Typography.Text strong>Total spans: </Typography.Text>

--- a/web/src/components/RunDetailLayout/RunDetailLayout.styled.ts
+++ b/web/src/components/RunDetailLayout/RunDetailLayout.styled.ts
@@ -93,7 +93,6 @@ export const StateContainer = styled.div`
   align-items: center;
   display: flex;
   justify-self: flex-end;
-  cursor: pointer;
 `;
 
 export const StateText = styled(Typography.Text)`

--- a/web/src/components/RunDetailTrigger/RunDetailTrigger.tsx
+++ b/web/src/components/RunDetailTrigger/RunDetailTrigger.tsx
@@ -17,7 +17,7 @@ interface IProps {
 }
 
 const RunDetailTrigger = ({test, run: {state, triggerResult, triggerTime}, runEvents, isError}: IProps) => {
-  const shouldDisplayError = isError || state === TestState.FAILED;
+  const shouldDisplayError = isError || state === TestState.TRIGGER_FAILED;
 
   return (
     <S.Container>

--- a/web/src/components/RunEvents/RunEventsTrace.tsx
+++ b/web/src/components/RunEvents/RunEventsTrace.tsx
@@ -3,6 +3,7 @@ import {Typography} from 'antd';
 import {TRACE_DOCUMENTATION_URL} from 'constants/Common.constants';
 import {TestState} from 'constants/TestRun.constants';
 import {TraceEventType} from 'constants/TestRunEvents.constants';
+import {isRunStateFailed} from 'models/TestRun.model';
 import TestRunService from 'services/TestRun.service';
 import RunEvent, {IPropsEvent} from './RunEvent';
 import RunEventDataStore from './RunEventDataStore';
@@ -33,7 +34,19 @@ const RunEventsTrace = ({events, state}: IPropsComponent) => {
     </>
   );
 
-  const failedHeader = (
+  const failedTriggerHeader = (
+    <>
+      <S.ErrorIcon />
+      <Typography.Title level={2} type="secondary">
+        Test Trigger Failed
+      </Typography.Title>
+      <S.Paragraph type="secondary">
+        The test failed in the Trigger stage, review the Trigger tab to see the breakdown of diagnostic steps.
+      </S.Paragraph>
+    </>
+  );
+
+  const failedTraceHeader = (
     <>
       <S.ErrorIcon />
       <Typography.Title level={2} type="secondary">
@@ -47,7 +60,9 @@ const RunEventsTrace = ({events, state}: IPropsComponent) => {
 
   return (
     <S.Container $hasScroll>
-      {state === TestState.FAILED ? failedHeader : loadingHeader}
+      {state === TestState.TRIGGER_FAILED && failedTriggerHeader}
+      {state === TestState.TRACE_FAILED && failedTraceHeader}
+      {!isRunStateFailed(state) && loadingHeader}
 
       <S.ListContainer>
         {filteredEvents.map(event => {

--- a/web/src/constants/TestRun.constants.ts
+++ b/web/src/constants/TestRun.constants.ts
@@ -3,6 +3,9 @@ export enum TestState {
   EXECUTING = 'EXECUTING',
   AWAITING_TRACE = 'AWAITING_TRACE',
   AWAITING_TEST_RESULTS = 'AWAITING_TEST_RESULTS',
+  TRIGGER_FAILED = 'TRIGGER_FAILED',
+  TRACE_FAILED = 'TRACE_FAILED',
+  ASSERTION_FAILED = 'ASSERTION_FAILED',
   FAILED = 'FAILED',
   FINISHED = 'FINISHED',
   WAITING = 'WAITING',
@@ -35,6 +38,18 @@ export const TestStateMap: Record<
   [TestState.FAILED]: {
     status: 'error',
     label: 'Failed',
+  },
+  [TestState.TRIGGER_FAILED]: {
+    status: 'error',
+    label: 'Trigger Failed',
+  },
+  [TestState.TRACE_FAILED]: {
+    status: 'error',
+    label: 'Trace Failed',
+  },
+  [TestState.ASSERTION_FAILED]: {
+    status: 'error',
+    label: 'Test Specs Failed',
   },
   [TestState.FINISHED]: {
     status: 'success',

--- a/web/src/models/TestRun.model.ts
+++ b/web/src/models/TestRun.model.ts
@@ -1,5 +1,6 @@
+import {TestState} from 'constants/TestRun.constants';
+import {Model, Modify, TTestSchemas, TTriggerSchemas} from 'types/Common.types';
 import {TTestRunState} from 'types/TestRun.types';
-import {Model, Modify, TTestSchemas, TTriggerSchemas} from '../types/Common.types';
 import AssertionResults, {TRawAssertionResults} from './AssertionResults.model';
 import Environment from './Environment.model';
 import TestRunOutput from './TestRunOutput.model';
@@ -54,6 +55,16 @@ const getTestResultCount = (
     }
   }).length;
 };
+
+export function isRunStateFinished(state: TTestRunState) {
+  return (
+    [TestState.FINISHED, TestState.TRIGGER_FAILED, TestState.TRACE_FAILED, TestState.ASSERTION_FAILED] as string[]
+  ).includes(state);
+}
+
+export function isRunStateFailed(state: TTestRunState) {
+  return ([TestState.TRIGGER_FAILED, TestState.TRACE_FAILED, TestState.ASSERTION_FAILED] as string[]).includes(state);
+}
 
 const TestRun = ({
   id = '',

--- a/web/src/models/TransactionRun.model.ts
+++ b/web/src/models/TransactionRun.model.ts
@@ -1,4 +1,4 @@
-import { Model, TTransactionsSchemas } from '../types/Common.types';
+import {Model, TTransactionsSchemas} from 'types/Common.types';
 import Environment from './Environment.model';
 import TestRun from './TestRun.model';
 

--- a/web/src/types/Generated.types.ts
+++ b/web/src/types/Generated.types.ts
@@ -1888,7 +1888,9 @@ export interface external {
             | "AWAITING_TRACE"
             | "AWAITING_TEST_RESULTS"
             | "FINISHED"
-            | "FAILED";
+            | "TRIGGER_FAILED"
+            | "TRACE_FAILED"
+            | "ASSERTION_FAILED";
           /** @description Details of the cause for the last `FAILED` state */
           lastErrorState?: string;
           /** @description time in seconds it took for the test to complete, either success or fail. If the test is still running, it will show the time up to the time of the request */

--- a/web/src/types/TestRun.types.ts
+++ b/web/src/types/TestRun.types.ts
@@ -5,4 +5,4 @@ export enum RunErrorTypes {
   Unknown = 'unknown',
 }
 
-export type TTestRunState = NonNullable<TTestSchemas['TestRun']['state'] | 'WAITING' | 'SKIPPED'>;
+export type TTestRunState = NonNullable<TTestSchemas['TestRun']['state'] | 'WAITING' | 'SKIPPED' | 'FAILED'>;


### PR DESCRIPTION
This PR makes the TestRun state more accurate by providing a new set of statuses: `TRACE_FAILED`, `TRIGGER_FAILED` and `ASSERTION_FAILED`.

## Changes

- add new states and implement where applicable

## Fixes

- #2285

## Checklist

- [X] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
