### PR TITLE
chore: pin postgres version on docker compose files

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -27,7 +27,7 @@ services:
       TRACETEST_DEV: ${TRACETEST_DEV}
 
   postgres:
-    image: postgres
+    image: postgres:14
     environment:
       POSTGRES_PASSWORD: postgres
       POSTGRES_USER: postgres

--- a/docs/docs/examples-tutorials/recipes/running-tracetest-with-datadog.md
+++ b/docs/docs/examples-tutorials/recipes/running-tracetest-with-datadog.md
@@ -100,7 +100,7 @@ services:
       TRACETEST_DEV: ${TRACETEST_DEV}
 
   tt-postgres:
-    image: postgres
+    image: postgres:14
     container_name: tt-postgres
     environment:
       POSTGRES_PASSWORD: postgres

--- a/docs/docs/examples-tutorials/recipes/running-tracetest-with-lightstep.md
+++ b/docs/docs/examples-tutorials/recipes/running-tracetest-with-lightstep.md
@@ -94,7 +94,7 @@ services:
       TRACETEST_DEV: ${TRACETEST_DEV}
 
   postgres:
-    image: postgres
+    image: postgres:14
     environment:
       POSTGRES_PASSWORD: postgres
       POSTGRES_USER: postgres

--- a/docs/docs/examples-tutorials/recipes/running-tracetest-with-new-relic.md
+++ b/docs/docs/examples-tutorials/recipes/running-tracetest-with-new-relic.md
@@ -94,7 +94,7 @@ services:
       TRACETEST_DEV: ${TRACETEST_DEV}
 
   postgres:
-    image: postgres
+    image: postgres:14
     environment:
       POSTGRES_PASSWORD: postgres
       POSTGRES_USER: postgres

--- a/examples/quick-start-datadog-nodejs/tracetest/docker-compose.yaml
+++ b/examples/quick-start-datadog-nodejs/tracetest/docker-compose.yaml
@@ -30,7 +30,7 @@ services:
       TRACETEST_DEV: ${TRACETEST_DEV}
 
   postgres:
-    image: postgres
+    image: postgres:14
     environment:
       POSTGRES_PASSWORD: postgres
       POSTGRES_USER: postgres

--- a/examples/tracetest-datadog/tracetest/docker-compose.yaml
+++ b/examples/tracetest-datadog/tracetest/docker-compose.yaml
@@ -37,7 +37,7 @@ services:
       TRACETEST_DEV: ${TRACETEST_DEV}
 
   tt-postgres:
-    image: postgres
+    image: postgres:14
     container_name: tt-postgres
     environment:
       POSTGRES_PASSWORD: postgres

--- a/examples/tracetest-lightstep-otel-demo/README.md
+++ b/examples/tracetest-lightstep-otel-demo/README.md
@@ -84,7 +84,7 @@ The `TRACETEST_SERVICE_PORT` is configured in the `.env` file
 
   # Postgres used by the Tracetest instance
   tt_postgres:
-    image: postgres
+    image: postgres:14
     environment:
       POSTGRES_PASSWORD: postgres
       POSTGRES_USER: postgres

--- a/examples/tracetest-lightstep-otel-demo/docker-compose.yaml
+++ b/examples/tracetest-lightstep-otel-demo/docker-compose.yaml
@@ -677,7 +677,7 @@ services:
 
   # Postgres used by the Tracetest instance
   tt_postgres:
-    image: postgres
+    image: postgres:14
     environment:
       POSTGRES_PASSWORD: postgres
       POSTGRES_USER: postgres

--- a/examples/tracetest-lightstep/tracetest/docker-compose.yaml
+++ b/examples/tracetest-lightstep/tracetest/docker-compose.yaml
@@ -30,7 +30,7 @@ services:
       TRACETEST_DEV: ${TRACETEST_DEV}
 
   postgres:
-    image: postgres
+    image: postgres:14
     environment:
       POSTGRES_PASSWORD: postgres
       POSTGRES_USER: postgres

--- a/examples/tracetest-new-relic-otel-demo/README.md
+++ b/examples/tracetest-new-relic-otel-demo/README.md
@@ -84,7 +84,7 @@ The `TRACETEST_SERVICE_PORT` is configured in the `.env` file
 
   # Postgres used by the Tracetest instance
   tt_postgres:
-    image: postgres
+    image: postgres:14
     environment:
       POSTGRES_PASSWORD: postgres
       POSTGRES_USER: postgres

--- a/examples/tracetest-new-relic-otel-demo/docker-compose.yaml
+++ b/examples/tracetest-new-relic-otel-demo/docker-compose.yaml
@@ -677,7 +677,7 @@ services:
 
   # Postgres used by the Tracetest instance
   tt_postgres:
-    image: postgres
+    image: postgres:14
     environment:
       POSTGRES_PASSWORD: postgres
       POSTGRES_USER: postgres

--- a/examples/tracetest-new-relic/tracetest/docker-compose.yaml
+++ b/examples/tracetest-new-relic/tracetest/docker-compose.yaml
@@ -30,7 +30,7 @@ services:
       TRACETEST_DEV: ${TRACETEST_DEV}
 
   postgres:
-    image: postgres
+    image: postgres:14
     environment:
       POSTGRES_PASSWORD: postgres
       POSTGRES_USER: postgres

--- a/examples/tracetest-otel-demo/docker-compose.yaml
+++ b/examples/tracetest-otel-demo/docker-compose.yaml
@@ -32,7 +32,7 @@ services:
       TRACETEST_DEV: ${TRACETEST_DEV}
 
   postgres:
-    image: postgres
+    image: postgres:14
     environment:
       POSTGRES_PASSWORD: postgres
       POSTGRES_USER: postgres
@@ -43,7 +43,7 @@ services:
       retries: 60
 
   tt_postgres:
-    image: postgres
+    image: postgres:14
     environment:
       POSTGRES_PASSWORD: postgres
       POSTGRES_USER: postgres


### PR DESCRIPTION
This PR pins a specific postgres version (14) to some docker compose files that didn't have it. Not having the version pinned can create problems. For example, today for some reason docker decided that I needed to use the `15` version on my existing DB, and the storage formats are not compatible, so tracetest was not starting.

This fixes this issue

## Changes

-

## Fixes

-

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
