### PR TITLE
Update server.md to add http server  options for server

### DIFF
--- a/docs/docs/configuration/server.md
+++ b/docs/docs/configuration/server.md
@@ -26,6 +26,11 @@ The list of environment variables and example values is:
 - `TRACETEST_POSTGRES_PASSWORD: "postgres"`
 - `TRACETEST_POSTGRES_PARAMS: ""`
 
+You can also change the defaults for the Tracetest server, altering the port and path you access the dashboard from. For a docker based install done locally, this url is typically http://localhost:11633/. You can alter it by setting either of these environmental variables: 
+
+- `TRACETEST_SERVER_HTTPPORT=11633`
+- `TRACETEST_SERVER_PATHPREFIX="/"`
+
 
 You can also intitalize the server with a number of resources the first time it is launched by using [provisioning](./provisioning).
 

--- a/docs/docs/configuration/server.md
+++ b/docs/docs/configuration/server.md
@@ -26,7 +26,7 @@ The list of environment variables and example values is:
 - `TRACETEST_POSTGRES_PASSWORD: "postgres"`
 - `TRACETEST_POSTGRES_PARAMS: ""`
 
-You can also change the defaults for the Tracetest server, altering the port and path you access the dashboard from. For a docker based install done locally, this url is typically http://localhost:11633/. You can alter it by setting either of these environmental variables: 
+You can also change the defaults for the Tracetest server, altering the port and path you access the dashboard from. For a Docker-based install done locally, this URL is typically `http://localhost:11633/`. You can alter it by setting either of the environment variables or using the `server` object in the server configuration file:
 
 - `TRACETEST_SERVER_HTTPPORT=11633`
 - `TRACETEST_SERVER_PATHPREFIX="/"`


### PR DESCRIPTION
Update server.md to add http server  options for server, including TRACETEST_SERVER_HTTPPORT and TRACETEST_SERVER_PATHPREFIX

This PR...

## Changes

-

## Fixes

-

## Checklist

- [ ] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
