### PR TITLE
feature(backend): Enabling environment upsert endpoint when creating

### DIFF
--- a/server/environment/manager.go
+++ b/server/environment/manager.go
@@ -84,9 +84,17 @@ func (r *Repository) SetID(environment Environment, id id.ID) Environment {
 
 func (r *Repository) Create(ctx context.Context, environment Environment) (Environment, error) {
 	environment.ID = environment.Slug()
-	environment.CreatedAt = time.Now().UTC().Format(time.RFC3339Nano)
+	_, err := r.Get(ctx, environment.ID)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			environment.CreatedAt = time.Now().UTC().Format(time.RFC3339Nano)
+			return r.insertIntoEnvironments(ctx, environment)
+		}
 
-	return r.insertIntoEnvironments(ctx, environment)
+		return Environment{}, err
+	}
+
+	return r.Update(ctx, environment)
 }
 
 func (r *Repository) Update(ctx context.Context, environment Environment) (Environment, error) {


### PR DESCRIPTION
This PR enables upsert when trying to create an environment with no id, this allows users to initialize a new environment without having to specify and id in case it exists.

## Changes

- Route now tries finding the environment before creating

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
