### PR TITLE
fix(frontend): removing decross option for the dat layout

### DIFF
--- a/web/src/services/DAG.service.ts
+++ b/web/src/services/DAG.service.ts
@@ -1,4 +1,4 @@
-import {coordCenter, Dag, dagStratify, decrossOpt, layeringSimplex, sugiyama} from 'd3-dag';
+import {coordCenter, Dag, dagStratify, layeringSimplex, sugiyama} from 'd3-dag';
 import {MarkerType} from 'react-flow-renderer';
 
 import {theme} from 'constants/Theme.constants';
@@ -10,7 +10,6 @@ function getDagLayout<T>(nodesDatum: INodeDatum<T>[]) {
 
   const dagLayout = sugiyama()
     .layering(layeringSimplex())
-    .decross(decrossOpt())
     .coord(coordCenter())
     .nodeSize(() => [220, 180]);
 


### PR DESCRIPTION
This PR removes the decross option from the dag layout setup, as it breaks with large traces

Related issue https://github.com/erikbrinkman/d3-dag/issues/98

## Changes

- Removes decross option from dag layout setup

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
