### PR TITLE
fix json unmarshal and remove connection test event from untestable datastores

### DIFF
--- a/server/http/controller.go
+++ b/server/http/controller.go
@@ -1274,10 +1274,15 @@ func (c *controller) TestConnection(ctx context.Context, dataStore openapi.DataS
 		return openapi.Response(http.StatusBadRequest, err.Error()), err
 	}
 
-	testResult := tdb.TestConnection(ctx)
+	testResult := model.ConnectionResult{}
 	statusCode := http.StatusOK
-	if !testResult.HasSucceed() {
-		statusCode = http.StatusUnprocessableEntity
+
+	if testableTraceDB, ok := tdb.(tracedb.TestableTraceDB); ok {
+		testResult = testableTraceDB.TestConnection(ctx)
+		statusCode = http.StatusOK
+		if !testResult.HasSucceed() {
+			statusCode = http.StatusUnprocessableEntity
+		}
 	}
 
 	return openapi.Response(statusCode, c.mappers.Out.ConnectionTestResult(testResult)), nil

--- a/server/model/connection_test_result.go
+++ b/server/model/connection_test_result.go
@@ -1,5 +1,10 @@
 package model
 
+import (
+	"encoding/json"
+	"errors"
+)
+
 type ConnectionResult struct {
 	PortCheck      ConnectionTestStep
 	Connectivity   ConnectionTestStep
@@ -16,6 +21,27 @@ type ConnectionTestStep struct {
 	Status  Status
 	Message string
 	Error   error
+}
+
+func (s *ConnectionTestStep) UnmarshalJSON(bytes []byte) error {
+	var step struct {
+		Passed       bool
+		Status       Status
+		Message      string
+		ErrorMessage string
+	}
+
+	err := json.Unmarshal(bytes, &step)
+	if err != nil {
+		return err
+	}
+
+	s.Passed = step.Passed
+	s.Status = step.Status
+	s.Message = step.Message
+	s.Error = errors.New(step.ErrorMessage)
+
+	return nil
 }
 
 func (r *ConnectionTestStep) HasSucceed() bool {

--- a/server/model/connection_test_result.go
+++ b/server/model/connection_test_result.go
@@ -39,7 +39,9 @@ func (s *ConnectionTestStep) UnmarshalJSON(bytes []byte) error {
 	s.Passed = step.Passed
 	s.Status = step.Status
 	s.Message = step.Message
-	s.Error = errors.New(step.ErrorMessage)
+	if step.ErrorMessage != "" {
+		s.Error = errors.New(step.ErrorMessage)
+	}
 
 	return nil
 }

--- a/server/tracedb/otlp.go
+++ b/server/tracedb/otlp.go
@@ -33,10 +33,6 @@ func (tdb *OTLPTraceDB) Close() error {
 	return nil
 }
 
-func (jtd *OTLPTraceDB) TestConnection(ctx context.Context) model.ConnectionResult {
-	return model.ConnectionResult{}
-}
-
 // GetTraceByID implements TraceDB
 func (tdb *OTLPTraceDB) GetTraceByID(ctx context.Context, id string) (model.Trace, error) {
 	run, err := tdb.db.GetRunByTraceID(ctx, traces.DecodeTraceID(id))

--- a/server/tracedb/tracedb.go
+++ b/server/tracedb/tracedb.go
@@ -17,8 +17,11 @@ type TraceDB interface {
 	ShouldRetry() bool
 	GetTraceID() trace.TraceID
 	GetTraceByID(ctx context.Context, traceID string) (model.Trace, error)
-	TestConnection(ctx context.Context) model.ConnectionResult
 	Close() error
+}
+
+type TestableTraceDB interface {
+	TestConnection(ctx context.Context) model.ConnectionResult
 }
 
 type noopTraceDB struct{}

--- a/server/tracedb/tracedb.go
+++ b/server/tracedb/tracedb.go
@@ -21,6 +21,7 @@ type TraceDB interface {
 }
 
 type TestableTraceDB interface {
+	TraceDB
 	TestConnection(ctx context.Context) model.ConnectionResult
 }
 


### PR DESCRIPTION
This PR fixes the issue when unmarshalling the data store test struct

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
