### PR TITLE
Adding provisioning and server db config docs

### DIFF
--- a/docs/docs/configuration/overview.md
+++ b/docs/docs/configuration/overview.md
@@ -1,10 +1,8 @@
 # Configuration Overview
 
-There is one way you can set configuration options in Tracetest. By using a configuration file, commonly known as the `tracetest.config.yaml` file.
-
-When using Docker, ensure that the configuration file is mounted to `/app/config.yaml` within the Tracetest Docker container.
-
-<!-- To view all the configuration options see the [config file reference page](./config-file-reference). -->
+There are several configuration options with Tracetest:
+- [Server configuration](./server) to set database connection information needed to connect to required PostgreSQL instance.
+- [Provisioning configuration](./provisioning) to 'preload' the Tracetest server with resources when first running the Tracetest server.
 
 ## Supported Trace Data Stores
 

--- a/docs/docs/configuration/provisioning.md
+++ b/docs/docs/configuration/provisioning.md
@@ -1,0 +1,50 @@
+# Provisioning server
+
+Tracetest allows a server to be provisioned the first time a new Tracetest server is installed and launched. Provisioning sets certain resources in the server to the specified values, allowing you to configure the server. It is convenient in a CI/CD flow where you want to launch a server with a specified configuration. 
+
+The server is provisioned by specifying a series of yaml snippets which will configure various resources. Each snippet is separated with the yaml separator, ---.
+
+Currently, the following resources can be provisioned: 
+- DataStore
+- PollingProfile
+- Config
+- Demo
+
+For docker based installs, the provisioning file is placed in the ./tracetest/tracetest-provisioning.yaml file by default when you run the 'tracetest server install' command and select the 'Using Docker Compose' option. The first time you start tracetest with a 'docker compose -f tracetest/docker-compose.yaml  up -d' command, the server will use the contents of this file to provision the server. To provision differently, you would alter the contents of the tracetest-provisioning.yaml file before launching tracetest in docker.
+
+This is an example of a tracetest-provisioning.yaml file:
+
+```yaml
+---
+type: DataStore
+spec:
+  name: otlp
+  type: otlp
+  otlp:
+    type: otlp
+---
+type: Config
+spec:
+  analyticsEnabled: true
+---
+type: PollingProfile
+spec:
+  name: Custom Profile
+  strategy: periodic
+  default: true
+  periodic:
+    timeout: 2m
+    retryDelay: 3s
+---
+type: Demo
+spec:
+  name: pokeshop
+  type: pokeshop
+  enabled: true
+  pokeshop:
+    httpEndpoint: http://demo-api:8081
+    grpcEndpoint: demo-api:8082
+```
+
+Alternatively, we support setting an environment variable called TRACETEST_PROVISIONING to provision the server when it first is started. Take the provisioning YAML you want to utilize, base64 encode it, and set the TRACETEST_PROVISIONING environment variable with the result. The Tracetest server will then provision based on the base64 encoded provisioning data in this environment variable the first time it is launched.
+

--- a/docs/docs/configuration/provisioning.md
+++ b/docs/docs/configuration/provisioning.md
@@ -46,5 +46,5 @@ spec:
     grpcEndpoint: demo-api:8082
 ```
 
-Alternatively, we support setting an environment variable called TRACETEST_PROVISIONING to provision the server when it is first started. Base64 encode the provisioning YAML you want to utilize and set the TRACETEST_PROVISIONING environment variable with the result. The Tracetest server will then provision based on the Base64 encoded provisioning data in this environment variable the first time it is launched.
+Alternatively, we support setting an environment variable called `TRACETEST_PROVISIONING` to provision the server when it is first started. Base64 encode the provisioning YAML you want to utilize and set the `TRACETEST_PROVISIONING` environment variable with the result. The Tracetest server will then provision based on the Base64 encoded provisioning data in this environment variable the first time it is launched.
 

--- a/docs/docs/configuration/provisioning.md
+++ b/docs/docs/configuration/provisioning.md
@@ -2,7 +2,7 @@
 
 Tracetest allows a server to be provisioned the first time a new Tracetest server is installed and launched. Provisioning sets certain resources in the server to the specified values, allowing you to configure the server. It is convenient in a CI/CD flow where you want to launch a server with a specified configuration. 
 
-The server is provisioned by specifying a series of YAML snippets which will configure various resources. Each snippet is separated with the YAML separator, ---.
+The server is provisioned by specifying a series of YAML snippets which will configure various resources. Each snippet is separated with the YAML separator, `---`.
 
 Currently, the following resources can be provisioned: 
 - DataStore

--- a/docs/docs/configuration/provisioning.md
+++ b/docs/docs/configuration/provisioning.md
@@ -12,7 +12,7 @@ Currently, the following resources can be provisioned:
 
 For Docker-based installs, the provisioning file is placed in the `./tracetest/tracetest-provisioning.yaml` file by default when you run the `tracetest server install` command and select the `Using Docker Compose` option. The first time you start Tracetest with a `docker compose -f tracetest/docker-compose.yaml  up -d` command, the server will use the contents of this file to provision the server. To provision differently, you would alter the contents of the `tracetest-provisioning.yaml` file before launching Tracetest in Docker.
 
-This is an example of a tracetest-provisioning.yaml file:
+This is an example of a `tracetest-provisioning.yaml` file:
 
 ```yaml
 ---

