### PR TITLE
Fixing typo on Lightstep examples

### DIFF
--- a/examples/tracetest-lightstep-otel-demo/tracetest/tracetest-provision.yaml
+++ b/examples/tracetest-lightstep-otel-demo/tracetest/tracetest-provision.yaml
@@ -2,7 +2,7 @@
 type: DataStore
 spec:
   name: Lightstep
-  type: lighstep
+  type: lightstep
 
 ---
 type: Demo

--- a/examples/tracetest-lightstep/tracetest/tracetest-provision.yaml
+++ b/examples/tracetest-lightstep/tracetest/tracetest-provision.yaml
@@ -2,7 +2,7 @@
 type: DataStore
 spec:
   name: Lightstep
-  type: lighstep
+  type: lightstep
 
 ---
 type: Demo


### PR DESCRIPTION
This PR changes the Lightstep provider id to `lightstep` on our examples.

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
