### PR TITLE
feature(backend): adding event logs for otlp endpoints

### DIFF
--- a/server/model/events/events.go
+++ b/server/model/events/events.go
@@ -397,14 +397,14 @@ func TestSpecsAssertionWarning(testID id.ID, runID int, err error, spanID string
 	}
 }
 
-func TraceOtlpServerReceivedSpans(testID id.ID, runID int, spanCount int) model.TestRunEvent {
+func TraceOtlpServerReceivedSpans(testID id.ID, runID, spanCount int, requestType string) model.TestRunEvent {
 	return model.TestRunEvent{
 		TestID:              testID,
 		RunID:               runID,
 		Stage:               model.StageTrace,
 		Type:                "OTLP_SERVER_RECEIVED_SPANS",
-		Title:               "OTLP server received spans",
-		Description:         fmt.Sprintf("The Tracetest OTLP server received %d spans", spanCount),
+		Title:               fmt.Sprintf("%s OTLP server endpoint received spans", requestType),
+		Description:         fmt.Sprintf("The Tracetest %s OTLP endpoint server received %d spans", requestType, spanCount),
 		CreatedAt:           time.Now(),
 		DataStoreConnection: model.ConnectionResult{},
 		Polling:             model.PollingInfo{},

--- a/server/model/events/events.go
+++ b/server/model/events/events.go
@@ -396,3 +396,18 @@ func TestSpecsAssertionWarning(testID id.ID, runID int, err error, spanID string
 		Outputs:             []model.OutputInfo{},
 	}
 }
+
+func TraceOtlpServerReceivedSpans(testID id.ID, runID int, spanCount int) model.TestRunEvent {
+	return model.TestRunEvent{
+		TestID:              testID,
+		RunID:               runID,
+		Stage:               model.StageTrace,
+		Type:                "OTLP_SERVER_RECEIVED_SPANS",
+		Title:               "OTLP server received spans",
+		Description:         fmt.Sprintf("The Tracetest OTLP server received %d spans", spanCount),
+		CreatedAt:           time.Now(),
+		DataStoreConnection: model.ConnectionResult{},
+		Polling:             model.PollingInfo{},
+		Outputs:             []model.OutputInfo{},
+	}
+}

--- a/server/otlp/grpc_server.go
+++ b/server/otlp/grpc_server.go
@@ -40,5 +40,5 @@ func (s *grpcServer) Stop() {
 }
 
 func (s grpcServer) Export(ctx context.Context, request *pb.ExportTraceServiceRequest) (*pb.ExportTraceServiceResponse, error) {
-	return s.ingester.Ingest(ctx, request)
+	return s.ingester.Ingest(ctx, request, "gRPC")
 }

--- a/server/otlp/http_server.go
+++ b/server/otlp/http_server.go
@@ -70,7 +70,7 @@ func (s httpServer) Export(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	result, err := s.ingester.Ingest(r.Context(), request)
+	result, err := s.ingester.Ingest(r.Context(), request, "HTTP")
 	if err != nil {
 		response.sendError(http.StatusInternalServerError, status.Errorf(codes.InvalidArgument, "Error when ingesting spans %s", err.Error()))
 		return

--- a/server/otlp/ingester.go
+++ b/server/otlp/ingester.go
@@ -5,7 +5,9 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/kubeshop/tracetest/server/executor"
 	"github.com/kubeshop/tracetest/server/model"
+	"github.com/kubeshop/tracetest/server/model/events"
 	"github.com/kubeshop/tracetest/server/traces"
 	"go.opentelemetry.io/otel/trace"
 	pb "go.opentelemetry.io/proto/otlp/collector/trace/v1"
@@ -13,12 +15,14 @@ import (
 )
 
 type ingester struct {
-	db model.Repository
+	db           model.Repository
+	eventEmitter executor.EventEmitter
 }
 
-func NewIngester(db model.Repository) ingester {
+func NewIngester(db model.Repository, eventEmitter executor.EventEmitter) ingester {
 	return ingester{
-		db: db,
+		db:           db,
+		eventEmitter: eventEmitter,
 	}
 }
 
@@ -104,6 +108,7 @@ func (e ingester) saveSpansIntoTest(ctx context.Context, traceID trace.TraceID, 
 	newSpans := append(existingSpans, spans...)
 	newTrace := model.NewTrace(traceID.String(), newSpans)
 
+	e.eventEmitter.Emit(ctx, events.TraceOtlpServerReceivedSpans(run.TestID, run.ID, len(newSpans)))
 	run.Trace = &newTrace
 
 	err = e.db.UpdateRun(ctx, run)


### PR DESCRIPTION
This PR adds events logs for the otlp server endpoints when receiving spans

## Changes

- Adds the event emitter instance to the ingester module
- Triggers new event after saving spans to the run object

## Fixes

- #2383 

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test


https://www.loom.com/share/9334810050d44bd59caa392b6921a0d4