### PR TITLE
fix(cli): fix datastore and environment deprecated commands

### DIFF
--- a/cli/cmd/datastore_legacy_cmd.go
+++ b/cli/cmd/datastore_legacy_cmd.go
@@ -1,8 +1,6 @@
 package cmd
 
 import (
-	"fmt"
-
 	"github.com/spf13/cobra"
 )
 
@@ -15,31 +13,25 @@ var (
 )
 
 var dataStoreCmd = &cobra.Command{
-	GroupID: cmdGroupConfig.ID,
-	Use:     "datastore",
-	Short:   "Manage your tracetest data stores",
-	Long:    "Manage your tracetest data stores",
-	PreRun:  setupCommand(),
+	GroupID:    cmdGroupConfig.ID,
+	Use:        "datastore",
+	Short:      "Manage your tracetest data stores",
+	Long:       "Manage your tracetest data stores",
+	Deprecated: "Please use `tracetest (apply|delete|export|get) datastore` commands instead.",
+	PreRun:     setupCommand(),
 	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Println("Warning! This is a deprecated command and it will be removed on Tracetest future versions!")
-		fmt.Println("Please use `tracetest (apply|delete|export|get) datastore` commands instead.")
-		fmt.Println("")
-
 		cmd.Help()
 	},
 	PostRun: teardownCommand,
 }
 
 var dataStoreApplyCmd = &cobra.Command{
-	Use:    "apply",
-	Short:  "Apply (create/update) data store configuration to your Tracetest server",
-	Long:   "Apply (create/update) data store configuration to your Tracetest server",
-	PreRun: setupCommand(),
+	Use:        "apply",
+	Short:      "Apply (create/update) data store configuration to your Tracetest server",
+	Long:       "Apply (create/update) data store configuration to your Tracetest server",
+	Deprecated: "Please use `tracetest apply datastore --file [path]` command instead.",
+	PreRun:     setupCommand(),
 	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Println("Warning! This is a deprecated command and it will be removed on Tracetest future versions!")
-		fmt.Println("Please use `tracetest apply datastore --file [path]` command instead.")
-		fmt.Println("")
-
 		// call new apply command
 		definitionFile = dataStoreApplyFile
 		applyCmd.Run(applyCmd, []string{"datastore"})
@@ -48,15 +40,12 @@ var dataStoreApplyCmd = &cobra.Command{
 }
 
 var dataStoreExportCmd = &cobra.Command{
-	Use:    "export",
-	Short:  "Exports a data store configuration into a file",
-	Long:   "Exports a data store configuration into a file",
-	PreRun: setupCommand(),
+	Use:        "export",
+	Short:      "Exports a data store configuration into a file",
+	Long:       "Exports a data store configuration into a file",
+	Deprecated: "Please use `tracetest export datastore --id [id]` command instead.",
+	PreRun:     setupCommand(),
 	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Println("Warning! This is a deprecated command and it will be removed on Tracetest future versions!")
-		fmt.Println("Please use `tracetest export datastore --id current` command instead.")
-		fmt.Println("")
-
 		// call new export command
 		exportResourceID = "current"
 		exportResourceFile = exportOutputFile
@@ -66,15 +55,12 @@ var dataStoreExportCmd = &cobra.Command{
 }
 
 var dataStoreListCmd = &cobra.Command{
-	Use:    "list",
-	Short:  "List data store configurations to your tracetest server",
-	Long:   "List data store configurations to your tracetest server",
-	PreRun: setupCommand(),
+	Use:        "list",
+	Short:      "List data store configurations to your tracetest server",
+	Long:       "List data store configurations to your tracetest server",
+	Deprecated: "Please use `tracetest get datastore --id current` command instead.",
+	PreRun:     setupCommand(),
 	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Println("Warning! This is a deprecated command and it will be removed on Tracetest future versions!")
-		fmt.Println("Please use `tracetest get datastore --id current` command instead.")
-		fmt.Println("")
-
 		// call new get command
 		resourceID = "current"
 		getCmd.Run(getCmd, []string{"datastore"})

--- a/cli/cmd/environment_legacy_cmd.go
+++ b/cli/cmd/environment_legacy_cmd.go
@@ -1,19 +1,18 @@
 package cmd
 
 import (
-	"fmt"
-
 	"github.com/spf13/cobra"
 )
 
 var environmentApplyFile string
 
 var environmentCmd = &cobra.Command{
-	GroupID: cmdGroupConfig.ID,
-	Use:     "environment",
-	Short:   "Manage your tracetest environments",
-	Long:    "Manage your tracetest environments",
-	PreRun:  setupCommand(),
+	GroupID:    cmdGroupConfig.ID,
+	Use:        "environment",
+	Short:      "Manage your tracetest environments",
+	Long:       "Manage your tracetest environments",
+	Deprecated: "Please use `tracetest (apply|delete|list|get|export) environment` commands instead.",
+	PreRun:     setupCommand(),
 	Run: func(cmd *cobra.Command, args []string) {
 		cmd.Help()
 	},
@@ -21,15 +20,12 @@ var environmentCmd = &cobra.Command{
 }
 
 var environmentApplyCmd = &cobra.Command{
-	Use:    "apply",
-	Short:  "Create or update an environment to Tracetest",
-	Long:   "Create or update an environment to Tracetest",
-	PreRun: setupCommand(),
+	Use:        "apply",
+	Short:      "Create or update an environment to Tracetest",
+	Long:       "Create or update an environment to Tracetest",
+	Deprecated: "Please use `tracetest apply environment --file [path]` command instead.",
+	PreRun:     setupCommand(),
 	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Println("Warning! This is a deprecated command and it will be removed on Tracetest future versions!")
-		fmt.Println("Please use `tracetest apply environment --file [path]` command instead.")
-		fmt.Println("")
-
 		// call new apply command
 		definitionFile = dataStoreApplyFile
 		applyCmd.Run(applyCmd, []string{"environment"})


### PR DESCRIPTION
This PR labels the `tracetest environment` and `tracetest datastore` commands as deprecated using the `Deprecated` cobra field. This prints a warning message in the CLI, and also removes the command from the `CLI reference documentation`.

## Changes

- Label the `tracetest environment` and `tracetest datastore` commands as deprecated

## Fixes

-

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Screenshots

<img width="979" alt="Screenshot 2023-05-05 at 16 38 01" src="https://user-images.githubusercontent.com/3879892/236580536-3fa6ed17-f8b0-4bf3-b761-711161ac98d5.png">
<img width="909" alt="Screenshot 2023-05-05 at 16 38 31" src="https://user-images.githubusercontent.com/3879892/236580538-4436353b-edd3-45ab-99c5-431e5507e690.png">

<img width="1187" alt="Screenshot 2023-05-05 at 16 36 46" src="https://user-images.githubusercontent.com/3879892/236580547-199ac9d8-4023-4009-9330-901d15140e35.png">
