### PR TITLE
fix(be): updating aws access key id

### DIFF
--- a/server/tracedb/datastoreresource/repository_test.go
+++ b/server/tracedb/datastoreresource/repository_test.go
@@ -94,7 +94,7 @@ func TestDataStoreResource_AWSXRay(t *testing.T) {
 				"createdAt": "2023-03-09T17:53:10.256383Z",
 				"awsxray": {
 					"region": "some-region",
-					"accessKeyID": "some-access-key",
+					"accessKeyId": "some-access-key",
 					"secretAccessKey": "some-secret-access-key",
 					"sessionToken": "some-session-token",
 					"useDefaultAuth": true
@@ -111,7 +111,7 @@ func TestDataStoreResource_AWSXRay(t *testing.T) {
 				"createdAt": "2023-03-09T17:53:10.256383Z",
 				"awsxray": {
 					"region": "some-region-updated",
-					"accessKeyID": "some-access-key-updated",
+					"accessKeyId": "some-access-key-updated",
 					"secretAccessKey": "some-access-key-updated",
 					"sessionToken": "some-session-token-updated",
 					"useDefaultAuth": true

--- a/server/tracedb/datastoreresource/resource_types.go
+++ b/server/tracedb/datastoreresource/resource_types.go
@@ -33,7 +33,7 @@ type DataStoreValues struct {
 
 type AWSXRayConfig struct {
 	Region          string `mapstructure:"region"`
-	AccessKeyID     string `mapstructure:"accessKeyID"`
+	AccessKeyID     string `mapstructure:"accessKeyId"`
 	SecretAccessKey string `mapstructure:"secretAccessKey"`
 	SessionToken    string `mapstructure:"sessionToken"`
 	UseDefaultAuth  bool   `mapstructure:"useDefaultAuth"`


### PR DESCRIPTION
This PR fixes the access id key for the aws data store

## Changes

-

## Fixes

-

## Checklist

- [ ] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
