### PR TITLE
fix: set static IDs for dogfood tests and transactions

### DIFF
--- a/testing/server-tracetesting/features/environment/01_create_environment.yml
+++ b/testing/server-tracetesting/features/environment/01_create_environment.yml
@@ -1,5 +1,6 @@
 type: Test
 spec:
+  id: oCzNeDQVRI
   name: Create Environment
   description: Test step of 'Environment Feature - Test Suite'
   trigger:

--- a/testing/server-tracetesting/features/environment/02_list_environment.yml
+++ b/testing/server-tracetesting/features/environment/02_list_environment.yml
@@ -1,5 +1,6 @@
 type: Test
 spec:
+  id: TCkN6vwVRN
   name: List Environment
   description: Test step of 'Environment Feature - Test Suite'
   trigger:

--- a/testing/server-tracetesting/features/environment/03_delete_environment.yml
+++ b/testing/server-tracetesting/features/environment/03_delete_environment.yml
@@ -1,6 +1,7 @@
 ---
 type: Test
 spec:
+  id: ojzN6vwVRv
   name: Delete Environment
   description: Test step of 'Environment Feature - Test Suite'
   trigger:

--- a/testing/server-tracetesting/features/environment/_test_suite.yml
+++ b/testing/server-tracetesting/features/environment/_test_suite.yml
@@ -1,5 +1,6 @@
 type: Transaction
 spec:
+  id: oCkH6vQ4gV
   name: Environment Feature
   description: Sequence of tests to validate if our Environment feature is working as expected
   steps:

--- a/testing/server-tracetesting/features/grpc_test/01_create_grpc_test.yml
+++ b/testing/server-tracetesting/features/grpc_test/01_create_grpc_test.yml
@@ -23,16 +23,14 @@ spec:
               "request": "{\"id\": 52}"
             }
           },
-          "specs": {
-            "specs": [
-              {
-                "selector": {
-                  "query": "span[name = \"queue.synchronizePokemon send\"]"
-                },
-                "assertions": ["attr:tracetest.selected_spans.count > 0"]
-              }
-            ]
-          }
+          "specs": [
+            {
+              "selectorParsed": {
+                "query": "span[name = \"queue.synchronizePokemon send\"]"
+              },
+              "assertions": ["attr:tracetest.selected_spans.count > 0"]
+            }
+          ]
         }
   specs:
     - selector: span[name = "Tracetest trigger"]

--- a/testing/server-tracetesting/features/grpc_test/01_create_grpc_test.yml
+++ b/testing/server-tracetesting/features/grpc_test/01_create_grpc_test.yml
@@ -1,5 +1,6 @@
 type: Test
 spec:
+  id: ojzHeDQ4gF
   name: Create gRPC Test
   description: Test step of 'gRPC Test Feature - Test Suite'
   trigger:

--- a/testing/server-tracetesting/features/grpc_test/02_list_grpc_test.yml
+++ b/testing/server-tracetesting/features/grpc_test/02_list_grpc_test.yml
@@ -1,5 +1,6 @@
 type: Test
 spec:
+  id: ojzHeDQ4Rc
   name: List gRPC Test
   description: Test step of 'gRPC Test Feature - Test Suite'
   trigger:

--- a/testing/server-tracetesting/features/grpc_test/03_run_grpc_test.yml
+++ b/testing/server-tracetesting/features/grpc_test/03_run_grpc_test.yml
@@ -1,5 +1,6 @@
 type: Test
 spec:
+  id: oCzH6DQVRp
   name: Run gRPC Test
   description: Test step of 'gRPC Test Feature - Test Suite'
   trigger:

--- a/testing/server-tracetesting/features/grpc_test/04_delete_grpc_test.yml
+++ b/testing/server-tracetesting/features/grpc_test/04_delete_grpc_test.yml
@@ -1,6 +1,7 @@
 ---
 type: Test
 spec:
