### PR TITLE
feature(frontend): adding test spec snippets

### DIFF
--- a/web/src/components/TestResults/AddTestSpecButton.tsx
+++ b/web/src/components/TestResults/AddTestSpecButton.tsx
@@ -1,18 +1,20 @@
-import React, {useCallback, useMemo} from 'react';
+import React, {useCallback, useEffect, useMemo, useRef} from 'react';
 import {CaretDownOutlined} from '@ant-design/icons';
 import {Dropdown, Menu} from 'antd';
 import SpanService from 'services/Span.service';
 import Span from 'models/Span.model';
+import {TEST_SPEC_SNIPPETS, TSnippet} from 'constants/TestSpecs.constants';
 import * as S from './TestResults.styled';
 import {useTestSpecForm} from '../TestSpecForm/TestSpecForm.provider';
-import {TEST_SPEC_SNIPPETS, TSnippet} from '../../constants/TestSpecs.constants';
 
 interface IProps {
   selectedSpan: Span;
+  visibleByDefault?: boolean;
 }
 
-const AddTestSpecButton = ({selectedSpan}: IProps) => {
+const AddTestSpecButton = ({selectedSpan, visibleByDefault = false}: IProps) => {
   const {open} = useTestSpecForm();
+  const caretRef = useRef<HTMLElement>(null);
   const handleEmptyTestSpec = useCallback(() => {
     const selector = SpanService.getSelectorInformation(selectedSpan);
 
@@ -36,6 +38,12 @@ const AddTestSpecButton = ({selectedSpan}: IProps) => {
     [open]
   );
 
+  useEffect(() => {
+    if (visibleByDefault && caretRef.current) {
+      caretRef.current?.click();
+    }
+  }, [visibleByDefault]);
+
   const menu = useMemo(
     () => (
       <Menu
@@ -50,10 +58,16 @@ const AddTestSpecButton = ({selectedSpan}: IProps) => {
               onClick: () => onSnippetClick(snippet),
             })),
           },
+          {type: 'divider'},
+          {
+            label: 'Empty Test Spec',
+            key: 'empty-test-spec',
+            onClick: handleEmptyTestSpec,
+          },
         ]}
       />
     ),
