### PR TITLE
fix(cli): fix default output for non-resources commands

### DIFF
--- a/cli/cmd/config.go
+++ b/cli/cmd/config.go
@@ -41,7 +41,7 @@ func setupCommand(options ...setupOption) func(cmd *cobra.Command, args []string
 	}
 
 	return func(cmd *cobra.Command, args []string) {
-		setupOutputFormat()
+		setupOutputFormat(cmd)
 		setupLogger(cmd, args)
 		loadConfig(cmd, args)
 		overrideConfig()
@@ -110,7 +110,11 @@ func overrideConfig() {
 	}
 }
 
-func setupOutputFormat() {
+func setupOutputFormat(cmd *cobra.Command) {
+	if cmd.GroupID != "resources" && output == string(formatters.Empty) {
+		output = string(formatters.DefaultOutput)
+	}
+
 	o := formatters.Output(output)
 	if !formatters.ValidOutput(o) {
 		fmt.Fprintf(os.Stderr, "Invalid output format %s. Available formats are [%s]\n", output, outputFormatsString)


### PR DESCRIPTION
This PR fixes a bug with the default output for non-resources commands.

## Changes

- fix cli default output

## Fixes

- fixes #2522 

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Screenshot

<img width="1070" alt="Screenshot 2023-05-11 at 19 36 02" src="https://github.com/kubeshop/tracetest/assets/3879892/6e43b71b-2769-4ffb-9b2a-7e3ff7d54727">