### PR TITLE
docs(config): add page for internal telemetry

### DIFF
--- a/docs/docs/configuration/telemetry.md
+++ b/docs/docs/configuration/telemetry.md
@@ -1,6 +1,8 @@
 # Telemetry
 
-The Tracetest server generates internal trace data. You can configure an exporter to send the trace data to an OpenTelemetry Collector and then store it safely in your trace data store for further analysis.
+The Tracetest server generates internal observability trace data. Use this data to track Tracetest test runs over time.
+
+You can configure an exporter to send the trace data to an OpenTelemetry Collector and then store it safely in your trace data store for further historical analysis.
 
 ## Configuring Tracetest Server Internal Telemetry
 

--- a/docs/docs/configuration/telemetry.md
+++ b/docs/docs/configuration/telemetry.md
@@ -1,10 +1,12 @@
 # Telemetry
 
-The Tracetest server generates internal observability trace data. Use this data to track Tracetest test runs over time.
+The Tracetest server generates internal observability trace data. You can use this data to track Tracetest test runs over time and gain observability of how the Tracetest server is behaving.
 
-You can configure an exporter to send the trace data to an OpenTelemetry Collector and then store it safely in your trace data store for further historical analysis.
+The Tracetest team uses an observability-driven development approach in developing the Tracetest server, capturing traces and then running Tracetest tests against it as part of the CI/CD process. You can read more about how we "eat our own dog food" in [this blog post](https://tracetest.io/blog/integrating-tracetest-with-github-actions-in-a-ci-pipeline) about the CI/CD configuration where we test Tracetest with Tracetest.
 
 ## Configuring Tracetest Server Internal Telemetry
+
+You can configure an exporter to send the trace data to an OpenTelemetry Collector and then store it safely in your trace data store for further historical analysis. View the [supported trace data stores](./overview#supported-trace-data-stores) for more guidance on setting them up.
 
 In the `tracetest-config.yaml` file, alongside the [configuration](./server.md) of connecting Tracetest to the Postgres instance, you can also define a `telemetry` and `server` section.
 

--- a/docs/docs/configuration/telemetry.md
+++ b/docs/docs/configuration/telemetry.md
@@ -12,7 +12,6 @@ With these two additional sections, you define an exporter where the Tracetest s
 
 ```yaml
 # tracetest-config.yaml
-
 postgres:
 # [...]
 

--- a/docs/docs/configuration/telemetry.md
+++ b/docs/docs/configuration/telemetry.md
@@ -1,0 +1,35 @@
+# Telemetry
+
+The Tracetest server generates internal trace data. You can configure an exporter to send the trace data to an OpenTelemetry Collector and then store it safely in your trace data store for further analysis.
+
+## Configuring Tracetest Server Internal Telemetry
+
+In the `tracetest-config.yaml` file, alongside the [configuration](./server.md) of connecting Tracetest to the Postgres instance, you can also define a `telemetry` and `server` section.
+
+With these two additional sections, you define an exporter where the Tracetest server's internal telemetry will be routed to. In the `telemetry` section, you define the endpoint of the OpenTelemetry Collector. And, in the `server` section you define which exporter the Tracetest server will use.
+
+```yaml
+# tracetest-config.yaml
+
+postgres:
+# [...]
+
+telemetry:
+  exporters:
+    collector:
+      serviceName: tracetest
+      sampling: 100 # 100%
+      exporter:
+        type: collector
+        collector:
+          endpoint: otel-collector:4317
+          # Replace with your OpenTelemetry Collector endpoint
+
+server:
+  telemetry:
+    exporter: collector
+```
+
+:::note
+Make sure to check what the service endpoint for the OpenTelemetry Collector in your infrastructure is. The example above is using `otel-collector` because that is the service name in Docker Compose. Your infrastructure might differ.
+:::

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -137,6 +137,11 @@ const sidebars = {
         },
         {
           type: "doc",
+          id: "configuration/telemetry",
+          label: "Telemetry",
+        },
+        {
+          type: "doc",
           id: "configuration/opentelemetry-collector-configuration-file-reference",
           label: "OpenTelemetry Collector Configuration File Reference",
         },

--- a/examples/quick-start-github-actions/readme.md
+++ b/examples/quick-start-github-actions/readme.md
@@ -1,5 +1,7 @@
 # GitHub Actions Sample for a Node.js app with OpenTelemetry and Tracetest
 
+> [Read the detailed recipe for setting up GitHub Actions with Tractest in our documentation.](https://docs.tracetest.io/ci-cd-automation/github-actions-pipeline)
+
 This is a simple quick start on how to configure GitHub Actions to run Tracetest against a Node.js app that uses OpenTelemetry instrumentation with traces, to enhancing your e2e and integration tests with trace-based testing.
 
 Feel free to check out the [docs](https://docs.tracetest.io/), and join our [Discord Community](https://discord.gg/8MtcMrQNbX) for more info!


### PR DESCRIPTION
This PR adds a config page in the docs for setting up internal telemetry.
![localhost_3000_configuration_telemetry](https://user-images.githubusercontent.com/15029531/235161232-6356b6cd-b6af-4cd1-8ee0-35d0290b39cf.png)

## Changes

-

## Fixes

-

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [x] updated the docs
- [ ] added a test
