### PR TITLE
feat: improved poller algorithm

### DIFF
--- a/server/app/facade.go
+++ b/server/app/facade.go
@@ -92,6 +92,8 @@ func newRunnerFacades(
 		eventEmitter,
 	)
 
+	pollerExecutor = executor.NewSelectorBasedPoller(pollerExecutor)
+
 	tracePoller := executor.NewTracePoller(
 		pollerExecutor,
 		ppRepo,

--- a/server/app/facade.go
+++ b/server/app/facade.go
@@ -92,7 +92,7 @@ func newRunnerFacades(
 		eventEmitter,
 	)
 
-	pollerExecutor = executor.NewSelectorBasedPoller(pollerExecutor)
+	pollerExecutor = executor.NewSelectorBasedPoller(pollerExecutor, eventEmitter)
 
 	tracePoller := executor.NewTracePoller(
 		pollerExecutor,
@@ -113,6 +113,7 @@ func newRunnerFacades(
 		tracedb.Factory(testDB),
 		dsRepo,
 		eventEmitter,
+		ppRepo,
 	)
 
 	transactionRunner := executor.NewTransactionRunner(

--- a/server/executor/default_poller_executor.go
+++ b/server/executor/default_poller_executor.go
@@ -78,11 +78,9 @@ func NewPollerExecutor(
 		eventEmitter: eventEmitter,
 	}
 
-	selectedBasedExecutor := NewSelectorBasedPoller(defaultExecutor)
-
 	return &InstrumentedPollerExecutor{
 		tracer:         tracer,
-		pollerExecutor: selectedBasedExecutor,
+		pollerExecutor: defaultExecutor,
 	}
 }
 

--- a/server/executor/default_poller_executor.go
+++ b/server/executor/default_poller_executor.go
@@ -194,8 +194,12 @@ func (pe DefaultPollerExecutor) donePollingTraces(job *PollingRequest, traceDB t
 	if !traceDB.ShouldRetry() {
 		return true, "TraceDB is not retryable"
 	}
-	pp := *pe.ppGetter.GetDefault(job.Context()).Periodic
-	maxTracePollRetry := pp.MaxTracePollRetry()
+	pp := pe.ppGetter.GetDefault(job.Context())
+	if pp.Periodic == nil {
+		return false, "Polling profile not configured"
+	}
+
+	maxTracePollRetry := pp.Periodic.MaxTracePollRetry()
 	// we're done if we have the same amount of spans after polling or `maxTracePollRetry` times
 	if job.count == maxTracePollRetry {
 		return true, fmt.Sprintf("Hit MaxRetry of %d", maxTracePollRetry)

--- a/server/executor/default_poller_executor.go
+++ b/server/executor/default_poller_executor.go
@@ -157,11 +157,6 @@ func (pe DefaultPollerExecutor) ExecuteRequest(request *PollingRequest) (bool, s
 		return false, "", run, nil
 	}
 
-	err = pe.eventEmitter.Emit(ctx, events.TracePollingSuccess(request.test.ID, request.run.ID, reason))
-	if err != nil {
-		log.Printf("[PollerExecutor] Test %s Run %d: failed to emit TracePollingSuccess event: error: %s\n", request.test.ID, request.run.ID, err.Error())
-	}
-
 	log.Printf("[PollerExecutor] Test %s Run %d: Done polling. (%s)\n", request.test.ID, request.run.ID, reason)
 
 	log.Printf("[PollerExecutor] Test %s Run %d: Start Sorting\n", request.test.ID, request.run.ID)

--- a/server/executor/default_poller_executor.go
+++ b/server/executor/default_poller_executor.go
@@ -70,7 +70,7 @@ func NewPollerExecutor(
 	eventEmitter EventEmitter,
 ) PollerExecutor {
 
-	pollerExecutor := &DefaultPollerExecutor{
+	defaultExecutor := &DefaultPollerExecutor{
 		ppGetter:     ppGetter,
 		updater:      updater,
 		newTraceDBFn: newTraceDBFn,
@@ -78,9 +78,11 @@ func NewPollerExecutor(
 		eventEmitter: eventEmitter,
 	}
 
+	selectedBasedExecutor := NewSelectorBasedPoller(defaultExecutor)
+
 	return &InstrumentedPollerExecutor{
 		tracer:         tracer,
-		pollerExecutor: pollerExecutor,
+		pollerExecutor: selectedBasedExecutor,
 	}
 }
 

--- a/server/executor/default_poller_executor.go
+++ b/server/executor/default_poller_executor.go
@@ -30,7 +30,7 @@ type InstrumentedPollerExecutor struct {
 }
 
 func (pe InstrumentedPollerExecutor) ExecuteRequest(request *PollingRequest) (bool, string, model.Run, error) {
-	_, span := pe.tracer.Start(request.ctx, "Fetch trace")
+	_, span := pe.tracer.Start(request.Context(), "Fetch trace")
 	defer span.End()
 
 	finished, finishReason, run, err := pe.pollerExecutor.ExecuteRequest(request)
@@ -101,8 +101,9 @@ func (pe DefaultPollerExecutor) traceDB(ctx context.Context) (tracedb.TraceDB, e
 func (pe DefaultPollerExecutor) ExecuteRequest(request *PollingRequest) (bool, string, model.Run, error) {
 	log.Printf("[PollerExecutor] Test %s Run %d: ExecuteRequest\n", request.test.ID, request.run.ID)
 	run := request.run
+	ctx := request.Context()
 
-	traceDB, err := pe.traceDB(request.ctx)
+	traceDB, err := pe.traceDB(ctx)
 	if err != nil {
 		log.Printf("[PollerExecutor] Test %s Run %d: GetDataStore error: %s\n", request.test.ID, request.run.ID, err.Error())
 		return false, "", model.Run{}, err
@@ -110,26 +111,30 @@ func (pe DefaultPollerExecutor) ExecuteRequest(request *PollingRequest) (bool, s
 
 	if request.IsFirstRequest() {
 		if testableTraceDB, ok := traceDB.(tracedb.TestableTraceDB); ok {
-			connectionResult := testableTraceDB.TestConnection(request.ctx)
+			connectionResult := testableTraceDB.TestConnection(ctx)
 
-			err = pe.eventEmitter.Emit(request.ctx, events.TraceDataStoreConnectionInfo(request.test.ID, request.run.ID, connectionResult))
+			err = pe.eventEmitter.Emit(ctx, events.TraceDataStoreConnectionInfo(request.test.ID, request.run.ID, connectionResult))
 			if err != nil {
 				log.Printf("[PollerExecutor] Test %s Run %d: failed to emit TraceDataStoreConnectionInfo event: error: %s\n", request.test.ID, request.run.ID, err.Error())
 			}
 		}
 
 		endpoints := traceDB.GetEndpoints()
-		ds, err := pe.dsRepo.Current(request.ctx)
-		err = pe.eventEmitter.Emit(request.ctx, events.TracePollingStart(request.test.ID, request.run.ID, string(ds.Type), endpoints))
+		ds, err := pe.dsRepo.Current(ctx)
+		if err != nil {
+			return false, "", model.Run{}, fmt.Errorf("could not get current datastore: %w", err)
+		}
+
+		err = pe.eventEmitter.Emit(ctx, events.TracePollingStart(request.test.ID, request.run.ID, string(ds.Type), endpoints))
 		if err != nil {
 			log.Printf("[PollerExecutor] Test %s Run %d: failed to emit TracePollingStart event: error: %s\n", request.test.ID, request.run.ID, err.Error())
 		}
 	}
 
 	traceID := run.TraceID.String()
-	trace, err := traceDB.GetTraceByID(request.ctx, traceID)
+	trace, err := traceDB.GetTraceByID(ctx, traceID)
 	if err != nil {
-		anotherErr := pe.eventEmitter.Emit(request.ctx, events.TracePollingIterationInfo(request.test.ID, request.run.ID, 0, request.count, false, err.Error()))
+		anotherErr := pe.eventEmitter.Emit(ctx, events.TracePollingIterationInfo(request.test.ID, request.run.ID, 0, request.count, false, err.Error()))
 		if anotherErr != nil {
 			log.Printf("[PollerExecutor] Test %s Run %d: failed to emit TracePollingIterationInfo event: error: %s\n", request.test.ID, request.run.ID, anotherErr.Error())
 		}
@@ -141,7 +146,7 @@ func (pe DefaultPollerExecutor) ExecuteRequest(request *PollingRequest) (bool, s
 	trace.ID = run.TraceID
 	done, reason := pe.donePollingTraces(request, traceDB, trace)
 	if !done {
-		err := pe.eventEmitter.Emit(request.ctx, events.TracePollingIterationInfo(request.test.ID, request.run.ID, len(trace.Flat), request.count, false, reason))
+		err := pe.eventEmitter.Emit(ctx, events.TracePollingIterationInfo(request.test.ID, request.run.ID, len(trace.Flat), request.count, false, reason))
 		if err != nil {
 			log.Printf("[PollerExecutor] Test %s Run %d: failed to emit TracePollingIterationInfo event: error: %s\n", request.test.ID, request.run.ID, err.Error())
 		}
@@ -152,7 +157,7 @@ func (pe DefaultPollerExecutor) ExecuteRequest(request *PollingRequest) (bool, s
 		return false, "", run, nil
 	}
 
-	err = pe.eventEmitter.Emit(request.ctx, events.TracePollingSuccess(request.test.ID, request.run.ID, reason))
+	err = pe.eventEmitter.Emit(ctx, events.TracePollingSuccess(request.test.ID, request.run.ID, reason))
 	if err != nil {
 		log.Printf("[PollerExecutor] Test %s Run %d: failed to emit TracePollingSuccess event: error: %s\n", request.test.ID, request.run.ID, err.Error())
 	}
@@ -176,7 +181,7 @@ func (pe DefaultPollerExecutor) ExecuteRequest(request *PollingRequest) (bool, s
 	fmt.Printf("[PollerExecutor] Completed polling process for Test Run %d after %d iterations, number of spans collected: %d \n", run.ID, request.count+1, len(run.Trace.Flat))
 
 	log.Printf("[PollerExecutor] Test %s Run %d: Start updating\n", request.test.ID, request.run.ID)
-	err = pe.updater.Update(request.ctx, run)
+	err = pe.updater.Update(ctx, run)
 	if err != nil {
 		log.Printf("[PollerExecutor] Test %s Run %d: Update error: %s\n", request.test.ID, request.run.ID, err.Error())
 		return false, "", model.Run{}, err
@@ -189,7 +194,7 @@ func (pe DefaultPollerExecutor) donePollingTraces(job *PollingRequest, traceDB t
 	if !traceDB.ShouldRetry() {
 		return true, "TraceDB is not retryable"
 	}
-	pp := *pe.ppGetter.GetDefault(job.ctx).Periodic
+	pp := *pe.ppGetter.GetDefault(job.Context()).Periodic
 	maxTracePollRetry := pp.MaxTracePollRetry()
 	// we're done if we have the same amount of spans after polling or `maxTracePollRetry` times
 	if job.count == maxTracePollRetry {

--- a/server/executor/poller_executor_test.go
+++ b/server/executor/poller_executor_test.go
@@ -456,7 +456,7 @@ func executeAndValidatePollingRequests(t *testing.T, pollerExecutor executor.Pol
 	}
 
 	for i, value := range expectedValues {
-		request := executor.NewPollingRequest(ctx, test, run, i)
+		request := executor.NewPollingRequest(ctx, test, run, i, pollingprofile.DefaultPollingProfile)
 
 		finished, finishReason, anotherRun, err := pollerExecutor.ExecuteRequest(request)
 		run = anotherRun // should store a run to use in another iteration
@@ -553,6 +553,21 @@ func (m *dataStoreRepositoryMock) Current(ctx context.Context) (datastoreresourc
 
 func getDataStoreRepositoryMock(t *testing.T) *dataStoreRepositoryMock {
 	return &dataStoreRepositoryMock{}
+}
+
+// PollingProfileGetter
+type pollingProfileGetterMock struct {
+	mock.Mock
+}
+
+func (m *pollingProfileGetterMock) GetDefault(ctx context.Context) pollingprofile.PollingProfile {
+	args := m.Called(ctx)
+	return args.Get(0).(pollingprofile.PollingProfile)
+}
+
+func getPollingProfileGetterMock(t *testing.T) executor.PollingProfileGetter {
+	t.Helper()
+	return new(pollingProfileGetterMock)
 }
 
 // EventEmitter

--- a/server/executor/poller_executor_test.go
+++ b/server/executor/poller_executor_test.go
@@ -555,21 +555,6 @@ func getDataStoreRepositoryMock(t *testing.T) *dataStoreRepositoryMock {
 	return &dataStoreRepositoryMock{}
 }
 
-// PollingProfileGetter
-type pollingProfileGetterMock struct {
-	mock.Mock
-}
-
-func (m *pollingProfileGetterMock) GetDefault(ctx context.Context) pollingprofile.PollingProfile {
-	args := m.Called(ctx)
-	return args.Get(0).(pollingprofile.PollingProfile)
-}
-
-func getPollingProfileGetterMock(t *testing.T) executor.PollingProfileGetter {
-	t.Helper()
-	return new(pollingProfileGetterMock)
-}
-
 // EventEmitter
 func getEventEmitterMock(t *testing.T, db model.Repository) executor.EventEmitter {
 	t.Helper()

--- a/server/executor/pollingprofile/polling_profile_resource.go
+++ b/server/executor/pollingprofile/polling_profile_resource.go
@@ -50,8 +50,9 @@ type PollingProfile struct {
 }
 
 type PeriodicPollingConfig struct {
-	RetryDelay string `json:"retryDelay"`
-	Timeout    string `json:"timeout"`
+	RetryDelay           string `json:"retryDelay"`
+	Timeout              string `json:"timeout"`
+	SelectorMatchRetries int    `json:"selectorMatchRetries"`
 }
 
 func (ppc *PeriodicPollingConfig) TimeoutDuration() time.Duration {

--- a/server/executor/pollingprofile/polling_profile_resource_test.go
+++ b/server/executor/pollingprofile/polling_profile_resource_test.go
@@ -38,7 +38,8 @@ func TestPollingProfileResource(t *testing.T) {
 				"strategy": "periodic",
 				"periodic": {
 					"timeout": "1m",
-					"retryDelay": "5s"
+					"retryDelay": "5s",
+					"selectorMatchRetries": 0
 				}
 			}
 		}`,
@@ -51,7 +52,8 @@ func TestPollingProfileResource(t *testing.T) {
 				"strategy": "periodic",
 				"periodic": {
 					"timeout": "1h",
-					"retryDelay": "25s"
+					"retryDelay": "25s",
+					"selectorMatchRetries": 0
 				}
 			}
 		}`,

--- a/server/executor/runner.go
+++ b/server/executor/runner.go
@@ -243,7 +243,7 @@ func (r persistentRunner) processExecQueue(job execReq) {
 		if isConnectionError(err) {
 			r.emitUnreachableEndpointEvent(job, err)
 
-			if isTargetLocalhost(job, err) && isServerRunningInsideContainer() {
+			if isTargetLocalhost(job) && isServerRunningInsideContainer() {
 				r.emitMismatchEndpointEvent(job, err)
 			}
 		}
@@ -331,7 +331,7 @@ func isConnectionError(err error) bool {
 	return false
 }
 
-func isTargetLocalhost(job execReq, err error) bool {
+func isTargetLocalhost(job execReq) bool {
 	var endpoint string
 	switch job.test.ServiceUnderTest.Type {
 	case model.TriggerTypeHTTP:

--- a/server/executor/runner_test.go
+++ b/server/executor/runner_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/kubeshop/tracetest/server/config"
 	"github.com/kubeshop/tracetest/server/environment"
 	"github.com/kubeshop/tracetest/server/executor"
+	"github.com/kubeshop/tracetest/server/executor/pollingprofile"
 	"github.com/kubeshop/tracetest/server/executor/trigger"
 	"github.com/kubeshop/tracetest/server/model"
 	"github.com/kubeshop/tracetest/server/pkg/id"
@@ -157,7 +158,9 @@ func runnerSetup(t *testing.T) runnerFixture {
 		subscription.NewManager(),
 		tracedb.Factory(&testDB),
 		getDataStoreRepositoryMock(t),
-		eventEmitter)
+		eventEmitter,
+		getPollingProfileGetterMock(t),
+	)
 
 	mtp.Test(t)
 	return runnerFixture{
@@ -244,7 +247,7 @@ type mockTracePoller struct {
 	t *testing.T
 }
 
-func (m *mockTracePoller) Poll(_ context.Context, test model.Test, run model.Run) {
+func (m *mockTracePoller) Poll(_ context.Context, test model.Test, run model.Run, pollingProfile pollingprofile.PollingProfile) {
 	m.Called(test.ID)
 }
 

--- a/server/executor/runner_test.go
+++ b/server/executor/runner_test.go
@@ -159,7 +159,7 @@ func runnerSetup(t *testing.T) runnerFixture {
 		tracedb.Factory(&testDB),
 		getDataStoreRepositoryMock(t),
 		eventEmitter,
-		getPollingProfileGetterMock(t),
+		defaultProfileGetter{5 * time.Second, 30 * time.Second},
 	)
 
 	mtp.Test(t)

--- a/server/executor/selector_based_poller_executor.go
+++ b/server/executor/selector_based_poller_executor.go
@@ -1,0 +1,14 @@
+package executor
+
+import "github.com/kubeshop/tracetest/server/model"
+
+type SelectorBasedPollerExecutor struct {
+	pollerExecutor PollerExecutor
+}
+
+func (pe SelectorBasedPollerExecutor) ExecuteRequest(request *PollingRequest) (bool, string, model.Run, error) {
+	ready, reason, run, err := pe.pollerExecutor.ExecuteRequest(request)
+	// if !ready {
+	return ready, reason, run, err
+	// }
+}

--- a/server/executor/selector_based_poller_executor.go
+++ b/server/executor/selector_based_poller_executor.go
@@ -27,8 +27,13 @@ func (pe selectorBasedPollerExecutor) ExecuteRequest(request *PollingRequest) (b
 		return ready, reason, run, err
 	}
 
+	maxNumberRetries := 0
+	if request.pollingProfile.Periodic != nil {
+		maxNumberRetries = request.pollingProfile.Periodic.SelectorMatchRetries
+	}
+
 	currentNumberTries := pe.getNumberTries(request)
-	if currentNumberTries >= selectorBasedPollerExecutorMaxTries {
+	if currentNumberTries >= maxNumberRetries {
 		return true, "not all selectors matched, but trace haven't changed in a while", run, err
 	}
 

--- a/server/executor/selector_based_poller_executor.go
+++ b/server/executor/selector_based_poller_executor.go
@@ -13,10 +13,11 @@ const (
 
 type selectorBasedPollerExecutor struct {
 	pollerExecutor PollerExecutor
+	eventEmitter   EventEmitter
 }
 
-func NewSelectorBasedPoller(innerPoller PollerExecutor) PollerExecutor {
-	return selectorBasedPollerExecutor{innerPoller}
+func NewSelectorBasedPoller(innerPoller PollerExecutor, eventEmitter EventEmitter) PollerExecutor {
+	return selectorBasedPollerExecutor{innerPoller, eventEmitter}
 }
 
 func (pe selectorBasedPollerExecutor) ExecuteRequest(request *PollingRequest) (bool, string, model.Run, error) {

--- a/server/executor/selector_based_poller_executor.go
+++ b/server/executor/selector_based_poller_executor.go
@@ -23,12 +23,12 @@ func NewSelectorBasedPoller(innerPoller PollerExecutor) PollerExecutor {
 func (pe selectorBasedPollerExecutor) ExecuteRequest(request *PollingRequest) (bool, string, model.Run, error) {
 	ready, reason, run, err := pe.pollerExecutor.ExecuteRequest(request)
 	if !ready {
-		request.SetHeader(selectorBasedPollerExecutorRetryHeader, "1")
+		request.SetHeader(selectorBasedPollerExecutorRetryHeader, "0")
 		return ready, reason, run, err
 	}
 
 	currentNumberTries := pe.getNumberTries(request)
-	if currentNumberTries > selectorBasedPollerExecutorMaxTries {
+	if currentNumberTries >= selectorBasedPollerExecutorMaxTries {
 		return true, "not all selectors matched, but trace haven't changed in a while", run, err
 	}
 

--- a/server/executor/selector_based_poller_executor.go
+++ b/server/executor/selector_based_poller_executor.go
@@ -1,14 +1,65 @@
 package executor
 
-import "github.com/kubeshop/tracetest/server/model"
+import (
+	"fmt"
+	"strconv"
 
-type SelectorBasedPollerExecutor struct {
+	"github.com/kubeshop/tracetest/server/model"
+)
+
+const (
+	selectorBasedPollerExecutorRetryHeader = "SelectorBasedPollerExecutor::retryCount"
+	selectorBasedPollerExecutorMaxTries    = 3
+)
+
+type selectorBasedPollerExecutor struct {
 	pollerExecutor PollerExecutor
 }
 
-func (pe SelectorBasedPollerExecutor) ExecuteRequest(request *PollingRequest) (bool, string, model.Run, error) {
+func NewSelectorBasedPoller(innerPoller PollerExecutor) PollerExecutor {
+	return selectorBasedPollerExecutor{innerPoller}
+}
+
+func (pe selectorBasedPollerExecutor) ExecuteRequest(request *PollingRequest) (bool, string, model.Run, error) {
 	ready, reason, run, err := pe.pollerExecutor.ExecuteRequest(request)
-	// if !ready {
-	return ready, reason, run, err
-	// }
+	if !ready {
+		request.SetHeader(selectorBasedPollerExecutorRetryHeader, "1")
+		return ready, reason, run, err
+	}
+
+	currentNumberTries := pe.getNumberTries(request)
+	if currentNumberTries > selectorBasedPollerExecutorMaxTries {
+		return true, "not all selectors matched, but trace haven't changed in a while", run, err
+	}
+
+	allSelectorsMatchSpans := pe.allSelectorsMatchSpans(request)
+	if allSelectorsMatchSpans {
+		return true, "all selectors have matched one or more spans", run, err
+	}
+
+	request.SetHeader(selectorBasedPollerExecutorRetryHeader, fmt.Sprintf("%d", currentNumberTries+1))
+	return false, "not all selectors got matching spans in the trace", run, err
+}
+
+func (pe selectorBasedPollerExecutor) getNumberTries(request *PollingRequest) int {
+	value := request.Header(selectorBasedPollerExecutorRetryHeader)
+	if intValue, err := strconv.Atoi(value); err == nil {
+		return intValue
+	}
+
+	return 0
+}
+
+func (pe selectorBasedPollerExecutor) allSelectorsMatchSpans(request *PollingRequest) bool {
+	allSelectorsHaveMatch := true
+	request.test.Specs.ForEach(func(selectorQuery model.SpanQuery, _ model.NamedAssertions) error {
+		spans := selector(selectorQuery).Filter(*request.run.Trace)
+		if len(spans) == 0 {
+			allSelectorsHaveMatch = false
+		}
+
+		return nil
+	})
+
+	return allSelectorsHaveMatch
 }

--- a/server/executor/selector_based_poller_executor.go
+++ b/server/executor/selector_based_poller_executor.go
@@ -1,14 +1,13 @@
 package executor
 
 import (
-	"fmt"
 	"strconv"
 
 	"github.com/kubeshop/tracetest/server/model"
 )
 
 const (
-	selectorBasedPollerExecutorRetryHeader = "SelectorBasedPollerExecutor::retryCount"
+	selectorBasedPollerExecutorRetryHeader = "SelectorBasedPollerExecutor.retryCount"
 	selectorBasedPollerExecutorMaxTries    = 3
 )
 
@@ -23,7 +22,7 @@ func NewSelectorBasedPoller(innerPoller PollerExecutor) PollerExecutor {
 func (pe selectorBasedPollerExecutor) ExecuteRequest(request *PollingRequest) (bool, string, model.Run, error) {
 	ready, reason, run, err := pe.pollerExecutor.ExecuteRequest(request)
 	if !ready {
-		request.SetHeader(selectorBasedPollerExecutorRetryHeader, "0")
+		request.SetHeaderInt(selectorBasedPollerExecutorRetryHeader, 0)
 		return ready, reason, run, err
 	}
 
@@ -42,7 +41,7 @@ func (pe selectorBasedPollerExecutor) ExecuteRequest(request *PollingRequest) (b
 		return true, "all selectors have matched one or more spans", run, err
 	}
 
-	request.SetHeader(selectorBasedPollerExecutorRetryHeader, fmt.Sprintf("%d", currentNumberTries+1))
+	request.SetHeaderInt(selectorBasedPollerExecutorRetryHeader, currentNumberTries+1)
 	return false, "not all selectors got matching spans in the trace", run, err
 }
 

--- a/server/executor/selector_based_poller_executor_test.go
+++ b/server/executor/selector_based_poller_executor_test.go
@@ -72,9 +72,14 @@ func TestSelectorBasedPollerExecutor(t *testing.T) {
 
 		request := executor.NewPollingRequest(context.Background(), test, run, 0)
 
-		defaultPoller.On("ExecuteRequest", mock.Anything).Return(true, "all spans found", run, nil)
+		defaultPoller.On("ExecuteRequest", mock.Anything).Return(false, "trace not found", run, nil).Once()
 
 		ready, _, _, _ := selectorBasedPoller.ExecuteRequest(request)
+		assert.False(t, ready)
+
+		defaultPoller.On("ExecuteRequest", mock.Anything).Return(true, "all spans found", run, nil)
+
+		ready, _, _, _ = selectorBasedPoller.ExecuteRequest(request)
 		assert.False(t, ready)
 		assert.Equal(t, "1", request.Header("SelectorBasedPollerExecutor::retryCount"))
 

--- a/server/executor/selector_based_poller_executor_test.go
+++ b/server/executor/selector_based_poller_executor_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/kubeshop/tracetest/server/executor"
+	"github.com/kubeshop/tracetest/server/executor/pollingprofile"
 	"github.com/kubeshop/tracetest/server/model"
 	"github.com/kubeshop/tracetest/server/pkg/maps"
 	"github.com/stretchr/testify/assert"
@@ -23,13 +24,36 @@ func (m *defaultPollerMock) ExecuteRequest(request *executor.PollingRequest) (bo
 
 var _ executor.PollerExecutor = &defaultPollerMock{}
 
+type eventEmitterMock struct {
+	mock.Mock
+}
+
+// Emit implements executor.EventEmitter
+func (m *eventEmitterMock) Emit(ctx context.Context, event model.TestRunEvent) error {
+	args := m.Called(ctx, event)
+	return args.Error(0)
+}
+
+var _ executor.EventEmitter = &eventEmitterMock{}
+
 func TestSelectorBasedPollerExecutor(t *testing.T) {
+
+	eventEmitter := new(eventEmitterMock)
+	eventEmitter.On("Emit", mock.Anything, mock.Anything).Return(nil)
+
+	createRequest := func(test model.Test, run model.Run) *executor.PollingRequest {
+		pollingProfile := pollingprofile.DefaultPollingProfile
+		pollingProfile.Periodic.SelectorMatchRetries = 3
+
+		request := executor.NewPollingRequest(context.Background(), test, run, 0, pollingProfile)
+		return request
+	}
 
 	t.Run("should return false when default poller returns false", func(t *testing.T) {
 		defaultPoller := new(defaultPollerMock)
-		selectorBasedPoller := executor.NewSelectorBasedPoller(defaultPoller)
+		selectorBasedPoller := executor.NewSelectorBasedPoller(defaultPoller, eventEmitter)
 
-		request := executor.NewPollingRequest(context.Background(), model.Test{}, model.Run{}, 0)
+		request := createRequest(model.Test{}, model.Run{})
 
 		defaultPoller.On("ExecuteRequest", mock.Anything).Return(false, "", model.Run{}, nil)
 		ready, _, _, _ := selectorBasedPoller.ExecuteRequest(request)
@@ -39,7 +63,7 @@ func TestSelectorBasedPollerExecutor(t *testing.T) {
 
 	t.Run("should return false when default poller returns true but not all selector match at least one span", func(t *testing.T) {
 		defaultPoller := new(defaultPollerMock)
-		selectorBasedPoller := executor.NewSelectorBasedPoller(defaultPoller)
+		selectorBasedPoller := executor.NewSelectorBasedPoller(defaultPoller, eventEmitter)
 
 		specs := maps.Ordered[model.SpanQuery, model.NamedAssertions]{}.
 			MustAdd(`span[name = "Tracetest trigger"]`, model.NamedAssertions{}).
@@ -49,7 +73,7 @@ func TestSelectorBasedPollerExecutor(t *testing.T) {
 		trace := model.NewTrace(randomIDGenerator.TraceID().String(), make([]model.Span, 0))
 		run := model.Run{Trace: &trace}
 
-		request := executor.NewPollingRequest(context.Background(), test, run, 0)
+		request := createRequest(test, run)
 
 		defaultPoller.On("ExecuteRequest", mock.Anything).Return(true, "all spans found", run, nil)
 		ready, _, _, _ := selectorBasedPoller.ExecuteRequest(request)
@@ -60,7 +84,7 @@ func TestSelectorBasedPollerExecutor(t *testing.T) {
 
 	t.Run("should return true if default poller returns true and selectors don't match spans 3 times in a row", func(t *testing.T) {
 		defaultPoller := new(defaultPollerMock)
-		selectorBasedPoller := executor.NewSelectorBasedPoller(defaultPoller)
+		selectorBasedPoller := executor.NewSelectorBasedPoller(defaultPoller, eventEmitter)
 
 		specs := maps.Ordered[model.SpanQuery, model.NamedAssertions]{}.
 			MustAdd(`span[name = "Tracetest trigger"]`, model.NamedAssertions{}).
@@ -70,7 +94,7 @@ func TestSelectorBasedPollerExecutor(t *testing.T) {
 		trace := model.NewTrace(randomIDGenerator.TraceID().String(), make([]model.Span, 0))
 		run := model.Run{Trace: &trace}
 
-		request := executor.NewPollingRequest(context.Background(), test, run, 0)
+		request := createRequest(test, run)
 
 		defaultPoller.On("ExecuteRequest", mock.Anything).Return(false, "trace not found", run, nil).Once()
 
@@ -97,7 +121,7 @@ func TestSelectorBasedPollerExecutor(t *testing.T) {
 
 	t.Run("should return true if default poller returns true and each selector match at least one span", func(t *testing.T) {
 		defaultPoller := new(defaultPollerMock)
-		selectorBasedPoller := executor.NewSelectorBasedPoller(defaultPoller)
+		selectorBasedPoller := executor.NewSelectorBasedPoller(defaultPoller, eventEmitter)
 
 		specs := maps.Ordered[model.SpanQuery, model.NamedAssertions]{}.
 			MustAdd(`span[name = "Tracetest trigger"]`, model.NamedAssertions{}).
@@ -111,7 +135,7 @@ func TestSelectorBasedPollerExecutor(t *testing.T) {
 		})
 		run := model.Run{Trace: &trace}
 
-		request := executor.NewPollingRequest(context.Background(), test, run, 0)
+		request := createRequest(test, run)
 
 		defaultPoller.On("ExecuteRequest", mock.Anything).Return(true, "all spans found", run, nil)
 

--- a/server/executor/selector_based_poller_executor_test.go
+++ b/server/executor/selector_based_poller_executor_test.go
@@ -1,0 +1,116 @@
+package executor_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/kubeshop/tracetest/server/executor"
+	"github.com/kubeshop/tracetest/server/model"
+	"github.com/kubeshop/tracetest/server/pkg/maps"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+type defaultPollerMock struct {
+	mock.Mock
+}
+
+// ExecuteRequest implements executor.PollerExecutor
+func (m *defaultPollerMock) ExecuteRequest(request *executor.PollingRequest) (bool, string, model.Run, error) {
+	args := m.Called(request)
+	return args.Bool(0), args.String(1), args.Get(2).(model.Run), args.Error(3)
+}
+
+var _ executor.PollerExecutor = &defaultPollerMock{}
+
+func TestSelectorBasedPollerExecutor(t *testing.T) {
+
+	t.Run("should return false when default poller returns false", func(t *testing.T) {
+		defaultPoller := new(defaultPollerMock)
+		selectorBasedPoller := executor.NewSelectorBasedPoller(defaultPoller)
+
+		request := executor.NewPollingRequest(context.Background(), model.Test{}, model.Run{}, 0)
+
+		defaultPoller.On("ExecuteRequest", mock.Anything).Return(false, "", model.Run{}, nil)
+		ready, _, _, _ := selectorBasedPoller.ExecuteRequest(request)
+
+		assert.False(t, ready)
+	})
+
+	t.Run("should return false when default poller returns true but not all selector match at least one span", func(t *testing.T) {
+		defaultPoller := new(defaultPollerMock)
+		selectorBasedPoller := executor.NewSelectorBasedPoller(defaultPoller)
+
+		specs := maps.Ordered[model.SpanQuery, model.NamedAssertions]{}.
+			MustAdd(`span[name = "Tracetest trigger"]`, model.NamedAssertions{}).
+			MustAdd(`span[name = "GET /api/tests"]`, model.NamedAssertions{})
+		test := model.Test{Specs: specs}
+
+		trace := model.NewTrace(randomIDGenerator.TraceID().String(), make([]model.Span, 0))
+		run := model.Run{Trace: &trace}
+
+		request := executor.NewPollingRequest(context.Background(), test, run, 0)
+
+		defaultPoller.On("ExecuteRequest", mock.Anything).Return(true, "all spans found", run, nil)
+		ready, _, _, _ := selectorBasedPoller.ExecuteRequest(request)
+
+		assert.False(t, ready)
+		assert.Equal(t, "1", request.Header("SelectorBasedPollerExecutor::retryCount"))
+	})
+
+	t.Run("should return true if default poller returns true and selectors don't match spans 3 times in a row", func(t *testing.T) {
+		defaultPoller := new(defaultPollerMock)
+		selectorBasedPoller := executor.NewSelectorBasedPoller(defaultPoller)
+
+		specs := maps.Ordered[model.SpanQuery, model.NamedAssertions]{}.
+			MustAdd(`span[name = "Tracetest trigger"]`, model.NamedAssertions{}).
+			MustAdd(`span[name = "GET /api/tests"]`, model.NamedAssertions{})
+		test := model.Test{Specs: specs}
+
+		trace := model.NewTrace(randomIDGenerator.TraceID().String(), make([]model.Span, 0))
+		run := model.Run{Trace: &trace}
+
+		request := executor.NewPollingRequest(context.Background(), test, run, 0)
+
+		defaultPoller.On("ExecuteRequest", mock.Anything).Return(true, "all spans found", run, nil)
+
+		ready, _, _, _ := selectorBasedPoller.ExecuteRequest(request)
+		assert.False(t, ready)
+		assert.Equal(t, "1", request.Header("SelectorBasedPollerExecutor::retryCount"))
+
+		ready, _, _, _ = selectorBasedPoller.ExecuteRequest(request)
+		assert.False(t, ready)
+		assert.Equal(t, "2", request.Header("SelectorBasedPollerExecutor::retryCount"))
+
+		ready, _, _, _ = selectorBasedPoller.ExecuteRequest(request)
+		assert.False(t, ready)
+		assert.Equal(t, "3", request.Header("SelectorBasedPollerExecutor::retryCount"))
+
+		ready, _, _, _ = selectorBasedPoller.ExecuteRequest(request)
+		assert.True(t, ready)
+	})
+
+	t.Run("should return true if default poller returns true and each selector match at least one span", func(t *testing.T) {
+		defaultPoller := new(defaultPollerMock)
+		selectorBasedPoller := executor.NewSelectorBasedPoller(defaultPoller)
+
+		specs := maps.Ordered[model.SpanQuery, model.NamedAssertions]{}.
+			MustAdd(`span[name = "Tracetest trigger"]`, model.NamedAssertions{}).
+			MustAdd(`span[name = "GET /api/tests"]`, model.NamedAssertions{})
+		test := model.Test{Specs: specs}
+
+		rootSpan := model.Span{ID: randomIDGenerator.SpanID(), Name: "Tracetest trigger", Attributes: make(model.Attributes)}
+		trace := model.NewTrace(randomIDGenerator.TraceID().String(), []model.Span{
+			rootSpan,
+			{ID: randomIDGenerator.SpanID(), Name: "GET /api/tests", Attributes: model.Attributes{"parent_id": rootSpan.ID.String()}},
+		})
+		run := model.Run{Trace: &trace}
+
+		request := executor.NewPollingRequest(context.Background(), test, run, 0)
+
+		defaultPoller.On("ExecuteRequest", mock.Anything).Return(true, "all spans found", run, nil)
+
+		ready, _, _, _ := selectorBasedPoller.ExecuteRequest(request)
+		assert.True(t, ready)
+	})
+}

--- a/server/executor/selector_based_poller_executor_test.go
+++ b/server/executor/selector_based_poller_executor_test.go
@@ -55,7 +55,7 @@ func TestSelectorBasedPollerExecutor(t *testing.T) {
 		ready, _, _, _ := selectorBasedPoller.ExecuteRequest(request)
 
 		assert.False(t, ready)
-		assert.Equal(t, "1", request.Header("SelectorBasedPollerExecutor::retryCount"))
+		assert.Equal(t, "1", request.Header("SelectorBasedPollerExecutor.retryCount"))
 	})
 
 	t.Run("should return true if default poller returns true and selectors don't match spans 3 times in a row", func(t *testing.T) {
@@ -81,15 +81,15 @@ func TestSelectorBasedPollerExecutor(t *testing.T) {
 
 		ready, _, _, _ = selectorBasedPoller.ExecuteRequest(request)
 		assert.False(t, ready)
-		assert.Equal(t, "1", request.Header("SelectorBasedPollerExecutor::retryCount"))
+		assert.Equal(t, "1", request.Header("SelectorBasedPollerExecutor.retryCount"))
 
 		ready, _, _, _ = selectorBasedPoller.ExecuteRequest(request)
 		assert.False(t, ready)
-		assert.Equal(t, "2", request.Header("SelectorBasedPollerExecutor::retryCount"))
+		assert.Equal(t, "2", request.Header("SelectorBasedPollerExecutor.retryCount"))
 
 		ready, _, _, _ = selectorBasedPoller.ExecuteRequest(request)
 		assert.False(t, ready)
-		assert.Equal(t, "3", request.Header("SelectorBasedPollerExecutor::retryCount"))
+		assert.Equal(t, "3", request.Header("SelectorBasedPollerExecutor.retryCount"))
 
 		ready, _, _, _ = selectorBasedPoller.ExecuteRequest(request)
 		assert.True(t, ready)

--- a/server/executor/trace_poller.go
+++ b/server/executor/trace_poller.go
@@ -103,10 +103,10 @@ func NewPollingRequest(ctx context.Context, test model.Test, run model.Run, coun
 		test:    test,
 		run:     run,
 		headers: make(map[string]string),
+		count:   count,
 	}
 
 	propagator.Inject(ctx, propagation.MapCarrier(request.headers))
-	request.SetHeader("count", fmt.Sprintf("%d", count))
 
 	return request
 }


### PR DESCRIPTION
This PR introduces another algorithm parameter for our trace poller. When we don't detect changes in the trace anymore, we try matching the selectors with spans. If all selectors get at least one span, we consider the polling successful, otherwise, try again in the next polling cycle. If we have no changes in the trace and we cannot match the selectors with spans from the trace 3 times in a row, we end the polling and mark it as complete (to prevent issues when writing TDD)

There are more things that could be done and  I'll do in the future if needed:
* Make this configurable via a polling profile option (either another strategy, or just an option inside the `periodic` object)

## Example

| # Run | Action |
|---|---|
| # 01  | Got initial trace |
| # 02  | Got more spans, continue |
| # 03  | Got more spans, continue |
| # 04  | No more spans, but not all selectors are working |
| # 05  | No more spans, but not all selectors are working |
| # 06  | No more spans, but not all selectors are working. But we tried 3 times already, so finish polling |
```

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [x] added a test
