### PR TITLE
fix(frontend): fix test run success message

### DIFF
--- a/web/src/components/TestSpecs/Empty.tsx
+++ b/web/src/components/TestSpecs/Empty.tsx
@@ -31,8 +31,9 @@ const Empty = () => {
       <S.EmptyTitle>There are no test specs for this test</S.EmptyTitle>
       <S.EmptyText>Add a test spec, or choose from our predefined test specs:</S.EmptyText>
       <S.SnippetsContainer>
-        {TEST_SPEC_SNIPPETS.map(snippet => (
-          <div>
+        {TEST_SPEC_SNIPPETS.map((snippet, index) => (
+          // eslint-disable-next-line react/no-array-index-key
+          <div key={`${snippet.selector}-${index}`}>
             <Button
               disabled={!isRunStateSucceeded(state)}
               icon={<AimOutlined />}


### PR DESCRIPTION
This PR fixes the Test Run success message to consider the case of No-Tracing Mode. So, if Tracetest is in No-Tracing mode we will display the following message: `Response received. Skipping looking for trace as you are in No-Trace Mode`.

## Changes

- Fix Test Run success message

## Fixes

- fixes #2510 

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
