### PR TITLE
chore: generate server arch graph for releases

### DIFF
--- a/.github/workflows/deploy-main.yml
+++ b/.github/workflows/deploy-main.yml
@@ -12,6 +12,37 @@ on:
       - 'cli/**'
 
 jobs:
+  backend-arch-graph:
+    name: Generate backend architecture graph
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Setup go
+        uses: actions/setup-go@v3
+        with:
+          go-version-file: 'go.work'
+          cache: true
+          cache-dependency-path: go.work
+      - name: install graph tool
+        run: |
+          mkdir /tmp/go-arch
+          cd /tmp/go-arch
+          curl -SLO https://github.com/mathnogueira/golang-arch-viewer/archive/refs/heads/master.zip
+          unzip master.zip
+          cd golang-arch-viewer-master
+          make
+          mv dist/go-arch /tmp/go-arch/go-arch
+      - name: generate graph
+        run: |
+          cd server
+          /tmp/go-arch/go-arch ../dist/architecture.png
+      - name: Upload assets
+        uses: actions/upload-artifact@v3
+        with:
+          name: architecture-graph
+          path: dist/architecture.png
 
   build-web:
     name: build web
@@ -145,6 +176,10 @@ jobs:
         with:
           name: tracetest-web
           path: web/build/
+      - uses: actions/download-artifact@v3
+        with:
+          name: architecture-graph
+          path: dist/architecture.png
 
       - uses: goreleaser/goreleaser-action@v4
         if: steps.cache.outputs.cache-hit != 'true'

--- a/.github/workflows/deploy-main.yml
+++ b/.github/workflows/deploy-main.yml
@@ -37,6 +37,7 @@ jobs:
       - name: generate graph
         run: |
           cd server
+          mkdir -p ../dist/
           /tmp/go-arch/go-arch ../dist/architecture.png
       - name: Upload assets
         uses: actions/upload-artifact@v3

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -42,6 +42,7 @@ jobs:
       - name: generate graph
         run: |
           cd server
+          mkdir -p ../dist/
           /tmp/go-arch/go-arch ../dist/architecture.png
       - name: Upload assets
         uses: actions/upload-artifact@v3

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -17,6 +17,38 @@ on:
       - k8s/**
 
 jobs:
+  backend-arch-graph:
+    name: Generate backend architecture graph
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Setup go
+        uses: actions/setup-go@v3
+        with:
+          go-version-file: 'go.work'
+          cache: true
+          cache-dependency-path: go.work
+      - name: install graph tool
+        run: |
+          mkdir /tmp/go-arch
+          cd /tmp/go-arch
+          curl -SLO https://github.com/mathnogueira/golang-arch-viewer/archive/refs/heads/master.zip
+          unzip master.zip
+          cd golang-arch-viewer-master
+          make
+          mv dist/go-arch /tmp/go-arch/go-arch
+      - name: generate graph
+        run: |
+          cd server
+          /tmp/go-arch/go-arch ../dist/architecture.png
+      - name: Upload assets
+        uses: actions/upload-artifact@v3
+        with:
+          name: architecture-graph
+          path: dist/architecture.png
+
   unit-test-cli:
     name: CLI unit tests
     runs-on: ubuntu-latest

--- a/.goreleaser.rc.yaml
+++ b/.goreleaser.rc.yaml
@@ -10,6 +10,8 @@ release:
   # discussion_category_name: General
   draft: false
   prerelease: "true"
+  extra_files:
+    - glob: ./dist/architecture.png
 before:
   hooks:
     - dir: ./server

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -10,6 +10,8 @@ release:
   # discussion_category_name: General
   draft: false
   prerelease: auto
+  extra_files:
+    - glob: ./dist/architecture.png
 before:
   hooks:
     - dir: ./server

--- a/server/arch.yaml
+++ b/server/arch.yaml
@@ -1,0 +1,134 @@
+name: tracetest
+
+style:
+  core:
+    color: "#c9e6be"
+  infrastructure:
+    color: "#a1bbe3"
+  mixed:
+    color: "#de957f"
+
+
+modules:
+
+  main:
+    type: infrastructure
+    group: startup
+
+  cmd:
+    type: infrastructure
+    group: startup
+
+  config/*:
+    type: core
+    group: config
+
+  expression/*:
+    type: core
+    group: assertion_engine
+
+  assertions/*:
+    type: core
+    group: assertion_engine
+
+  executor/*:
+    type: core
+    group: test_runner
+
+  tracedb/*:
+    type: core
+    group: test_runner
+
+  otlp/*:
+    type: mixed
+    group: otlp_ingestor
+
+  http/websocket:
+    type: infrastructure
+    group: notification
+
+  subscription:
+    type: infrastructure
+    group: notification
+
+  http:
+    type: infrastructure
+    group: api
+
+  http/validation:
+    type: infrastructure
+    group: api
+
+  openapi:
+    type: infrastructure
+    group: api
+
+  http/mappings:
+    type: infrastructure
+    group: api
+
+  junit:
+    type: infrastructure
+    group: api
+
+  model/yaml/*:
+    type: infrastructure
+    group: api
+
+  analytics:
+    type: infrastructure
+    group: observability
+
+  tracing:
+    type: infrastructure
+    group: observability
+
+  id:
+    type: infrastructure
+    group: libraries
+
+  resourcemanager:
+    type: infrastructure
+    group: libraries
+
+  testdb:
+    type: infrastructure
+    group: persistence
+
+  migrations:
+    type: infrastructure
+    group: persistence
+
+  app:
+    type: infrastructure
+    group: startup
+
+  provisioning:
+    type: infrastructure
+    group: startup
+
+  model:
+    type: core
+    group: models
+
+  model/events:
+    type: core
+    group: models
+
+  traces:
+    type: core
+    group: models
+
+
+clusters:
+  config:
+    color: "#20BF55"
+
+  assertion_engine:
+    color: "#0B4F6C"
+
+  test_runner:
+    color: "#976391"
+
+  startup:
+    color: "#293F14"


### PR DESCRIPTION
This PR adds an auto generated image of the backend architecture, so we can keep track of how it evolves over time.

## Changes

-

## Fixes

-

## Checklist

- [ ] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
