### PR TITLE
fix: add versioning for trigger encoding

### DIFF
--- a/go.work.sum
+++ b/go.work.sum
@@ -161,9 +161,8 @@ github.com/cespare/xxhash/v2 v2.1.2 h1:YRXhKfTDauu4ajMg1TPgFO5jnlC2HCbmLXMcTG5cb
 github.com/containerd/continuity v0.3.0 h1:nisirsYROK15TAMVukJOUyGJjz4BNQJBVsNvAXZJ/eg=
 github.com/containerd/ttrpc v1.1.0 h1:GbtyLRxb0gOLR0TYQWt3O6B0NvT8tMdorEHqIQo/lWI=
 github.com/containerd/typeurl v1.0.2 h1:Chlt8zIieDbzQFzXzAeBEF92KhExuE4p9p92/QmY7aY=
+github.com/creack/pty v1.1.11 h1:07n33Z8lZxZ2qwegKbObQohDhXDQxiMMz1NOUGYlesw=
 github.com/envoyproxy/go-control-plane v0.10.2-0.20220325020618-49ff273808a1/go.mod h1:KJwIaB5Mv44NWtYuAOFCVOjcI94vtpEz2JU/D2v6IjE=
-github.com/felixge/httpsnoop v1.0.3 h1:s/nj+GCswXYzN5v2DpNMuMQYe+0DDwt5WVCU6CWBdXk=
-github.com/felixge/httpsnoop v1.0.3/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/frankban/quicktest v1.14.3/go.mod h1:mgiwOwqx65TmIk1wJ6Q7wvnVMocbUorkibMOrVTHZps=
 github.com/go-kit/log v0.2.1/go.mod h1:NwTd00d/i8cPZ3xOwwiv2PO5MOcx78fFErGNcVmBjv0=
 github.com/go-ole/go-ole v1.2.6/go.mod h1:pprOEPIfldk/42T2oK7lQ4v4JSDwmV0As9GaiUsvbm0=
@@ -197,6 +196,7 @@ github.com/hashicorp/memberlist v0.3.0/go.mod h1:MS2lj3INKhZjWNqd3N0m3J+Jxf3DAOn
 github.com/hashicorp/memberlist v0.5.0/go.mod h1:yvyXLpo0QaGE59Y7hDTsTzDD25JYBZ4mHgHUZ8lrOI0=
 github.com/hashicorp/serf v0.9.6/go.mod h1:TXZNMjZQijwlDvp+r0b63xZ45H7JmCmgg4gpTwn9UV4=
 github.com/hashicorp/serf v0.10.1/go.mod h1:yL2t6BqATOLGc5HF7qbFkTfXoPIY0WZdWHfEvMqbG+4=
+github.com/hjson/hjson-go/v4 v4.0.0 h1:wlm6IYYqHjOdXH1gHev4VoXCaW20HdQAGCxdOEEg2cs=
 github.com/hjson/hjson-go/v4 v4.0.0/go.mod h1:KaYt3bTw3zhBjYqnXkYywcYctk0A2nxeEFTse3rH13E=
 github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51 h1:Z9n2FFNUXsshfwJMBgNA0RU6/i7WVaAegv3PtuIHPMs=
 github.com/klauspost/compress v1.15.9/go.mod h1:PhcZ0MbTNciWF3rruxRgKxI5NkcHHrHUDtV4Yw2GlzU=