--- a/docs/docs/configuration/provisioning.md
+++ b/docs/docs/configuration/provisioning.md
@@ -10,7 +10,7 @@ Currently, the following resources can be provisioned:
 - Config
 - Demo
 
-For docker based installs, the provisioning file is placed in the ./tracetest/tracetest-provisioning.yaml file by default when you run the 'tracetest server install' command and select the 'Using Docker Compose' option. The first time you start tracetest with a 'docker compose -f tracetest/docker-compose.yaml  up -d' command, the server will use the contents of this file to provision the server. To provision differently, you would alter the contents of the tracetest-provisioning.yaml file before launching tracetest in docker.
+For Docker based installs, the provisioning file is placed in the ./tracetest/tracetest-provisioning.yaml file by default when you run the 'tracetest server install' command and select the 'Using Docker Compose' option. The first time you start Tracetest with a 'docker compose -f tracetest/docker-compose.yaml  up -d' command, the server will use the contents of this file to provision the server. To provision differently, you would alter the contents of the tracetest-provisioning.yaml file before launching Tracetest in Docker.
 
 This is an example of a tracetest-provisioning.yaml file:
 

--- a/docs/docs/configuration/provisioning.md
+++ b/docs/docs/configuration/provisioning.md
@@ -10,7 +10,7 @@ Currently, the following resources can be provisioned:
 - Config
 - Demo
 
-For Docker based installs, the provisioning file is placed in the ./tracetest/tracetest-provisioning.yaml file by default when you run the 'tracetest server install' command and select the 'Using Docker Compose' option. The first time you start Tracetest with a 'docker compose -f tracetest/docker-compose.yaml  up -d' command, the server will use the contents of this file to provision the server. To provision differently, you would alter the contents of the tracetest-provisioning.yaml file before launching Tracetest in Docker.
+For Docker-based installs, the provisioning file is placed in the `./tracetest/tracetest-provisioning.yaml` file by default when you run the `tracetest server install` command and select the `Using Docker Compose` option. The first time you start Tracetest with a `docker compose -f tracetest/docker-compose.yaml  up -d` command, the server will use the contents of this file to provision the server. To provision differently, you would alter the contents of the `tracetest-provisioning.yaml` file before launching Tracetest in Docker.
 
 This is an example of a tracetest-provisioning.yaml file:
 

--- a/docs/docs/configuration/provisioning.md
+++ b/docs/docs/configuration/provisioning.md
@@ -20,8 +20,7 @@ type: DataStore
 spec:
   name: otlp
   type: otlp
-  otlp:
-    type: otlp
+  isdefault: true
 ---
 type: Config
 spec:

