### PR TITLE
Fix installer tracetest dev docker warning and add options to run installer directly without user input.

### DIFF
--- a/cli/cmd/server_install_cmd.go
+++ b/cli/cmd/server_install_cmd.go
@@ -7,7 +7,9 @@ import (
 )
 
 var (
-	force = false
+	force            = false
+	runEnvironment   = installer.NoneRunEnvironmentType
+	installationMode = installer.NotChosenInstallationModeType
 )
 
 var serverInstallCmd = &cobra.Command{
@@ -17,6 +19,9 @@ var serverInstallCmd = &cobra.Command{
 	PreRun: setupCommand(SkipConfigValidation()),
 	Run: func(cmd *cobra.Command, args []string) {
 		installer.Force = force
+		installer.RunEnvironment = runEnvironment
+		installer.InstallationMode = installationMode
+
 		analytics.Track("Server Install", "cmd", map[string]string{})
 		installer.Start()
 	},
@@ -24,6 +29,11 @@ var serverInstallCmd = &cobra.Command{
 }
 
 func init() {
-	serverInstallCmd.Flags().BoolVarP(&force, "force", "f", false, "overwrite existing files")
+	serverInstallCmd.Flags().BoolVarP(&force, "force", "f", false, "Overwrite existing files")
+
+	// these commands will not have shorthand parameters to avoid colision with existing ones in other commands
+	serverInstallCmd.Flags().Var(&installationMode, "mode", "Indicate the type of demo environment to be installed with Tracetest. It can be 'with-demo' or 'just-tracetest'.")
+	serverInstallCmd.Flags().Var(&runEnvironment, "run-environment", "Type of environment were Tracetest will be installed. It can be 'docker' or 'kubernetes'.")
+
 	serverCmd.AddCommand(serverInstallCmd)
 }

--- a/cli/installer/docker_compose.go
+++ b/cli/installer/docker_compose.go
@@ -325,6 +325,9 @@ func getCompleteProject(ui cliUI.UI, config configuration) *types.Project {
 	project, err := loader.Load(types.ConfigDetails{
 		WorkingDir:  workingDir,
 		ConfigFiles: configFiles,
+		Environment: map[string]string{
+			"TRACETEST_DEV": "",
+		},
 	})
 	if err != nil {
 		ui.Exit(fmt.Errorf("cannot parse docker-compose file: %w", err).Error())

--- a/cli/installer/kubernetes.go
+++ b/cli/installer/kubernetes.go
@@ -40,8 +40,8 @@ func windowsGnuToolsChecker(ui cliUI.UI) {
 
 	ui.Warning("I didn't find sed in your system")
 	option := ui.Select("What do you want to do?", []cliUI.Option{
-		{"Install sed", installSed},
-		{"Fix it manually", exitOption(
+		{Text: "Install sed", Fn: installSed},
+		{Text: "Fix it manually", Fn: exitOption(
 			"Check the helm install docs on https://community.chocolatey.org/packages/sed",
 		)},
 	}, 0)

--- a/cli/installer/types.go
+++ b/cli/installer/types.go
@@ -1,0 +1,63 @@
+package installer
+
+import (
+	"errors"
+
+	"github.com/spf13/pflag"
+)
+
+type RunEnvironmentType string
+
+var _ pflag.Value = (*RunEnvironmentType)(nil)
+
+const (
+	DockerRunEnvironmentType     RunEnvironmentType = "docker"
+	KubernetesRunEnvironmentType RunEnvironmentType = "kubernetes"
+	NoneRunEnvironmentType       RunEnvironmentType = "none" // stands for "no option chosen"
+)
+
+func (e *RunEnvironmentType) String() string {
+	return string(*e)
+}
+
+func (e *RunEnvironmentType) Set(v string) error {
+	switch v {
+	case "docker", "kubernetes":
+		*e = RunEnvironmentType(v)
+		return nil
+	default:
+		return errors.New(`must be "docker" or "kubernetes"`)
+	}
+}
+
+func (e *RunEnvironmentType) Type() string {
+	return "(docker|kubernetes)"
+}
+
+type InstallationModeType string
+
+var _ pflag.Value = (*InstallationModeType)(nil)
+
+const (
+	WithDemoInstallationModeType    InstallationModeType = "with-demo"
+	WithoutDemoInstallationModeType InstallationModeType = "just-tracetest"
+	NotChosenInstallationModeType   InstallationModeType = "none" // stands for "no option chosen"
+)
+
+func (e *InstallationModeType) String() string {
+	return string(*e)
+}
+
+func (e *InstallationModeType) Set(v string) error {
+	switch v {
+	case "with-demo", "just-tracetest":
+		*e = InstallationModeType(v)
+		return nil
+	default:
+		return errors.New(`must be "with-demo" or "just-tracetest"`)
+	}
+}
+
+func (e *InstallationModeType) Type() string {
+	return "(with-demo|just-tracetest)"
+}


### PR DESCRIPTION
This PR removes a warning that users receive when trying to install Tracetest with docker (as shown on the image below) and add two optional params to skip user input on `tracetest server install`.
<img width="903" alt="image" src="https://user-images.githubusercontent.com/12397879/235248673-e5c3c059-84e9-4185-aec8-3ee7fc31f216.png">

## Changes

- Added empty "TRACETEST_DEV" env when reading `docker-compose` for the first time to avoid warning
- Adding arguments to avoid user input when running CLI

## Fixes

- #2165

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
