### PR TITLE
feature(cli): adding flag and parameter validations for commands

### DIFF
--- a/cli/cmd/apply_cmd.go
+++ b/cli/cmd/apply_cmd.go
@@ -8,24 +8,19 @@ import (
 	"github.com/kubeshop/tracetest/cli/actions"
 	"github.com/kubeshop/tracetest/cli/analytics"
 	"github.com/kubeshop/tracetest/cli/formatters"
+	"github.com/kubeshop/tracetest/cli/parameters"
 	"github.com/spf13/cobra"
 )
 
-var definitionFile string
+var applyParams = &parameters.ApplyParams{}
 
 var applyCmd = &cobra.Command{
-	GroupID:   cmdGroupResources.ID,
-	Use:       fmt.Sprintf("apply %s", strings.Join(validArgs, "|")),
-	Short:     "Apply resources",
-	Long:      "Apply (create/update) resources to your Tracetest server",
-	PreRun:    setupCommand(),
-	Args:      cobra.MatchAll(cobra.MinimumNArgs(1), cobra.OnlyValidArgs),
-	ValidArgs: validArgs,
-	Run: WithResultHandler(func(cmd *cobra.Command, args []string) (string, error) {
-		if definitionFile == "" {
-			return "", fmt.Errorf("file with definition must be specified")
-		}
-
+	GroupID: cmdGroupResources.ID,
+	Use:     fmt.Sprintf("apply %s", strings.Join(parameters.ValidResources, "|")),
+	Short:   "Apply resources",
+	Long:    "Apply (create/update) resources to your Tracetest server",
+	PreRun:  setupCommand(),
+	Run: WithResourceMiddleware(func(_ *cobra.Command, args []string) (string, error) {
 		resourceType := args[0]
 		ctx := context.Background()
 
@@ -40,7 +35,7 @@ var applyCmd = &cobra.Command{
 		}
 
 		applyArgs := actions.ApplyArgs{
-			File: definitionFile,
+			File: applyParams.DefinitionFile,
 		}
 
 		resource, _, err := resourceActions.Apply(ctx, applyArgs)
@@ -57,11 +52,11 @@ var applyCmd = &cobra.Command{
 		}
 
 		return result, nil
-	}),
+	}, applyParams),
 	PostRun: teardownCommand,
 }
 
 func init() {
-	applyCmd.Flags().StringVarP(&definitionFile, "file", "f", "", "file path with name where to export the resource")
+	applyCmd.Flags().StringVarP(&applyParams.DefinitionFile, "file", "f", "", "file path with name where to export the resource")
 	rootCmd.AddCommand(applyCmd)
 }

--- a/cli/cmd/config.go
+++ b/cli/cmd/config.go
@@ -9,17 +9,20 @@ import (
 	"github.com/kubeshop/tracetest/cli/analytics"
 	"github.com/kubeshop/tracetest/cli/config"
 	"github.com/kubeshop/tracetest/cli/formatters"
+	"github.com/kubeshop/tracetest/cli/parameters"
 	"github.com/kubeshop/tracetest/cli/utils"
 	"github.com/spf13/cobra"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 )
 