--- a/docs/docs/configuration/provisioning.md
+++ b/docs/docs/configuration/provisioning.md
@@ -46,5 +46,5 @@ spec:
     grpcEndpoint: demo-api:8082
 ```
 
-Alternatively, we support setting an environment variable called TRACETEST_PROVISIONING to provision the server when it first is started. Take the provisioning YAML you want to utilize, base64 encode it, and set the TRACETEST_PROVISIONING environment variable with the result. The Tracetest server will then provision based on the base64 encoded provisioning data in this environment variable the first time it is launched.
+Alternatively, we support setting an environment variable called TRACETEST_PROVISIONING to provision the server when it is first started. Base64 encode the provisioning YAML you want to utilize and set the TRACETEST_PROVISIONING environment variable with the result. The Tracetest server will then provision based on the Base64 encoded provisioning data in this environment variable the first time it is launched.
 

--- a/docs/docs/configuration/provisioning.md
+++ b/docs/docs/configuration/provisioning.md
@@ -2,7 +2,7 @@
 
 Tracetest allows a server to be provisioned the first time a new Tracetest server is installed and launched. Provisioning sets certain resources in the server to the specified values, allowing you to configure the server. It is convenient in a CI/CD flow where you want to launch a server with a specified configuration. 
 
-The server is provisioned by specifying a series of yaml snippets which will configure various resources. Each snippet is separated with the yaml separator, ---.
+The server is provisioned by specifying a series of YAML snippets which will configure various resources. Each snippet is separated with the YAML separator, ---.
 
 Currently, the following resources can be provisioned: 
 - DataStore

--- a/docs/docs/configuration/server.md
+++ b/docs/docs/configuration/server.md
@@ -1,4 +1,4 @@
-# Configuring the Tracetest server
+# Configuring the Tracetest Server
 
 Tracetest requires a very minimal configuration to be launched, needing just the connection information to connect with the PostgreSQL database which is installed as part of the server install. There are a couple ways to provide this database connection information.
 

--- a/docs/docs/configuration/server.md
+++ b/docs/docs/configuration/server.md
@@ -25,5 +25,5 @@ The list of environment variables and example values is:
 - `TRACETEST_POSTGRES_USER: "postgres"`
 - `TRACETEST_POSTGRES_PASSWORD: "postgres"`
 
-You can also 'hydrate' the server with a number of resources the first time it is launched by using [provisioning](./provisioning).
+You can also provision the server with a number of resources the first time it is launched by using [provisioning](./provisioning).
 

--- a/docs/docs/configuration/server.md
+++ b/docs/docs/configuration/server.md
@@ -22,7 +22,7 @@ The list of environment variables and example values is:
 - TRACETEST_POSTGRES_HOST - example: postgres
 - TRACETEST_POSTGRES_PORT - example: 5432
 - `TRACETEST_POSTGRES_DBNAME: "postgres"`
-- TRACETEST_POSTGRES_USER - example: postgres
+- `TRACETEST_POSTGRES_USER: "postgres"`
 - TRACETEST_POSTGRES_PASSWORD - example: postgres
 
 You can also 'hydrate' the server with a number of resources the first time it is launched by using [provisioning](./provisioning).

--- a/docs/docs/configuration/server.md
+++ b/docs/docs/configuration/server.md
@@ -1,6 +1,6 @@
 # Configuring the Tracetest Server
 
-Tracetest requires a very minimal configuration to be launched, needing just the connection information to connect with the PostgreSQL database which is installed as part of the server install. There are a couple ways to provide this database connection information.
+Tracetest requires a very minimal configuration to be launched, needing just the connection information to connect with the PostgreSQL database which is installed as part of the server install. There are a couple of ways to provide this database connection information.
 
 For Docker-based installs, the server configuration file is placed in the ./tracetest/tracetest.yaml file by default when you run the 'tracetest server install' command and select the 'Using Docker Compose' option. The configuration file is mounted to `/app/config.yaml` within the Tracetest Docker container. When Tracetest is run with a 'docker compose -f tracetest/docker-compose.yaml  up -d' command, the server will use the contents of this file to connect to the Postgres database. All other configuration data is stored in the Postgres instance.
 

--- a/docs/docs/configuration/server.md
+++ b/docs/docs/configuration/server.md
@@ -25,5 +25,5 @@ The list of environment variables and example values is:
 - `TRACETEST_POSTGRES_USER: "postgres"`
 - `TRACETEST_POSTGRES_PASSWORD: "postgres"`
 
-You can also provision the server with a number of resources the first time it is launched by using [provisioning](./provisioning).
+You can also intitalize the server with a number of resources the first time it is launched by using [provisioning](./provisioning).
 

--- a/docs/docs/configuration/server.md
+++ b/docs/docs/configuration/server.md
@@ -18,7 +18,7 @@ postgres:
 
 Alternatively, we support setting a series of environment variables which can contain the connection information for the Postgres instance. If these environment variables are set, they will be used by the Tracetest server to connect to the database.
 
-The list of environment variables, and example values is:
+The list of environment variables and example values is:
 - TRACETEST_POSTGRES_HOST - example: postgres
 - TRACETEST_POSTGRES_PORT - example: 5432
 - TRACETEST_POSTGRES_DBNAME - example: postgres

--- a/docs/docs/configuration/server.md
+++ b/docs/docs/configuration/server.md
@@ -23,7 +23,7 @@ The list of environment variables and example values is:
 - TRACETEST_POSTGRES_PORT - example: 5432
 - `TRACETEST_POSTGRES_DBNAME: "postgres"`
 - `TRACETEST_POSTGRES_USER: "postgres"`
-- TRACETEST_POSTGRES_PASSWORD - example: postgres
+- `TRACETEST_POSTGRES_PASSWORD: "postgres"`
 
 You can also 'hydrate' the server with a number of resources the first time it is launched by using [provisioning](./provisioning).
 

--- a/docs/docs/configuration/server.md
+++ b/docs/docs/configuration/server.md
@@ -1,0 +1,29 @@
+# Configuring the Tracetest server
+
+Tracetest requires a very minimal configuration to be launched, needing just the connection information to connect with the PostgreSQL database which is installed as part of the server install. There are a couple ways to provide this database connection information.
+
+For docker based installs, the server configuration file is placed in the ./tracetest/tracetest.yaml file by default when you run the 'tracetest server install' command and select the 'Using Docker Compose' option. The configuration file is mounted to `/app/config.yaml` within the Tracetest Docker container. When tracetest is run with a 'docker compose -f tracetest/docker-compose.yaml  up -d' command, the server will use the contents of this file to connect to the Postgres database. All other configuration data is stored in the Postgres instance.
+
+This is an example of a tracetest.yaml file:
+
+```yaml
+postgres:
+  host: postgres
+  user: postgres
+  password: postgres
+  port: 5432
+  dbname: postgres
+  params: sslmode=disable
+```
+
+Alternatively, we support setting ana series of environment variables which can contain the connection information for the Postgres instance. If these environment variables are set, they will be used by the Tracetest server to connect to the database. The variables are:
+
+The list of environment variables, and example values is:
+- TRACETEST_POSTGRES_HOST - example: postgres
+- TRACETEST_POSTGRES_PORT - example: 5432
+- TRACETEST_POSTGRES_DBNAME - example: postgres
+- TRACETEST_POSTGRES_USER - example: postgres
+- TRACETEST_POSTGRES_PASSWORD - example: postgres
+
+You can also 'hydrate' the server with a number of resources the first time it is launched by using [provisioning](./provisioning).
+

--- a/docs/docs/configuration/server.md
+++ b/docs/docs/configuration/server.md
@@ -19,7 +19,7 @@ postgres:
 Alternatively, we support setting a series of environment variables which can contain the connection information for the Postgres instance. If these environment variables are set, they will be used by the Tracetest server to connect to the database.
 
 The list of environment variables and example values is:
-- TRACETEST_POSTGRES_HOST - example: postgres
+- `TRACETEST_POSTGRES_HOST: "postgres"`
 - TRACETEST_POSTGRES_PORT - example: 5432
 - `TRACETEST_POSTGRES_DBNAME: "postgres"`
 - `TRACETEST_POSTGRES_USER: "postgres"`

--- a/docs/docs/configuration/server.md
+++ b/docs/docs/configuration/server.md
@@ -20,7 +20,7 @@ Alternatively, we support setting a series of environment variables which can co
 
 The list of environment variables and example values is:
 - `TRACETEST_POSTGRES_HOST: "postgres"`
-- TRACETEST_POSTGRES_PORT - example: 5432
+- `TRACETEST_POSTGRES_PORT: "5432"`
 - `TRACETEST_POSTGRES_DBNAME: "postgres"`
 - `TRACETEST_POSTGRES_USER: "postgres"`
 - `TRACETEST_POSTGRES_PASSWORD: "postgres"`

--- a/docs/docs/configuration/server.md
+++ b/docs/docs/configuration/server.md
@@ -16,7 +16,7 @@ postgres:
   params: sslmode=disable
 ```
 
