### PR TITLE
Add migration to fix data_store ids

### DIFF
--- a/server/migrations/25_update_data_stores_id.down.sql
+++ b/server/migrations/25_update_data_stores_id.down.sql
@@ -1,0 +1,1 @@
+-- this is a one way migration

--- a/server/migrations/25_update_data_stores_id.up.sql
+++ b/server/migrations/25_update_data_stores_id.up.sql
@@ -2,7 +2,7 @@ BEGIN;
 
 UPDATE data_stores
 SET id = 'current'
-WHERE id = (select id from data_stores order by created_at limit 1);
+WHERE id = (select id from data_stores where is_default='true' order by created_at limit 1);
 
 DELETE FROM data_stores WHERE id != 'current';
 

--- a/server/migrations/25_update_data_stores_id.up.sql
+++ b/server/migrations/25_update_data_stores_id.up.sql
@@ -1,0 +1,9 @@
+BEGIN;
+
+UPDATE data_stores
+SET id = 'current'
+WHERE id = (select id from data_stores order by created_at limit 1);
+
+DELETE FROM data_stores WHERE id != 'current';
+
+COMMIT;


### PR DESCRIPTION
This PR adds a server migration to guarantee that preexisting data_stores will continue working on Tracetest.

## Changes

- Add migration

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
