### PR TITLE
fix(cli): fixing nested structs output format

### DIFF
--- a/cli/formatters/config.go
+++ b/cli/formatters/config.go
@@ -6,8 +6,6 @@ import (
 	"github.com/alexeyco/simpletable"
 	"github.com/kubeshop/tracetest/cli/file"
 	"github.com/kubeshop/tracetest/cli/openapi"
-
-	"gopkg.in/yaml.v2"
 )
 
 type ConfigFormatter struct{}
@@ -42,8 +40,9 @@ func (f ConfigFormatter) ToListTable(file *file.File) (*simpletable.Header, *sim
 
 func (f ConfigFormatter) ToStruct(file *file.File) (interface{}, error) {
 	var ConfigResource openapi.ConfigurationResource
+	nullableConfig := openapi.NewNullableConfigurationResource(&ConfigResource)
 
-	err := yaml.Unmarshal([]byte(file.Contents()), &ConfigResource)
+	err := nullableConfig.UnmarshalJSON([]byte(file.Contents()))
 	if err != nil {
 		return nil, err
 	}

--- a/cli/formatters/datastore.go
+++ b/cli/formatters/datastore.go
@@ -4,8 +4,6 @@ import (
 	"github.com/alexeyco/simpletable"
 	"github.com/kubeshop/tracetest/cli/file"
 	"github.com/kubeshop/tracetest/cli/openapi"
-
-	"gopkg.in/yaml.v2"
 )
 
 type DatastoreFormatter struct{}
@@ -40,8 +38,9 @@ func (f DatastoreFormatter) ToListTable(file *file.File) (*simpletable.Header, *
 
 func (f DatastoreFormatter) ToStruct(file *file.File) (interface{}, error) {
 	var datastoreResource openapi.DataStoreResource
+	nullableDataStore := openapi.NewNullableDataStoreResource(&datastoreResource)
 
-	err := yaml.Unmarshal([]byte(file.Contents()), &datastoreResource)
+	err := nullableDataStore.UnmarshalJSON([]byte(file.Contents()))
 	if err != nil {
 		return nil, err
 	}

--- a/cli/formatters/demo.go
+++ b/cli/formatters/demo.go
@@ -6,8 +6,6 @@ import (
 	"github.com/alexeyco/simpletable"
 	"github.com/kubeshop/tracetest/cli/file"
 	"github.com/kubeshop/tracetest/cli/openapi"
-
-	"gopkg.in/yaml.v2"
 )
 
 type DemoFormatter struct{}
@@ -58,7 +56,9 @@ func (f DemoFormatter) ToListTable(file *file.File) (*simpletable.Header, *simpl
 
 func (f DemoFormatter) ToStruct(file *file.File) (interface{}, error) {
 	var demoResource openapi.Demo
-	err := yaml.Unmarshal([]byte(file.Contents()), &demoResource)
+	nullableDemo := openapi.NewNullableDemo(&demoResource)
+
+	err := nullableDemo.UnmarshalJSON([]byte(file.Contents()))
 	if err != nil {
 		return nil, err
 	}
@@ -68,8 +68,9 @@ func (f DemoFormatter) ToStruct(file *file.File) (interface{}, error) {
 
 func (f DemoFormatter) ToListStruct(file *file.File) ([]interface{}, error) {
 	var demoList openapi.DemoList
+	nullableList := openapi.NewNullableDemoList(&demoList)
 
-	err := yaml.Unmarshal([]byte(file.Contents()), &demoList)
+	err := nullableList.UnmarshalJSON([]byte(file.Contents()))
 	if err != nil {
 		return nil, err
 	}

--- a/cli/formatters/environment.go
+++ b/cli/formatters/environment.go
@@ -4,8 +4,6 @@ import (
 	"github.com/alexeyco/simpletable"
 	"github.com/kubeshop/tracetest/cli/file"
 	"github.com/kubeshop/tracetest/cli/openapi"
-
-	"gopkg.in/yaml.v2"
 )
 
 type EnvironmentsFormatter struct{}
@@ -40,8 +38,6 @@ func (f EnvironmentsFormatter) ToListTable(file *file.File) (*simpletable.Header
 		return nil, nil, err
 	}
 
-	// environmentResourceList := rawEnvironmentList.(openapi.EnvironmentResourceList)
-
 	body := simpletable.Body{}
 	for _, rawDemo := range rawEnvironmentList {
 		environmentResource := rawDemo.(openapi.EnvironmentResource)
@@ -58,8 +54,9 @@ func (f EnvironmentsFormatter) ToListTable(file *file.File) (*simpletable.Header
 
 func (f EnvironmentsFormatter) ToStruct(file *file.File) (interface{}, error) {
 	var environmentResource openapi.EnvironmentResource
+	nullableEnvironment := openapi.NewNullableEnvironmentResource(&environmentResource)
 
-	err := yaml.Unmarshal([]byte(file.Contents()), &environmentResource)
+	err := nullableEnvironment.UnmarshalJSON([]byte(file.Contents()))
 	if err != nil {
 		return nil, err
 	}
@@ -69,8 +66,9 @@ func (f EnvironmentsFormatter) ToStruct(file *file.File) (interface{}, error) {
 
 func (f EnvironmentsFormatter) ToListStruct(file *file.File) ([]interface{}, error) {
 	var environmentResourceList openapi.EnvironmentResourceList
+	nullableList := openapi.NewNullableEnvironmentResourceList(&environmentResourceList)
 
-	err := yaml.Unmarshal([]byte(file.Contents()), &environmentResourceList)
+	err := nullableList.UnmarshalJSON([]byte(file.Contents()))
 	if err != nil {
 		return nil, err
 	}

--- a/cli/formatters/polling.go
+++ b/cli/formatters/polling.go
@@ -4,8 +4,6 @@ import (
 	"github.com/alexeyco/simpletable"
 	"github.com/kubeshop/tracetest/cli/file"
 	"github.com/kubeshop/tracetest/cli/openapi"
-
-	"gopkg.in/yaml.v2"
 )
 
 type PollingFormatter struct{}
@@ -40,8 +38,9 @@ func (f PollingFormatter) ToListTable(file *file.File) (*simpletable.Header, *si
 
 func (f PollingFormatter) ToStruct(file *file.File) (interface{}, error) {
 	var pollingResource openapi.PollingProfile
+	nullablePolling := openapi.NewNullablePollingProfile(&pollingResource)
 
-	err := yaml.Unmarshal([]byte(file.Contents()), &pollingResource)
+	err := nullablePolling.UnmarshalJSON([]byte(file.Contents()))
 	if err != nil {
 		return nil, err
 	}

--- a/cli/utils/api.go
+++ b/cli/utils/api.go
@@ -61,7 +61,7 @@ func GetResourceAPIClient(resourceType string, cliConfig config.Config) Resource
 	baseUrl := fmt.Sprintf("%s://%s/api/%s", cliConfig.Scheme, cliConfig.Endpoint, resourceType)
 	baseHeader := http.Header{
 		"x-client-id":  []string{analytics.ClientID()},
-		"Content-Type": []string{"text/yaml"},
+		"Content-Type": []string{"application/json"},
 	}
 
 	return ResourceClient{

--- a/go.work.sum
+++ b/go.work.sum
@@ -179,6 +179,7 @@ github.com/docker/go-events v0.0.0-20190806004212-e31b211e4f1c h1:+pKlWGMw7gf6bQ
 github.com/docker/go-metrics v0.0.1 h1:AgB/0SvBxihN0X8OR4SjsblXkbMvalQ8cjmtKQ2rQV8=
 github.com/docker/libtrust v0.0.0-20150114040149-fa567046d9b1 h1:ZClxb8laGDf5arXfYcAtECDFgAgHklGI8CxgjHnXKJ4=
 github.com/envoyproxy/go-control-plane v0.10.2-0.20220325020618-49ff273808a1/go.mod h1:KJwIaB5Mv44NWtYuAOFCVOjcI94vtpEz2JU/D2v6IjE=
+github.com/fatih/color v1.13.0 h1:8LOYc1KYPPmyKMuN8QV2DNRWNbLo6LZ0iLs8+mlH53w=
 github.com/fatih/color v1.13.0/go.mod h1:kLAiJbzzSOZDVNGyDpeOxJ47H46qBXwg5ILebYFFOfk=
 github.com/felixge/httpsnoop v1.0.3 h1:s/nj+GCswXYzN5v2DpNMuMQYe+0DDwt5WVCU6CWBdXk=
 github.com/felixge/httpsnoop v1.0.3/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
@@ -217,7 +218,9 @@ github.com/klauspost/cpuid/v2 v2.2.3/go.mod h1:RVVoqg1df56z8g3pUjL/3lE5UfnlrJX8t
 github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0/go.mod h1:zJYVVT2jmtg6P3p1VtQj7WsuWi/y4VnjVBn7F8KPB3I=
 github.com/magiconair/properties v1.8.6/go.mod h1:y3VJvCyxH9uVvJTWEGAELF3aiYNyPKd5NZ3oSwXrF60=
 github.com/mattn/go-colorable v0.1.9/go.mod h1:u6P/XSegPjTcexA+o6vUJrdnUu04hMope9wVRipJSqc=
+github.com/mattn/go-colorable v0.1.12 h1:jF+Du6AlPIjs2BiUiQlKOX0rt3SujHxPnksPKZbaA40=
 github.com/mattn/go-colorable v0.1.12/go.mod h1:u5H1YNBxpqRaxsYJYSkiCWKzEfiAb1Gb520KVy5xxl4=
+github.com/mattn/go-isatty v0.0.14 h1:yVuAays6BHfxijgZPzw+3Zlu5yQgKGP2/hcQbHb7S9Y=
 github.com/mattn/go-isatty v0.0.14/go.mod h1:7GGIvUiUoEMVVmxf/4nioHXj79iQHKdU27kJ6hsGG94=
 github.com/matttproud/golang_protobuf_extensions v1.0.4 h1:mmDVorXM7PCGKw94cs5zkfA9PSy5pEvNWRP0ET0TIVo=
 github.com/matttproud/golang_protobuf_extensions v1.0.4/go.mod h1:BSXmuO+STAnVfrANrmjBb36TMTDstsz7MSK+HVaYKv4=
@@ -324,6 +327,7 @@ golang.org/x/tools v0.6.0/go.mod h1:Xwgl3UAJ/d3gWutnCtw505GrjyAbvKui8lOU390QaIU=
 golang.org/x/xerrors v0.0.0-20220411194840-2f41105eb62f/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20220517211312-f3a8303e98df/go.mod h1:K8+ghG5WaK9qNqU5K3HdILfMLy1f3aNYFI/wnl100a8=
 golang.org/x/xerrors v0.0.0-20220609144429-65e65417b02f/go.mod h1:K8+ghG5WaK9qNqU5K3HdILfMLy1f3aNYFI/wnl100a8=
+golang.org/x/xerrors v0.0.0-20220907171357-04be3eba64a2 h1:H2TDz8ibqkAF6YGhCdN3jS9O0/s90v0rJh3X/OLHEUk=
 golang.org/x/xerrors v0.0.0-20220907171357-04be3eba64a2/go.mod h1:K8+ghG5WaK9qNqU5K3HdILfMLy1f3aNYFI/wnl100a8=
 google.golang.org/api v0.63.0/go.mod h1:gs4ij2ffTRXwuzzgJl/56BdwJaA194ijkfn++9tDuPo=
 google.golang.org/api v0.67.0/go.mod h1:ShHKP8E60yPsKNw/w8w+VYaj9H6buA5UqDp8dhbQZ6g=


### PR DESCRIPTION
This PR fixes an issue we had when parsing YAML strings into structs when having nested structures similar to the Demo.
When parsing the Demo objects the values for the pokeshop and the open telemetry store objects were empty.

In this case, we are now using the open API provided logic to unmarshal JSON bytes into structs.

## Changes

- The API now uses JSON
- Removing usage of yaml parsing for responses and relying on the open API functionality

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

Wrong output:
<img width="424" alt="Screenshot 2023-05-05 at 13 33 38" src="https://user-images.githubusercontent.com/11051031/236553123-829e028e-3050-44a6-9812-bb6a9cf85a65.png">

Fixed output:
<img width="495" alt="Screenshot 2023-05-05 at 13 33 57" src="https://user-images.githubusercontent.com/11051031/236553129-2b7eb862-1a7c-4cbd-a86b-7acef9cad63b.png">

