### PR TITLE
feature(backend): adding analytics events for test run checkpoints

### DIFF
--- a/server/analytics/analytics.go
+++ b/server/analytics/analytics.go
@@ -39,17 +39,26 @@ func Ready() bool {
 	return defaultClient != nil && defaultClient.Ready()
 }
 
-func SendEvent(name, category, clientID string) error {
+func SendEvent(name, category, clientID string, data *map[string]string) error {
 	fmt.Printf(`sending event "%s" (%s)%s`, name, category, "\n")
 	if !Ready() {
 		err := fmt.Errorf("uninitalized client. Call analytics.Init")
 		fmt.Printf(`could not send event "%s" (%s): %s%s`, name, category, err.Error(), "\n")
 		return err
 	}
-	err := defaultClient.Track(name, map[string]string{
+
+	eventData := map[string]string{
 		"category": category,
 		"clientID": clientID,
-	})
+	}
+
+	if data != nil {
+		for k, v := range *data {
+			eventData[k] = v
+		}
+	}
+
+	err := defaultClient.Track(name, eventData)
 	if err != nil {
 		fmt.Printf(`could not send event "%s" (%s): %s%s`, name, category, err.Error(), "\n")
 	} else {

--- a/server/app/app.go
+++ b/server/app/app.go
@@ -172,7 +172,7 @@ func (app *App) Start(opts ...appOption) error {
 
 	fmt.Println("New install?", isNewInstall)
 	if isNewInstall {
-		err = analytics.SendEvent("Install", "beacon", "")
+		err = analytics.SendEvent("Install", "beacon", "", nil)
 		if err != nil {
 			return err
 		}
@@ -220,7 +220,7 @@ func (app *App) Start(opts ...appOption) error {
 		rf.assertionRunner.Stop()
 	})
 
-	err = analytics.SendEvent("Server Started", "beacon", "")
+	err = analytics.SendEvent("Server Started", "beacon", "", nil)
 	if err != nil {
 		return err
 	}

--- a/server/executor/runner.go
+++ b/server/executor/runner.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/kubeshop/tracetest/server/analytics"
 	"github.com/kubeshop/tracetest/server/executor/trigger"
 	"github.com/kubeshop/tracetest/server/expression"
 	"github.com/kubeshop/tracetest/server/model"
@@ -272,7 +273,13 @@ func (r persistentRunner) processExecQueue(job execReq) {
 func (r persistentRunner) handleExecutionResult(run model.Run, response trigger.Response, err error) model.Run {
 	run = run.TriggerCompleted(response.Result)
 	if err != nil {
-		return run.TriggerFailed(err)
+		run = run.TriggerFailed(err)
+
+		analytics.SendEvent("test_run_finished", "error", "", &map[string]string{
+			"finalState": string(run.State),
+		})
+
+		return run
 	}
 
 	return run.SuccessfullyTriggered()

--- a/server/executor/trace_poller.go
+++ b/server/executor/trace_poller.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"time"
 
+	"github.com/kubeshop/tracetest/server/analytics"
 	"github.com/kubeshop/tracetest/server/executor/pollingprofile"
 	"github.com/kubeshop/tracetest/server/model"
 	"github.com/kubeshop/tracetest/server/model/events"
@@ -213,7 +214,12 @@ func (tp tracePoller) handleTraceDBError(job PollingRequest, err error) (bool, s
 		fmt.Println("[TracePoller] Unknown error", err)
 	}
 
-	tp.handleDBError(tp.updater.Update(job.ctx, run.TraceFailed(err)))
+	run = run.TraceFailed(err)
+	analytics.SendEvent("test_run_finished", "error", "", &map[string]string{
+		"finalState": string(run.State),
+	})
+
+	tp.handleDBError(tp.updater.Update(job.ctx, run))
 
 	tp.subscriptionManager.PublishUpdate(subscription.Message{
 		ResourceID: run.TransactionStepResourceID(),

--- a/server/http/custom_routes.go
+++ b/server/http/custom_routes.go
@@ -244,7 +244,7 @@ func toWords(str string) string {
 func (c *customController) analytics(name string, f http.HandlerFunc) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		machineID := r.Header.Get("x-client-id")
-		analytics.SendEvent(toWords(name), "test", machineID)
+		analytics.SendEvent(toWords(name), "test", machineID, nil)
 
 		f(w, r)
 	}


### PR DESCRIPTION
This PR adds analytics events for the checkpoints that end a test run execution

## Changes

- Adding analytics events at the different levels where a test run ends

## Fixes

- #2245 

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
