### PR TITLE
feat: change openapi spec for transactions to consider resource manager

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -84,7 +84,7 @@ paths:
                   items:
                     type: array
                     items:
-                      $ref: "./transactions.yaml#/components/schemas/Transaction"
+                      $ref: "./transactions.yaml#/components/schemas/TransactionResource"
             text/yaml:
               schema:
                 type: object
@@ -94,7 +94,7 @@ paths:
                   items:
                     type: array
                     items:
-                      $ref: "./transactions.yaml#/components/schemas/Transaction"
+                      $ref: "./transactions.yaml#/components/schemas/TransactionResource"
         400:
           description: "invalid query for transactions, some data was sent in incorrect format."
         500:
@@ -109,20 +109,20 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "./transactions.yaml#/components/schemas/Transaction"
+              $ref: "./transactions.yaml#/components/schemas/TransactionResource"
           text/yaml:
             schema:
-              $ref: "./transactions.yaml#/components/schemas/Transaction"
+              $ref: "./transactions.yaml#/components/schemas/TransactionResource"
       responses:
         201:
           description: successful operation
           content:
             application/json:
               schema:
-                $ref: "./transactions.yaml#/components/schemas/Transaction"
+                $ref: "./transactions.yaml#/components/schemas/TransactionResource"
             text/yaml:
               schema:
-                $ref: "./transactions.yaml#/components/schemas/Transaction"
+                $ref: "./transactions.yaml#/components/schemas/TransactionResource"
         400:
           description: "trying to create a transaction with an already existing ID"
         500:
@@ -142,10 +142,10 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "./transactions.yaml#/components/schemas/Transaction"
+                $ref: "./transactions.yaml#/components/schemas/TransactionResource"
             text/yaml:
               schema:
-                $ref: "./transactions.yaml#/components/schemas/Transaction"
+                $ref: "./transactions.yaml#/components/schemas/TransactionResource"
         404:
           description: "transaction not found"
         500:
@@ -162,20 +162,20 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "./transactions.yaml#/components/schemas/Transaction"
+              $ref: "./transactions.yaml#/components/schemas/TransactionResource"
           text/yaml:
             schema:
-              $ref: "./transactions.yaml#/components/schemas/Transaction"
+              $ref: "./transactions.yaml#/components/schemas/TransactionResource"
       responses:
         200:
           description: successful operation
           content:
             application/json:
               schema:
-                $ref: "./transactions.yaml#/components/schemas/Transaction"
+                $ref: "./transactions.yaml#/components/schemas/TransactionResource"
             text/yaml:
               schema:
-                $ref: "./transactions.yaml#/components/schemas/Transaction"
+                $ref: "./transactions.yaml#/components/schemas/TransactionResource"
         400:
           description: "invalid transaction, some data was sent in incorrect format."
         404:

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -61,7 +61,7 @@ paths:
   /transactions:
     get:
       tags:
-        - api
+        - resource-api
       summary: "Get transactions"
       description: "get transactions"
       operationId: getTransactions
@@ -74,22 +74,34 @@ paths:
       responses:
         200:
           description: successful operation
-          headers:
-            X-Total-Count:
-              schema:
-                type: integer
-              description: Total records count
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  $ref: "./transactions.yaml#/components/schemas/Transaction"
+                type: object
+                properties:
+                  count:
+                    type: integer
+                  items:
+                    type: array
+                    items:
+                      $ref: "./transactions.yaml#/components/schemas/Transaction"
+            text/yaml:
+              schema:
+                type: object
+                properties:
+                  count:
+                    type: integer
+                  items:
+                    type: array
+                    items:
+                      $ref: "./transactions.yaml#/components/schemas/Transaction"
+        400:
+          description: "invalid query for transactions, some data was sent in incorrect format."
         500:
           description: "problem with getting transactions"
     post:
       tags:
-        - api
+        - resource-api
       summary: "Create new transaction"
       description: "Create new transaction"
       operationId: createTransaction
@@ -98,19 +110,27 @@ paths:
           application/json:
             schema:
               $ref: "./transactions.yaml#/components/schemas/Transaction"
+          text/yaml:
+            schema:
+              $ref: "./transactions.yaml#/components/schemas/Transaction"
       responses:
-        200:
+        201:
           description: successful operation
           content:
             application/json:
               schema:
                 $ref: "./transactions.yaml#/components/schemas/Transaction"
+            text/yaml:
+              schema:
+                $ref: "./transactions.yaml#/components/schemas/Transaction"
         400:
           description: "trying to create a transaction with an already existing ID"
+        500:
+          description: "problem creating a transaction"
   /transactions/{transactionId}:
     get:
       tags:
-        - api
+        - resource-api
       parameters:
         - $ref: "./parameters.yaml#/components/parameters/transactionId"
       summary: "get transaction"
@@ -123,11 +143,16 @@ paths:
             application/json:
               schema:
                 $ref: "./transactions.yaml#/components/schemas/Transaction"
+            text/yaml:
+              schema:
+                $ref: "./transactions.yaml#/components/schemas/Transaction"
+        404:
+          description: "transaction not found"
         500:
-          description: "problem with getting a transaction"
+          description: "problem getting an transaction"
     put:
       tags:
-        - api
+        - resource-api
       parameters:
         - $ref: "./parameters.yaml#/components/parameters/transactionId"
       summary: "update transaction"
@@ -138,22 +163,40 @@ paths:
           application/json:
             schema:
               $ref: "./transactions.yaml#/components/schemas/Transaction"
+          text/yaml:
+            schema:
+              $ref: "./transactions.yaml#/components/schemas/Transaction"
       responses:
-        204:
+        200:
           description: successful operation
+          content:
+            application/json:
+              schema:
+                $ref: "./transactions.yaml#/components/schemas/Transaction"
+            text/yaml:
+              schema:
+                $ref: "./transactions.yaml#/components/schemas/Transaction"
+        400:
+          description: "invalid transaction, some data was sent in incorrect format."
+        404:
+          description: "transaction not found"
         500:
-          description: "problem with updating transaction"
+          description: "problem updating a transaction"
     delete:
       tags:
-        - api
+        - resource-api
       parameters:
         - $ref: "./parameters.yaml#/components/parameters/transactionId"
       summary: "delete a transaction"
       description: "delete a transaction"
       operationId: deleteTransaction
       responses:
-        "204":
-          description: OK
+        204:
+          description: successful operation
+        404:
+          description: "transaction not found"
+        500:
+          description: "problem deleting a transaction"
   /transactions/{transactionId}/version/{version}:
     get:
       tags:

--- a/api/transactions.yaml
+++ b/api/transactions.yaml
@@ -1,6 +1,19 @@
 openapi: 3.0.0
 components:
   schemas:
+
+    TransactionResource:
+      type: object
+      description: "Represents a transaction structured into the Resources format."
+      properties:
+        type:
+          type: string
+          description: "Represents the type of this resource. It should always be set as 'Transaction'."
+          enum:
+            - Transaction
+        spec:
+          $ref: "#/components/schemas/Transaction"
+
     Transaction:
       type: object
       properties:

--- a/api/transactions.yaml
+++ b/api/transactions.yaml
@@ -29,6 +29,12 @@ components:
           description: version number of the test
         steps:
           type: array
+          description: list of steps of the transaction containing just each test id
+          items:
+            type: string
+        fullSteps:
+          type: array
+          description: list of steps of the transaction containing the whole test object
           items:
             $ref: "./tests.yaml#/components/schemas/Test"
         createdAt:


### PR DESCRIPTION
This PR changes the CRUD operations on transactions to use the resource manager strategy

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
