### PR TITLE
Added mutex to avoid concurrency errors on SubscriptionManager

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -186,7 +186,7 @@ jobs:
 
   test-examples:
     name: Test examples
-    needs:  [build-docker]
+    needs:  [test-server, build-docker]
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -88,6 +88,7 @@ jobs:
 
   build-go:
     name: Build go binaries (API Server and CLI)
+    needs: [unit-test-cli, test-server]
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
@@ -186,7 +187,7 @@ jobs:
 
   test-examples:
     name: Test examples
-    needs:  [test-server, build-docker]
+    needs:  [build-docker]
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/server/executor/eventemitter.go
+++ b/server/executor/eventemitter.go
@@ -2,6 +2,7 @@ package executor
 
 import (
 	"context"
+	"sync"
 
 	"github.com/kubeshop/tracetest/server/model"
 )
@@ -17,6 +18,7 @@ type publisher interface {
 type internalEventEmitter struct {
 	repository model.TestRunEventRepository
 	publisher  publisher
+	mutex      sync.Mutex
 }
 
 func NewEventEmitter(repository model.TestRunEventRepository, publisher publisher) EventEmitter {
@@ -31,6 +33,9 @@ func (em *internalEventEmitter) Emit(ctx context.Context, event model.TestRunEve
 	if err != nil {
 		return err
 	}
+
+	em.mutex.Lock()
+	defer em.mutex.Unlock()
 
 	em.publisher.Publish(event.ResourceID(), event)
 

--- a/server/subscription/manager.go
+++ b/server/subscription/manager.go
@@ -48,9 +48,6 @@ func (m *Manager) Unsubscribe(resourceID string, subscriptionID string) {
 }
 
 func (m *Manager) PublishUpdate(message Message) {
-	m.mutex.Lock()
-	defer m.mutex.Unlock()
-
 	if subscribers, ok := m.subscriptions[message.ResourceID]; ok {
 		for _, subscriber := range subscribers {
 			subscriber.Notify(message)
@@ -59,9 +56,6 @@ func (m *Manager) PublishUpdate(message Message) {
 }
 
 func (m *Manager) Publish(resourceID string, message any) {
-	m.mutex.Lock()
-	defer m.mutex.Unlock()
-
 	if subscribers, ok := m.subscriptions[resourceID]; ok {
 		for _, subscriber := range subscribers {
 			subscriber.Notify(Message{

--- a/server/subscription/manager.go
+++ b/server/subscription/manager.go
@@ -48,6 +48,9 @@ func (m *Manager) Unsubscribe(resourceID string, subscriptionID string) {
 }
 
 func (m *Manager) PublishUpdate(message Message) {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+
 	if subscribers, ok := m.subscriptions[message.ResourceID]; ok {
 		for _, subscriber := range subscribers {
 			subscriber.Notify(message)
@@ -56,6 +59,9 @@ func (m *Manager) PublishUpdate(message Message) {
 }
 
 func (m *Manager) Publish(resourceID string, message any) {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+
 	if subscribers, ok := m.subscriptions[resourceID]; ok {
 		for _, subscriber := range subscribers {
 			subscriber.Notify(Message{


### PR DESCRIPTION
This PR aims to fix a concurrency error that is happening on Tracetest:

```
persistentRunner job. ID 1, testID JFxVPFY4R, TraceID 8ec5afeaca8d38668e5053fc4fb79998, SpanID b8a543d68fd34165
fatal error: concurrent map read and map write

goroutine 49 [running]:
github.com/kubeshop/tracetest/server/subscription.(*Manager).Publish(0x1a97540?, {0xc002b95740, 0x1a}, {0x1a97540, 0xc0033331e0})
	/home/runner/work/tracetest/tracetest/server/subscription/manager.go:59 +0x65
github.com/kubeshop/tracetest/server/executor.(*internalEventEmitter).Emit(_, {_, _}, {0x0, {0x1b2908b, 0xc}, {0x1b1a196, 0x7}, {0x1b5697d, 0x1c}, ...})
	/home/runner/work/tracetest/tracetest/server/executor/eventemitter.go:35 +0x18d
github.com/kubeshop/tracetest/server/executor.persistentRunner.processExecQueue({0xc0006b7fb0, {0x7f86d6a14208, 0xc000522e40}, {0x7f86d6a141b8, 0xc000136068}, {0x1f32940, 0xc000131410}, {0x1f2fda0, 0xc000092940}, 0xc0002a2050, ...}, ...)
	/home/runner/work/tracetest/tracetest/server/executor/runner.go:177 +0x262
github.com/kubeshop/tracetest/server/executor.persistentRunner.Start.func1()
	/home/runner/work/tracetest/tracetest/server/executor/runner.go:115 +0x238
created by github.com/kubeshop/tracetest/server/executor.persistentRunner.Start
	/home/runner/work/tracetest/tracetest/server/executor/runner.go:100 +0x85
```

## Changes

-

## Fixes

-

## Checklist

- [ ] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
