### PR TITLE
Update OpenAPI spec for resource manager APIs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,12 @@ help: Makefile ## show list of commands
 	@echo ""
 	@awk 'BEGIN {FS = ":.*?## "} /[a-zA-Z_-]+:.*?## / {sub("\\\\n",sprintf("\n%22c"," "), $$2);printf "\033[36m%-40s\033[0m %s\n", $$1, $$2}' $(MAKEFILE_LIST) | sort
 
+view-open-api: ## See OpenAPI specs on browser
+	@echo "Running SwaggerUI..."
+	@echo "Open http://localhost:9002 after the message 'Configuration complete; ready for start up'"
+	@echo ""
+	@docker run --rm -p 9002:8080 -v $(shell pwd)/api:/api -e SWAGGER_JSON=/api/openapi.yaml swaggerapi/swagger-ui
+
 .PHONY: run build build-go build-web build-docker
 run: build-docker ## build and run tracetest using docker compose
 	docker compose up

--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ help: Makefile ## show list of commands
 	@echo ""
 	@awk 'BEGIN {FS = ":.*?## "} /[a-zA-Z_-]+:.*?## / {sub("\\\\n",sprintf("\n%22c"," "), $$2);printf "\033[36m%-40s\033[0m %s\n", $$1, $$2}' $(MAKEFILE_LIST) | sort
 
-view-open-api: ## See OpenAPI specs on browser
+view-open-api: ## Run SwaggerUI locally to see OpenAPI documentation
 	@echo "Running SwaggerUI..."
 	@echo "Open http://localhost:9002 after the message 'Configuration complete; ready for start up'"
 	@echo ""

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -1292,7 +1292,7 @@ paths:
           content:
             application/json:
               schema:
-                teyp: object
+                type: object
                 properties:
                   count:
                     type: integer

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -877,6 +877,7 @@ paths:
                 type: array
                 items:
                   $ref: "./testEvents.yaml#/components/schemas/TestRunEvent"
+
   # Environments
   /environments:
     get:
@@ -1186,87 +1187,6 @@ paths:
           description: "problem updating configuration"
 
   # Polling Profile
-  /pollingprofile:
-    get:
-      tags:
-        - resource-api
-      summary: "List Polling Profiles"
-      description: "List polling profiles used on Tracetest to configure how to fetch traces in a test."
-      operationId: listPollingProfiles
-      parameters:
-        - in: query
-          name: take
-          description: "Indicates the maximum number of polling profiles that can be returned on this call."
-          schema:
-            type: integer
-            default: 20
-        - in: query
-          name: skip
-          description: "Indicates how many polling profiles will be skipped when paginating."
-          schema:
-            type: integer
-            default: 0
-        - in: query
-          name: sortBy
-          description: "Indicates the sort field for on which all polling profiles will be sorted."
-          schema:
-            type: string
-            enum: [id, name, strategy]
-        - in: query
-          name: sortDirection
-          description: "Indicates the sort direction for the polling profiles (ascending or descending)."
-          schema:
-            type: string
-            enum: [asc, desc]
-      responses:
-        200:
-          description: successful operation
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  count:
-                    type: integer
-                  items:
-                    type: array
-                    items:
-                      $ref: "./config.yaml#/components/schemas/PollingProfile"
-            text/yaml:
-              schema:
-                type: array
-                items:
-                  $ref: "./config.yaml#/components/schemas/PollingProfile"
-        400:
-          description: "invalid query for polling profiles, some data was sent in incorrect format."
-        500:
-          description: "problem listing polling profile"
-    post:
-      tags:
-        - resource-api
-      summary: "Create a Polling Profile"
-      description: "Create a polling profile used on Tracetest to configure how to fetch traces in a test."
-      operationId: createPollingProfile
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: "./config.yaml#/components/schemas/PollingProfile"
-          text/yaml:
-            schema:
-              $ref: "./config.yaml#/components/schemas/PollingProfile"
-      responses:
-        201:
-          description: successful operation
-          content:
-            application/json:
-              schema:
-                $ref: "./config.yaml#/components/schemas/PollingProfile"
-            text/yaml:
-              schema:
-                $ref: "./config.yaml#/components/schemas/PollingProfile"
-        500:
-          description: "problem creating a polling profile"
   /pollingprofile/{pollingProfileId}:
     get:
       tags:
