### PR TITLE
Fix transaction run reporting

### DIFF
--- a/cli/cmd/test_run_cmd.go
+++ b/cli/cmd/test_run_cmd.go
@@ -31,7 +31,7 @@ var testRunCmd = &cobra.Command{
 		environmentOptions := append(baseOptions, actions.WithClient(utils.GetResourceAPIClient("environments", cliConfig)))
 		environmentActions := actions.NewEnvironmentsActions(environmentOptions...)
 
-		runTestAction := actions.NewRunTestAction(cliConfig, cliLogger, client, environmentActions)
+		runTestAction := actions.NewRunTestAction(cliConfig, cliLogger, client, environmentActions, ExitCLI)
 		actionArgs := actions.RunResourceArgs{
 			DefinitionFile: runTestFileDefinition,
 			EnvID:          runTestEnvID,

--- a/cli/formatters/test_run.go
+++ b/cli/formatters/test_run.go
@@ -111,6 +111,10 @@ func (f testRun) formatSuccessfulTest(test openapi.Test, run openapi.TestRun) st
 	buffer.WriteString(message)
 
 	for i, specResult := range run.Result.Results {
+		if len(test.Specs) <= i {
+			break // guard clause: this means that the server sent more results than specs
+		}
+
 		title := f.getTestSpecTitle(test.Specs[i].GetName(), specResult)
 		message := f.formatMessage("\t%s %s\n", PASSED_TEST_ICON, title)
 		message = f.getColoredText(true, message)
@@ -145,7 +149,6 @@ func (f testRun) formatFailedTest(test openapi.Test, run openapi.TestRun) string
 		allPassed := true
 
 		for _, result := range specResult.Results {
-
 			for _, spanResult := range result.SpanResults {
 				// meta assertions such as tracetest.selected_spans.count don't have a spanID,
 				// so they will be treated differently. To overcome them, we will place all
@@ -180,6 +183,10 @@ func (f testRun) formatFailedTest(test openapi.Test, run openapi.TestRun) string
 
 				results[spanID] = spanResults
 			}
+		}
+
+		if len(test.Specs) <= i {
+			break // guard clause: this means that the server sent more results than specs
 		}
 
 		title := f.getTestSpecTitle(test.Specs[i].GetName(), specResult)

--- a/server/testdb/runs.go
+++ b/server/testdb/runs.go
@@ -334,12 +334,12 @@ SELECT
 	"environment",
 
 	-- transaction run
-	transaction_run.transaction_run_id,
-	transaction_run.transaction_run_transaction_id
-FROM test_runs
-LEFT OUTER JOIN
-	transaction_run_steps transaction_run
-ON transaction_run.test_run_id = id AND transaction_run.test_run_test_id = test_id
+	transaction_run_steps.transaction_run_id,
+	transaction_run_steps.transaction_run_transaction_id
+FROM
+	test_runs
+		LEFT OUTER JOIN transaction_run_steps
+		ON transaction_run_steps.test_run_id = test_runs.id AND transaction_run_steps.test_run_test_id = test_runs.test_id
 `
 
 func (td *postgresDB) GetRun(ctx context.Context, testID id.ID, runID int) (model.Run, error) {
@@ -554,11 +554,12 @@ func readRunRow(row scanner) (model.Run, error) {
 }
 
 func (td *postgresDB) GetTransactionRunSteps(ctx context.Context, tr tests.TransactionRun) ([]model.Run, error) {
-	// stmt, err := td.db.Prepare(selectRunQuery + " WHERE id = $1 AND test_id = $2")
-	stmt, err := td.db.Prepare(selectRunQuery + ` INNER JOIN
-		transaction_run_steps trs ON
-			test_runs.id = trs.test_run_id AND test_runs.test_id = trs.test_run_test_id
-		WHERE trs.transaction_run_id = $1 AND trs.transaction_run_transaction_id = $2`)
+	query := selectRunQuery + `
+WHERE transaction_run_steps.transaction_run_id = $1 AND transaction_run_steps.transaction_run_transaction_id = $2
+ORDER BY test_runs.completed_at ASC
+`
+
+	stmt, err := td.db.Prepare(query)
 	if err != nil {
 		return []model.Run{}, fmt.Errorf("prepare: %w", err)
 	}

--- a/testing/cli-e2etest/testscenarios/test/resources/test-with-assertion-with-missing-span.yaml
+++ b/testing/cli-e2etest/testscenarios/test/resources/test-with-assertion-with-missing-span.yaml
@@ -1,0 +1,22 @@
+type: Test
+spec:
+  id: aZobhTwVg
+  name: Test with Assertion with Missing Span
+  trigger:
+    type: http
+    httpRequest:
+      url: http://localhost:11633/api/tests
+      method: GET
+      headers:
+      - key: Content-Type
+        value: application/json
+  specs:
+  - name: It should call /api/tests on HTTP
+    selector: span[tracetest.span.type="http" name="GET /api/tests" http.target="/api/tests"
+      http.method="GET"]
+    assertions:
+    - attr:http.target = "/api/tests"
+  - name: It should not have grpc spans
+    selector: span[tracetest.span.type="grpc"]
+    assertions:
+    - attr:name = unknown

--- a/testing/cli-e2etest/testscenarios/test/run_test_with_assertions_missingspan_test.go
+++ b/testing/cli-e2etest/testscenarios/test/run_test_with_assertions_missingspan_test.go
@@ -1,0 +1,36 @@
+package test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/kubeshop/tracetest/cli-e2etest/environment"
+	"github.com/kubeshop/tracetest/cli-e2etest/helpers"
+	"github.com/kubeshop/tracetest/cli-e2etest/tracetestcli"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRunWithAssertionMissingSpan(t *testing.T) {
+	// instantiate require with testing helper
+	require := require.New(t)
+
+	// setup isolated e2e environment
+	env := environment.CreateAndStart(t)
+	defer env.Close(t)
+
+	cliConfig := env.GetCLIConfigPath(t)
+
+	// Given I am a Tracetest CLI user
+	// And I have my server recently created
+
+	// When I try run a test that has a selector that will find a span
+	// And  a selector that will find no spans
+	// Then it run, fail and return only the assertion to the selector with spans
+	testWithAssertionWithNoSpan := env.GetTestResourcePath(t, "test-with-assertion-with-missing-span")
+
+	command := fmt.Sprintf("test run -w -d %s", testWithAssertionWithNoSpan)
+	result := tracetestcli.Exec(t, command, tracetestcli.WithCLIConfig(cliConfig))
+	helpers.RequireExitCodeEqual(t, result, 1) // test failed
+	require.Contains(result.StdOut, "It should call /api/tests on HTTP")
+	require.NotContains(result.StdOut, "It should not have grpc spans")
+}


### PR DESCRIPTION
This PR fixes the transaction run reporting that sometimes can be shown incorrectly to the user on both FE and CLI.

## Changes

- Added guard clause on CLI to avoid fatal errors on test formatting
- Fixed GetTransactionRunSteps query to return steps in the correct order

## Fixes

- https://github.com/kubeshop/tracetest/issues/1755
- https://github.com/kubeshop/tracetest/issues/2483

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
