### PR TITLE
fix: improve test and transaction output when it fails

### DIFF
--- a/cli/formatters/test_run.go
+++ b/cli/formatters/test_run.go
@@ -79,7 +79,16 @@ func (f testRun) json(output TestRunOutput) string {
 
 func (f testRun) pretty(output TestRunOutput) string {
 	if utils.RunStateIsFailed(output.Run.GetState()) {
-		return f.getColoredText(false, f.formatMessage("Failed to execute test: %s", *output.Run.LastErrorState))
+		return f.getColoredText(false, fmt.Sprintf("%s\n%s",
+			f.formatMessage("%s %s (%s)",
+				FAILED_TEST_ICON,
+				*output.Test.Name,
+				output.RunWebURL,
+			),
+			f.formatMessage("\tReason: %s",
+				*output.Run.LastErrorState,
+			),
+		))
 	}
 
 	if !output.HasResults {

--- a/cli/formatters/test_run.go
+++ b/cli/formatters/test_run.go
@@ -85,7 +85,7 @@ func (f testRun) pretty(output TestRunOutput) string {
 				*output.Test.Name,
 				output.RunWebURL,
 			),
-			f.formatMessage("\tReason: %s",
+			f.formatMessage("\tReason: %s\n",
 				*output.Run.LastErrorState,
 			),
 		))

--- a/cli/formatters/transaction_run.go
+++ b/cli/formatters/transaction_run.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/kubeshop/tracetest/cli/config"
 	"github.com/kubeshop/tracetest/cli/openapi"
-	"github.com/kubeshop/tracetest/cli/utils"
 	"github.com/pterm/pterm"
 )
 
@@ -79,19 +78,6 @@ func (f transactionRun) json(output TransactionRunOutput) string {
 }
 
 func (f transactionRun) pretty(output TransactionRunOutput) string {
-	if utils.RunStateIsFailed(output.Run.GetState()) {
-		errorMessage := ""
-		if len(output.Run.Steps) > 0 {
-			lastStep := output.Run.Steps[len(output.Run.Steps)-1]
-			lastError := lastStep.LastErrorState
-			if lastError != nil {
-				errorMessage = *lastError
-			}
-		}
-
-		return f.getColoredText(false, fmt.Sprintf("Failed to execute transaction: %s\n", errorMessage))
-	}
-
 	if !output.HasResults {
 		return ""
 	}


### PR DESCRIPTION
This PR improves the generated output when a test or a transaction step fails. Instead of showing `Failed to execute transaction: <reason>` it shows the test name and the link for the user to see more details on the UI.

![image](https://user-images.githubusercontent.com/2704737/234383718-5e4373de-49cd-404f-9b9f-039d6d389d91.png)


## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
