### PR TITLE
fix(frontend): highlight selected span

### DIFF
--- a/web/src/components/Visualization/components/DAG/SpanNode.styled.ts
+++ b/web/src/components/Visualization/components/DAG/SpanNode.styled.ts
@@ -62,7 +62,8 @@ export const Container = styled.div<{$matched: boolean; $selected: boolean}>`
   align-items: center;
   background-color: ${({theme}) => theme.color.white};
   border: ${({theme, $selected}) =>
-    $selected ? `1px solid ${theme.color.interactive}` : `1px solid ${theme.color.border}`};
+    $selected ? `2px solid ${theme.color.interactive}` : `1px solid ${theme.color.border}`};
+  box-shadow: ${({$selected}) => $selected && '3px 3px 6px 0px rgba(59, 97, 246, 0.6)'};
   border-radius: 10px;
   display: flex;
   flex-direction: column;
@@ -74,7 +75,7 @@ export const Container = styled.div<{$matched: boolean; $selected: boolean}>`
     $matched &&
     css`
       border: ${({theme}) => !$selected && `1px solid ${theme.color.text}`};
-      box-shadow: ${({theme}) => `2px 2px 0px ${theme.color.text}`};
+      box-shadow: ${({theme}) => !$selected && `2px 2px 0px ${theme.color.text}`};
     `}
 `;
 


### PR DESCRIPTION
In our current graph view, we highlight the selected span by using a blue line around the span. However, it is not easy no identify it specially when you are in the "Test Spec" detail mode. This PR improves this design to have a clear understanding of which span is selected.

## Changes

- Improve selected span in graph view

## Fixes

- fixes #2495 

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Screenshots

<img width="1503" alt="Screenshot 2023-05-09 at 16 00 05" src="https://user-images.githubusercontent.com/3879892/237019226-de1b0fb1-890c-4acd-b8c5-ad53983ab00e.png">
<img width="1501" alt="Screenshot 2023-05-09 at 15 59 51" src="https://user-images.githubusercontent.com/3879892/237019271-a5f41728-02ed-476e-bafd-63fdceb1cd27.png">