### PR TITLE
feat(server): improve resource manager test suit debug output

### DIFF
--- a/server/resourcemanager/testutil/operations_augmented.go
+++ b/server/resourcemanager/testutil/operations_augmented.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	rm "github.com/kubeshop/tracetest/server/resourcemanager"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -27,7 +28,7 @@ var getAugmentedSuccessOperation = buildSingleStepOperation(singleStepOperationT
 	},
 	assertResponse: func(t *testing.T, resp *http.Response, ct contentTypeConverter, rt ResourceTypeTest) {
 		t.Helper()
-		require.Equal(t, 200, resp.StatusCode)
+		dumpResponseIfNot(t, assert.Equal(t, 200, resp.StatusCode), resp)
 
 		jsonBody := responseBodyJSON(t, resp, ct)
 
@@ -59,7 +60,7 @@ var ListAugmentedSuccessOperation = buildSingleStepOperation(singleStepOperation
 	},
 	assertResponse: func(t *testing.T, resp *http.Response, ct contentTypeConverter, rt ResourceTypeTest) {
 		t.Helper()
-		require.Equal(t, 200, resp.StatusCode)
+		dumpResponseIfNot(t, assert.Equal(t, 200, resp.StatusCode), resp)
 
 		jsonBody := responseBodyJSON(t, resp, ct)
 

--- a/server/resourcemanager/testutil/operations_create.go
+++ b/server/resourcemanager/testutil/operations_create.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	rm "github.com/kubeshop/tracetest/server/resourcemanager"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -35,7 +36,7 @@ var createNoIDOperation = buildSingleStepOperation(singleStepOperationTester{
 		)
 	},
 	assertResponse: func(t *testing.T, resp *http.Response, ct contentTypeConverter, rt ResourceTypeTest) {
-		require.Equal(t, 201, resp.StatusCode)
+		dumpResponseIfNot(t, assert.Equal(t, 201, resp.StatusCode), resp)
 
 		jsonBody := responseBodyJSON(t, resp, ct)
 
@@ -43,7 +44,7 @@ var createNoIDOperation = buildSingleStepOperation(singleStepOperationTester{
 		expected := ct.toJSON(clean)
 
 		rt.customJSONComparer(t, OperationCreateNoID, expected, removeIDFromJSON(jsonBody))
-		require.NotEmpty(t, extractID(jsonBody))
+		dumpResponseIfNot(t, assert.NotEmpty(t, extractID(jsonBody)), resp)
 	},
 })
 
@@ -62,7 +63,7 @@ var createSuccessOperation = buildSingleStepOperation(singleStepOperationTester{
 		)
 	},
 	assertResponse: func(t *testing.T, resp *http.Response, ct contentTypeConverter, rt ResourceTypeTest) {
-		require.Equal(t, 201, resp.StatusCode)
+		dumpResponseIfNot(t, assert.Equal(t, 201, resp.StatusCode), resp)
 
 		jsonBody := responseBodyJSON(t, resp, ct)
 		expected := ct.toJSON(rt.SampleJSON)

--- a/server/resourcemanager/testutil/operations_delete.go
+++ b/server/resourcemanager/testutil/operations_delete.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	rm "github.com/kubeshop/tracetest/server/resourcemanager"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/exp/slices"
 )
@@ -38,15 +39,15 @@ var deleteSuccessOperation = buildSingleStepOperation(singleStepOperationTester{
 
 		req := buildGetRequest(rt, ct, testServer, t)
 		resp := doRequest(t, req, ct.contentType, testServer)
-		require.Equal(t, 404, resp.StatusCode)
+		dumpResponseIfNot(t, assert.Equal(t, 404, resp.StatusCode), resp)
 	},
 	buildRequest: func(t *testing.T, testServer *httptest.Server, ct contentTypeConverter, rt ResourceTypeTest) *http.Request {
 		return buildDeleteRequest(rt, ct, testServer, t)
 	},
 	assertResponse: func(t *testing.T, resp *http.Response, ct contentTypeConverter, rt ResourceTypeTest) {
 		t.Helper()
-		require.Equal(t, 204, resp.StatusCode)
-		require.Empty(t, responseBody(t, resp))
+		dumpResponseIfNot(t, assert.Equal(t, 204, resp.StatusCode), resp)
+		dumpResponseIfNot(t, assert.Empty(t, responseBody(t, resp)), resp)
 	},
 })
 
@@ -60,7 +61,7 @@ var deleteNotFoundOperation = buildSingleStepOperation(singleStepOperationTester
 	},
 	assertResponse: func(t *testing.T, resp *http.Response, ct contentTypeConverter, rt ResourceTypeTest) {
 		t.Helper()
-		require.Equal(t, 404, resp.StatusCode)
+		dumpResponseIfNot(t, assert.Equal(t, 404, resp.StatusCode), resp)
 	},
 })
 

