### PR TITLE
fix: duplicated datastore test events

### DIFF
--- a/server/executor/trace_poller.go
+++ b/server/executor/trace_poller.go
@@ -119,7 +119,7 @@ func (pr *PollingRequest) HeaderBool(name string) bool {
 }
 
 func (pr PollingRequest) IsFirstRequest() bool {
-	return pr.HeaderBool("requeued")
+	return !pr.HeaderBool("requeued")
 }
 
 func NewPollingRequest(ctx context.Context, test model.Test, run model.Run, count int, pollingProfile pollingprofile.PollingProfile) *PollingRequest {


### PR DESCRIPTION
This PR fixes the issue that was making Tracetest test the data store connection multiple times.

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
