### PR TITLE
docs(config): add honeycomb to list of supported trace data stores

### DIFF
--- a/docs/docs/configuration/overview.md
+++ b/docs/docs/configuration/overview.md
@@ -20,6 +20,7 @@ Currently, Tracetest supports the following data stores. Click on the respective
 - [New Relic](./connecting-to-data-stores/new-relic)
 - [AWS X-Ray](./connecting-to-data-stores/awsxray)
 - [Datadog](./connecting-to-data-stores/datadog)
+- [Honeycomb](./connecting-to-data-stores/honeycomb)
 
 ## Using Tracetest without a Trace Data Store
 


### PR DESCRIPTION
This PR adds Honeycomb to the list of supported trace data stores.

## Changes

-

## Fixes

-

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [x] updated the docs
- [ ] added a test
