### PR TITLE
feat(server): add traceDB endpoints to event log

### DIFF
--- a/server/executor/poller_executor.go
+++ b/server/executor/poller_executor.go
@@ -118,7 +118,9 @@ func (pe DefaultPollerExecutor) ExecuteRequest(request *PollingRequest) (bool, s
 			}
 		}
 
-		err = pe.eventEmitter.Emit(request.ctx, events.TracePollingStart(request.test.ID, request.run.ID))
+		endpoints := traceDB.GetEndpoints()
+		ds, err := pe.dsRepo.Current(request.ctx)
+		err = pe.eventEmitter.Emit(request.ctx, events.TracePollingStart(request.test.ID, request.run.ID, string(ds.Type), endpoints))
 		if err != nil {
 			log.Printf("[PollerExecutor] Test %s Run %d: failed to emit TracePollingStart event: error: %s\n", request.test.ID, request.run.ID, err.Error())
 		}

--- a/server/executor/poller_executor_test.go
+++ b/server/executor/poller_executor_test.go
@@ -601,6 +601,7 @@ func (db *traceDBMock) GetTraceID() trace.TraceID {
 func (db *traceDBMock) Connect(ctx context.Context) error { return nil }
 func (db *traceDBMock) Close() error                      { return nil }
 func (db *traceDBMock) Ready() bool                       { return true }
+func (db *traceDBMock) GetEndpoints() string              { return "" }
 func (db *traceDBMock) TestConnection(ctx context.Context) model.ConnectionResult {
 	return model.ConnectionResult{}
 }

--- a/server/model/events/events.go
+++ b/server/model/events/events.go
@@ -173,14 +173,18 @@ func TraceDataStoreConnectionInfo(testID id.ID, runID int, connectionResult mode
 	}
 }
 
