### PR TITLE
fix(docs): fix connecting to datastores docs

### DIFF
--- a/docs/docs/configuration/connecting-to-data-stores/lightstep.md
+++ b/docs/docs/configuration/connecting-to-data-stores/lightstep.md
@@ -86,8 +86,8 @@ Or, if you prefer using the CLI, you can use this file config.
 ```yaml
 type: DataStore
 spec:
-  name: Opentelemetry Collector pipeline
-  type: otlp
+  name: Lightstep pipeline
+  type: lightstep
   default: true
 ```
 

--- a/docs/docs/configuration/connecting-to-data-stores/new-relic.md
+++ b/docs/docs/configuration/connecting-to-data-stores/new-relic.md
@@ -6,7 +6,7 @@ If you want to use [New Relic](https://newrelic.com/) as the trace data store, y
 Examples of configuring Tracetest with New Relic can be found in the [`examples` folder of the Tracetest GitHub repo](https://github.com/kubeshop/tracetest/tree/main/examples).
 :::
 
-## Configuring OpenTelemetry Collector to Send Traces to B New Relic and Tracetest
+## Configuring OpenTelemetry Collector to Send Traces to both New Relic and Tracetest
 
 In your OpenTelemetry Collector config file:
 
@@ -88,8 +88,8 @@ Or, if you prefer using the CLI, you can use this file config.
 ```yaml
 type: DataStore
 spec:
-  name: Opentelemetry Collector pipeline
-  type: otlp
+  name: New Relic pipeline
+  type: newrelic
   default: true
 ```
 

--- a/docs/docs/configuration/connecting-to-data-stores/opensearch.md
+++ b/docs/docs/configuration/connecting-to-data-stores/opensearch.md
@@ -43,7 +43,7 @@ Or, if you prefer using the CLI, you can use this file config.
 type: DataStore
 spec:
   name: OpenSearch Data Store
-  type: openSearch
+  type: opensearch
   default: true
   opensearch:
     addresses:

--- a/docs/docs/configuration/connecting-to-data-stores/signalfx.md
+++ b/docs/docs/configuration/connecting-to-data-stores/signalfx.md
@@ -37,9 +37,9 @@ Or, if you prefer using the CLI, you can use this file config.
 type: DataStore
 spec:
   name: SignalFX
-  type: signalFx
+  type: signalfx
   default: true
-  signalFx:
+  signalfx:
     realm: us1
     token: mytoken
 ```


### PR DESCRIPTION
This PR adds some fixes for the Connection to DataStores section in our docs.

## Changes

- Fix datastore types

## Fixes

-

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
