### PR TITLE
feature(backend): add temporary buffer to subscription manager

### DIFF
--- a/server/executor/eventemitter.go
+++ b/server/executor/eventemitter.go
@@ -29,6 +29,7 @@ func NewEventEmitter(repository model.TestRunEventRepository, publisher publishe
 }
 
 func (em *internalEventEmitter) Emit(ctx context.Context, event model.TestRunEvent) error {
+	event.CreatedAt = event.CreatedAt.UTC()
 	err := em.repository.CreateTestRunEvent(ctx, event)
 	if err != nil {
 		return err

--- a/server/subscription/buffer.go
+++ b/server/subscription/buffer.go
@@ -1,0 +1,114 @@
+package subscription
+
+import (
+	"sync"
+	"time"
+)
+
+type TemporaryBuffer struct {
+	messages             []Message
+	lastMessageTimestamp time.Time
+}
+
+func NewTemporaryBuffer() *TemporaryBuffer {
+	return &TemporaryBuffer{
+		messages:             make([]Message, 0),
+		lastMessageTimestamp: time.Now(),
+	}
+}
+
+func (b *TemporaryBuffer) AddMessage(message Message) {
+	b.messages = append(b.messages, message)
+	b.lastMessageTimestamp = time.Now()
+}
+
+func (b *TemporaryBuffer) GetMessages() []Message {
+	return b.messages
+}
+
+func (b *TemporaryBuffer) CleanUp() {
+	if len(b.messages) > 0 && time.Since(b.lastMessageTimestamp) > 10*time.Second {
+		b.messages = make([]Message, 0)
+		b.lastMessageTimestamp = time.Now()
+	}
+}
+
+type BufferedSubscriptions struct {
+	subscriptions  map[string][]Subscriber
+	messageBuffers map[string]*TemporaryBuffer
+	mutex          *sync.Mutex
+}
+
+func NewBufferedSubscriptions() *BufferedSubscriptions {
+	var mutex sync.Mutex
+	return &BufferedSubscriptions{
+		subscriptions:  make(map[string][]Subscriber),
+		messageBuffers: make(map[string]*TemporaryBuffer),
+		mutex:          &mutex,
+	}
+}
+
+func (bs *BufferedSubscriptions) CleanUp() {
+	for _, buffer := range bs.messageBuffers {
+		buffer.CleanUp()
+	}
+}
+
+func (bs *BufferedSubscriptions) NotifySubscribers(resourceID string, message Message) {
+	bs.mutex.Lock()
+	defer bs.mutex.Unlock()
+
+	bs.initResource(resourceID)
+
+	bs.messageBuffers[resourceID].AddMessage(message)
+
+	if subscribers, ok := bs.subscriptions[resourceID]; ok {
+		for _, subscriber := range subscribers {
+			subscriber.Notify(message)
+		}
+	}
+}
+
+func (bs *BufferedSubscriptions) AddSubscriber(resourceID string, subscriber Subscriber) {
+	bs.mutex.Lock()
+	defer bs.mutex.Unlock()
+
+	bs.initResource(resourceID)
+
+	bs.subscriptions[resourceID] = append(bs.subscriptions[resourceID], subscriber)
+
+	for _, message := range bs.messageBuffers[resourceID].GetMessages() {
+		subscriber.Notify(message)
+	}
+}
+
+func (bs *BufferedSubscriptions) RemoveSubscriber(resourceID string, subscriptionID string) {
+	bs.mutex.Lock()
+	defer bs.mutex.Unlock()
+
+	if _, ok := bs.subscriptions[resourceID]; !ok {
+		return
+	}
+
+	subscribers := bs.subscriptions[resourceID]
+
+	newArray := make([]Subscriber, 0, len(subscribers)-1)
+	for _, item := range subscribers {
+		if item.ID() != subscriptionID {
+			newArray = append(newArray, item)
+		}
+	}
+
+	bs.subscriptions[resourceID] = newArray
+}
+
+func (bs *BufferedSubscriptions) initResource(resourceID string) {
+	if _, ok := bs.messageBuffers[resourceID]; !ok {
+		bs.messageBuffers[resourceID] = NewTemporaryBuffer()
+	}
+
+	if _, ok := bs.subscriptions[resourceID]; !ok {
+		bs.subscriptions[resourceID] = make([]Subscriber, 0)
+	}
+
+}

--- a/server/subscription/manager_test.go
+++ b/server/subscription/manager_test.go
@@ -2,6 +2,7 @@ package subscription_test
 
 import (
 	"testing"
+	"time"
 
 	"github.com/kubeshop/tracetest/server/subscription"
 	"github.com/stretchr/testify/assert"
@@ -105,4 +106,64 @@ func TestManagerUnsubscribe(t *testing.T) {
 	assert.Equal(t, message1.Type, receivedMessage.Type, "subscriber should not be notified after unsubscribed")
 	assert.Equal(t, message1.Content, receivedMessage.Content, "subscriber should not be notified after unsubscribed")
 
+}
+
+func TestBufferedMessages(t *testing.T) {
+	manager := subscription.NewManager()
+	receivedMessages := make([]subscription.Message, 0)
+
+	subscriber := subscription.NewSubscriberFunction(func(message subscription.Message) error {
+		receivedMessages = append(receivedMessages, message)
+		return nil
+	})
+
+	message1 := subscription.Message{
+		ResourceID: "test:1",
+		Type:       "test_update",
+		Content:    "Test was updated",
+	}
+
+	message2 := subscription.Message{
+		ResourceID: "test:1",
+		Type:       "test_deleted",
+		Content:    "Test was deleted",
+	}
+
+	manager.PublishUpdate(message1)
+	time.Sleep(1 * time.Second)
+	manager.Subscribe("test:1", subscriber)
+
+	manager.PublishUpdate(message2)
+
+	assert.Len(t, receivedMessages, 2)
+}
+
+func TestBufferedMessagesDisapearAfter10S(t *testing.T) {
+	manager := subscription.NewManager()
+	receivedMessages := make([]subscription.Message, 0)
+
+	subscriber := subscription.NewSubscriberFunction(func(message subscription.Message) error {
+		receivedMessages = append(receivedMessages, message)
+		return nil
+	})
+
+	message1 := subscription.Message{
+		ResourceID: "test:1",
+		Type:       "test_update",
+		Content:    "Test was updated",
+	}
+
+	message2 := subscription.Message{
+		ResourceID: "test:1",
+		Type:       "test_deleted",
+		Content:    "Test was deleted",
+	}
+
+	manager.PublishUpdate(message1)
+	time.Sleep(10 * time.Second)
+	manager.Subscribe("test:1", subscriber)
+
+	manager.PublishUpdate(message2)
+
+	assert.Len(t, receivedMessages, 1)
 }

--- a/web/src/models/TestRunEvent.model.ts
+++ b/web/src/models/TestRunEvent.model.ts
@@ -1,5 +1,6 @@
 import {LogLevel, OutputInfoLogLevel, PollingInfoType, TestRunStage} from 'constants/TestRunEvents.constants';
 import {Model, TTestEventsSchemas} from 'types/Common.types';
+import Date from 'utils/Date';
 import ConnectionResult from './ConnectionResult.model';
 
 export type TRawTestRunEvent = TTestEventsSchemas['TestRunEvent'];
@@ -10,7 +11,13 @@ type PollingInfo = Model<TRawPollingInfo, {}>;
 type OutputInfo = Model<TRawOutputInfo, {}>;
 type TestRunEvent = Model<
   TRawTestRunEvent,
-  {logLevel: LogLevel; dataStoreConnection?: ConnectionResult; polling?: PollingInfo; outputs?: OutputInfo[]}
+  {
+    timestamp: Number;
+    logLevel: LogLevel;
+    dataStoreConnection?: ConnectionResult;
+    polling?: PollingInfo;
+    outputs?: OutputInfo[];
+  }
 >;
 
 function PollingInfo({
@@ -66,6 +73,7 @@ function TestRunEvent({
     title,
     description,
     createdAt,
+    timestamp: Date.getTimestamp(createdAt),
     testId,
     runId,
     logLevel: logLevel ?? LogLevel.Info,

--- a/web/src/redux/apis/endpoints/TestRun.endpoints.ts
+++ b/web/src/redux/apis/endpoints/TestRun.endpoints.ts
@@ -11,6 +11,7 @@ import {TEnvironmentValue} from 'models/Environment.model';
 import {TRawTestSpecs} from 'models/TestSpecs.model';
 import Test from 'models/Test.model';
 import TestRunEvent, {TRawTestRunEvent} from 'models/TestRunEvent.model';
+import {last} from 'lodash';
 
 function getTotalCountFromHeaders(meta: any) {
   return Number(meta?.response?.headers.get('x-total-count') || 0);
@@ -105,7 +106,11 @@ const TestRunEndpoint = (builder: TTestApiEndpointBuilder) => ({
     async onCacheEntryAdded(arg, {cacheDataLoaded, cacheEntryRemoved, updateCachedData}) {
       const listener: IListenerFunction<TRawTestRunEvent> = data => {
         updateCachedData(draft => {
-          draft.push(TestRunEvent(data.event));
+          const lastTestRunEvent = last(draft);
+          const testRunEvent = TestRunEvent(data.event);
+          if (!lastTestRunEvent || testRunEvent.timestamp > lastTestRunEvent.timestamp) {
+            draft.push(TestRunEvent(data.event));
+          }
         });
       };
       await WebSocketService.initWebSocketSubscription({

--- a/web/src/utils/Date.ts
+++ b/web/src/utils/Date.ts
@@ -1,4 +1,4 @@
-import {format, formatDistanceToNowStrict, isValid, parseISO} from 'date-fns';
+import {format, formatDistanceToNowStrict, getTime, isValid, parseISO} from 'date-fns';
 
 const Date = {
   format(date: string, dateFormat = "EEEE, yyyy/MM/dd 'at' HH:mm:ss") {
@@ -14,6 +14,13 @@ const Date = {
       return '';
     }
     return formatDistanceToNowStrict(isoDate, {addSuffix: true});
+  },
+  getTimestamp(date: string) {
+    const isoDate = parseISO(date);
+    if (!isValid(isoDate)) {
+      return 0;
+    }
+    return getTime(isoDate);
   },
 };
 


### PR DESCRIPTION
This PR adds a temporary buffer to the subscription manager. This makes sure that if someone subscribes to a topic after an event is received, it will still receive those events.

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [x] added a test
