### PR TITLE
fix(frontend): fix error handling for test specs

### DIFF
--- a/web/src/components/TestSpecDetail/Assertion.tsx
+++ b/web/src/components/TestSpecDetail/Assertion.tsx
@@ -1,4 +1,5 @@
 import AttributeValue from 'components/AttributeValue';
+import AssertionService from 'services/Assertion.service';
 import OperatorService from 'services/Operator.service';
 import {ICheckResult} from 'types/Assertion.types';
 import {TCompareOperatorSymbol} from 'types/Operator.types';
@@ -16,7 +17,7 @@ interface IProps {
 const Assertion = ({check, testId, runId, selector}: IProps) => (
   <S.CheckItemContainer>
     <S.GridContainer>
-      {check.result.error ? (
+      {check.result.error && AssertionService.isValidError(check.result.error) ? (
         <>
           <S.Row $justify="center">
             <S.IconWarning />

--- a/web/src/constants/TestSpecs.constants.ts
+++ b/web/src/constants/TestSpecs.constants.ts
@@ -82,3 +82,5 @@ export const TEST_SPEC_SNIPPETS: TSnippet[] = [
   DB_SPANS_RESPONSE_TIME,
   DB_SPANS_QUALITY_DB_STATEMENT_PRESENT,
 ];
+
+export const TestSpecErrors = ['resolution error', 'invalid syntax'];

--- a/web/src/services/Assertion.service.ts
+++ b/web/src/services/Assertion.service.ts
@@ -1,13 +1,14 @@
 import countBy from 'lodash/countBy';
 import uniq from 'lodash/uniq';
 
-import {ICheckResult, TStructuredAssertion} from 'types/Assertion.types';
 import {durationRegExp} from 'constants/Common.constants';
-import {Attributes} from 'constants/SpanAttribute.constants';
 import {CompareOperatorSymbolMap, OperatorRegexp} from 'constants/Operator.constants';
+import {Attributes} from 'constants/SpanAttribute.constants';
+import {TestSpecErrors} from 'constants/TestSpecs.constants';
+import AssertionResult, {TRawAssertionResult} from 'models/AssertionResult.model';
+import {ICheckResult, TStructuredAssertion} from 'types/Assertion.types';
 import {TCompareOperatorSymbol} from 'types/Operator.types';
 import {isJson} from 'utils/Common';
-import AssertionResult, {TRawAssertionResult} from 'models/AssertionResult.model';
 
 const isNumeric = (num: string): boolean => /^-?\d+(?:\.\d+)?$/.test(num);
 const isNumericTime = (num: string): boolean => durationRegExp.test(num);
@@ -42,8 +43,14 @@ const AssertionService = () => ({
     return countBy(passedResults);
   },
 
+  isValidError(error: string) {
+    return TestSpecErrors.some(testSpecError => error.includes(testSpecError));
+  },
+
   hasError(resultList: AssertionResult[]) {
-    return resultList.map(({spanResults}) => spanResults.some(({error}) => !!error)).some(result => !!result);
+    return resultList
+      .map(({spanResults}) => spanResults.some(({error}) => !!error && this.isValidError(error)))
+      .some(result => !!result);
   },
 
   getResultsHashedBySpanId(resultList: AssertionResult[]) {


### PR DESCRIPTION
This PR adds a fix for the error handling logic related to test specs. We only need to consider an assertion as an error if it contains the `resolution error` or `invalid syntax` message.

## Changes

- fix error handling logic related to test specs

## Fixes

-

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