--- a/server/resourcemanager/testutil/operations_get.go
+++ b/server/resourcemanager/testutil/operations_get.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	rm "github.com/kubeshop/tracetest/server/resourcemanager"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -39,7 +40,7 @@ var getSuccessOperation = buildSingleStepOperation(singleStepOperationTester{
 	},
 	assertResponse: func(t *testing.T, resp *http.Response, ct contentTypeConverter, rt ResourceTypeTest) {
 		t.Helper()
-		require.Equal(t, 200, resp.StatusCode)
+		dumpResponseIfNot(t, assert.Equal(t, 200, resp.StatusCode), resp)
 
 		jsonBody := responseBodyJSON(t, resp, ct)
 
@@ -59,7 +60,7 @@ var getNotFoundOperation = buildSingleStepOperation(singleStepOperationTester{
 	},
 	assertResponse: func(t *testing.T, resp *http.Response, ct contentTypeConverter, rt ResourceTypeTest) {
 		t.Helper()
-		require.Equal(t, 404, resp.StatusCode)
+		dumpResponseIfNot(t, assert.Equal(t, 404, resp.StatusCode), resp)
 	},
 })
 

--- a/server/resourcemanager/testutil/operations_list.go
+++ b/server/resourcemanager/testutil/operations_list.go
@@ -52,7 +52,7 @@ var listNoResultsOperation = buildSingleStepOperation(singleStepOperationTester{
 		)
 	},
 	assertResponse: func(t *testing.T, resp *http.Response, ct contentTypeConverter, rt ResourceTypeTest) {
-		require.Equal(t, 200, resp.StatusCode)
+		dumpResponseIfNot(t, assert.Equal(t, 200, resp.StatusCode), resp)
 
 		jsonBody := responseBodyJSON(t, resp, ct)
 
@@ -61,7 +61,7 @@ var listNoResultsOperation = buildSingleStepOperation(singleStepOperationTester{
 			"items": []
 		}`
 
-		require.JSONEq(t, expected, jsonBody)
+		dumpResponseIfNot(t, assert.JSONEq(t, expected, jsonBody), resp)
 	},
 })
 
@@ -80,7 +80,7 @@ var listSuccessOperation = buildSingleStepOperation(singleStepOperationTester{
 		)
 	},
 	assertResponse: func(t *testing.T, resp *http.Response, ct contentTypeConverter, rt ResourceTypeTest) {
-		require.Equal(t, 200, resp.StatusCode)
+		dumpResponseIfNot(t, assert.Equal(t, 200, resp.StatusCode), resp)
 
 		jsonBody := responseBodyJSON(t, resp, ct)
 
@@ -90,11 +90,11 @@ var listSuccessOperation = buildSingleStepOperation(singleStepOperationTester{
 		}
 		json.Unmarshal([]byte(jsonBody), &parsedJsonBody)
 
-		require.Equal(t, 1, parsedJsonBody.Count)
-		require.Equal(t, 1, len(parsedJsonBody.Items))
+		dumpResponseIfNot(t, assert.Equal(t, 1, parsedJsonBody.Count), resp)
+		dumpResponseIfNot(t, assert.Equal(t, 1, len(parsedJsonBody.Items)), resp)
 
 		obtainedAsBytes, err := json.Marshal(parsedJsonBody.Items[0])
-		require.NoError(t, err)
+		dumpResponseIfNot(t, assert.NoError(t, err), resp)
 
 		expected := ct.toJSON(rt.SampleJSON)
 		obtained := string(obtainedAsBytes)
@@ -125,7 +125,7 @@ var listWithInvalidSortFieldOperation = buildSingleStepOperation(singleStepOpera
 		)
 	},
 	assertResponse: func(t *testing.T, resp *http.Response, ct contentTypeConverter, rt ResourceTypeTest) {
-		require.Equal(t, 400, resp.StatusCode)
+		dumpResponseIfNot(t, assert.Equal(t, 400, resp.StatusCode), resp)
 	},
 })
 
@@ -169,7 +169,7 @@ func buildPaginationOperationStep(sortDirection, sortField string) operationTest
 		},
 		assertResponse: func(t *testing.T, resp *http.Response, ct contentTypeConverter, rt ResourceTypeTest) {
 			sortField := sortField
-			require.Equal(t, 200, resp.StatusCode)
+			dumpResponseIfNot(t, assert.Equal(t, 200, resp.StatusCode), resp)
 
 			jsonBody := responseBodyJSON(t, resp, ct)
 
@@ -179,8 +179,8 @@ func buildPaginationOperationStep(sortDirection, sortField string) operationTest
 			}
 			json.Unmarshal([]byte(jsonBody), &parsedJsonBody)
 
-			require.Equal(t, 3, parsedJsonBody.Count)
-			require.Greater(t, len(parsedJsonBody.Items), 1)
+			dumpResponseIfNot(t, assert.Equal(t, 3, parsedJsonBody.Count), resp)
+			dumpResponseIfNot(t, assert.Greater(t, len(parsedJsonBody.Items), 1), resp)
 
 			// we skip the 1st item, so starting in 1 instead of 0
 			// makes things match later when comparing to len(parsedJsonBody.Items)

--- a/server/resourcemanager/testutil/operations_update.go
+++ b/server/resourcemanager/testutil/operations_update.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	rm "github.com/kubeshop/tracetest/server/resourcemanager"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -32,7 +33,7 @@ var updateSuccessOperation = buildSingleStepOperation(singleStepOperationTester{
 	},
 	assertResponse: func(t *testing.T, resp *http.Response, ct contentTypeConverter, rt ResourceTypeTest) {
 		t.Helper()
-		require.Equal(t, 200, resp.StatusCode)
+		dumpResponseIfNot(t, assert.Equal(t, 200, resp.StatusCode), resp)
 
 		jsonBody := responseBodyJSON(t, resp, ct)
 
@@ -52,7 +53,7 @@ var updateNotFoundOperation = buildSingleStepOperation(singleStepOperationTester
 	},
 	assertResponse: func(t *testing.T, resp *http.Response, ct contentTypeConverter, rt ResourceTypeTest) {
 		t.Helper()
-		require.Equal(t, 404, resp.StatusCode)
+		dumpResponseIfNot(t, assert.Equal(t, 204, resp.StatusCode), resp)
 	},
 })
 


### PR DESCRIPTION
This PR improves the resource manager reusable test suit. It dumps the http response when a test fails, so it's eaiser to understand why the test is not passing.

Example:

![Screenshot 2023-05-04 at 15 30 09](https://user-images.githubusercontent.com/314548/236296401-bb7f0ab3-0a09-4af6-97fc-b641919c5eaa.png)


## Changes

-

## Fixes

-

## Checklist

- [ ] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
