### PR TITLE
fix: improve resourcemanager handling of augmented header

### DIFF
--- a/server/resourcemanager/resource_manager.go
+++ b/server/resourcemanager/resource_manager.go
@@ -393,7 +393,7 @@ func (m *manager[T]) get(w http.ResponseWriter, r *http.Request) {
 	id := id.ID(vars["id"])
 
 	getterFn := m.rh.Get
-	if isRequestForAugmented(r) {
+	if isRequestForAugmented(r) && m.rh.GetAugmented != nil {
 		getterFn = m.rh.GetAugmented
 	}
 


### PR DESCRIPTION
This PR fixes an issue triggered by running `tracetest get datastore  --id current -o json`, where the server panics. The underlying issue is that the request is being sent with the `X-Tracetest-Agumented` header, but the resource handler doesn't implement the method, causing a nil pointer reference.

This PR handles the nil pointer.


## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
