### PR TITLE
fix(server): fix TestRunEvent mapping in WebSocket

### DIFF
--- a/server/http/websocket/subscribe.go
+++ b/server/http/websocket/subscribe.go
@@ -66,6 +66,8 @@ func (e subscribeCommandExecutor) ResourceUpdatedEvent(resource interface{}) Eve
 		mapped = e.mappers.Out.TransactionRun(v)
 	case *model.TransactionRun:
 		mapped = e.mappers.Out.TransactionRun(*v)
+	case model.TestRunEvent:
+		mapped = e.mappers.Out.TestRunEvent(v)
 	default:
 		fmt.Printf("type %T mapping not supported\n", v)
 		mapped = v


### PR DESCRIPTION
This PR adds OpenAPI mapping to websocket response for `TestRunEvents`.

## Changes

- fix TestRunEvent mapping in WebSocket

## Fixes

-

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