+  id: ojzNeDw4gh
   name: Delete gRPC Test
   description: Test step of 'gRPC Test Feature - Test Suite'
   trigger:

--- a/testing/server-tracetesting/features/grpc_test/05_create_grpc_test_with_invalid_metadata.yml
+++ b/testing/server-tracetesting/features/grpc_test/05_create_grpc_test_with_invalid_metadata.yml
@@ -1,5 +1,6 @@
 type: Test
 spec:
+  id: oCzH6vw4go
   name: Create gRPC Test with invalid metadata
   description: Test step of 'gRPC Test Feature - Test Suite'
   trigger:

--- a/testing/server-tracetesting/features/grpc_test/05_create_grpc_test_with_invalid_metadata.yml
+++ b/testing/server-tracetesting/features/grpc_test/05_create_grpc_test_with_invalid_metadata.yml
@@ -24,16 +24,14 @@ spec:
               "metadata": [{}]
             }
           },
-          "specs": {
-            "specs": [
-              {
-                "selector": {
-                  "query": "span[name = \"queue.synchronizePokemon send\"]"
-                },
-                "assertions": ["attr:tracetest.selected_spans.count > 0"]
-              }
-            ]
-          }
+          "specs":  [
+            {
+              "selectorParsed": {
+                "query": "span[name = \"queue.synchronizePokemon send\"]"
+              },
+              "assertions": ["attr:tracetest.selected_spans.count > 0"]
+            }
+          ]
         }
   specs:
   - selector: span[name = "Tracetest trigger"]

--- a/testing/server-tracetesting/features/grpc_test/06_run_grpc_test_with_invalid_metadata.yml
+++ b/testing/server-tracetesting/features/grpc_test/06_run_grpc_test_with_invalid_metadata.yml
@@ -1,5 +1,6 @@
 type: Test
 spec:
+  id: TCzN6DQ4g0
   name: Run gRPC Test with invalid metadata
   description: ""
   trigger:

--- a/testing/server-tracetesting/features/grpc_test/_test_suite.yml
+++ b/testing/server-tracetesting/features/grpc_test/_test_suite.yml
@@ -1,5 +1,6 @@
 type: Transaction
 spec:
+  id: ojkNeDwVgO
   name: gRPC Test Feature
   description: Sequence of tests to validate if our gRPC Test feature is working as expected
   steps:

--- a/testing/server-tracetesting/features/http_test/01_delete_http_test_with_non_existing_id.yml
+++ b/testing/server-tracetesting/features/http_test/01_delete_http_test_with_non_existing_id.yml
@@ -1,5 +1,6 @@
 type: Test
 spec:
+  id: ojzN6DwVRx
   name: Delete HTTP Test with non-existing ID
   description: Test step of 'HTTP Test Feature - Test Suite'
   trigger:

--- a/testing/server-tracetesting/features/http_test/02_create_http_test_with_non_existing_id.yml
+++ b/testing/server-tracetesting/features/http_test/02_create_http_test_with_non_existing_id.yml
@@ -1,5 +1,6 @@
 type: Test
 spec:
+  id: oCkHevQ4R-
   name: Create HTTP Test with non-existing ID
   description: Test step of 'HTTP Test Feature - Test Suite'
   trigger:

--- a/testing/server-tracetesting/features/http_test/04_delete_http_test_with_existing_id.yml
+++ b/testing/server-tracetesting/features/http_test/04_delete_http_test_with_existing_id.yml
@@ -1,5 +1,6 @@
 type: Test
 spec:
+  id: TCkHeDwVRf
   name: Delete HTTP Test with existing ID
   description: Test step of 'HTTP Test Feature - Test Suite'
   trigger:

--- a/testing/server-tracetesting/features/http_test/05_create_http_test.yml
+++ b/testing/server-tracetesting/features/http_test/05_create_http_test.yml
@@ -1,5 +1,6 @@
 type: Test
 spec:
