### PR TITLE
feature(cli): adding server and cli version match

### DIFF
--- a/cli/actions/version.go
+++ b/cli/actions/version.go
@@ -21,37 +21,34 @@ func NewGetServerVersionAction(options ...ActionArgsOption) versionAction {
 }
 
 func (a versionAction) Run(ctx context.Context, args VersionConfig) error {
-	versionText := a.GetVersionText(ctx)
+	versionText, _ := a.GetVersion(ctx)
 
 	fmt.Println(versionText)
 	return nil
 }
 
-func (a versionAction) GetVersionText(ctx context.Context) string {
+func (a versionAction) GetVersion(ctx context.Context) (string, bool) {
 	result := fmt.Sprintf(`CLI: %s`, config.Version)
 
 	if a.config.IsEmpty() {
 		return result + `
-Server: Not Configured`
+Server: Not Configured`, false
 	}
 
 	version, err := a.GetServerVersion(ctx)
 	if err != nil {
 		return result + fmt.Sprintf(`
-Server: Failed to get the server version - %s`, err.Error())
+Server: Failed to get the server version - %s`, err.Error()), false
 	}
 
 	isVersionMatch := version == config.Version
 	if isVersionMatch {
 		version += `
 ✔️ Version match`
-	} else {
-		version += `
-✖️ Version mismatch`
 	}
 
 	return result + fmt.Sprintf(`
-Server: %s`, version)
+Server: %s`, version), isVersionMatch
 }
 
 func (a versionAction) GetServerVersion(ctx context.Context) (string, error) {

--- a/cli/cmd/config.go
+++ b/cli/cmd/config.go
@@ -200,7 +200,7 @@ func setupVersion() {
 	action := actions.NewGetServerVersionAction(options...)
 	versionText, isVersionMatch = action.GetVersion(ctx)
 
-	if !isVersionMatch && os.Getenv("TRACETEST_DEV") != "" {
+	if !isVersionMatch && os.Getenv("TRACETEST_DEV") == "" {
 		fmt.Fprintf(os.Stderr, versionText+`
 ✖️ Version Mismatch. Ensure the Tracetest server and CLI use the same version.
 For more information. Please visit https://docs.tracetest.io/cli/version-mismatch

--- a/cli/cmd/config.go
+++ b/cli/cmd/config.go
@@ -205,8 +205,10 @@ func setupVersion() {
 
 	if !isVersionMatch && os.Getenv("TRACETEST_DEV") == "" {
 		fmt.Fprintf(os.Stderr, versionText+`
-✖️ Version Mismatch. Ensure the Tracetest server and CLI use the same version.
-For more information. Please visit https://docs.tracetest.io/cli/version-mismatch
+✖️ Error: Version Mismatch
+The CLI version and the server version are not compatible. To fix this, you'll need to make sure that both your CLI and server are using compatible versions.
+We recommend upgrading both of them to the latest available version. Check out our documentation https://docs.tracetest.io/configuration/upgrade for simple instructions on how to upgrade.
+Thank you for using Tracetest! We apologize for any inconvenience caused.
 `)
 		ExitCLI(1)
 	}

--- a/cli/cmd/config.go
+++ b/cli/cmd/config.go
@@ -20,6 +20,7 @@ var cliLogger *zap.Logger
 var resourceRegistry = actions.NewResourceRegistry()
 var validArgs = []string{"config", "datastore", "demo", "environment", "pollingprofile", "transaction"}
 var versionText string
+var isVersionMatch bool
 
 type setupConfig struct {
 	shouldValidateConfig bool
@@ -197,7 +198,13 @@ func setupVersion() {
 	}
 
 	action := actions.NewGetServerVersionAction(options...)
-	version := action.GetVersionText(ctx)
+	versionText, isVersionMatch = action.GetVersion(ctx)
 
-	versionText = version
+	if !isVersionMatch && os.Getenv("TRACETEST_DEV") != "" {
+		fmt.Fprintf(os.Stderr, versionText+`
+✖️ Version Mismatch. Ensure the Tracetest server and CLI use the same version.
+For more information. Please visit https://docs.tracetest.io/cli/version-mismatch
+`)
+		ExitCLI(1)
+	}
 }

--- a/testing/cli-e2etest/testscenarios/version_test.go
+++ b/testing/cli-e2etest/testscenarios/version_test.go
@@ -1,9 +1,9 @@
 package testscenarios
 
 import (
-	"fmt"
 	"testing"
 
+	"github.com/kubeshop/tracetest/cli-e2etest/environment"
 	"github.com/kubeshop/tracetest/cli-e2etest/tracetestcli"
 	"github.com/stretchr/testify/require"
 )
@@ -12,14 +12,14 @@ func TestVersionCommand(t *testing.T) {
 	// instantiate require with testing helper
 	require := require.New(t)
 
+	// setup test server environment
+	env := environment.CreateAndStart(t)
+	defer env.Close(t)
+
 	// Given I am a Tracetest CLI user
 	// When I try to check the tracetest version
 	// Then I should receive a version string with success
-
 	result := tracetestcli.Exec(t, "version")
-	fmt.Println("STD OUT: ", result.StdOut)
-	fmt.Println("COMMAND: ", result.CommandExecuted)
-	fmt.Println("STD ERR: ", result.StdErr)
 
 	require.Equal(0, result.ExitCode)
 	require.Greater(len(result.StdOut), 0)

--- a/testing/cli-e2etest/testscenarios/version_test.go
+++ b/testing/cli-e2etest/testscenarios/version_test.go
@@ -18,6 +18,8 @@ func TestVersionCommand(t *testing.T) {
 
 	result := tracetestcli.Exec(t, "version")
 	fmt.Println("STD OUT: ", result.StdOut)
+	fmt.Println("COMMAND: ", result.CommandExecuted)
+	fmt.Println("STD ERR: ", result.StdErr)
 
 	require.Equal(0, result.ExitCode)
 	require.Greater(len(result.StdOut), 0)

--- a/testing/cli-e2etest/testscenarios/version_test.go
+++ b/testing/cli-e2etest/testscenarios/version_test.go
@@ -1,6 +1,7 @@
 package testscenarios
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/kubeshop/tracetest/cli-e2etest/tracetestcli"
@@ -13,9 +14,11 @@ func TestVersionCommand(t *testing.T) {
 
 	// Given I am a Tracetest CLI user
 	// When I try to check the tracetest version
-	// Then I should receive a version string with sucess
+	// Then I should receive a version string with success
 
 	result := tracetestcli.Exec(t, "version")
+	fmt.Println("STD OUT: ", result.StdOut)
+
 	require.Equal(0, result.ExitCode)
 	require.Greater(len(result.StdOut), 0)
 }

--- a/testing/cli-e2etest/testscenarios/version_test.go
+++ b/testing/cli-e2etest/testscenarios/version_test.go
@@ -16,10 +16,12 @@ func TestVersionCommand(t *testing.T) {
 	env := environment.CreateAndStart(t)
 	defer env.Close(t)
 
+	cliConfig := env.GetCLIConfigPath(t)
+
 	// Given I am a Tracetest CLI user
 	// When I try to check the tracetest version
 	// Then I should receive a version string with success
-	result := tracetestcli.Exec(t, "version")
+	result := tracetestcli.Exec(t, "version", tracetestcli.WithCLIConfig(cliConfig))
 
 	require.Equal(0, result.ExitCode)
 	require.Greater(len(result.StdOut), 0)


### PR DESCRIPTION
This PR adds a server version match for the CLI. It automatically breaks any command if we find a mismatch.

It is skipped if the `TRACETEST_DEV` flag is set.

## Changes

- Adds version match for server and CLI

## Fixes

- #2298 

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

https://www.loom.com/share/b09b566e12664f49bfcdcda73a079576
