### PR TITLE
Adding customJSON comparer to RM tests

### DIFF
--- a/server/resourcemanager/testutil/common_functions.go
+++ b/server/resourcemanager/testutil/common_functions.go
@@ -16,12 +16,28 @@ func generateRandomString() string {
 	return generator.TraceID().String()
 }
 
-func removeID(input map[string]any) map[string]any {
+func RemoveFieldFromJSONResource(field, jsonResource string) string {
+	resourceAsMap := parseJSON(jsonResource)
+
+	clean := removeFieldFromResource(field, resourceAsMap)
+
+	out, err := json.Marshal(clean)
+	if err != nil {
+		panic(err)
+	}
+	return string(out)
+}
+
+func removeIDFromJSON(input string) string {
+	return RemoveFieldFromJSONResource("id", input)
+}
+
+func removeFieldFromResource(field string, input map[string]any) map[string]any {
 	out := map[string]any{}
 	out["type"] = input["type"]
 	newSpec := map[string]any{}
 	for k, v := range input["spec"].(map[string]any) {
-		if k == "id" {
+		if k == field {
 			continue
 		}
 		newSpec[k] = v
@@ -40,17 +56,6 @@ func parseJSON(input string) map[string]any {
 	}
 
 	return parsed
-}
-
-func removeIDFromJSON(input string) string {
-
-	clean := removeID(parseJSON(input))
-
-	out, err := json.Marshal(clean)
-	if err != nil {
-		panic(err)
-	}
-	return string(out)
 }
 
 func extractID(input string) string {

--- a/server/resourcemanager/testutil/operations_create.go
+++ b/server/resourcemanager/testutil/operations_create.go
@@ -42,7 +42,7 @@ var createNoIDOperation = buildSingleStepOperation(singleStepOperationTester{
 		clean := removeIDFromJSON(rt.SampleJSON)
 		expected := ct.toJSON(clean)
 
-		require.JSONEq(t, expected, removeIDFromJSON(jsonBody))
+		rt.customJSONComparer(t, OperationCreateNoID, expected, removeIDFromJSON(jsonBody))
 		require.NotEmpty(t, extractID(jsonBody))
 	},
 })
@@ -67,7 +67,7 @@ var createSuccessOperation = buildSingleStepOperation(singleStepOperationTester{
 		jsonBody := responseBodyJSON(t, resp, ct)
 		expected := ct.toJSON(rt.SampleJSON)
 
-		require.JSONEq(t, expected, jsonBody)
+		rt.customJSONComparer(t, OperationCreateSuccess, expected, jsonBody)
 	},
 })
 

--- a/server/resourcemanager/testutil/operations_get.go
+++ b/server/resourcemanager/testutil/operations_get.go
@@ -41,7 +41,7 @@ var getSuccessOperation = buildSingleStepOperation(singleStepOperationTester{
 
 		expected := ct.toJSON(rt.SampleJSON)
 
-		require.JSONEq(t, expected, jsonBody)
+		rt.customJSONComparer(t, OperationGetSuccess, expected, jsonBody)
 	},
 })
 

--- a/server/resourcemanager/testutil/operations_list.go
+++ b/server/resourcemanager/testutil/operations_list.go
@@ -84,12 +84,22 @@ var listSuccessOperation = buildSingleStepOperation(singleStepOperationTester{
 
 		jsonBody := responseBodyJSON(t, resp, ct)
 
-		expected := `{
-			"count": 1,
-			"items": [` + ct.toJSON(rt.SampleJSON) + `]
-		}`
+		var parsedJsonBody struct {
+			Count int   `json:"count"`
+			Items []any `json:"items"`
+		}
+		json.Unmarshal([]byte(jsonBody), &parsedJsonBody)
 
-		require.JSONEq(t, expected, jsonBody)
+		require.Equal(t, 1, parsedJsonBody.Count)
+		require.Equal(t, len(parsedJsonBody.Items), 1)
+
+		obtainedAsBytes, err := json.Marshal(parsedJsonBody.Items[0])
+		require.NoError(t, err)
+
+		expected := ct.toJSON(rt.SampleJSON)
+		obtained := string(obtainedAsBytes)
+
+		rt.customJSONComparer(t, OperationListSuccess, expected, obtained)
 	},
 })
 

--- a/server/resourcemanager/testutil/operations_update.go
+++ b/server/resourcemanager/testutil/operations_update.go
@@ -38,7 +38,7 @@ var updateSuccessOperation = buildSingleStepOperation(singleStepOperationTester{
 
 		expected := ct.toJSON(rt.SampleJSONUpdated)
 
-		require.JSONEq(t, expected, jsonBody)
+		rt.customJSONComparer(t, OperationUpdateSuccess, expected, jsonBody)
 	},
 })
 


### PR DESCRIPTION
This PR adds a new JSON comparer on ResourceManager tests, to help with custom comparisons like [this one](https://github.com/kubeshop/tracetest/pull/2385/files#diff-cd7dc885f7101522d2abd1018432f17e64eae778fc1fa7c73efe4b411f3001cfR17) that I needed to build while migrating DataStores to RM.

## Changes

- Add support to custom JSON comparer on ResourceManager tests

## Fixes

- (partially) https://github.com/kubeshop/tracetest/issues/2341

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
