### PR TITLE
fix: make resource manager take server prefix into consideration

### DIFF
--- a/server/app/app.go
+++ b/server/app/app.go
@@ -248,7 +248,10 @@ func (app *App) Start(opts ...appOption) error {
 	router, mappers := controller(app.cfg, testDB, transactionsRepository, tracer, environmentRepo, rf, triggerRegistry)
 	registerWSHandler(router, mappers, subscriptionManager)
 
-	apiRouter := router.PathPrefix("/api").Subrouter()
+	apiRouter := router.
+		PathPrefix(app.cfg.ServerPathPrefix()).
+		PathPrefix("/api").
+		Subrouter()
 
 	registerTransactionResource(transactionsRepository, apiRouter, provisioner, tracer)
 


### PR DESCRIPTION
This PR makes the resource manager take the server path prefix into consideration when building the routes. Related to one problem related in #2565 


## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