-var cliConfig config.Config
-var cliLogger *zap.Logger
-var resourceRegistry = actions.NewResourceRegistry()
-var validArgs = []string{"config", "datastore", "demo", "environment", "pollingprofile", "transaction"}
-var versionText string
+var (
+	cliConfig        config.Config
+	cliLogger        *zap.Logger
+	resourceRegistry = actions.NewResourceRegistry()
+	versionText      string
+	resourceParams   = &parameters.ResourceParams{}
+)
 
 type setupConfig struct {
 	shouldValidateConfig bool

--- a/cli/cmd/datastore_legacy_cmd.go
+++ b/cli/cmd/datastore_legacy_cmd.go
@@ -33,7 +33,7 @@ var dataStoreApplyCmd = &cobra.Command{
 	PreRun:     setupCommand(),
 	Run: func(cmd *cobra.Command, args []string) {
 		// call new apply command
-		definitionFile = dataStoreApplyFile
+		applyParams.DefinitionFile = dataStoreApplyFile
 		applyCmd.Run(applyCmd, []string{"datastore"})
 	},
 	PostRun: teardownCommand,
@@ -62,7 +62,7 @@ var dataStoreListCmd = &cobra.Command{
 	PreRun:     setupCommand(),
 	Run: func(cmd *cobra.Command, args []string) {
 		// call new get command
-		resourceID = "current"
+		getParams.ResourceId = "current"
 		getCmd.Run(getCmd, []string{"datastore"})
 	},
 	PostRun: teardownCommand,

--- a/cli/cmd/environment_legacy_cmd.go
+++ b/cli/cmd/environment_legacy_cmd.go
@@ -27,7 +27,7 @@ var environmentApplyCmd = &cobra.Command{
 	PreRun:     setupCommand(),
 	Run: func(cmd *cobra.Command, args []string) {
 		// call new apply command
-		definitionFile = dataStoreApplyFile
+		applyParams.DefinitionFile = dataStoreApplyFile
 		applyCmd.Run(applyCmd, []string{"environment"})
 	},
 	PostRun: teardownCommand,

--- a/cli/cmd/export_cmd.go
+++ b/cli/cmd/export_cmd.go
@@ -3,8 +3,10 @@ package cmd
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/kubeshop/tracetest/cli/analytics"
+	"github.com/kubeshop/tracetest/cli/parameters"
 	"github.com/spf13/cobra"
 )
 
@@ -15,12 +17,11 @@ var (
 
 var exportCmd = &cobra.Command{
 	GroupID: cmdGroupResources.ID,
-	Use:     "export [resource type]",
+	Use:     fmt.Sprintf("export %s", strings.Join(parameters.ValidResources, "|")),
 	Long:    "Export a resource from your Tracetest server",
 	Short:   "Export resource",
 	PreRun:  setupCommand(),
-	Args:    cobra.MinimumNArgs(1),
-	Run: WithResultHandler(func(cmd *cobra.Command, args []string) (string, error) {
+	Run: WithResultHandler(func(_ *cobra.Command, args []string) (string, error) {
 		resourceType := args[0]
 		ctx := context.Background()
 

--- a/cli/cmd/get_cmd.go
+++ b/cli/cmd/get_cmd.go
@@ -20,6 +20,7 @@ var getCmd = &cobra.Command{
 	Use:     fmt.Sprintf("get %s", strings.Join(parameters.ValidResources, "|")),
 	Short:   "Get resource",
 	Long:    "Get a resource from your Tracetest server",
+	PreRun:  setupCommand(),
 	Run: WithResourceMiddleware(func(_ *cobra.Command, args []string) (string, error) {
 		resourceType := args[0]
 		ctx := context.Background()

--- a/cli/cmd/get_cmd.go
+++ b/cli/cmd/get_cmd.go
@@ -8,25 +8,19 @@ import (
 
 	"github.com/kubeshop/tracetest/cli/analytics"
 	"github.com/kubeshop/tracetest/cli/formatters"
+	"github.com/kubeshop/tracetest/cli/parameters"
 	"github.com/kubeshop/tracetest/cli/utils"
 	"github.com/spf13/cobra"
 )
 
-var resourceID string
+var getParams = &parameters.ResourceIdParams{}
 
 var getCmd = &cobra.Command{
-	GroupID:   cmdGroupResources.ID,
-	Use:       fmt.Sprintf("get %s", strings.Join(validArgs, "|")),
-	Short:     "Get resource",
-	Long:      "Get a resource from your Tracetest server",
-	PreRun:    setupCommand(),
-	Args:      cobra.MatchAll(cobra.MinimumNArgs(1), cobra.OnlyValidArgs),
-	ValidArgs: validArgs,
-	Run: WithResultHandler(func(cmd *cobra.Command, args []string) (string, error) {
-		if resourceID == "" {
-			return "", fmt.Errorf("id of the resource to get must be specified")
-		}
-
+	GroupID: cmdGroupResources.ID,
+	Use:     fmt.Sprintf("get %s", strings.Join(parameters.ValidResources, "|")),
+	Short:   "Get resource",
+	Long:    "Get a resource from your Tracetest server",
+	Run: WithResourceMiddleware(func(_ *cobra.Command, args []string) (string, error) {
 		resourceType := args[0]
 		ctx := context.Background()
 
@@ -43,9 +37,9 @@ var getCmd = &cobra.Command{
 			ctx = context.WithValue(ctx, "X-Tracetest-Augmented", true)
 		}
 
-		resource, err := resourceActions.Get(ctx, resourceID)
+		resource, err := resourceActions.Get(ctx, getParams.ResourceId)
 		if err != nil && errors.Is(err, utils.ResourceNotFound) {
-			return fmt.Sprintf("Resource %s with ID %s not found", resourceType, resourceID), nil
+			return fmt.Sprintf("Resource %s with ID %s not found", resourceType, getParams.ResourceId), nil
 		} else if err != nil {
 			return "", err
 		}
@@ -59,11 +53,11 @@ var getCmd = &cobra.Command{
 		}
 
 		return result, nil
-	}),
+	}, getParams),
 	PostRun: teardownCommand,
 }
 
 func init() {
-	getCmd.Flags().StringVar(&resourceID, "id", "", "id of the resource to get")
+	getCmd.Flags().StringVar(&getParams.ResourceId, "id", "", "id of the resource to get")
 	rootCmd.AddCommand(getCmd)
 }

--- a/cli/cmd/list_cmd.go
+++ b/cli/cmd/list_cmd.go
@@ -7,27 +7,20 @@ import (
 
 	"github.com/kubeshop/tracetest/cli/analytics"
 	"github.com/kubeshop/tracetest/cli/formatters"
+	"github.com/kubeshop/tracetest/cli/parameters"
 	"github.com/kubeshop/tracetest/cli/utils"
 	"github.com/spf13/cobra"
 )
 
-var (
-	listTake          int32
-	listSkip          int32
-	listSortBy        string
-	listSortDirection string
-	listAll           bool
-)
+var listParams = &parameters.ListParams{}
 
 var listCmd = &cobra.Command{
-	GroupID:   cmdGroupResources.ID,
-	Use:       fmt.Sprintf("list %s", strings.Join(validArgs, "|")),
-	Short:     "List resources",
-	Long:      "List resources from your Tracetest server",
-	PreRun:    setupCommand(),
-	Args:      cobra.MatchAll(cobra.MinimumNArgs(1), cobra.OnlyValidArgs),
-	ValidArgs: validArgs,
-	Run: WithResultHandler(func(cmd *cobra.Command, args []string) (string, error) {
+	GroupID: cmdGroupResources.ID,
+	Use:     fmt.Sprintf("list %s", strings.Join(parameters.ValidResources, "|")),
+	Short:   "List resources",
+	Long:    "List resources from your Tracetest server",
+	PreRun:  setupCommand(),
+	Run: WithResourceMiddleware(func(_ *cobra.Command, args []string) (string, error) {
 		resourceType := args[0]
 		ctx := context.Background()
 
@@ -41,11 +34,11 @@ var listCmd = &cobra.Command{
 		}
 
 		listArgs := utils.ListArgs{
-			Take:          listTake,
-			Skip:          listSkip,
-			SortDirection: listSortDirection,
-			SortBy:        listSortBy,
-			All:           listAll,
+			Take:          listParams.Take,
+			Skip:          listParams.Skip,
+			SortDirection: listParams.SortDirection,
+			SortBy:        listParams.SortBy,
+			All:           listParams.All,
 		}
 
 		resource, err := resourceActions.List(ctx, listArgs)
@@ -62,16 +55,16 @@ var listCmd = &cobra.Command{
 		}
 
 		return result, nil
-	}),
+	}, listParams),
 	PostRun: teardownCommand,
 }
 
 func init() {
-	listCmd.Flags().Int32Var(&listTake, "take", 20, "Take number")
-	listCmd.Flags().Int32Var(&listSkip, "skip", 0, "Skip number")
-	listCmd.Flags().StringVar(&listSortBy, "sortBy", "", "Sort by")
-	listCmd.Flags().StringVar(&listSortDirection, "sortDirection", "desc", "Sort direction")
-	listCmd.Flags().BoolVar(&listAll, "all", false, "All")
+	listCmd.Flags().Int32Var(&listParams.Take, "take", 20, "Take number")
+	listCmd.Flags().Int32Var(&listParams.Skip, "skip", 0, "Skip number")
+	listCmd.Flags().StringVar(&listParams.SortBy, "sortBy", "", "Sort by")
+	listCmd.Flags().StringVar(&listParams.SortDirection, "sortDirection", "desc", "Sort direction")
+	listCmd.Flags().BoolVar(&listParams.All, "all", false, "All")
 
 	rootCmd.AddCommand(listCmd)
 }

--- a/cli/cmd/server_install_cmd.go
+++ b/cli/cmd/server_install_cmd.go
@@ -3,26 +3,27 @@ package cmd
 import (
 	"github.com/kubeshop/tracetest/cli/analytics"
 	"github.com/kubeshop/tracetest/cli/installer"
+	"github.com/kubeshop/tracetest/cli/parameters"
 	"github.com/spf13/cobra"
 )
 
-var (
-	force             = false
-	runEnvironment    = installer.NoneRunEnvironmentType
-	installationMode  = installer.NotChosenInstallationModeType
-	kubernetesContext = ""
-)
+var installerParams = &parameters.InstallerParams{
+	Force:             false,
+	RunEnvironment:    installer.NoneRunEnvironmentType,
+	InstallationMode:  installer.NotChosenInstallationModeType,
+	KubernetesContext: "",
+}
 
 var serverInstallCmd = &cobra.Command{
 	Use:    "install",
 	Short:  "Install a new Tracetest server",
 	Long:   "Install a new Tracetest server",
 	PreRun: setupCommand(SkipConfigValidation()),
-	Run: func(cmd *cobra.Command, args []string) {
-		installer.Force = force
-		installer.RunEnvironment = runEnvironment
-		installer.InstallationMode = installationMode
-		installer.KubernetesContext = kubernetesContext
+	Run: func(_ *cobra.Command, _ []string) {
+		installer.Force = installerParams.Force
+		installer.RunEnvironment = installerParams.RunEnvironment
+		installer.InstallationMode = installerParams.InstallationMode
+		installer.KubernetesContext = installerParams.KubernetesContext
 
 		analytics.Track("Server Install", "cmd", map[string]string{})
 		installer.Start()
@@ -31,12 +32,12 @@ var serverInstallCmd = &cobra.Command{
 }
 
 func init() {
-	serverInstallCmd.Flags().BoolVarP(&force, "force", "f", false, "Overwrite existing files")
-	serverInstallCmd.Flags().StringVar(&kubernetesContext, "kubernetes-context", "", "Kubernetes context used to install Tracetest. It will be only used if 'run-environment' is set as 'kubernetes'.")
+	serverInstallCmd.Flags().BoolVarP(&installerParams.Force, "force", "f", false, "Overwrite existing files")
+	serverInstallCmd.Flags().StringVar(&installerParams.KubernetesContext, "kubernetes-context", "", "Kubernetes context used to install Tracetest. It will be only used if 'run-environment' is set as 'kubernetes'.")
 
 	// these commands will not have shorthand parameters to avoid colision with existing ones in other commands
-	serverInstallCmd.Flags().Var(&installationMode, "mode", "Indicate the type of demo environment to be installed with Tracetest. It can be 'with-demo' or 'just-tracetest'.")
-	serverInstallCmd.Flags().Var(&runEnvironment, "run-environment", "Type of environment were Tracetest will be installed. It can be 'docker' or 'kubernetes'.")
+	serverInstallCmd.Flags().Var(&installerParams.InstallationMode, "mode", "Indicate the type of demo environment to be installed with Tracetest. It can be 'with-demo' or 'just-tracetest'.")
+	serverInstallCmd.Flags().Var(&installerParams.RunEnvironment, "run-environment", "Type of environment were Tracetest will be installed. It can be 'docker' or 'kubernetes'.")
 
 	serverCmd.AddCommand(serverInstallCmd)
 }

--- a/cli/cmd/test_list_cmd.go
+++ b/cli/cmd/test_list_cmd.go
@@ -15,7 +15,7 @@ var testListCmd = &cobra.Command{
 	Short:  "List all tests",
 	Long:   "List all tests",
 	PreRun: setupCommand(),
-	Run: WithResultHandler(func(cmd *cobra.Command, args []string) (string, error) {
+	Run: WithResultHandler(func(_ *cobra.Command, _ []string) (string, error) {
 		analytics.Track("Test List", "cmd", map[string]string{})
 
 		ctx := context.Background()

--- a/cli/cmd/version_cmd.go
+++ b/cli/cmd/version_cmd.go
@@ -11,7 +11,7 @@ var versionCmd = &cobra.Command{
 	Short:   "Display this CLI tool version",
 	Long:    "Display this CLI tool version",
 	PreRun:  setupCommand(),
-	Run: WithResultHandler(func(cmd *cobra.Command, args []string) (string, error) {
+	Run: WithResultHandler(func(_ *cobra.Command, _ []string) (string, error) {
 		analytics.Track("Version", "cmd", map[string]string{})
 
 		return versionText, nil

--- a/cli/parameters/configure.go
+++ b/cli/parameters/configure.go
@@ -1,0 +1,36 @@
+package parameters
+
+import (
+	"net/url"
+
+	"github.com/spf13/cobra"
+)
+
+type ConfigureParams struct {
+	AnalyticsEnabled bool
+	Endpoint         string
+	Global           bool
+}
+
+var _ Params = &ConfigureParams{}
+
+func (p *ConfigureParams) Validate(cmd *cobra.Command, args []string) []ParamError {
+	var errors []ParamError
+
+	if cmd.Flags().Lookup("endpoint").Changed && p.Endpoint == "" {
+		errors = append(errors, ParamError{
+			Parameter: "endpoint",
+			Message:   "endpoint cannot be empty",
+		})
+
+		_, err := url.Parse(p.Endpoint)
+		if err != nil {
+			errors = append(errors, ParamError{
+				Parameter: "endpoint",
+				Message:   "endpoint is not a valid URL",
+			})
+		}
+	}
+
+	return errors
+}

--- a/cli/parameters/configure.go
+++ b/cli/parameters/configure.go
@@ -17,18 +17,20 @@ var _ Params = &ConfigureParams{}
 func (p *ConfigureParams) Validate(cmd *cobra.Command, args []string) []ParamError {
 	var errors []ParamError
 
-	if cmd.Flags().Lookup("endpoint").Changed && p.Endpoint == "" {
-		errors = append(errors, ParamError{
-			Parameter: "endpoint",
-			Message:   "endpoint cannot be empty",
-		})
-
-		_, err := url.Parse(p.Endpoint)
-		if err != nil {
+	if cmd.Flags().Lookup("endpoint").Changed {
+		if p.Endpoint == "" {
 			errors = append(errors, ParamError{
 				Parameter: "endpoint",
-				Message:   "endpoint is not a valid URL",
+				Message:   "endpoint cannot be empty",
 			})
+		} else {
+			_, err := url.Parse(p.Endpoint)
+			if err != nil {
+				errors = append(errors, ParamError{
+					Parameter: "endpoint",
+					Message:   "endpoint is not a valid URL",
+				})
+			}
 		}
 	}
 

--- a/cli/parameters/installer.go
+++ b/cli/parameters/installer.go
@@ -3,6 +3,20 @@ package parameters
 import (
 	"github.com/kubeshop/tracetest/cli/installer"
 	"github.com/spf13/cobra"
+	"golang.org/x/exp/slices"
+)
+
+var (
+	AllowedRunEnvironments = []installer.RunEnvironmentType{
+		installer.DockerRunEnvironmentType,
+		installer.KubernetesRunEnvironmentType,
+		installer.NoneRunEnvironmentType,
+	}
+	AllowedInstallationMode = []installer.InstallationModeType{
+		installer.WithDemoInstallationModeType,
+		installer.WithoutDemoInstallationModeType,
+		installer.NotChosenInstallationModeType,
+	}
 )
 
 type InstallerParams struct {
@@ -17,14 +31,14 @@ var _ Params = &InstallerParams{}
 func (p *InstallerParams) Validate(cmd *cobra.Command, args []string) []ParamError {
 	errors := make([]ParamError, 0)
 
-	if cmd.Flags().Lookup("run-environment").Changed && p.RunEnvironment != installer.NoneRunEnvironmentType && p.RunEnvironment != installer.DockerRunEnvironmentType && p.RunEnvironment != installer.KubernetesRunEnvironmentType {
+	if cmd.Flags().Lookup("run-environment").Changed && slices.Contains(AllowedRunEnvironments, p.RunEnvironment) {
 		errors = append(errors, ParamError{
 			Parameter: "run-environment",
 			Message:   "run-environment must be one of 'none', 'docker' or 'kubernetes'",
 		})
 	}
 
-	if cmd.Flags().Lookup("mode").Changed && p.InstallationMode != installer.NotChosenInstallationModeType && p.InstallationMode != installer.WithDemoInstallationModeType && p.InstallationMode != installer.WithoutDemoInstallationModeType {
+	if cmd.Flags().Lookup("mode").Changed && slices.Contains(AllowedInstallationMode, p.InstallationMode) {
 		errors = append(errors, ParamError{
 			Parameter: "mode",
 			Message:   "mode must be one of 'not-chosen', 'with-demo' or 'just-tracetest'",

--- a/cli/parameters/installer.go
+++ b/cli/parameters/installer.go
@@ -1,0 +1,42 @@
+package parameters
+
+import (
+	"github.com/kubeshop/tracetest/cli/installer"
+	"github.com/spf13/cobra"
+)
+
+type InstallerParams struct {
+	Force             bool
+	RunEnvironment    installer.RunEnvironmentType
+	InstallationMode  installer.InstallationModeType
+	KubernetesContext string
+}
+
+var _ Params = &InstallerParams{}
+
+func (p *InstallerParams) Validate(cmd *cobra.Command, args []string) []ParamError {
+	errors := make([]ParamError, 0)
+
+	if cmd.Flags().Lookup("run-environment").Changed && p.RunEnvironment != installer.NoneRunEnvironmentType && p.RunEnvironment != installer.DockerRunEnvironmentType && p.RunEnvironment != installer.KubernetesRunEnvironmentType {
+		errors = append(errors, ParamError{
+			Parameter: "run-environment",
+			Message:   "run-environment must be one of 'none', 'docker' or 'kubernetes'",
+		})
+	}
+
+	if cmd.Flags().Lookup("mode").Changed && p.InstallationMode != installer.NotChosenInstallationModeType && p.InstallationMode != installer.WithDemoInstallationModeType && p.InstallationMode != installer.WithoutDemoInstallationModeType {
+		errors = append(errors, ParamError{
+			Parameter: "mode",
+			Message:   "mode must be one of 'not-chosen', 'with-demo' or 'just-tracetest'",
+		})
+	}
+
+	if cmd.Flags().Lookup("kubernetes-context").Changed && p.KubernetesContext == "" {
+		errors = append(errors, ParamError{
+			Parameter: "kubernetes-context",
+			Message:   "kubernetes-context cannot be empty",
+		})
+	}
+
+	return errors
+}

--- a/cli/parameters/parameters.go
+++ b/cli/parameters/parameters.go
@@ -1,0 +1,22 @@
+package parameters
+
+import "github.com/spf13/cobra"
+
+type ParamError struct {
+	Parameter string
+	Message   string
+}
+
+type Params interface {
+	Validate(cmd *cobra.Command, args []string) []ParamError
+}
+
+func ValidateParams(cmd *cobra.Command, args []string, params ...Params) []ParamError {
+	errors := make([]ParamError, 0)
+
+	for _, param := range params {
+		errors = append(errors, param.Validate(cmd, args)...)
+	}
+
+	return errors
+}

--- a/cli/parameters/resources.go
+++ b/cli/parameters/resources.go
@@ -1,0 +1,120 @@
+package parameters
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+type ListParams struct {
+	Take          int32
+	Skip          int32
+	SortBy        string
+	SortDirection string
+	All           bool
+}
+
+var _ Params = &ListParams{}
+
+func (p *ListParams) Validate(cmd *cobra.Command, args []string) []ParamError {
+	errors := make([]ParamError, 0)
+
+	if p.Take < 0 {
+		errors = append(errors, ParamError{
+			Parameter: "take",
+			Message:   "take parameter must be greater than 0",
+		})
+	}
+
+	if p.Skip < 0 {
+		errors = append(errors, ParamError{
+			Parameter: "skip",
+			Message:   "skip parameter must be greater than 0",
+		})
+	}
+
+	if p.SortDirection != "" && p.SortDirection != "asc" && p.SortDirection != "desc" {
+		errors = append(errors, ParamError{
+			Parameter: "sortDirection",
+			Message:   "sortDirection parameter must be either asc or desc",
+		})
+	}
+
+	return errors
+}
+
+type ResourceIdParams struct {
+	ResourceId string
+}
+
+var _ Params = &ResourceIdParams{}
+
+func (p *ResourceIdParams) Validate(cmd *cobra.Command, args []string) []ParamError {
+	errors := make([]ParamError, 0)
+
+	if p.ResourceId == "" {
+		errors = append(errors, ParamError{
+			Parameter: "id",
+			Message:   "resource id must be provided",
+		})
+	}
+
+	return errors
+}
+
+type ApplyParams struct {
+	DefinitionFile string
+}
+
+var _ Params = &ApplyParams{}
+
+func (p *ApplyParams) Validate(cmd *cobra.Command, args []string) []ParamError {
+	errors := make([]ParamError, 0)
+
+	if p.DefinitionFile == "" {
+		errors = append(errors, ParamError{
+			Parameter: "file",
+			Message:   "Definition file must be provided",
+		})
+	}
+
+	return errors
+}
+
+type ResourceParams struct {
+	ResourceName string
+}
+
+var _ Params = &ResourceParams{}
+var ValidResources = []string{"config", "datastore", "demo", "environment", "pollingprofile", "transaction"}
+
+func (p *ResourceParams) Validate(cmd *cobra.Command, args []string) []ParamError {
+	errors := make([]ParamError, 0)
+
+	p.ResourceName = args[0]
+
+	if p.ResourceName == "" {
+		errors = append(errors, ParamError{
+			Parameter: "resource",
+			Message:   "resource name must be provided",
+		})
+	}
+
+	exists := false
+	for _, validArg := range ValidResources {
+		if validArg == p.ResourceName {
+			exists = true
+			break
+		}
+	}
+
+	if !exists {
+		errors = append(errors, ParamError{
+			Parameter: "resource",
+			Message:   fmt.Sprintf("resource must be one of %s", strings.Join(ValidResources, ", ")),
+		})
+	}
+
+	return errors
+}

--- a/cli/parameters/resources.go
+++ b/cli/parameters/resources.go
@@ -92,8 +92,16 @@ var ValidResources = []string{"config", "datastore", "demo", "environment", "pol
 func (p *ResourceParams) Validate(cmd *cobra.Command, args []string) []ParamError {
 	errors := make([]ParamError, 0)
 
-	p.ResourceName = args[0]
+	if len(args) == 0 {
+		errors = append(errors, ParamError{
+			Parameter: "resource",
+			Message:   "resource name must be provided",
+		})
 
+		return errors
+	}
+
+	p.ResourceName = args[0]
 	if p.ResourceName == "" {
 		errors = append(errors, ParamError{
 			Parameter: "resource",


### PR DESCRIPTION
This PR adds parameter based logic to validate different flags and args for each of the commands, returns all errors at once depending on the validation checks

## Changes

- Adds new middleware to support parameter validation
- Adds new parameters interface and validators for commands

## Fixes

- #2305 

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

https://www.loom.com/share/9efaab50749045bf9ce4557b93230806
