### PR TITLE
fix: make sure temporary root span is not added to the trace if Tracetest Trigger span already exists

### DIFF
--- a/server/model/traces.go
+++ b/server/model/traces.go
@@ -56,8 +56,14 @@ func getRootSpan(allRoots []*Span) *Span {
 
 	var root *Span
 	for _, span := range allRoots {
-		if span.Name == TriggerSpanName {
-			// This is the Tracetest trigger span, use it as the root of all root spans
+		if span.Name == TriggerSpanName || span.Name == TemporaryRootSpanName {
+			// This span should be promoted because it's either a temporary root or the definitive root
+			if root != nil && root.Name == TriggerSpanName {
+				// We cannot override the root because we already have the definitive root, otherwise,
+				// we will replace the definitive root with the temporary root.
+				continue
+			}
+
 			root = span
 		}
 	}

--- a/server/model/traces_test.go
+++ b/server/model/traces_test.go
@@ -131,6 +131,34 @@ func TestInjectingNewRootWhenMultipleRoots(t *testing.T) {
 	}
 }
 
+func TestNoTemporaryRootIfTracetestRootExists(t *testing.T) {
+	root1 := newSpan("Root 1", nil)
+	root1Child := newSpan("Child from root 1", &root1)
+	root2 := newSpan(model.TriggerSpanName, nil)
+	root2Child := newSpan("Child from root 2", &root2)
+	root3 := newSpan("Root 3", nil)
+	root3Child := newSpan("Child from root 3", &root3)
+
+	spans := []model.Span{root1, root1Child, root2, root2Child, root3, root3Child}
+	trace := model.NewTrace("trace", spans)
+
+	assert.Equal(t, root2.Name, trace.RootSpan.Name)
+}
+
+func TestNoTemporaryRootIfATemporaryRootExists(t *testing.T) {
+	root1 := newSpan("Root 1", nil)
+	root1Child := newSpan("Child from root 1", &root1)
+	root2 := newSpan(model.TemporaryRootSpanName, nil)
+	root2Child := newSpan("Child from root 2", &root2)
+	root3 := newSpan("Root 3", nil)
+	root3Child := newSpan("Child from root 3", &root3)
+
+	spans := []model.Span{root1, root1Child, root2, root2Child, root3, root3Child}
+	trace := model.NewTrace("trace", spans)
+
+	assert.Equal(t, root2.Name, trace.RootSpan.Name)
+}
+
 func newSpan(name string, parent *model.Span) model.Span {
 	span := model.Span{
 		ID:         model.IDGen.SpanID(),

--- a/server/model/traces_test.go
+++ b/server/model/traces_test.go
@@ -142,6 +142,7 @@ func TestNoTemporaryRootIfTracetestRootExists(t *testing.T) {
 	spans := []model.Span{root1, root1Child, root2, root2Child, root3, root3Child}
 	trace := model.NewTrace("trace", spans)
 
+	assert.Equal(t, root2.ID, trace.RootSpan.ID)
 	assert.Equal(t, root2.Name, trace.RootSpan.Name)
 }
 
@@ -156,7 +157,23 @@ func TestNoTemporaryRootIfATemporaryRootExists(t *testing.T) {
 	spans := []model.Span{root1, root1Child, root2, root2Child, root3, root3Child}
 	trace := model.NewTrace("trace", spans)
 
+	assert.Equal(t, root2.ID, trace.RootSpan.ID)
 	assert.Equal(t, root2.Name, trace.RootSpan.Name)
+}
+
+func TestTriggerSpanShouldBeRootWhenTemporaryRootExistsToo(t *testing.T) {
+	root1 := newSpan(model.TriggerSpanName, nil)
+	root1Child := newSpan("Child from root 1", &root1)
+	root2 := newSpan(model.TemporaryRootSpanName, nil)
+	root2Child := newSpan("Child from root 2", &root2)
+	root3 := newSpan("Root 3", nil)
+	root3Child := newSpan("Child from root 3", &root3)
+
+	spans := []model.Span{root1, root1Child, root2, root2Child, root3, root3Child}
+	trace := model.NewTrace("trace", spans)
+
+	assert.Equal(t, root1.ID, trace.RootSpan.ID)
+	assert.Equal(t, root1.Name, trace.RootSpan.Name)
 }
 
 func newSpan(name string, parent *model.Span) model.Span {


### PR DESCRIPTION
This PR adds new conditions on when to add the temporary root span in the trace. Now, if one of the root spans is the `Tracetest trigger` span, it gets promoted as the root span. This prevents the issue of having two `Tracetest trigger` spans in the same trace

## Fixes

- #2637 

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [x] added a test
