### PR TITLE
Adding context flag on server install

### DIFF
--- a/cli/cmd/server_install_cmd.go
+++ b/cli/cmd/server_install_cmd.go
@@ -7,9 +7,10 @@ import (
 )
 
 var (
-	force            = false
-	runEnvironment   = installer.NoneRunEnvironmentType
-	installationMode = installer.NotChosenInstallationModeType
+	force             = false
+	runEnvironment    = installer.NoneRunEnvironmentType
+	installationMode  = installer.NotChosenInstallationModeType
+	kubernetesContext = ""
 )
 
 var serverInstallCmd = &cobra.Command{
@@ -21,6 +22,7 @@ var serverInstallCmd = &cobra.Command{
 		installer.Force = force
 		installer.RunEnvironment = runEnvironment
 		installer.InstallationMode = installationMode
+		installer.KubernetesContext = kubernetesContext
 
 		analytics.Track("Server Install", "cmd", map[string]string{})
 		installer.Start()
@@ -30,6 +32,7 @@ var serverInstallCmd = &cobra.Command{
 
 func init() {
 	serverInstallCmd.Flags().BoolVarP(&force, "force", "f", false, "Overwrite existing files")
+	serverInstallCmd.Flags().StringVar(&kubernetesContext, "kubernetes-context", "", "Kubernetes context used to install Tracetest. It will be only used if 'run-environment' is set as 'kubernetes'.")
 
 	// these commands will not have shorthand parameters to avoid colision with existing ones in other commands
 	serverInstallCmd.Flags().Var(&installationMode, "mode", "Indicate the type of demo environment to be installed with Tracetest. It can be 'with-demo' or 'just-tracetest'.")

--- a/cli/installer/installer.go
+++ b/cli/installer/installer.go
@@ -8,9 +8,10 @@ import (
 )
 
 var (
-	Force            = false
-	RunEnvironment   = NoneRunEnvironmentType
-	InstallationMode = NotChosenInstallationModeType
+	Force             = false
+	RunEnvironment    = NoneRunEnvironmentType
+	InstallationMode  = NotChosenInstallationModeType
+	KubernetesContext = ""
 )
 
 const createIssueMsg = "If you need help, please create an issue: https://github.com/kubeshop/tracetest/issues/new/choose"


### PR DESCRIPTION
This PR adds a context flag to allow users to bypass the inputs on our CLI.

With that, we can install tracetest on Kubernetes by running the following command:
```sh
tracetest server install --run-environment kubernetes --mode with-demo --kubernetes-context docker-desktop
```

## Changes

- Added `kubernetes-context` flag on `server install` command

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