+  id: TCzHeDw4gY
   name: Create HTTP Test
   description: Test step of 'HTTP Test Feature - Test Suite'
   trigger:

--- a/testing/server-tracetesting/features/http_test/05_create_http_test.yml
+++ b/testing/server-tracetesting/features/http_test/05_create_http_test.yml
@@ -27,20 +27,18 @@ spec:
               ]
             }
           },
-          "specs": {
-            "specs": [
-              {
-                "selector": {
-                  "query": "span[name = \"pg.query:SELECT pokeshop\"]"
-                },
-                "assertions": ["attr:tracetest.selected_spans.count > 0"]
-              }
-            ]
-          },
+          "specs": [
+            {
+              "selectorParsed": {
+                "query": "span[name = \"pg.query:SELECT pokeshop\"]"
+              },
+              "assertions": ["attr:tracetest.selected_spans.count > 0"]
+            }
+          ],
           "outputs": [
             {
               "name": "TRIGGER_COUNT",
-              "selector": {
+              "selectorParsed": {
                 "query": "span[name = \"Tracetest trigger\"]"
               },
               "value": "attr:tracetest.selected_spans.count"

--- a/testing/server-tracetesting/features/http_test/06_list_http_test.yml
+++ b/testing/server-tracetesting/features/http_test/06_list_http_test.yml
@@ -1,5 +1,6 @@
 type: Test
 spec:
+  id: oCkHevwVgP
   name: List HTTP Test
   description: Test step of 'HTTP Test Feature - Test Suite'
   trigger:

--- a/testing/server-tracetesting/features/http_test/07_run_http_test.yml
+++ b/testing/server-tracetesting/features/http_test/07_run_http_test.yml
@@ -1,5 +1,6 @@
 type: Test
 spec:
+  id: TjkNevQ4Rs
   name: Run HTTP Test
   description: Test step of 'HTTP Test Feature - Test Suite'
   trigger:

--- a/testing/server-tracetesting/features/http_test/08_rerun_http_test.yml
+++ b/testing/server-tracetesting/features/http_test/08_rerun_http_test.yml
@@ -1,5 +1,6 @@
 type: Test
 spec:
+  id: oCzHevQVR8
   name: Re-Run HTTP Test
   description: Test step of 'HTTP Test Feature - Test Suite'
   trigger:

--- a/testing/server-tracetesting/features/http_test/09_delete_http_test_run.yml
+++ b/testing/server-tracetesting/features/http_test/09_delete_http_test_run.yml
@@ -1,5 +1,6 @@
 type: Test
 spec:
+  id: TCzH6vQ4RQ
   name: Delete HTTP Test Run
   description: Test step of 'HTTP Test Feature - Test Suite'
   trigger:

--- a/testing/server-tracetesting/features/http_test/10_delete_http_test.yml
+++ b/testing/server-tracetesting/features/http_test/10_delete_http_test.yml
@@ -1,5 +1,6 @@
 type: Test
 spec:
+  id: TCkHevQVR_
   name: Delete HTTP Test
   description: Test step of 'HTTP Test Feature - Test Suite'
   trigger:

--- a/testing/server-tracetesting/features/http_test/_test_suite.yml
+++ b/testing/server-tracetesting/features/http_test/_test_suite.yml
@@ -1,5 +1,6 @@
 type: Transaction
 spec:
+  id: TjkHeDQVg1
   name: HTTP Test Feature
   description: Sequence of tests to validate if our HTTP Test feature is working as expected
   steps:

--- a/testing/server-tracetesting/features/transaction/_test_suite.yml
+++ b/testing/server-tracetesting/features/transaction/_test_suite.yml
@@ -1,5 +1,6 @@
 type: Transaction
 spec:
+  id: ILYjqDQ4g
   name: Transaction Feature
   description: Sequence of tests to validate if our Transaction feature is working as expected
   steps:

--- a/testing/server-tracetesting/features/transaction/create_transaction.yml
+++ b/testing/server-tracetesting/features/transaction/create_transaction.yml
@@ -1,6 +1,7 @@
 ---
 type: Test
 spec:
+  id: TCzH6vw4R
   name: Create transaction
   description: Test step of 'Transaction Feature - Test Suite'
   trigger:

--- a/testing/server-tracetesting/features/transaction/create_transaction_step.yml
+++ b/testing/server-tracetesting/features/transaction/create_transaction_step.yml
@@ -27,20 +27,18 @@ spec:
               ]
             }
           },
