### PR TITLE
feat: support dashes in attribute names

### DIFF
--- a/server/expression/executor_test.go
+++ b/server/expression/executor_test.go
@@ -108,6 +108,19 @@ func TestAttributeExecution(t *testing.T) {
 				},
 			},
 		},
+		{
+			Name:       "should_get_values_from_attributes_with_dashes",
+			Query:      "attr:dapr-app-id = 42",
+			ShouldPass: true,
+
+			AttributeDataStore: expression.AttributeDataStore{
+				Span: model.Span{
+					Attributes: model.Attributes{
+						"dapr-app-id": "42",
+					},
+				},
+			},
+		},
 	}
 
 	executeTestCases(t, testCases)

--- a/server/expression/parser_rules.go
+++ b/server/expression/parser_rules.go
@@ -55,7 +55,7 @@ var languageLexer = lexer.MustStateful(lexer.Rules{
 
 		{Name: "Duration", Pattern: `([0-9]+(\.[0-9]+)?)( )?(ns|us|ms|s|m|h)`},
 		{Name: "Number", Pattern: `([0-9]+(\.[0-9]+)?)`},
-		{Name: "Attribute", Pattern: `attr:[a-zA-Z_0-9][a-zA-Z_0-9.]*`, Action: nil},
+		{Name: "Attribute", Pattern: `attr:[a-zA-Z_0-9][a-zA-Z_0-9.-]*`, Action: nil},
 		{Name: "Environment", Pattern: `env:[a-zA-Z_0-9][a-zA-Z_0-9.]*`, Action: nil},
 		{Name: "QuotedString", Pattern: `"(\\"|[^"])*"`, Action: nil},
 		{Name: "SingleQuotedString", Pattern: `'(\\'|[^'])*'`, Action: nil},

--- a/server/expression/parser_test.go
+++ b/server/expression/parser_test.go
@@ -54,6 +54,15 @@ func TestSimpleParsingRules(t *testing.T) {
 			},
 		},
 		{
+			Name:  "should_parse_dashed_attributes",
+			Query: `attr:app-id = attr:abc`,
+			ExpectedOutput: expression.Statement{
+				Left:       attrExpr("app-id"),
+				Comparator: "=",
+				Right:      attrExpr("abc"),
+			},
+		},
+		{
 			Name:  "should_parse_abc=abc",
 			Query: `"abc" = "abc"`,
 			ExpectedOutput: expression.Statement{


### PR DESCRIPTION
This PR makes the assertion engine support dashes in attribute names. Related to #2564 

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [x] added a test
