### PR TITLE
fix(frontend): fix otel semantic conventions repository url

### DIFF
--- a/web/src/redux/apis/OtelRepo.api.ts
+++ b/web/src/redux/apis/OtelRepo.api.ts
@@ -3,7 +3,7 @@ import * as jsyaml from 'js-yaml';
 import {OtelReference} from '../../components/TestSpecForm/hooks/useGetOTELSemanticConventionAttributesInfo';
 import {CompleteAttribute, OTELYaml} from './OTELYaml';
 
-const PATH = `https://raw.githubusercontent.com/open-telemetry/opentelemetry-specification/main/`;
+const PATH = 'https://raw.githubusercontent.com/open-telemetry/semantic-conventions/main/';
 
 enum Tags {
   TAGS = 'tags',


### PR DESCRIPTION
This PR fixes the OpenTelemetry Semantic Conventions URL. We use this repository to get details about the Trace Semantic Conventions and display it in our attribute list component. In the last release (`v1.21.0`) of the [Opentelemetry Specification](https://github.com/open-telemetry/opentelemetry-specification) they moved the [Semantic Conventions](https://github.com/open-telemetry/semantic-conventions) to a separate repository.

## Changes

- fix OpenTelemetry Semantic Conventions URL

## Fixes

-

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Screenshots

![Screenshot 2023-05-29 at 15 46 03](https://github.com/kubeshop/tracetest/assets/3879892/3637e91a-6f9e-4a63-a2fa-892261ae93e6)
