### PR TITLE
fix(frontend): fix grpc test spec snippet

### DIFF
--- a/web/src/constants/TestSpecs.constants.ts
+++ b/web/src/constants/TestSpecs.constants.ts
@@ -55,7 +55,7 @@ export const GRPC_SPANS_STATUS_CODE: TSnippet = {
   selector: 'span[tracetest.span.type="rpc" rpc.system="grpc"]',
   assertions: [
     {
-      left: 'attr:grpc.status_code',
+      left: 'attr:rpc.grpc.status_code',
       comparator: '=',
       right: '0',
     },


### PR DESCRIPTION
This PR fixes the attribute in the Test Spec snippet for `All gRPC Spans: Status is Ok`

## Changes

- fix attribute in test spec snippet

## Fixes

- fix #2601 

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Screenshot

![Screenshot 2023-05-29 at 11 22 55](https://github.com/kubeshop/tracetest/assets/3879892/9f2f7eb1-4712-4bff-972a-e1613e50aa4b)