### PR TITLE
fix(frontend): update discord menu to online chat

### DIFF
--- a/web/src/components/Header/Menu.tsx
+++ b/web/src/components/Header/Menu.tsx
@@ -40,7 +40,7 @@ const Menu = () => {
               key: 'discord',
               label: (
                 <a data-cy="discord-link" href={DISCORD_URL} target="_blank">
-                  Discord
+                  Online Chat
                 </a>
               ),
             },


### PR DESCRIPTION
This PR updates the `Discord` menu to `Online Chat`.

## Changes

- discord menu

## Fixes

- fixes #2391

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Screenshot

![Screenshot 2023-04-17 at 10 37 30](https://user-images.githubusercontent.com/3879892/232537760-418c09da-bd8e-47a1-b432-29a5d340556b.png)