-func TracePollingStart(testID id.ID, runID int) model.TestRunEvent {
+func TracePollingStart(testID id.ID, runID int, dsType, endpoints string) model.TestRunEvent {
+	endpointsDescription := ""
+	if endpoints != "" {
+		endpointsDescription = fmt.Sprintf(" with the following endpoints: %s", endpoints)
+	}
 	return model.TestRunEvent{
 		TestID:              testID,
 		RunID:               runID,
 		Stage:               model.StageTrace,
 		Type:                "POLLING_START",
 		Title:               "Trace polling started",
-		Description:         "The trace polling process has started",
+		Description:         fmt.Sprintf("The trace polling process has started using %s %s", dsType, endpointsDescription),
 		CreatedAt:           time.Now(),
 		DataStoreConnection: model.ConnectionResult{},
 		Polling: model.PollingInfo{

--- a/server/tracedb/awsxray.go
+++ b/server/tracedb/awsxray.go
@@ -88,6 +88,10 @@ func (db *awsxrayDB) Close() error {
 	return nil
 }
 
+func (db *awsxrayDB) GetEndpoints() string {
+	return fmt.Sprintf("xray.%s.amazonaws.com:443", db.region)
+}
+
 func (db *awsxrayDB) TestConnection(ctx context.Context) model.ConnectionResult {
 	url := fmt.Sprintf("xray.%s.amazonaws.com:443", db.region)
 	tester := connection.NewTester(

--- a/server/tracedb/elasticsearchdb.go
+++ b/server/tracedb/elasticsearchdb.go
@@ -39,6 +39,10 @@ func (db *elasticsearchDB) Close() error {
 	return nil
 }
 
+func (db *elasticsearchDB) GetEndpoints() string {
+	return strings.Join(db.config.Addresses, ", ")
+}
+
 func (db *elasticsearchDB) TestConnection(ctx context.Context) model.ConnectionResult {
 	tester := connection.NewTester(
 		connection.WithPortLintingTest(connection.PortLinter("ElasticSearch", elasticSearchDefaultPorts(), db.config.Addresses...)),

--- a/server/tracedb/jaegerdb.go
+++ b/server/tracedb/jaegerdb.go
@@ -46,6 +46,10 @@ func (jtd *jaegerTraceDB) Connect(ctx context.Context) error {
 	return jtd.dataSource.Connect(ctx)
 }
 
+func (jtd *jaegerTraceDB) GetEndpoints() string {
+	return jtd.dataSource.Endpoint()
+}
+
 func (jtd *jaegerTraceDB) TestConnection(ctx context.Context) model.ConnectionResult {
 	tester := connection.NewTester(
 		connection.WithPortLintingTest(connection.PortLinter("Jaeger", jaegerDefaultPorts(), jtd.dataSource.Endpoint())),

--- a/server/tracedb/opensearchdb.go
+++ b/server/tracedb/opensearchdb.go
@@ -37,6 +37,10 @@ func (db *opensearchDB) Close() error {
 	return nil
 }
 
+func (db *opensearchDB) GetEndpoints() string {
+	return strings.Join(db.config.Addresses, ", ")
+}
+
 func (db *opensearchDB) TestConnection(ctx context.Context) model.ConnectionResult {
 	tester := connection.NewTester(
 		connection.WithPortLintingTest(connection.PortLinter("OpenSearch", opensearchDefaultPorts(), db.config.Addresses...)),

--- a/server/tracedb/otlp.go
+++ b/server/tracedb/otlp.go
@@ -33,6 +33,10 @@ func (tdb *OTLPTraceDB) Close() error {
 	return nil
 }
 
+func (tdb *OTLPTraceDB) GetEndpoints() string {
+	return ""
+}
+
 // GetTraceByID implements TraceDB
 func (tdb *OTLPTraceDB) GetTraceByID(ctx context.Context, id string) (model.Trace, error) {
 	run, err := tdb.db.GetRunByTraceID(ctx, traces.DecodeTraceID(id))

--- a/server/tracedb/signalfxdb.go
+++ b/server/tracedb/signalfxdb.go
@@ -47,6 +47,10 @@ func (db *signalfxDB) Close() error {
 	return nil
 }
 
+func (db *signalfxDB) GetEndpoints() string {
+	return fmt.Sprintf("%s:%s", db.getURL(), "443")
+}
+
 func (db *signalfxDB) TestConnection(ctx context.Context) model.ConnectionResult {
 	url := fmt.Sprintf("%s:%s", db.getURL(), "443")
 	tester := connection.NewTester(

--- a/server/tracedb/tempodb.go
+++ b/server/tracedb/tempodb.go
@@ -46,6 +46,10 @@ func (tdb *tempoTraceDB) Connect(ctx context.Context) error {
 	return tdb.dataSource.Connect(ctx)
 }
 
+func (ttd *tempoTraceDB) GetEndpoints() string {
+	return ttd.dataSource.Endpoint()
+}
+
 func (ttd *tempoTraceDB) TestConnection(ctx context.Context) model.ConnectionResult {
 	tester := connection.NewTester(
 		connection.WithPortLintingTest(connection.PortLinter("Tempo", tempoDefaultPorts(), ttd.dataSource.Endpoint())),

--- a/server/tracedb/tracedb.go
+++ b/server/tracedb/tracedb.go
@@ -19,6 +19,7 @@ type TraceDB interface {
 	GetTraceID() trace.TraceID
 	GetTraceByID(ctx context.Context, traceID string) (model.Trace, error)
 	Close() error
+	GetEndpoints() string
 }
 
 type TestableTraceDB interface {
@@ -39,6 +40,7 @@ func (db *noopTraceDB) Connect(ctx context.Context) error { return nil }
 func (db *noopTraceDB) Close() error                      { return nil }
 func (db *noopTraceDB) ShouldRetry() bool                 { return false }
 func (db *noopTraceDB) Ready() bool                       { return true }
+func (db *noopTraceDB) GetEndpoints() string              { return "" }
 func (db *noopTraceDB) TestConnection(ctx context.Context) model.ConnectionResult {
 	return model.ConnectionResult{}
 }


### PR DESCRIPTION
This PR updates the `TracePollingStart` event to include information as the DataStore `type` and `URLs`.

## Changes

- Update `TracePollingStart` event

## Fixes

- fixes #2508 

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Screenshots

<img width="1490" alt="Screenshot 2023-05-10 at 17 06 38" src="https://github.com/kubeshop/tracetest/assets/3879892/6a59b8b3-4579-44e7-80d8-a646ff3db1f2">

<img width="1494" alt="Screenshot 2023-05-10 at 17 07 09" src="https://github.com/kubeshop/tracetest/assets/3879892/b34255ed-0f65-4f07-8cf9-e28e9bef4508">

<img width="1494" alt="Screenshot 2023-05-10 at 17 07 45" src="https://github.com/kubeshop/tracetest/assets/3879892/72bb4414-d3f0-4556-b17b-5e07f5ea0138">