-          "specs": {
-            "specs": [
-              {
-                "selector": {
-                  "query": "span[name = \"pg.query:SELECT pokeshop\"]"
-                },
-                "assertions": ["attr:tracetest.selected_spans.count > 0"]
-              }
-            ]
-          },
+          "specs": [
+            {
+              "selectorParsed": {
+                "query": "span[name = \"pg.query:SELECT pokeshop\"]"
+              },
+              "assertions": ["attr:tracetest.selected_spans.count > 0"]
+            }
+          ],
           "outputs": [
             {
               "name": "TRIGGER_COUNT",
-              "selector": {
+              "selectorParsed": {
                 "query": "span[name = \"Tracetest trigger\"]"
               },
               "value": "attr:tracetest.selected_spans.count"

--- a/testing/server-tracetesting/features/transaction/create_transaction_step.yml
+++ b/testing/server-tracetesting/features/transaction/create_transaction_step.yml
@@ -1,5 +1,6 @@
 type: Test
 spec:
+  id: hCzNevwVg
   name: Create transaction step
   description: Test step of 'Transaction Feature - Test Suite'
   trigger:

--- a/testing/server-tracetesting/features/transaction/delete_transaction.yml
+++ b/testing/server-tracetesting/features/transaction/delete_transaction.yml
@@ -1,6 +1,7 @@
 ---
 type: Test
 spec:
+  id: TjkHeDw4gm
   name: Delete Transaction
   description: Test step of 'Transaction Feature - Test Suite'
   trigger:

--- a/testing/server-tracetesting/features/transaction/delete_transaction_step.yml
+++ b/testing/server-tracetesting/features/transaction/delete_transaction_step.yml
@@ -1,6 +1,7 @@
 ---
 type: Test
 spec:
+  id: TCzNeDwVgz
   name: Delete Transaction Step
   description: Test step of 'Transaction Feature - Test Suite'
   trigger:

--- a/testing/server-tracetesting/features/transaction/list_transaction.yml
+++ b/testing/server-tracetesting/features/transaction/list_transaction.yml
@@ -1,6 +1,7 @@
 ---
 type: Test
 spec:
+  id: TjkNeDwVgM
   name: List Transaction
   description: Test step of 'Transaction Feature - Test Suite'
   trigger:

--- a/testing/server-tracetesting/features/transaction/list_transaction_as_resource.yml
+++ b/testing/server-tracetesting/features/transaction/list_transaction_as_resource.yml
@@ -1,6 +1,7 @@
 ---
 type: Test
 spec:
+  id: TjkNeDwVRZ
   name: List Transaction as Resource
   description: Test step of 'Transaction Feature - Test Suite'
   trigger:

--- a/testing/server-tracetesting/features/transaction/update_transaction.yml
+++ b/testing/server-tracetesting/features/transaction/update_transaction.yml
@@ -1,6 +1,7 @@
 ---
 type: Test
 spec:
+  id: TjkNeDQ4R7
   name: Update transaction
   description: Test step of 'Transaction Feature - Test Suite'
   trigger:


### PR DESCRIPTION
This PR sets static IDs for tests. This allows tests to be updated instead of always created as new. This makes it easier to navigate the integration UI and makes the history of runs visually clearer


## Checklist

- [ ] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
