### PR TITLE
Adding database connection cleanup procedure on Resource Manager tests

### DIFF
--- a/server/config/configresource/config_resource_test.go
+++ b/server/config/configresource/config_resource_test.go
@@ -2,6 +2,7 @@ package configresource_test
 
 import (
 	"context"
+	"database/sql"
 	"os"
 	"testing"
 
@@ -100,8 +101,7 @@ func TestConfigResource(t *testing.T) {
 	rmtests.TestResourceType(t, rmtests.ResourceTypeTest{
 		ResourceTypeSingular: configresource.ResourceName,
 		ResourceTypePlural:   configresource.ResourceNamePlural,
-		RegisterManagerFn: func(router *mux.Router) resourcemanager.Manager {
-			db := testmock.CreateMigratedDatabase()
+		RegisterManagerFn: func(router *mux.Router, db *sql.DB) resourcemanager.Manager {
 			configRepo := configresource.NewRepository(db)
 
 			manager := resourcemanager.New[configresource.Config](

--- a/server/config/demoresource/demo_resource_test.go
+++ b/server/config/demoresource/demo_resource_test.go
@@ -2,6 +2,7 @@ package demoresource_test
 
 import (
 	"context"
+	"database/sql"
 	"testing"
 
 	"github.com/gorilla/mux"
@@ -9,7 +10,6 @@ import (
 	"github.com/kubeshop/tracetest/server/pkg/id"
 	"github.com/kubeshop/tracetest/server/resourcemanager"
 	rmtests "github.com/kubeshop/tracetest/server/resourcemanager/testutil"
-	"github.com/kubeshop/tracetest/server/testmock"
 )
 
 func TestPokeshopDemoResource(t *testing.T) {
@@ -49,8 +49,7 @@ func TestPokeshopDemoResource(t *testing.T) {
 	rmtests.TestResourceType(t, rmtests.ResourceTypeTest{
 		ResourceTypeSingular: demoresource.ResourceName,
 		ResourceTypePlural:   demoresource.ResourceNamePlural,
-		RegisterManagerFn: func(router *mux.Router) resourcemanager.Manager {
-			db := testmock.CreateMigratedDatabase()
+		RegisterManagerFn: func(router *mux.Router, db *sql.DB) resourcemanager.Manager {
 			demoRepository := demoresource.NewRepository(db)
 
 			manager := resourcemanager.New[demoresource.Demo](
@@ -149,8 +148,7 @@ func TestOpenTelemetryStoreDemoResource(t *testing.T) {
 	rmtests.TestResourceType(t, rmtests.ResourceTypeTest{
 		ResourceTypeSingular: demoresource.ResourceName,
 		ResourceTypePlural:   demoresource.ResourceNamePlural,
-		RegisterManagerFn: func(router *mux.Router) resourcemanager.Manager {
-			db := testmock.CreateMigratedDatabase()
+		RegisterManagerFn: func(router *mux.Router, db *sql.DB) resourcemanager.Manager {
 			demoRepository := demoresource.NewRepository(db)
 
 			manager := resourcemanager.New[demoresource.Demo](

--- a/server/executor/pollingprofile/polling_profile_resource_test.go
+++ b/server/executor/pollingprofile/polling_profile_resource_test.go
@@ -1,6 +1,7 @@
 package pollingprofile_test
 
 import (
+	"database/sql"
 	"testing"
 
 	"github.com/gorilla/mux"
@@ -8,15 +9,13 @@ import (
 	"github.com/kubeshop/tracetest/server/pkg/id"
 	"github.com/kubeshop/tracetest/server/resourcemanager"
 	rmtests "github.com/kubeshop/tracetest/server/resourcemanager/testutil"
-	"github.com/kubeshop/tracetest/server/testmock"
 )
 
 func TestPollingProfileResource(t *testing.T) {
 	rmtests.TestResourceType(t, rmtests.ResourceTypeTest{
 		ResourceTypeSingular: pollingprofile.ResourceName,
 		ResourceTypePlural:   pollingprofile.ResourceNamePlural,
-		RegisterManagerFn: func(router *mux.Router) resourcemanager.Manager {
-			db := testmock.CreateMigratedDatabase()
+		RegisterManagerFn: func(router *mux.Router, db *sql.DB) resourcemanager.Manager {
 			pollingProfileRepo := pollingprofile.NewRepository(db)
 
 			manager := resourcemanager.New[pollingprofile.PollingProfile](

--- a/server/resourcemanager/main_test.go
+++ b/server/resourcemanager/main_test.go
@@ -1,0 +1,18 @@
+package resourcemanager_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/kubeshop/tracetest/server/testmock"
+)
+
+func TestMain(m *testing.M) {
+	testmock.StartTestEnvironment()
+
+	exitVal := m.Run()
+
+	testmock.StopTestEnvironment()
+
+	os.Exit(exitVal)
+}

--- a/server/resourcemanager/resource_manager_test.go
+++ b/server/resourcemanager/resource_manager_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/gorilla/mux"
 	"github.com/kubeshop/tracetest/server/pkg/id"
+	"github.com/kubeshop/tracetest/server/resourcemanager"
 	rm "github.com/kubeshop/tracetest/server/resourcemanager"
 	rmtests "github.com/kubeshop/tracetest/server/resourcemanager/testutil"
 	"github.com/stretchr/testify/mock"
@@ -74,7 +75,7 @@ func TestSampleResource(t *testing.T) {
 	rmtests.TestResourceTypeWithErrorOperations(t, rmtests.ResourceTypeTest{
 		ResourceTypeSingular: "SampleResource",
 		ResourceTypePlural:   "SampleResources",
-		RegisterManagerFn: func(router *mux.Router) rm.Manager {
+		RegisterManagerFn: func(router *mux.Router, db *sql.DB) resourcemanager.Manager {
 			mockManager := new(sampleResourceManager)
 			manager := rm.New[sampleResource](
 				"SampleResource",
@@ -223,7 +224,7 @@ func TestRestrictedResource(t *testing.T) {
 	rmtests.TestResourceTypeWithErrorOperations(t, rmtests.ResourceTypeTest{
 		ResourceTypeSingular: "RestrictedResource",
 		ResourceTypePlural:   "RestrictedResources",
-		RegisterManagerFn: func(router *mux.Router) rm.Manager {
+		RegisterManagerFn: func(router *mux.Router, db *sql.DB) rm.Manager {
 			mockManager := new(restrictedResourceManager)
 			manager := rm.New[sampleResource](
 				"RestrictedResource",

--- a/server/resourcemanager/testutil/test_provisioning.go
+++ b/server/resourcemanager/testutil/test_provisioning.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/gorilla/mux"
 	"github.com/kubeshop/tracetest/server/resourcemanager"
+	"github.com/kubeshop/tracetest/server/testmock"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v2"
 )
@@ -19,7 +20,10 @@ const (
 func testProvisioning(t *testing.T, rt ResourceTypeTest) {
 	t.Run("Provisioning", func(t *testing.T) {
 		t.Run("Success", func(t *testing.T) {
-			manager := rt.RegisterManagerFn(mux.NewRouter())
+			db := testmock.CreateMigratedDatabase()
+			defer db.Close()
+
+			manager := rt.RegisterManagerFn(mux.NewRouter(), db)
 			if rt.Prepare != nil {
 				rt.Prepare(t, OperationProvisioningSuccess, manager)
 			}
@@ -34,7 +38,10 @@ func testProvisioning(t *testing.T, rt ResourceTypeTest) {
 		})
 
 		t.Run("UnacceptableType", func(t *testing.T) {
-			manager := rt.RegisterManagerFn(mux.NewRouter())
+			db := testmock.CreateMigratedDatabase()
+			defer db.Close()
+
+			manager := rt.RegisterManagerFn(mux.NewRouter(), db)
 			if rt.Prepare != nil {
 				rt.Prepare(t, OperationProvisioningTypeNotSupported, manager)
 			}

--- a/server/testdb/data_stores_test.go
+++ b/server/testdb/data_stores_test.go
@@ -2,6 +2,7 @@ package testdb_test
 
 import (
 	"context"
+	"database/sql"
 	"testing"
 
 	"github.com/gorilla/mux"
@@ -9,7 +10,6 @@ import (
 	"github.com/kubeshop/tracetest/server/resourcemanager"
 	rmtests "github.com/kubeshop/tracetest/server/resourcemanager/testutil"
 	"github.com/kubeshop/tracetest/server/testdb"
-	"github.com/kubeshop/tracetest/server/testmock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/config/configgrpc"
@@ -177,8 +177,7 @@ func TestDataStoreProvisioner(t *testing.T) {
 	rmtests.TestResourceType(t, rmtests.ResourceTypeTest{
 		ResourceTypeSingular: testdb.DataStoreResourceName,
 		ResourceTypePlural:   testdb.DataStoreResourceName,
-		RegisterManagerFn: func(router *mux.Router) resourcemanager.Manager {
-			db := testmock.CreateMigratedDatabase()
+		RegisterManagerFn: func(router *mux.Router, db *sql.DB) resourcemanager.Manager {
 			dsRepo, err := testdb.Postgres(testdb.WithDB(db))
 			require.NoError(t, err)
 
@@ -186,7 +185,7 @@ func TestDataStoreProvisioner(t *testing.T) {
 				testdb.DataStoreResourceName,
 				testdb.DataStoreResourceNamePlural,
 				testdb.NewDataStoreResourceProvisioner(dsRepo),
-				// this resource exists only for provisiooning at the moment``
+				// this resource exists only for provisioning at the moment
 				resourcemanager.WithOperations(resourcemanager.OperationNoop),
 			)
 			manager.RegisterRoutes(router)


### PR DESCRIPTION
This PR adds a database connection cleanup on RM tests to avoid surpassing PG connection capabilities when testing a package.

## Changes

- Changed RM tests to receive a database connection
- Added code to manage database connection cleanup on Resource Manager tests

## Fixes

- (partially) #2341

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
