### PR TITLE
fix(cli): fix resources URLs

### DIFF
--- a/cli/cmd/config.go
+++ b/cli/cmd/config.go
@@ -46,15 +46,15 @@ func setupCommand(options ...setupOption) func(cmd *cobra.Command, args []string
 
 		baseOptions := []actions.ResourceArgsOption{actions.WithLogger(cliLogger), actions.WithConfig(cliConfig)}
 
-		configOptions := append(baseOptions, actions.WithClient(utils.GetResourceAPIClient("config", cliConfig)))
+		configOptions := append(baseOptions, actions.WithClient(utils.GetResourceAPIClient("configs", cliConfig)))
 		configActions := actions.NewConfigActions(configOptions...)
 		resourceRegistry.Register(configActions)
 
-		pollingOptions := append(baseOptions, actions.WithClient(utils.GetResourceAPIClient("pollingprofile", cliConfig)))
+		pollingOptions := append(baseOptions, actions.WithClient(utils.GetResourceAPIClient("pollingprofiles", cliConfig)))
 		pollingActions := actions.NewPollingActions(pollingOptions...)
 		resourceRegistry.Register(pollingActions)
 
-		demoOptions := append(baseOptions, actions.WithClient(utils.GetResourceAPIClient("demo", cliConfig)))
+		demoOptions := append(baseOptions, actions.WithClient(utils.GetResourceAPIClient("demos", cliConfig)))
 		demoActions := actions.NewDemoActions(demoOptions...)
 		resourceRegistry.Register(demoActions)
 


### PR DESCRIPTION
This PR fixes the CLI base URLs for resources: `Config`, `PollingProfile` and `Demo`

## Changes

- Fix CLI base URLs for resources

## Fixes

-

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
