### PR TITLE
feat: emit error event when expression engine return parsing errors

### DIFF
--- a/server/executor/assertion_runner.go
+++ b/server/executor/assertion_runner.go
@@ -196,6 +196,16 @@ func (e *defaultAssertionRunner) emitFailedAssertions(ctx context.Context, req A
 					))
 				}
 
+				if errors.Is(spanAssertionResult.CompareErr, expression.ErrInvalidSyntax) {
+					e.eventEmitter.Emit(ctx, events.TestSpecsAssertionError(
+						req.Run.TestID,
+						req.Run.ID,
+						spanAssertionResult.CompareErr,
+						spanAssertionResult.SpanID.String(),
+						string(assertionResult.Assertion),
+					))
+				}
+
 			}
 		}
 	}

--- a/server/expression/errors.go
+++ b/server/expression/errors.go
@@ -6,6 +6,7 @@ import (
 )
 
 var ErrExpressionResolution error = errors.New("resolution error")
+var ErrInvalidSyntax error = errors.New("invalid syntax")
 
 type ResolutionError struct {
 	innerErr error
@@ -30,4 +31,29 @@ func (e *ResolutionError) Unwrap() error {
 
 func resolutionError(innerErr error) error {
 	return &ResolutionError{innerErr: innerErr}
+}
+
+type InvalidSyntaxError struct {
+	innerErr error
+}
+
+func (e *InvalidSyntaxError) Error() string {
+	return e.innerErr.Error()
+}
+
+func (e *InvalidSyntaxError) Is(target error) bool {
+	if errors.Is(target, ErrInvalidSyntax) {
+		return true
+	}
+
+	return errors.Is(e.innerErr, target)
+}
+
+func (e *InvalidSyntaxError) Unwrap() error {
+	return errors.Unwrap(e.innerErr)
+}
+
+func invalidSyntaxError(err error, expression string) error {
+	innerErr := fmt.Errorf(`invalid syntax "%s": %w`, expression, err)
+	return &InvalidSyntaxError{innerErr: innerErr}
 }

--- a/server/expression/executor.go
+++ b/server/expression/executor.go
@@ -34,7 +34,7 @@ func NewExecutor(dataStores ...DataStore) Executor {
 func (e Executor) Statement(statement string) (string, string, error) {
 	parsedStatement, err := ParseStatement(statement)
 	if err != nil {
-		return "", "", fmt.Errorf("could not parse statement: %w", err)
+		return "", "", err
 	}
 
 	leftValue, err := e.ResolveExpression(parsedStatement.Left)
@@ -77,7 +77,7 @@ func (e Executor) GetParsedStatement(statement string) (Statement, error) {
 		expression, err := Parse(statement)
 		if err != nil {
 			// it's really invalid
-			return Statement{}, fmt.Errorf("could not parse statement: %w", err)
+			return Statement{}, invalidSyntaxError(err, statement)
 		}
 
 		parsedStatement.Left = &expression
@@ -122,7 +122,7 @@ func (e Executor) Expression(expression string) (value.Value, error) {
 	var expr Expr
 	err = parser.ParseString("", expression, &expr)
 	if err != nil {
-		return value.Nil, fmt.Errorf(`could not parse expression "%s": %w`, expression, err)
+		return value.Nil, invalidSyntaxError(err, expression)
 	}
 
 	return e.ResolveExpression(&expr)

--- a/server/expression/parser.go
+++ b/server/expression/parser.go
@@ -33,7 +33,7 @@ func ParseStatement(statement string) (Statement, error) {
 
 	err = parser.ParseString("", statement, &parsedStatement)
 	if err != nil {
-		return Statement{}, fmt.Errorf(`could not parse statement "%s": %w`, statement, err)
+		return Statement{}, invalidSyntaxError(err, statement)
 	}
 
 	return parsedStatement, nil
@@ -63,7 +63,7 @@ func Parse(expression string) (Expr, error) {
 
 	err = parser.ParseString("", expression, &parsedExpression)
 	if err != nil {
-		return Expr{}, fmt.Errorf(`could not parse statement "%s": %w`, expression, err)
+		return Expr{}, invalidSyntaxError(err, expression)
 	}
 
 	return parsedExpression, nil

--- a/server/expression/parser_errors_test.go
+++ b/server/expression/parser_errors_test.go
@@ -1,0 +1,32 @@
+package expression_test
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/kubeshop/tracetest/server/expression"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestStatementParsingErrors(t *testing.T) {
+	executor := expression.NewExecutor()
+	_, _, err := executor.Statement(`1 1 + = 2`)
+
+	assert.Error(t, err)
+	assert.True(t, strings.HasPrefix(err.Error(), `invalid syntax "1 1 + = 2": `))
+
+	unwrappedErr := errors.Unwrap(err)
+	assert.False(t, strings.HasPrefix(unwrappedErr.Error(), `invalid syntax "1 1 + = 2": `))
+}
+
+func TestExpressionParsingErrors(t *testing.T) {
+	executor := expression.NewExecutor()
+	_, err := executor.Expression(`attr:attribute env:number`)
+
+	assert.Error(t, err)
+	assert.True(t, strings.HasPrefix(err.Error(), `invalid syntax "attr:attribute env:number": `))
+
+	unwrappedErr := errors.Unwrap(err)
+	assert.False(t, strings.HasPrefix(unwrappedErr.Error(), `invalid syntax "attr:attribute env:number": `))
+}

--- a/server/expression/tokens.go
+++ b/server/expression/tokens.go
@@ -1,9 +1,5 @@
 package expression
 
-import (
-	"fmt"
-)
-
 type Token struct {
 	Identifier string
 	Type       TermType
@@ -12,7 +8,7 @@ type Token struct {
 func GetTokens(statement string) ([]Token, error) {
 	parsedStatement, err := ParseStatement(statement)
 	if err != nil {
-		return []Token{}, fmt.Errorf("could not parse statement: %w", err)
+		return []Token{}, invalidSyntaxError(err, statement)
 	}
 
 	leftTokens := extractTokensFromExpression(parsedStatement.Left)
@@ -31,7 +27,7 @@ func GetTokens(statement string) ([]Token, error) {
 func GetTokensFromExpression(expression string) ([]Token, error) {
 	parsedExpression, err := Parse(expression)
 	if err != nil {
-		return []Token{}, fmt.Errorf("could not parse statement: %w", err)
+		return []Token{}, invalidSyntaxError(err, expression)
 	}
 
 	return extractTokensFromExpression(&parsedExpression), nil


### PR DESCRIPTION
This PR makes the assertion runner emit a `TEST_SPECS_ASSERTION_ERROR` in case of invalid syntax in the assertion.

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [x] added a test
