### PR TITLE
chore(cicd): make pr pipeline clenaup only on success

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -395,7 +395,6 @@ jobs:
     name: Cleanup test infra
     runs-on: ubuntu-latest
     needs: [trace-testing, e2e]
-    if: always()
     steps:
       - uses: google-github-actions/setup-gcloud@94337306dda8180d967a56932ceb4ddcf01edae7
         with:


### PR DESCRIPTION
This PR makes the cleanup step of the PR pipeline run only when the run is successful. This change makes it easier to debug failed runs, and makes it faster to re run if needed.

## Checklist

- [ ] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
