### PR TITLE
fix: block fe analytics if TRACETEST_DEV is present

### DIFF
--- a/server/app/app.go
+++ b/server/app/app.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"os"
 
 	"github.com/gorilla/handlers"
 	"github.com/gorilla/mux"
@@ -250,7 +251,8 @@ func (app *App) Start(opts ...appOption) error {
 
 	registerDataStoreResource(dataStoreRepo, apiRouter, db, provisioner, tracer)
 
-	registerSPAHandler(router, app.cfg, configFromDB.IsAnalyticsEnabled(), serverID)
+	isTracetestDev := os.Getenv("TRACETEST_DEV") != ""
+	registerSPAHandler(router, app.cfg, configFromDB.IsAnalyticsEnabled(), serverID, isTracetestDev)
 
 	if isNewInstall {
 		provision(provisioner, app.provisioningFile)
@@ -272,7 +274,7 @@ func (app *App) Start(opts ...appOption) error {
 	return nil
 }
 
-func registerSPAHandler(router *mux.Router, cfg httpServerConfig, analyticsEnabled bool, serverID string) {
+func registerSPAHandler(router *mux.Router, cfg httpServerConfig, analyticsEnabled bool, serverID string, isTracetestDev bool) {
 	router.
 		PathPrefix(cfg.ServerPathPrefix()).
 		Handler(
@@ -282,6 +284,7 @@ func registerSPAHandler(router *mux.Router, cfg httpServerConfig, analyticsEnabl
 				serverID,
 				Version,
 				Env,
+				isTracetestDev,
 			),
 		)
 }

--- a/server/http/spa.go
+++ b/server/http/spa.go
@@ -57,7 +57,7 @@ type spaConfig interface {
 	ExperimentalFeatures() []string
 }
 
-func SPAHandler(conf spaConfig, analyticsEnabled bool, serverID, version, env string) http.HandlerFunc {
+func SPAHandler(conf spaConfig, analyticsEnabled bool, serverID, version, env string, isTracetestDev bool) http.HandlerFunc {
 	pathPrefix := conf.ServerPathPrefix()
 	return spaHandler(
 		pathPrefix,
@@ -73,6 +73,7 @@ func SPAHandler(conf spaConfig, analyticsEnabled bool, serverID, version, env st
 			"DemoEnabled":          jsonEscape(conf.DemoEnabled()),
 			"DemoEndpoints":        jsonEscape(conf.DemoEndpoints()),
 			"ExperimentalFeatures": jsonEscape(conf.ExperimentalFeatures()),
+			"IsTracetestDev":       fmt.Sprintf("%t", isTracetestDev),
 		},
 	)
 }

--- a/web/public/index.html
+++ b/web/public/index.html
@@ -67,6 +67,7 @@
           appVersion: getTemplateValue('{{ .AppVersion }}', '', parser.toString),
           env: getTemplateValue('{{ .Env }}', '', parser.toString),
           experimentalFeatures: getTemplateValue('{{ .ExperimentalFeatures }}', '[]', parser.toArray),
+          isTracetestDev: getTemplateValue('{{ .IsTracetestDev }}', 'false', parser.toBoolean),
         };
 
         var base = document.createElement('base');

--- a/web/src/services/Analytics/Analytics.service.ts
+++ b/web/src/services/Analytics/Analytics.service.ts
@@ -3,7 +3,7 @@ import posthog from 'posthog-js';
 import {Categories} from 'constants/Analytics.constants';
 import Env from 'utils/Env';
 
-const isAnalyticsEnabled = () => Env.get('analyticsEnabled');
+const isAnalyticsEnabled = () => Env.get('analyticsEnabled') && !Env.get('isTracetestDev');
 const appVersion = Env.get('appVersion');
 const env = Env.get('env');
 const serverID = Env.get('serverID');

--- a/web/src/types/Common.types.ts
+++ b/web/src/types/Common.types.ts
@@ -9,6 +9,7 @@ export interface IEnv {
   serverID: string;
   serverPathPrefix: string;
   segmentLoaded: boolean;
+  isTracetestDev: boolean;
 }
 
 export interface IMockFactory<T, R> {

--- a/web/src/utils/Env.ts
+++ b/web/src/utils/Env.ts
@@ -11,6 +11,7 @@ const emptyValues: IEnv = {
   serverID: '',
   serverPathPrefix: '/',
   segmentLoaded: false,
+  isTracetestDev: false,
 };
 
 const Env = {


### PR DESCRIPTION
This PR fixes an issue to prevent the webApp to send analytics (`segment` & `posthog`) when the `TRACETEST_DEV` variable is present

## Changes

- fix fe analytics when TRACETEST_DEV is present

## Fixes

-

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
