### PR TITLE
fix(installer): updating grpc host when installing the docker version with pokeshop

### DIFF
--- a/cli/installer/tracetest.go
+++ b/cli/installer/tracetest.go
@@ -17,7 +17,7 @@ func configureDemoApp(conf configuration, ui cliUI.UI) configuration {
 	switch conf.String("installer") {
 	case "docker-compose":
 		conf.set("demo.endpoint.pokeshop.http", "http://demo-api:8081")
-		conf.set("demo.endpoint.pokeshop.grpc", "demo-api:8082")
+		conf.set("demo.endpoint.pokeshop.grpc", "demo-rpc:8082")
 		conf.set("demo.endpoint.otel.frontend", "http://otel-frontend:8084")
 		conf.set("demo.endpoint.otel.product_catalog", "otel-productcatalogservice:3550")
 		conf.set("demo.endpoint.otel.cart", "otel-cartservice:7070")


### PR DESCRIPTION
This PR fixes the hostname for the demo rpc endpoint when installing tracetest using docker and the pokeshop demo

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