-Alternatively, we support setting ana series of environment variables which can contain the connection information for the Postgres instance. If these environment variables are set, they will be used by the Tracetest server to connect to the database. The variables are:
+Alternatively, we support setting a series of environment variables which can contain the connection information for the Postgres instance. If these environment variables are set, they will be used by the Tracetest server to connect to the database.
 
 The list of environment variables, and example values is:
 - TRACETEST_POSTGRES_HOST - example: postgres

--- a/docs/docs/configuration/server.md
+++ b/docs/docs/configuration/server.md
@@ -2,7 +2,7 @@
 
 Tracetest requires a very minimal configuration to be launched, needing just the connection information to connect with the PostgreSQL database which is installed as part of the server install. There are a couple ways to provide this database connection information.
 
-For docker based installs, the server configuration file is placed in the ./tracetest/tracetest.yaml file by default when you run the 'tracetest server install' command and select the 'Using Docker Compose' option. The configuration file is mounted to `/app/config.yaml` within the Tracetest Docker container. When tracetest is run with a 'docker compose -f tracetest/docker-compose.yaml  up -d' command, the server will use the contents of this file to connect to the Postgres database. All other configuration data is stored in the Postgres instance.
+For Docker-based installs, the server configuration file is placed in the ./tracetest/tracetest.yaml file by default when you run the 'tracetest server install' command and select the 'Using Docker Compose' option. The configuration file is mounted to `/app/config.yaml` within the Tracetest Docker container. When Tracetest is run with a 'docker compose -f tracetest/docker-compose.yaml  up -d' command, the server will use the contents of this file to connect to the Postgres database. All other configuration data is stored in the Postgres instance.
 
 This is an example of a tracetest.yaml file:
 

