### PR TITLE
fix(frontend): add minor improvements for error handling

### DIFF
--- a/web/src/components/RunDetailLayout/HeaderRight.tsx
+++ b/web/src/components/RunDetailLayout/HeaderRight.tsx
@@ -3,6 +3,7 @@ import RunActionsMenu from 'components/RunActionsMenu';
 import TestActions from 'components/TestActions';
 import TestState from 'components/TestState';
 import {TestState as TestStateEnum} from 'constants/TestRun.constants';
+import {isRunStateFinished} from 'models/TestRun.model';
 import {useTest} from 'providers/Test/Test.provider';
 import {useTestRun} from 'providers/TestRun/TestRun.provider';
 import {useTestSpecs} from 'providers/TestSpecs/TestSpecs.provider';
@@ -31,7 +32,7 @@ const HeaderRight = ({testId, testVersion}: IProps) => {
           <TestState testState={state} />
         </S.StateContainer>
       )}
-      {!isDraftMode && state && state === TestStateEnum.FINISHED && (
+      {!isDraftMode && state && isRunStateFinished(state) && (
         <Button data-cy="run-test-button" ghost onClick={() => onRun(run.id)} type="primary">
           Run Test
         </Button>

--- a/web/src/components/RunDetailTest/RunDetailTest.tsx
+++ b/web/src/components/RunDetailTest/RunDetailTest.tsx
@@ -13,6 +13,7 @@ import TestSpecDetail from 'components/TestSpecDetail';
 import TestSpecForm from 'components/TestSpecForm';
 import {useTestSpecForm} from 'components/TestSpecForm/TestSpecForm.provider';
 import Switch from 'components/Visualization/components/Switch';
+import {TestState} from 'constants/TestRun.constants';
 import {TAssertionResultEntry} from 'models/AssertionResults.model';
 import TestRun from 'models/TestRun.model';
 import TestRunEvent from 'models/TestRunEvent.model';
@@ -118,13 +119,15 @@ const RunDetailTest = ({run, runEvents, testId}: IProps) => {
           <S.Container>
             <S.SectionLeft>
               <S.SwitchContainer>
-                <Switch
-                  onChange={type => {
-                    TestRunAnalytics.onSwitchDiagramView(type);
-                    setVisualizationType(type);
-                  }}
-                  type={visualizationType}
-                />
+                {run.state === TestState.FINISHED && (
+                  <Switch
+                    onChange={type => {
+                      TestRunAnalytics.onSwitchDiagramView(type);
+                      setVisualizationType(type);
+                    }}
+                    type={visualizationType}
+                  />
+                )}
               </S.SwitchContainer>
 
               <Visualization

--- a/web/src/components/SpanDetail/Header.tsx
+++ b/web/src/components/SpanDetail/Header.tsx
@@ -18,6 +18,14 @@ const Header = ({span, assertions = {}}: IProps) => {
   const {kind, name, service, system, type} = SpanService.getSpanInfo(span);
   const {failed, passed} = useMemo(() => SpanService.getAssertionResultSummary(assertions), [assertions]);
 
+  if (!span) {
+    return (
+      <S.Header>
+        <S.HeaderTitle level={3}>Span Attributes</S.HeaderTitle>
+      </S.Header>
+    );
+  }
+
   return (
     <S.Header>
       <S.Column>


### PR DESCRIPTION
This PR introduces some minor improvements related to the error handling epic.

## Changes

- Fix Span Attributes header
- Remove trace visualization Switch when the trace stage failed
- Add RunTest button in header if run failed

## Fixes

- fixes #2326 

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
