### PR TITLE
Adding upsert capability for Environment resource

### DIFF
--- a/server/environment/manager.go
+++ b/server/environment/manager.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -90,6 +91,10 @@ func (r *Repository) Create(ctx context.Context, environment Environment) (Envir
 
 func (r *Repository) Update(ctx context.Context, environment Environment) (Environment, error) {
 	oldEnvironment, err := r.Get(ctx, environment.ID)
+	if err != nil && errors.Is(err, sql.ErrNoRows) {
+		// this is a new environment, and we should create it
+		return r.Create(ctx, environment)
+	}
 	if err != nil {
 		return Environment{}, err
 	}

--- a/server/environment/manager_test.go
+++ b/server/environment/manager_test.go
@@ -103,7 +103,13 @@ func TestEnvironment(t *testing.T) {
 		}`,
 	}
 
-	rmtests.TestResourceType(t, resourceTypeTest, rmtests.JSONComparer(environmentJSONComparer))
+	rmtests.TestResourceType(
+		t, resourceTypeTest,
+		rmtests.JSONComparer(environmentJSONComparer),
+		rmtests.ExcludeOperations(
+			rmtests.OperationUpdateNotFound,
+		),
+	)
 }
 
 func environmentJSONComparer(t require.TestingT, operation rmtests.Operation, firstValue, secondValue string) {


### PR DESCRIPTION
This PR adds upsert capabilities to the `Environment` resource, allowing us to create an environment with an ID

## Changes

- Updated Environment Resource manager Update method to have behave like an upsert

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
