### PR TITLE
fix(docs): fix cli transactions menu

### DIFF
--- a/docs/docs/cli/creating-transactions.md
+++ b/docs/docs/cli/creating-transactions.md
@@ -1,19 +1,19 @@
 # Creating Transactions
 
-Just like other structures of Tracetest, you can also manager your transactions using the CLI and definition files.
+Just like other structures of Tracetest, you can also manage your transactions using the CLI and definition files.
 
 A definition file for a transaction looks like the following:
 
 ```yaml
 type: Transaction
 spec:
-    name: Test purchase flow
-    description: Test a flow of purchasing an item
-    steps:
-      - ./tests/create-product.yaml
-      - ./tests/add-product-to-cart.yaml
-      - ./tests/complete-purschase.yaml
-      - testID # you can also reference tests by their ids instead of referencing the definition file
+  name: Test purchase flow
+  description: Test a flow of purchasing an item
+  steps:
+    - ./tests/create-product.yaml
+    - ./tests/add-product-to-cart.yaml
+    - ./tests/complete-purschase.yaml
+    - testID # you can also reference tests by their ids instead of referencing the definition file
 ```
 
 In order to apply this transaction to your Tracetest instance, make sure to have your [CLI configured](./configuring-your-cli.md) and run:

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -32,7 +32,8 @@ const sidebars = {
       type: "category",
       label: "Getting Started",
       link: {
-        type: 'doc', id: 'getting-started/installation'
+        type: "doc",
+        id: "getting-started/installation",
       },
       items: [
         {
@@ -46,7 +47,8 @@ const sidebars = {
       type: "category",
       label: "Configuration",
       link: {
-        type: 'doc', id: 'configuration/overview'
+        type: "doc",
+        id: "configuration/overview",
       },
       items: [
         // {
@@ -156,7 +158,8 @@ const sidebars = {
       type: "category",
       label: "Deployment",
       link: {
-        type: 'doc', id: 'deployment/overview'
+        type: "doc",
+        id: "deployment/overview",
       },
       items: [
         // {
@@ -243,11 +246,6 @@ const sidebars = {
       items: [
         {
           type: "doc",
-          id: "web-ui/creating-environments",
-          label: "Creating environments",
-        },
-        {
-          type: "doc",
           id: "web-ui/creating-tests",
           label: "Creating Tests",
         },
@@ -265,11 +263,6 @@ const sidebars = {
           type: "doc",
           id: "web-ui/test-results",
           label: "Test Results",
-        },
-        {
-          type: "doc",
-          id: "web-ui/creating-transactions",
-          label: "Creating transactions",
         },
         {
           type: "doc",
@@ -297,11 +290,11 @@ const sidebars = {
           id: "cli/creating-data-stores",
           label: "Creating Data Stores",
         },
-        // {
-        //   type: "doc",
-        //   id: "cli/creating-environments",
-        //   label: "Creating environments",
-        // },
+        {
+          type: "doc",
+          id: "cli/creating-environments",
+          label: "Creating Environments",
+        },
         {
           type: "doc",
           id: "cli/creating-tests",
@@ -312,11 +305,11 @@ const sidebars = {
           id: "cli/running-tests",
           label: "Running Tests",
         },
-        // {
-        //   type: "doc",
-        //   id: "cli/creating-transactions",
-        //   label: "Creating transactions",
-        // },
+        {
+          type: "doc",
+          id: "cli/creating-transactions",
+          label: "Creating Transactions",
+        },
         // {
         //   type: "doc",
         //   id: "cli/exporting-tests",
@@ -333,7 +326,8 @@ const sidebars = {
       type: "category",
       label: "CI/CD Automation",
       link: {
-        type: 'doc', id: 'ci-cd-automation/overview'
+        type: "doc",
+        id: "ci-cd-automation/overview",
       },
       items: [
         {
@@ -347,7 +341,8 @@ const sidebars = {
       type: "category",
       label: "Tools & Integrations",
       link: {
-        type: 'doc', id: 'tools-and-integrations/overview'
+        type: "doc",
+        id: "tools-and-integrations/overview",
       },
       items: [
         {
@@ -371,7 +366,8 @@ const sidebars = {
       type: "category",
       label: "Examples & Tutorials",
       link: {
-        type: 'doc', id: 'examples-tutorials/overview'
+        type: "doc",
+        id: "examples-tutorials/overview",
       },
       items: [
         {


### PR DESCRIPTION
This PR fixes an issue with the sidebar menu in our docs. It removes the Creating environments and Creating transactions menu from the Web UI section, and enables it under the CLI section.

## Changes

- fix sidebar menu in docs

## Fixes

-

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