@@ -1277,7 +1197,7 @@ paths:
           schema:
             type: string
           required: true
-          description: "ID of a polling profile used on Tracetest to configure how to fetch traces in a test."
+          description: "ID of a polling profile used on Tracetest to configure how to fetch traces in a test. It should be set as 'current'."
       summary: "Get Polling Profile"
       description: "Get a polling profile used on Tracetest to configure how to fetch traces in a test."
       operationId: getPollingProfile
@@ -1304,7 +1224,7 @@ paths:
           schema:
             type: string
           required: true
-          description: "ID of a polling profile used on Tracetest to configure how to fetch traces in a test."
+          description: "ID of a polling profile used on Tracetest to configure how to fetch traces in a test. It should be set as 'current'."
       summary: "Update a Polling Profile"
       description: "Update a polling profile used on Tracetest to configure how to fetch traces in a test."
       operationId: updatePollingProfile
@@ -1332,28 +1252,6 @@ paths:
           description: "polling profile not found"
         500:
           description: "problem updating a polling profile"
-    delete:
-      tags:
-        - resource-api
-      parameters:
-        - in: path
-          name: pollingProfileId
-          schema:
-            type: string
-          required: true
-          description: "ID of a polling profile used on Tracetest to configure how to fetch traces in a test."
-      summary: "Delete a Polling Profile"
-      description: "Delete a polling profile used on Tracetest to configure how to fetch traces in a test."
-      operationId: deletePollingProfile
-      responses:
-        204:
-          description: successful operation
-        400:
-          description: "invalid polling profile, some data was sent in incorrect format."
-        404:
-          description: "polling profile not found"
-        500:
-          description: "problem deleting a polling profile"
 
   # Demo
   /demo:
@@ -1393,15 +1291,23 @@ paths:
           description: successful operation
           content:
             application/json:
-              schema:
-                type: array
+              schema: object
+              properties:
+                count:
+                  type: integer
                 items:
-                  $ref: "./config.yaml#/components/schemas/Demo"
+                  type: array
+                  items:
+                    $ref: "./config.yaml#/components/schemas/Demo"
             text/yaml:
-              schema:
-                type: array
+              schema: object
+              properties:
+                count:
+                  type: integer
                 items:
-                  $ref: "./config.yaml#/components/schemas/Demo"
+                  type: array
+                  items:
+                    $ref: "./config.yaml#/components/schemas/Demo"
         400:
           description: "invalid query for demos, some data was sent in incorrect format."
         500:

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -1291,23 +1291,25 @@ paths:
           description: successful operation
           content:
             application/json:
-              schema: object
-              properties:
-                count:
-                  type: integer
-                items:
-                  type: array
+              schema:
+                teyp: object
+                properties:
+                  count:
+                    type: integer
                   items:
-                    $ref: "./config.yaml#/components/schemas/Demo"
+                    type: array
+                    items:
+                      $ref: "./config.yaml#/components/schemas/Demo"
             text/yaml:
-              schema: object
-              properties:
-                count:
-                  type: integer
-                items:
-                  type: array
+              schema:
+                type: object
+                properties:
+                  count:
+                    type: integer
                   items:
-                    $ref: "./config.yaml#/components/schemas/Demo"
+                    type: array
+                    items:
+                      $ref: "./config.yaml#/components/schemas/Demo"
         400:
           description: "invalid query for demos, some data was sent in incorrect format."
         500:


### PR DESCRIPTION
This PR updates our OpenAPI spec to consider changes we did on Resource Manager-based APIs.

To test it locally, just run `make view-open-api` and follow the instructions.

## Changes

- Updated `api/openapi.yaml`

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [x] updated the docs
- [ ] added a test
