### PR TITLE
chore(cicd): replace cache with arctifacts so pipeline fails on error

### DIFF
--- a/.github/workflows/deploy-main.yml
+++ b/.github/workflows/deploy-main.yml
@@ -93,6 +93,11 @@ jobs:
           TRACETEST_ENV: main
           ANALYTICS_FE_KEY: ${{ secrets.ANALYTICS_FE_KEY }}
           ANALYTICS_BE_KEY: ${{ secrets.ANALYTICS_BE_KEY }}
+      - name: Upload assets
+        uses: actions/upload-artifact@v3
+        with:
+          name: dist-${{ matrix.GOOS }}
+          path: dist/${{ matrix.GOOS }}
 
   release:
     runs-on: ubuntu-latest
@@ -124,18 +129,18 @@ jobs:
       - shell: bash
         run: |
           echo "sha_short=$(git rev-parse --short=8 $GITHUB_SHA)" >> $GITHUB_ENV
-      - uses: actions/cache@v3
+      - uses: actions/download-artifact@v3
         with:
           path: dist/linux
-          key: linux-${{ env.sha_short }}
-      - uses: actions/cache@v3
+          key: dist-linux
+      - uses: actions/download-artifact@v3
         with:
           path: dist/darwin
-          key: darwin-${{ env.sha_short }}
-      - uses: actions/cache@v3
+          key: dist-darwin
+      - uses: actions/download-artifact@v3
         with:
           path: dist/windows
-          key: windows-${{ env.sha_short }}
+          key: dist-windows
       - uses: actions/download-artifact@v3
         with:
           name: tracetest-web


### PR DESCRIPTION
This PR replaces method for transmitting builds between the steps of the `deploy main` pipline from a `cache` to an `arctifact`. The difference is that an cache will fail silently to upload or download, while an arctifact fully fails on error.

This prevents issues like on [this run](https://github.com/kubeshop/tracetest/actions/runs/4767008554/jobs/8474956842), where the pipeline succeeded but the actual result was a nightly release with the linux binaries missing.

## Changes

-

## Fixes

-

## Checklist

- [ ] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