--- a/server/model/tests.go
+++ b/server/model/tests.go
@@ -11,7 +11,7 @@ import (
 )
 
 type (
-	// this file yaml/json encoding is handled at ./test_json.go for custom encodings
+	// this struct yaml/json encoding is handled at ./test_json.go for custom encodings
 	Test struct {
 		ID               id.ID
 		CreatedAt        time.Time
@@ -47,11 +47,12 @@ type (
 
 	TriggerType string
 
+	// this struct yaml/json encoding is handled at ./trigger_json.go for custom encodings
 	Trigger struct {
-		Type    TriggerType     `json:"triggerType"`
-		HTTP    *HTTPRequest    `json:"http,omitempty"`
-		GRPC    *GRPCRequest    `json:"grpc,omitempty"`
-		TraceID *TRACEIDRequest `json:"traceid,omitempty"`
+		Type    TriggerType
+		HTTP    *HTTPRequest
+		GRPC    *GRPCRequest
+		TraceID *TRACEIDRequest
 	}
 
 	TriggerResult struct {

--- a/server/model/trigger_json.go
+++ b/server/model/trigger_json.go
@@ -2,6 +2,7 @@ package model
 
 import (
 	"encoding/json"
+	"fmt"
 
 	"github.com/fluidtruck/deepcopy"
 )
@@ -68,5 +69,5 @@ func (t *Trigger) UnmarshalJSON(data []byte) error {
 		return deepcopy.DeepCopy(v2, t)
 	}
 
-	return nil
+	return fmt.Errorf("unexpected json format")
 }

--- a/server/model/trigger_json.go
+++ b/server/model/trigger_json.go
@@ -2,7 +2,6 @@ package model
 
 import (
 	"encoding/json"
-	"fmt"
 
 	"github.com/fluidtruck/deepcopy"
 )
@@ -69,5 +68,5 @@ func (t *Trigger) UnmarshalJSON(data []byte) error {
 		return deepcopy.DeepCopy(v2, t)
 	}
 
-	return fmt.Errorf("unexpected json format")
+	return nil
 }

--- a/server/model/trigger_json.go
+++ b/server/model/trigger_json.go
@@ -1,0 +1,72 @@
+package model
+
+import (
+	"encoding/json"
+
+	"github.com/fluidtruck/deepcopy"
+)
+
+type triggerJSONV2 struct {
+	Type    TriggerType     `json:"triggerType"`
+	HTTP    *HTTPRequest    `json:"http,omitempty"`
+	GRPC    *GRPCRequest    `json:"grpc,omitempty"`
+	TraceID *TRACEIDRequest `json:"traceid,omitempty"`
+}
+
+func (v2 triggerJSONV2) valid() bool {
+	// has a valid type and at least one not nil trigger type settings
+	return v2.Type != "" &&
+		(v2.HTTP != nil ||
+			v2.GRPC != nil ||
+			v2.TraceID != nil)
+}
+
+type triggerJSONV1 struct {
+	Type    TriggerType
+	HTTP    *HTTPRequest
+	GRPC    *GRPCRequest
+	TraceID *TRACEIDRequest
+}
+
+func (v1 triggerJSONV1) valid() bool {
+	// has a valid type and at least one not nil trigger type settings
+	return v1.Type != "" &&
+		(v1.HTTP != nil ||
+			v1.GRPC != nil ||
+			v1.TraceID != nil)
+}
+
+func (t Trigger) MarshalJSON() ([]byte, error) {
+	jt := triggerJSONV2{}
+	err := deepcopy.DeepCopy(t, &jt)
+	if err != nil {
+		return nil, err
+	}
+
+	return json.Marshal(jt)
+}
+
+func (t *Trigger) UnmarshalJSON(data []byte) error {
+	var err error
+	// start with older versions and move up to the latest
+	v1 := triggerJSONV1{}
+	err = json.Unmarshal(data, &v1)
+	if err != nil {
+		return err
+	}
+	if v1.valid() {
+		return deepcopy.DeepCopy(v1, t)
+	}
+
+	// v2
+	v2 := triggerJSONV2{}
+	err = json.Unmarshal(data, &v2)
+	if err != nil {
+		return err
+	}
+	if v2.valid() {
+		return deepcopy.DeepCopy(v2, t)
+	}
+
+	return nil
+}

--- a/server/model/trigger_json_test.go
+++ b/server/model/trigger_json_test.go
@@ -72,3 +72,24 @@ func TestTriggerFormatV2(t *testing.T) {
 
 	assert.Equal(t, expected, current)
 }
+
+func TestTriggerFormatInvalid(t *testing.T) {
+	v2 := struct {
+		Type    model.TriggerType     `json:"invalid"`
+		HTTP    *model.HTTPRequest    `json:"http,omitempty"`
+		GRPC    *model.GRPCRequest    `json:"grpc,omitempty"`
+		TraceID *model.TRACEIDRequest `json:"traceid,omitempty"`
+	}{
+		Type: model.TriggerTypeHTTP,
+	}
+
+	v2Json, err := json.Marshal(v2)
+	require.NoError(t, err)
+
+	current := model.Trigger{}
+	err = json.Unmarshal(v2Json, &current)
+
+	assert.Error(t, err)
+	assert.ErrorContains(t, err, "unexpected json format")
+
+}

--- a/server/model/trigger_json_test.go
+++ b/server/model/trigger_json_test.go
@@ -1,0 +1,74 @@
+package model_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/kubeshop/tracetest/server/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTriggerFormatV1(t *testing.T) {
+	v1 := struct {
+		Type    model.TriggerType
+		HTTP    *model.HTTPRequest
+		GRPC    *model.GRPCRequest
+		TraceID *model.TRACEIDRequest
+	}{
+		Type: model.TriggerTypeHTTP,
+		HTTP: &model.HTTPRequest{
+			Method: model.HTTPMethodGET,
+			URL:    "http://example.com/list",
+		},
+	}
+
+	expected := model.Trigger{
+		Type: model.TriggerTypeHTTP,
+		HTTP: &model.HTTPRequest{
+			Method: model.HTTPMethodGET,
+			URL:    "http://example.com/list",
+		},
+	}
+
+	v1Json, err := json.Marshal(v1)
+	require.NoError(t, err)
+
+	current := model.Trigger{}
+	err = json.Unmarshal(v1Json, &current)
+	require.NoError(t, err)
+
+	assert.Equal(t, expected, current)
+}
+
+func TestTriggerFormatV2(t *testing.T) {
+	v2 := struct {
+		Type    model.TriggerType     `json:"triggerType"`
+		HTTP    *model.HTTPRequest    `json:"http,omitempty"`
+		GRPC    *model.GRPCRequest    `json:"grpc,omitempty"`
+		TraceID *model.TRACEIDRequest `json:"traceid,omitempty"`
+	}{
+		Type: model.TriggerTypeHTTP,
+		HTTP: &model.HTTPRequest{
+			Method: model.HTTPMethodGET,
+			URL:    "http://example.com/list",
+		},
+	}
+
+	expected := model.Trigger{
+		Type: model.TriggerTypeHTTP,
+		HTTP: &model.HTTPRequest{
+			Method: model.HTTPMethodGET,
+			URL:    "http://example.com/list",
+		},
+	}
+
+	v2Json, err := json.Marshal(v2)
+	require.NoError(t, err)
+
+	current := model.Trigger{}
+	err = json.Unmarshal(v2Json, &current)
+	require.NoError(t, err)
+
+	assert.Equal(t, expected, current)
+}

--- a/server/model/trigger_json_test.go
+++ b/server/model/trigger_json_test.go
@@ -72,24 +72,3 @@ func TestTriggerFormatV2(t *testing.T) {
 
 	assert.Equal(t, expected, current)
 }
-
-func TestTriggerFormatInvalid(t *testing.T) {
-	v2 := struct {
-		Type    model.TriggerType     `json:"invalid"`
-		HTTP    *model.HTTPRequest    `json:"http,omitempty"`
-		GRPC    *model.GRPCRequest    `json:"grpc,omitempty"`
-		TraceID *model.TRACEIDRequest `json:"traceid,omitempty"`
-	}{
-		Type: model.TriggerTypeHTTP,
-	}
-
-	v2Json, err := json.Marshal(v2)
-	require.NoError(t, err)
-
-	current := model.Trigger{}
-	err = json.Unmarshal(v2Json, &current)
-
-	assert.Error(t, err)
-	assert.ErrorContains(t, err, "unexpected json format")
-
-}


### PR DESCRIPTION
This PR fixes a retrocompat issue, where tests created before this version would fail to be correctly read from DB. This was caused by a change in the JSON encoding of the `model.Trigger` entity.

This PR fixes this by adding basic versioning support for the entity

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [x] added a test
