### PR TITLE
fix(cli): adding skip of version mismatch for the server install cmd

### DIFF
--- a/cli/cmd/server_cmd.go
+++ b/cli/cmd/server_cmd.go
@@ -9,7 +9,7 @@ var serverCmd = &cobra.Command{
 	Use:     "server",
 	Short:   "Manage your tracetest server",
 	Long:    "Manage your tracetest server",
-	PreRun:  setupCommand(),
+	PreRun:  setupCommand(SkipVersionMismatchCheck()),
 	Run: func(cmd *cobra.Command, args []string) {
 		cmd.Help()
 	},

--- a/cli/cmd/server_install_cmd.go
+++ b/cli/cmd/server_install_cmd.go
@@ -18,7 +18,7 @@ var serverInstallCmd = &cobra.Command{
 	Use:    "install",
 	Short:  "Install a new Tracetest server",
 	Long:   "Install a new Tracetest server",
-	PreRun: setupCommand(SkipConfigValidation()),
+	PreRun: setupCommand(SkipConfigValidation(), SkipVersionMismatchCheck()),
 	Run: func(_ *cobra.Command, _ []string) {
 		installer.Force = installerParams.Force
 		installer.RunEnvironment = installerParams.RunEnvironment


### PR DESCRIPTION
This PR adds a way to skip version mismatch checks for commands when using the `setupCommand` function

## Changes

- Updates the setup command function to have a way to skip version mismatch validations

## Fixes

- A release bug when trying to install tracetest

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