--- a/docs/docs/configuration/server.md
+++ b/docs/docs/configuration/server.md
@@ -24,6 +24,8 @@ The list of environment variables and example values is:
 - `TRACETEST_POSTGRES_DBNAME: "postgres"`
 - `TRACETEST_POSTGRES_USER: "postgres"`
 - `TRACETEST_POSTGRES_PASSWORD: "postgres"`
+- `TRACETEST_POSTGRES_PARAMS: ""`
+
 
 You can also intitalize the server with a number of resources the first time it is launched by using [provisioning](./provisioning).
 

--- a/docs/docs/configuration/server.md
+++ b/docs/docs/configuration/server.md
@@ -21,7 +21,7 @@ Alternatively, we support setting a series of environment variables which can co
 The list of environment variables and example values is:
 - TRACETEST_POSTGRES_HOST - example: postgres
 - TRACETEST_POSTGRES_PORT - example: 5432
-- TRACETEST_POSTGRES_DBNAME - example: postgres
+- `TRACETEST_POSTGRES_DBNAME: "postgres"`
 - TRACETEST_POSTGRES_USER - example: postgres
 - TRACETEST_POSTGRES_PASSWORD - example: postgres
 

--- a/docs/docs/configuration/server.md
+++ b/docs/docs/configuration/server.md
@@ -2,7 +2,7 @@
 
 Tracetest requires a very minimal configuration to be launched, needing just the connection information to connect with the PostgreSQL database which is installed as part of the server install. There are a couple of ways to provide this database connection information.
 
-For Docker-based installs, the server configuration file is placed in the ./tracetest/tracetest.yaml file by default when you run the 'tracetest server install' command and select the 'Using Docker Compose' option. The configuration file is mounted to `/app/config.yaml` within the Tracetest Docker container. When Tracetest is run with a 'docker compose -f tracetest/docker-compose.yaml  up -d' command, the server will use the contents of this file to connect to the Postgres database. All other configuration data is stored in the Postgres instance.
+For Docker-based installs, the server configuration file is placed in the `./tracetest/tracetest.yaml` file by default when you run the `tracetest server install` command and select the `Using Docker Compose` option. The configuration file is mounted to `/app/config.yaml` within the Tracetest Docker container. When Tracetest is run with a `docker compose -f tracetest/docker-compose.yaml  up -d` command, the server will use the contents of this file to connect to the Postgres database. All other configuration data is stored in the Postgres instance.
 
 This is an example of a tracetest.yaml file:
 

--- a/docs/docs/configuration/server.md
+++ b/docs/docs/configuration/server.md
@@ -4,7 +4,7 @@ Tracetest requires a very minimal configuration to be launched, needing just the
 
 For Docker-based installs, the server configuration file is placed in the `./tracetest/tracetest.yaml` file by default when you run the `tracetest server install` command and select the `Using Docker Compose` option. The configuration file is mounted to `/app/config.yaml` within the Tracetest Docker container. When Tracetest is run with a `docker compose -f tracetest/docker-compose.yaml  up -d` command, the server will use the contents of this file to connect to the Postgres database. All other configuration data is stored in the Postgres instance.
 
-This is an example of a tracetest.yaml file:
+This is an example of a `tracetest.yaml` file:
 
 ```yaml
 postgres:

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -127,7 +127,7 @@ const sidebars = {
         {
           type: "doc",
           id: "configuration/provisioning",
-          label: "Provisioning Server",
+          label: "Provisioning a Tracetest Server",
         },
         {
           type: "doc",

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -121,6 +121,16 @@ const sidebars = {
         },
         {
           type: "doc",
+          id: "configuration/server",
+          label: "Tracetest Server Configuration",
+        },
+        {
+          type: "doc",
+          id: "configuration/provisioning",
+          label: "Provisioning Server",
+        },
+        {
+          type: "doc",
           id: "configuration/trace-polling",
           label: "Trace Polling",
         },


### PR DESCRIPTION
Adding provisioning and server db config docs. Did not add an overall 'what is resources' as our cli is fairly fragmented right now. We need to add a resources page once we put out the CLI improvements.
