### PR TITLE
fix: handle delete for transactions with more than 1 run

### DIFF
--- a/testing/server-tracetesting/features/transaction/05_delete_transaction.yml
+++ b/testing/server-tracetesting/features/transaction/05_delete_transaction.yml
@@ -21,4 +21,4 @@ spec:
         - attr:tracetest.selected_spans.count = 1
     - selector: span[name = "exec DELETE"]
       assertions:
-        - attr:tracetest.selected_spans.count = 3
+        - attr:tracetest.selected_spans.count = 4


### PR DESCRIPTION
This PR fixes the delete transaction method

## Changes

-

## Fixes

-

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [x] added a test
