### PR TITLE
fix(cli): fix TRACETEST_DEV in docker compose installer

### DIFF
--- a/cli/analytics/analytics.go
+++ b/cli/analytics/analytics.go
@@ -1,10 +1,11 @@
 package analytics
 
 import (
+	"os"
+
 	"github.com/denisbrodbeck/machineid"
 	"github.com/kubeshop/tracetest/cli/config"
 	segment "github.com/segmentio/analytics-go/v3"
-	"os"
 )
 
 var (

--- a/cli/installer/docker_compose.go
+++ b/cli/installer/docker_compose.go
@@ -71,7 +71,7 @@ func dockerComposeInstaller(config configuration, ui cliUI.UI) {
 	dockerComposeFName := filepath.Join(dir, dockerComposeFilename)
 
 	dockerCmd := fmt.Sprintf(
-		"docker compose -f %s  up -d",
+		"docker compose -f %s up -d",
 		dockerComposeFName,
 	)
 
@@ -130,6 +130,7 @@ func getDockerComposeFileContents(ui cliUI.UI, config configuration) []byte {
 
 	sout := fixPortConfig(string(output))
 	sout = strings.ReplaceAll(sout, "$", "$$")
+	sout = strings.ReplaceAll(sout, "$${TRACETEST_DEV}", "${TRACETEST_DEV}")
 
 	return []byte(sout)
 }
@@ -259,6 +260,8 @@ func fixTracetestContainer(config configuration, project *types.Project, version
 	tts.Image = "kubeshop/tracetest:" + version
 	tts.Build = nil
 	tts.Volumes[0].Source = tracetestConfigFilename
+	tracetestDevEnv := "${TRACETEST_DEV}"
+	tts.Environment["TRACETEST_DEV"] = &tracetestDevEnv
 
 	replaceService(project, serviceName, tts)
 


### PR DESCRIPTION
This PR applies a fix to the installer to allow us to use the `TRACETEST_DEV` environment variable in our shell to populate the value inside the Compose file generated by the installer.

## Changes

- CLI installer fix

## Fixes

- fixes #2348 

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