-    [onSnippetClick]
+    [handleEmptyTestSpec, onSnippetClick]
   );
 
   return (
@@ -65,7 +79,7 @@ const AddTestSpecButton = ({selectedSpan}: IProps) => {
       type="primary"
       buttonsRender={([leftButton]) => [
         React.cloneElement(leftButton as React.ReactElement<any, string>, {'data-cy': 'add-test-spec-button'}),
-        <S.CaretDropdownButton type="primary" data-cy="create-button">
+        <S.CaretDropdownButton ref={caretRef} type="primary" data-cy="create-button">
           <CaretDownOutlined />
         </S.CaretDropdownButton>,
       ]}

--- a/web/src/components/TestResults/AddTestSpecButton.tsx
+++ b/web/src/components/TestResults/AddTestSpecButton.tsx
@@ -1,0 +1,78 @@
+import React, {useCallback, useMemo} from 'react';
+import {CaretDownOutlined} from '@ant-design/icons';
+import {Dropdown, Menu} from 'antd';
+import SpanService from 'services/Span.service';
+import Span from 'models/Span.model';
+import * as S from './TestResults.styled';
+import {useTestSpecForm} from '../TestSpecForm/TestSpecForm.provider';
+import {TEST_SPEC_SNIPPETS, TSnippet} from '../../constants/TestSpecs.constants';
+
+interface IProps {
+  selectedSpan: Span;
+}
+
+const AddTestSpecButton = ({selectedSpan}: IProps) => {
+  const {open} = useTestSpecForm();
+  const handleEmptyTestSpec = useCallback(() => {
+    const selector = SpanService.getSelectorInformation(selectedSpan);
+
+    open({
+      isEditing: false,
+      selector,
+      defaultValues: {
+        selector,
+      },
+    });
+  }, [open, selectedSpan]);
+
+  const onSnippetClick = useCallback(
+    (snippet: TSnippet) => {
+      open({
+        isEditing: false,
+        selector: snippet.selector,
+        defaultValues: snippet,
+      });
+    },
+    [open]
+  );
+
+  const menu = useMemo(
+    () => (
+      <Menu
+        items={[
+          {
+            label: 'Try these snippets for quick testing:',
+            key: 'test',
+            type: 'group',
+            children: TEST_SPEC_SNIPPETS.map(snippet => ({
+              label: snippet.name,
+              key: snippet.name,
+              onClick: () => onSnippetClick(snippet),
+            })),
+          },
+        ]}
+      />
+    ),
+    [onSnippetClick]
+  );
+
+  return (
+    <Dropdown.Button
+      overlay={menu}
+      trigger={['click']}
+      placement="bottomRight"
+      onClick={handleEmptyTestSpec}
+      type="primary"
+      buttonsRender={([leftButton]) => [
+        React.cloneElement(leftButton as React.ReactElement<any, string>, {'data-cy': 'add-test-spec-button'}),
+        <S.CaretDropdownButton type="primary" data-cy="create-button">
+          <CaretDownOutlined />
+        </S.CaretDropdownButton>,
+      ]}
+    >
+      Add Test Spec
+    </Dropdown.Button>
+  );
+};
+
+export default AddTestSpecButton;

--- a/web/src/components/TestResults/Header.tsx
+++ b/web/src/components/TestResults/Header.tsx
@@ -10,6 +10,8 @@ interface IProps {
 }
 
 const Header = ({selectedSpan, totalFailedSpecs, totalPassedSpecs}: IProps) => {
+  const hasSpecs = !!(totalFailedSpecs || totalPassedSpecs);
+
   return (
     <S.HeaderContainer>
       <S.Row>
@@ -30,7 +32,7 @@ const Header = ({selectedSpan, totalFailedSpecs, totalPassedSpecs}: IProps) => {
         </div>
       </S.Row>
 
-      <AddTestSpecButton selectedSpan={selectedSpan} />
+      <AddTestSpecButton selectedSpan={selectedSpan} visibleByDefault={!hasSpecs} />
     </S.HeaderContainer>
   );
 };

--- a/web/src/components/TestResults/Header.tsx
+++ b/web/src/components/TestResults/Header.tsx
@@ -1,9 +1,7 @@
-import {StepsID} from 'components/GuidedTour/testRunSteps';
-import {useTestSpecForm} from 'components/TestSpecForm/TestSpecForm.provider';
-import SpanService from 'services/Span.service';
 import {singularOrPlural} from 'utils/Common';
 import Span from 'models/Span.model';
 import * as S from './TestResults.styled';
+import AddTestSpecButton from './AddTestSpecButton';
 
 interface IProps {
   selectedSpan: Span;
@@ -12,19 +10,6 @@ interface IProps {
 }
 
 const Header = ({selectedSpan, totalFailedSpecs, totalPassedSpecs}: IProps) => {
-  const {open} = useTestSpecForm();
-
-  const handleAddTestSpecOnClick = () => {
-    const selector = SpanService.getSelectorInformation(selectedSpan!);
-    open({
-      isEditing: false,
-      selector,
-      defaultValues: {
-        selector,
-      },
-    });
-  };
-
   return (
     <S.HeaderContainer>
       <S.Row>
@@ -45,9 +30,7 @@ const Header = ({selectedSpan, totalFailedSpecs, totalPassedSpecs}: IProps) => {
         </div>
       </S.Row>
 
-      <S.PrimaryButton data-tour={StepsID.TestSpecs} data-cy="add-test-spec-button" onClick={handleAddTestSpecOnClick}>
-        Add Test Spec
-      </S.PrimaryButton>
+      <AddTestSpecButton selectedSpan={selectedSpan} />
     </S.HeaderContainer>
   );
 };

--- a/web/src/components/TestResults/TestResults.styled.ts
+++ b/web/src/components/TestResults/TestResults.styled.ts
@@ -40,12 +40,15 @@ export const LoadingContainer = styled.div`
   text-align: center;
 `;
 
-export const PrimaryButton = styled(Button).attrs({
-  type: 'primary',
-})``;
-
 export const Row = styled.div`
   align-items: center;
   display: flex;
   gap: 8px;
+`;
+
+export const CaretDropdownButton = styled(Button)`
+  font-weight: 600;
+  opacity: 0.7;
+  width: 32px;
+  padding: 0px;
 `;

--- a/web/src/components/TestResults/TestResults.tsx
+++ b/web/src/components/TestResults/TestResults.tsx
@@ -36,8 +36,6 @@ const TestResults = ({onDelete, onEdit, onRevert}: IProps) => {
 
   return (
     <S.Container>
-      <Header selectedSpan={selectedSpan!} totalFailedSpecs={totalFailedSpecs} totalPassedSpecs={totalPassedSpecs} />
-
       {isLoading && (
         <S.LoadingContainer>
           <LoadingSpinner />
@@ -45,13 +43,20 @@ const TestResults = ({onDelete, onEdit, onRevert}: IProps) => {
       )}
 
       {!isLoading && (
-        <TestSpecs
-          assertionResults={assertionResults}
-          onDelete={onDelete}
-          onEdit={onEdit}
-          onOpen={handleOpen}
-          onRevert={onRevert}
-        />
+        <>
+          <Header
+            selectedSpan={selectedSpan!}
+            totalFailedSpecs={totalFailedSpecs}
+            totalPassedSpecs={totalPassedSpecs}
+          />
+          <TestSpecs
+            assertionResults={assertionResults}
+            onDelete={onDelete}
+            onEdit={onEdit}
+            onOpen={handleOpen}
+            onRevert={onRevert}
+          />
+        </>
       )}
     </S.Container>
   );

--- a/web/src/constants/TestSpecs.constants.ts
+++ b/web/src/constants/TestSpecs.constants.ts
@@ -1,0 +1,45 @@
+import {IValues} from 'components/TestSpecForm/TestSpecForm';
+
+export type TSnippet = Required<IValues>;
+
+export const HTTP_SPANS_STATUS_CODE: TSnippet = {
+  name: 'All HTTP Spans: Status  code is 200',
+  selector: 'span[tracetest.span.type="http"]',
+  assertions: [
+    {
+      left: 'attr:http.status_code',
+      comparator: '=',
+      right: '200',
+    },
+  ],
+};
+
+export const TRIGGER_SPAN_RESPONSE_TIME: TSnippet = {
+  name: 'Trigger Span: Response time is less than 200ms',
+  selector: 'span[tracetest.span.type="general" name="Tracetest trigger"]',
+  assertions: [
+    {
+      left: 'attr:tracetest.span.duration',
+      comparator: '<',
+      right: '200ms',
+    },
+  ],
+};
+
+export const DB_SPANS_RESPONSE_TIME: TSnippet = {
+  name: 'All Database Spans: Processing time is less than 100ms',
+  selector: 'span[tracetest.span.type="database"]',
+  assertions: [
+    {
+      left: 'attr:tracetest.span.duration',
+      comparator: '<',
+      right: '100ms',
+    },
+  ],
+};
+
+export const TEST_SPEC_SNIPPETS: TSnippet[] = [
+  HTTP_SPANS_STATUS_CODE,
+  TRIGGER_SPAN_RESPONSE_TIME,
+  DB_SPANS_RESPONSE_TIME,
+];

--- a/web/src/constants/TestSpecs.constants.ts
+++ b/web/src/constants/TestSpecs.constants.ts
@@ -38,8 +38,47 @@ export const DB_SPANS_RESPONSE_TIME: TSnippet = {
   ],
 };
 
+export const TRIGGER_SPAN_RESPONSE_BODY_CONTAINS: TSnippet = {
+  name: 'Trigger Span: Response body contains "this string"',
+  selector: 'span[tracetest.span.type="general" name="Tracetest trigger"]',
+  assertions: [
+    {
+      left: 'attr:tracetest.response.body',
+      comparator: 'contains',
+      right: '"this string"',
+    },
+  ],
+};
+
+export const GRPC_SPANS_STATUS_CODE: TSnippet = {
+  name: 'All gRPC Spans: Status is Ok',
+  selector: 'span[tracetest.span.type="rpc" rpc.system="grpc"]',
+  assertions: [
+    {
+      left: 'attr:grpc.status_code',
+      comparator: '=',
+      right: '0',
+    },
+  ],
+};
+
+export const DB_SPANS_QUALITY_DB_STATEMENT_PRESENT: TSnippet = {
+  name: 'All Database Spans: db.statement should always be defined (QUALITY)',
+  selector: 'span[tracetest.span.type="database"]',
+  assertions: [
+    {
+      left: 'attr:db.system',
+      comparator: '!=',
+      right: '""',
+    },
+  ],
+};
+
 export const TEST_SPEC_SNIPPETS: TSnippet[] = [
   HTTP_SPANS_STATUS_CODE,
+  GRPC_SPANS_STATUS_CODE,
   TRIGGER_SPAN_RESPONSE_TIME,
+  TRIGGER_SPAN_RESPONSE_BODY_CONTAINS,
   DB_SPANS_RESPONSE_TIME,
+  DB_SPANS_QUALITY_DB_STATEMENT_PRESENT,
 ];


### PR DESCRIPTION
This PR adds a way for users to select a predefined test spec snippet so they have a quick start when adding checks for a trace

## Changes

- Updating add test spec button
- Adding source for snippets

## Fixes

- #2174 

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

https://www.loom.com/share/dee7d821ab7d4bb1b4f53d81659e02c3
