### PR TITLE
feat: add support for get augmented

### DIFF
--- a/server/resourcemanager/resource_manager.go
+++ b/server/resourcemanager/resource_manager.go
@@ -206,7 +206,12 @@ func (m *manager[T]) list(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	items, err := m.rh.List(
+	listFn := m.rh.List
+	if isRequestForAugmented(r) {
+		listFn = m.rh.ListAugmented
+	}
+
+	items, err := listFn(
 		ctx,
 		take,
 		skip,

--- a/server/resourcemanager/testutil/operations.go
+++ b/server/resourcemanager/testutil/operations.go
@@ -66,6 +66,8 @@ var (
 		getNotFoundOperation,
 		getSuccessOperation,
 
+		getAugmentedSuccessOperation,
+
 		deleteNotFoundOperation,
 		deleteSuccessOperation,
 

--- a/server/resourcemanager/testutil/operations_augmented.go
+++ b/server/resourcemanager/testutil/operations_augmented.go
@@ -36,3 +36,35 @@ var getAugmentedSuccessOperation = buildSingleStepOperation(singleStepOperationT
 		rt.customJSONComparer(t, OperationGetAugmentedSuccess, expected, jsonBody)
 	},
 })
+
+func buildAugmentedListRequest(rt ResourceTypeTest, ct contentTypeConverter, testServer *httptest.Server, t *testing.T) *http.Request {
+	req := buildListRequest(
+		rt.ResourceTypePlural,
+		map[string]string{},
+		ct,
+		testServer,
+		t,
+	)
+	req.Header.Set(rm.HeaderAugmented, "true")
+	return req
+}
+
+const OperationListAugmentedSuccess Operation = "ListAugmentedSuccess"
+
+var ListAugmentedSuccessOperation = buildSingleStepOperation(singleStepOperationTester{
+	name:               OperationListAugmentedSuccess,
+	neededForOperation: rm.OperationListAugmented,
+	buildRequest: func(t *testing.T, testServer *httptest.Server, ct contentTypeConverter, rt ResourceTypeTest) *http.Request {
+		return buildAugmentedListRequest(rt, ct, testServer, t)
+	},
+	assertResponse: func(t *testing.T, resp *http.Response, ct contentTypeConverter, rt ResourceTypeTest) {
+		t.Helper()
+		require.Equal(t, 200, resp.StatusCode)
+
+		jsonBody := responseBodyJSON(t, resp, ct)
+
+		expected := ct.toJSON(rt.SampleJSONAugmented)
+
+		rt.customJSONComparer(t, OperationGetAugmentedSuccess, expected, jsonBody)
+	},
+})

--- a/server/resourcemanager/testutil/operations_get.go
+++ b/server/resourcemanager/testutil/operations_get.go
@@ -11,8 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildGetRequest(rt ResourceTypeTest, ct contentTypeConverter, testServer *httptest.Server, t *testing.T) *http.Request {
-	id := extractID(rt.SampleJSON)
+func getRequestForID(id string, rt ResourceTypeTest, testServer *httptest.Server) (*http.Request, error) {
 	url := fmt.Sprintf(
 		"%s/%s/%s",
 		testServer.URL,
@@ -20,7 +19,12 @@ func buildGetRequest(rt ResourceTypeTest, ct contentTypeConverter, testServer *h
 		id,
 	)
 
-	req, err := http.NewRequest(http.MethodGet, url, nil)
+	return http.NewRequest(http.MethodGet, url, nil)
+}
+
+func buildGetRequest(rt ResourceTypeTest, ct contentTypeConverter, testServer *httptest.Server, t *testing.T) *http.Request {
+	id := extractID(rt.SampleJSON)
+	req, err := getRequestForID(id, rt, testServer)
 	require.NoError(t, err)
 	return req
 }

--- a/server/resourcemanager/testutil/operations_get_augmented.go
+++ b/server/resourcemanager/testutil/operations_get_augmented.go
@@ -1,0 +1,38 @@
+package testutil
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	rm "github.com/kubeshop/tracetest/server/resourcemanager"
+	"github.com/stretchr/testify/require"
+)
+
+func buildAugmentedGetRequest(rt ResourceTypeTest, ct contentTypeConverter, testServer *httptest.Server, t *testing.T) *http.Request {
+	id := extractID(rt.SampleJSONAugmented)
+	req, err := getRequestForID(id, rt, testServer)
+	require.NoError(t, err)
+	req.Header.Set(rm.HeaderAugmented, "true")
+	return req
+}
+
+const OperationGetAugmentedSuccess Operation = "GetAugmentedSuccess"
+
+var getAugmentedSuccessOperation = buildSingleStepOperation(singleStepOperationTester{
+	name:               OperationGetAugmentedSuccess,
+	neededForOperation: rm.OperationGetAugmented,
+	buildRequest: func(t *testing.T, testServer *httptest.Server, ct contentTypeConverter, rt ResourceTypeTest) *http.Request {
+		return buildAugmentedGetRequest(rt, ct, testServer, t)
+	},
+	assertResponse: func(t *testing.T, resp *http.Response, ct contentTypeConverter, rt ResourceTypeTest) {
+		t.Helper()
+		require.Equal(t, 200, resp.StatusCode)
+
+		jsonBody := responseBodyJSON(t, resp, ct)
+
+		expected := ct.toJSON(rt.SampleJSONAugmented)
+
+		rt.customJSONComparer(t, OperationGetAugmentedSuccess, expected, jsonBody)
+	},
+})

--- a/server/resourcemanager/testutil/test_resource.go
+++ b/server/resourcemanager/testutil/test_resource.go
@@ -20,8 +20,9 @@ type ResourceTypeTest struct {
 	RegisterManagerFn    func(*mux.Router, *sql.DB) rm.Manager
 	Prepare              func(t *testing.T, operation Operation, manager rm.Manager)
 
-	SampleJSON        string
-	SampleJSONUpdated string
+	SampleJSON          string
+	SampleJSONUpdated   string
+	SampleJSONAugmented string
 
 	// private fields
 	sortFields                  []string


### PR DESCRIPTION
This PR adds support for augmented entities. This is a feature needed, for example, in transactions. We have 2 "representations" of transactions: the one used in files, which looks like this:

```yaml
type: Transaction
spec:
  id: transactionID
  name: some feature
  description: do stuff in sequence
  steps:
    - testID_1
    - testID_2
```

it contains just the information needed to create/update the transaction, and just a test ID to reference the step tests.

We also have another representation used in the API, that looks like this: (redacted)

```json
{
  "id": "_2yuIhL4g",
  "name": "01- Transaction",
  "version": 1,
  "steps": [
    {
      "id": "XK1UI2L4R",
      "name": "01- Pokeshop - List",
      "description": "Get a Pokemon",
      // the rest of the test
    },
    {
      "id": "K74lShYVR",
      "name": "02 - Pokeshop - Add",
      "description": "Add a Pokemon",
      // the rest of the test
    }
  ],
  "createdAt": "2023-04-06T14:30:19.354747Z",
  "summary": {
    "runs": 2,
    "lastRun": {
      "time": "2023-04-06T14:31:00.770013Z",
      "fails": 3
    }
  }
}
```


With this PR, we allow resources to define "base" fields and "augmented" fields. In this example, the transaction base fields would be:

- id
- name
- description
- testIDs

And then the augmented fields would be:

- tests
- createdAt
- summary


The "augmented" version is the sum of base and augmented fields.

The augmented version is requested by passing the `X-Tracettest-Augmented: true` header. It works on `Get` and `List`.

Since augmentation can be expensive in tems of DB querying, the ResourceManager allows resource handlers to specify methods to deal with augmented requests (`GetAugmented` and `ListAugmented`). 

The resource struct can define the "augmented" fields just by making them optional. Like:
```go 
type Transaction struct{
  // this is a "base" fields, because it's not optional
  ID id.ID `mapstructure:"id"`

  // this field is augmented because it's optional (because omitempty is enabled
  Summary Summary `mapstructure:"summary,omitempty"`
}

```



## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [x] added a test
