### PR TITLE
fix: add nil pointer checks

### DIFF
--- a/server/model/yaml/yamlconvert/datastore.go
+++ b/server/model/yaml/yamlconvert/datastore.go
@@ -9,14 +9,25 @@ import (
 func DataStore(in model.DataStore) yaml.File {
 	out := yaml.DataStore{}
 	deepcopy.DeepCopy(in, &out)
-	deepcopy.DeepCopy(in.Values.Jaeger, &out.Jaeger)
-	deepcopy.DeepCopy(in.Values.Jaeger.TLSSetting, &out.Jaeger.Tls)
-	deepcopy.DeepCopy(in.Values.Tempo, &out.Tempo)
-	deepcopy.DeepCopy(in.Values.Tempo.Grpc.TLSSetting, &out.Tempo.Grpc.Tls)
-	deepcopy.DeepCopy(in.Values.Tempo.Http.TLSSetting, &out.Tempo.Http.Tls)
-	deepcopy.DeepCopy(in.Values.OpenSearch, &out.OpenSearch)
-	deepcopy.DeepCopy(in.Values.SignalFx, &out.SignalFx)
-	deepcopy.DeepCopy(in.Values.AwsXRay, &out.AwsXRay)
+	if in.Values.Jaeger != nil {
+		deepcopy.DeepCopy(in.Values.Jaeger, &out.Jaeger)
+		deepcopy.DeepCopy(in.Values.Jaeger.TLSSetting, &out.Jaeger.Tls)
+	}
+	if in.Values.Tempo != nil {
+		deepcopy.DeepCopy(in.Values.Tempo, &out.Tempo)
+		deepcopy.DeepCopy(in.Values.Tempo.Grpc.TLSSetting, &out.Tempo.Grpc.Tls)
+		deepcopy.DeepCopy(in.Values.Tempo.Http.TLSSetting, &out.Tempo.Http.Tls)
+	}
+
+	if in.Values.OpenSearch != nil {
+		deepcopy.DeepCopy(in.Values.OpenSearch, &out.OpenSearch)
+	}
+	if in.Values.SignalFx != nil {
+		deepcopy.DeepCopy(in.Values.SignalFx, &out.SignalFx)
+	}
+	if in.Values.AwsXRay != nil {
+		deepcopy.DeepCopy(in.Values.AwsXRay, &out.AwsXRay)
+	}
 
 	return yaml.File{
 		Type: yaml.FileTypeDataStore,


### PR DESCRIPTION
This PR adds missing nil pointer checks that causes panic when trying to export a datastore that has only been configured as otlp, making `Values` nil.

## Changes

-

## Fixes

-

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
