### PR TITLE
fix: move transactions to it's own module

### DIFF
--- a/server/app/app.go
+++ b/server/app/app.go
@@ -36,7 +36,6 @@ import (
 	"github.com/kubeshop/tracetest/server/traces"
 	"github.com/kubeshop/tracetest/server/tracing"
 	"github.com/kubeshop/tracetest/server/transactions"
-	tests "github.com/kubeshop/tracetest/server/transactions"
 	"go.opentelemetry.io/otel/trace"
 )
 
@@ -151,7 +150,7 @@ func (app *App) Start(opts ...appOption) error {
 		log.Fatal(err)
 	}
 
-	transactionsRepository := tests.NewTransactionsRepository(db, testDB)
+	transactionsRepository := transactions.NewTransactionsRepository(db, testDB)
 
 	subscriptionManager := subscription.NewManager()
 	app.subscribeToConfigChanges(subscriptionManager)

--- a/server/app/app.go
+++ b/server/app/app.go
@@ -31,11 +31,12 @@ import (
 	"github.com/kubeshop/tracetest/server/resourcemanager"
 	"github.com/kubeshop/tracetest/server/subscription"
 	"github.com/kubeshop/tracetest/server/testdb"
-	"github.com/kubeshop/tracetest/server/tests"
 	"github.com/kubeshop/tracetest/server/tracedb"
 	"github.com/kubeshop/tracetest/server/tracedb/datastoreresource"
 	"github.com/kubeshop/tracetest/server/traces"
 	"github.com/kubeshop/tracetest/server/tracing"
+	"github.com/kubeshop/tracetest/server/transactions"
+	tests "github.com/kubeshop/tracetest/server/transactions"
 	"go.opentelemetry.io/otel/trace"
 )
 
@@ -332,10 +333,10 @@ func registerlinterResource(linterRepo *linterResource.Repository, router *mux.R
 	provisioner.AddResourceProvisioner(manager)
 }
 
-func registerTransactionResource(repo *tests.TransactionsRepository, router *mux.Router, provisioner *provisioning.Provisioner, tracer trace.Tracer) {
-	manager := resourcemanager.New[tests.Transaction](
-		tests.TransactionResourceName,
-		tests.TransactionResourceNamePlural,
+func registerTransactionResource(repo *transactions.TransactionsRepository, router *mux.Router, provisioner *provisioning.Provisioner, tracer trace.Tracer) {
+	manager := resourcemanager.New[transactions.Transaction](
+		transactions.TransactionResourceName,
+		transactions.TransactionResourceNamePlural,
 		repo,
 		resourcemanager.CanBeAugmented(),
 		resourcemanager.WithTracer(tracer),
@@ -432,7 +433,7 @@ func registerWSHandler(router *mux.Router, mappers mappings.Mappings, subscripti
 func controller(
 	cfg httpServerConfig,
 	testDB model.Repository,
-	transactions *tests.TransactionsRepository,
+	transactions *transactions.TransactionsRepository,
 	tracer trace.Tracer,
 	environmentRepo *environment.Repository,
 	rf *runnerFacade,
@@ -448,7 +449,7 @@ func controller(
 func httpRouter(
 	cfg httpServerConfig,
 	testDB model.Repository,
-	transactions *tests.TransactionsRepository,
+	transactions *transactions.TransactionsRepository,
 	tracer trace.Tracer,
 	environmentRepo *environment.Repository,
 	rf *runnerFacade,

--- a/server/app/facade.go
+++ b/server/app/facade.go
@@ -11,9 +11,9 @@ import (
 	"github.com/kubeshop/tracetest/server/model"
 	"github.com/kubeshop/tracetest/server/pkg/id"
 	"github.com/kubeshop/tracetest/server/subscription"
-	"github.com/kubeshop/tracetest/server/tests"
 	"github.com/kubeshop/tracetest/server/tracedb"
 	"github.com/kubeshop/tracetest/server/tracedb/datastoreresource"
+	"github.com/kubeshop/tracetest/server/transactions"
 	"go.opentelemetry.io/otel/trace"
 )
 
@@ -42,7 +42,7 @@ func (rf runnerFacade) RunTest(ctx context.Context, test model.Test, rm model.Ru
 	return rf.runner.Run(ctx, test, rm, env)
 }
 
-func (rf runnerFacade) RunTransaction(ctx context.Context, tr tests.Transaction, rm model.RunMetadata, env environment.Environment) tests.TransactionRun {
+func (rf runnerFacade) RunTransaction(ctx context.Context, tr transactions.Transaction, rm model.RunMetadata, env environment.Environment) transactions.TransactionRun {
 	return rf.transactionRunner.Run(ctx, tr, rm, env)
 }
 
@@ -55,7 +55,7 @@ func newRunnerFacades(
 	dsRepo *datastoreresource.Repository,
 	lintRepo *linterResource.Repository,
 	testDB model.Repository,
-	transactions *tests.TransactionsRepository,
+	transactions *transactions.TransactionsRepository,
 	appTracer trace.Tracer,
 	tracer trace.Tracer,
 	subscriptionManager *subscription.Manager,

--- a/server/executor/transaction_run_updater.go
+++ b/server/executor/transaction_run_updater.go
@@ -5,11 +5,11 @@ import (
 	"fmt"
 
 	"github.com/kubeshop/tracetest/server/subscription"
-	"github.com/kubeshop/tracetest/server/tests"
+	"github.com/kubeshop/tracetest/server/transactions"
 )
 
 type TransactionRunUpdater interface {
-	Update(context.Context, tests.TransactionRun) error
+	Update(context.Context, transactions.TransactionRun) error
 }
 
 type CompositeTransactionUpdater struct {
@@ -23,7 +23,7 @@ func (u CompositeTransactionUpdater) Add(l TransactionRunUpdater) CompositeTrans
 
 var _ TransactionRunUpdater = CompositeTransactionUpdater{}
 
-func (u CompositeTransactionUpdater) Update(ctx context.Context, run tests.TransactionRun) error {
+func (u CompositeTransactionUpdater) Update(ctx context.Context, run transactions.TransactionRun) error {
 	for _, l := range u.listeners {
 		if err := l.Update(ctx, run); err != nil {
 			return fmt.Errorf("composite updating error: %w", err)
@@ -38,14 +38,14 @@ type dbTransactionUpdater struct {
 }
 
 type transactionUpdater interface {
-	UpdateRun(context.Context, tests.TransactionRun) error
+	UpdateRun(context.Context, transactions.TransactionRun) error
 }
 
 func NewDBTranasctionUpdater(repo transactionUpdater) TransactionRunUpdater {
 	return dbTransactionUpdater{repo}
 }
 
-func (u dbTransactionUpdater) Update(ctx context.Context, run tests.TransactionRun) error {
+func (u dbTransactionUpdater) Update(ctx context.Context, run transactions.TransactionRun) error {
 	return u.repo.UpdateRun(ctx, run)
 }
 
@@ -57,7 +57,7 @@ func NewSubscriptionTransactionUpdater(manager *subscription.Manager) Transactio
 	return subscriptionTransactionUpdater{manager}
 }
 
-func (u subscriptionTransactionUpdater) Update(ctx context.Context, run tests.TransactionRun) error {
+func (u subscriptionTransactionUpdater) Update(ctx context.Context, run transactions.TransactionRun) error {
 	u.manager.PublishUpdate(subscription.Message{
 		ResourceID: run.ResourceID(),
 		Type:       "result_update",

--- a/server/executor/transaction_runner.go
+++ b/server/executor/transaction_runner.go
@@ -8,11 +8,11 @@ import (
 	"github.com/kubeshop/tracetest/server/model"
 	"github.com/kubeshop/tracetest/server/pkg/maps"
 	"github.com/kubeshop/tracetest/server/subscription"
-	"github.com/kubeshop/tracetest/server/tests"
+	"github.com/kubeshop/tracetest/server/transactions"
 )
 
 type TransactionRunner interface {
-	Run(context.Context, tests.Transaction, model.RunMetadata, environment.Environment) tests.TransactionRun
+	Run(context.Context, transactions.Transaction, model.RunMetadata, environment.Environment) transactions.TransactionRun
 }
 
 type PersistentTransactionRunner interface {
@@ -22,7 +22,7 @@ type PersistentTransactionRunner interface {
 
 type transactionRunRepository interface {
 	transactionUpdater
-	CreateRun(context.Context, tests.TransactionRun) (tests.TransactionRun, error)
+	CreateRun(context.Context, transactions.TransactionRun) (transactions.TransactionRun, error)
 }
 
 func NewTransactionRunner(
@@ -48,8 +48,8 @@ func NewTransactionRunner(
 
 type transactionRunJob struct {
 	ctx         context.Context
-	transaction tests.Transaction
-	run         tests.TransactionRun
+	transaction transactions.Transaction
+	run         transactions.TransactionRun
 }
 
 type persistentTransactionRunner struct {
@@ -62,7 +62,7 @@ type persistentTransactionRunner struct {
 	exit                chan bool
 }
 
-func (r persistentTransactionRunner) Run(ctx context.Context, transaction tests.Transaction, metadata model.RunMetadata, environment environment.Environment) tests.TransactionRun {
+func (r persistentTransactionRunner) Run(ctx context.Context, transaction transactions.Transaction, metadata model.RunMetadata, environment environment.Environment) transactions.TransactionRun {
 	run := transaction.NewRun()
 	run.Metadata = metadata
 	run.Environment = environment
@@ -104,8 +104,8 @@ func (r persistentTransactionRunner) Start(workers int) {
 	}
 }
 
-func (r persistentTransactionRunner) runTransaction(ctx context.Context, transaction tests.Transaction, run tests.TransactionRun) error {
-	run.State = tests.TransactionRunStateExecuting
+func (r persistentTransactionRunner) runTransaction(ctx context.Context, transaction transactions.Transaction, run transactions.TransactionRun) error {
+	run.State = transactions.TransactionRunStateExecuting
 
 	var err error
 
@@ -115,7 +115,7 @@ func (r persistentTransactionRunner) runTransaction(ctx context.Context, transac
 			return fmt.Errorf("could not execute step %d of transaction %s: %w", step, run.TransactionID, err)
 		}
 
-		if run.State == tests.TransactionRunStateFailed {
+		if run.State == transactions.TransactionRunStateFailed {
 			break
 		}
 
@@ -126,18 +126,18 @@ func (r persistentTransactionRunner) runTransaction(ctx context.Context, transac
 		}
 	}
 
-	if run.State != tests.TransactionRunStateFailed {
-		run.State = tests.TransactionRunStateFinished
+	if run.State != transactions.TransactionRunStateFailed {
+		run.State = transactions.TransactionRunStateFinished
 	}
 
 	return r.updater.Update(ctx, run)
 }
 
-func (r persistentTransactionRunner) runTransactionStep(ctx context.Context, tr tests.TransactionRun, step int, test model.Test) (tests.TransactionRun, error) {
+func (r persistentTransactionRunner) runTransactionStep(ctx context.Context, tr transactions.TransactionRun, step int, test model.Test) (transactions.TransactionRun, error) {
 	testRun := r.testRunner.Run(ctx, test, tr.Metadata, tr.Environment)
 	tr, err := r.updateStepRun(ctx, tr, step, testRun)
 	if err != nil {
-		return tests.TransactionRun{}, fmt.Errorf("could not update transaction run: %w", err)
+		return transactions.TransactionRun{}, fmt.Errorf("could not update transaction run: %w", err)
 	}
 
 	done := make(chan bool)
@@ -146,7 +146,7 @@ func (r persistentTransactionRunner) runTransactionStep(ctx context.Context, tr 
 		func(m subscription.Message) error {
 			testRun := m.Content.(model.Run)
 			if testRun.LastError != nil {
-				tr.State = tests.TransactionRunStateFailed
+				tr.State = transactions.TransactionRunStateFailed
 				tr.LastError = testRun.LastError
 			}
 
@@ -175,7 +175,7 @@ func (r persistentTransactionRunner) runTransactionStep(ctx context.Context, tr 
 	return tr, err
 }
 
-func (r persistentTransactionRunner) updateStepRun(ctx context.Context, tr tests.TransactionRun, step int, run model.Run) (tests.TransactionRun, error) {
+func (r persistentTransactionRunner) updateStepRun(ctx context.Context, tr transactions.TransactionRun, step int, run model.Run) (transactions.TransactionRun, error) {
 	if len(tr.Steps) <= step {
 		tr.Steps = append(tr.Steps, model.Run{})
 	}
@@ -183,7 +183,7 @@ func (r persistentTransactionRunner) updateStepRun(ctx context.Context, tr tests
 	tr.Steps[step] = run
 	err := r.updater.Update(ctx, tr)
 	if err != nil {
-		return tests.TransactionRun{}, fmt.Errorf("could not update transaction run: %w", err)
+		return transactions.TransactionRun{}, fmt.Errorf("could not update transaction run: %w", err)
 	}
 
 	return tr, nil

--- a/server/executor/transaction_runner_test.go
+++ b/server/executor/transaction_runner_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/kubeshop/tracetest/server/subscription"
 	"github.com/kubeshop/tracetest/server/testdb"
 	"github.com/kubeshop/tracetest/server/testmock"
-	"github.com/kubeshop/tracetest/server/tests"
+	tests "github.com/kubeshop/tracetest/server/transactions"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/server/http/mappings/tests.go
+++ b/server/http/mappings/tests.go
@@ -12,8 +12,8 @@ import (
 	"github.com/kubeshop/tracetest/server/openapi"
 	"github.com/kubeshop/tracetest/server/pkg/id"
 	"github.com/kubeshop/tracetest/server/pkg/maps"
-	"github.com/kubeshop/tracetest/server/tests"
 	"github.com/kubeshop/tracetest/server/traces"
+	"github.com/kubeshop/tracetest/server/transactions"
 	"go.opentelemetry.io/otel/trace"
 )
 
@@ -31,7 +31,7 @@ func optionalTime(in time.Time) *time.Time {
 	return &in
 }
 
-func (m OpenAPI) TransactionRun(in tests.TransactionRun) openapi.TransactionRun {
+func (m OpenAPI) TransactionRun(in transactions.TransactionRun) openapi.TransactionRun {
 	steps := make([]openapi.TestRun, 0, len(in.Steps))
 
 	for _, step := range in.Steps {

--- a/server/http/validation/variable.go
+++ b/server/http/validation/variable.go
@@ -9,7 +9,7 @@ import (
 	"github.com/kubeshop/tracetest/server/model"
 	"github.com/kubeshop/tracetest/server/openapi"
 	"github.com/kubeshop/tracetest/server/testdb"
-	"github.com/kubeshop/tracetest/server/tests"
+	"github.com/kubeshop/tracetest/server/transactions"
 )
 
 var ErrMissingVariables = errors.New("variables are missing")
@@ -86,7 +86,7 @@ func getPreviousEnvironmentValues(ctx context.Context, db model.Repository, test
 	return map[string]environment.EnvironmentValue{}, nil
 }
 
-func ValidateMissingVariablesFromTransaction(ctx context.Context, db model.Repository, transaction tests.Transaction, env environment.Environment) (openapi.MissingVariablesError, error) {
+func ValidateMissingVariablesFromTransaction(ctx context.Context, db model.Repository, transaction transactions.Transaction, env environment.Environment) (openapi.MissingVariablesError, error) {
 	missingVariables := make([]openapi.MissingVariable, 0)
 	for _, step := range transaction.Steps {
 		stepValidationResult, err := ValidateMissingVariables(ctx, db, step, env)

--- a/server/http/websocket/subscribe.go
+++ b/server/http/websocket/subscribe.go
@@ -8,7 +8,7 @@ import (
 	"github.com/kubeshop/tracetest/server/http/mappings"
 	"github.com/kubeshop/tracetest/server/model"
 	"github.com/kubeshop/tracetest/server/subscription"
-	"github.com/kubeshop/tracetest/server/tests"
+	"github.com/kubeshop/tracetest/server/transactions"
 )
 
 type subscriptionMessage struct {
@@ -63,9 +63,9 @@ func (e subscribeCommandExecutor) ResourceUpdatedEvent(resource interface{}) Eve
 		mapped = e.mappers.Out.Run(&v)
 	case *model.Run:
 		mapped = e.mappers.Out.Run(v)
-	case tests.TransactionRun:
+	case transactions.TransactionRun:
 		mapped = e.mappers.Out.TransactionRun(v)
-	case *tests.TransactionRun:
+	case *transactions.TransactionRun:
 		mapped = e.mappers.Out.TransactionRun(*v)
 	case model.TestRunEvent:
 		mapped = e.mappers.Out.TestRunEvent(v)

--- a/server/model/yaml/file_test.go
+++ b/server/model/yaml/file_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/kubeshop/tracetest/server/model/yaml"
 	"github.com/kubeshop/tracetest/server/pkg/id"
 	"github.com/kubeshop/tracetest/server/pkg/maps"
-	"github.com/kubeshop/tracetest/server/tests"
+	"github.com/kubeshop/tracetest/server/transactions"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -331,7 +331,7 @@ func TestTransactionModel(t *testing.T) {
 	cases := []struct {
 		name     string
 		in       yaml.Transaction
-		expected tests.Transaction
+		expected transactions.Transaction
 	}{
 		{
 			name: "Basic",
@@ -341,7 +341,7 @@ func TestTransactionModel(t *testing.T) {
 				Description: "Some transaction",
 				Steps:       []string{"345"},
 			},
-			expected: tests.Transaction{
+			expected: transactions.Transaction{
 				ID:          id.ID("123"),
 				Name:        "Transaction",
 				Description: "Some transaction",

--- a/server/model/yaml/transaction.go
+++ b/server/model/yaml/transaction.go
@@ -5,7 +5,7 @@ import (
 
 	dc "github.com/fluidtruck/deepcopy"
 	"github.com/kubeshop/tracetest/server/pkg/id"
-	"github.com/kubeshop/tracetest/server/tests"
+	"github.com/kubeshop/tracetest/server/transactions"
 )
 
 type Transaction struct {
@@ -16,8 +16,8 @@ type Transaction struct {
 	Steps       []string          `mapstructure:"steps"`
 }
 
-func (t Transaction) Model() tests.Transaction {
-	mt := tests.Transaction{}
+func (t Transaction) Model() transactions.Transaction {
+	mt := transactions.Transaction{}
 	dc.DeepCopy(t, &mt)
 	mt.StepIDs = make([]id.ID, 0, len(t.Steps))
 	for _, stepID := range t.Steps {

--- a/server/testdb/mock.go
+++ b/server/testdb/mock.go
@@ -6,7 +6,7 @@ import (
 	"github.com/kubeshop/tracetest/server/model"
 	"github.com/kubeshop/tracetest/server/pkg/id"
 	"github.com/kubeshop/tracetest/server/pkg/maps"
-	"github.com/kubeshop/tracetest/server/tests"
+	"github.com/kubeshop/tracetest/server/transactions"
 	"github.com/stretchr/testify/mock"
 	"go.opentelemetry.io/otel/trace"
 )
@@ -129,24 +129,24 @@ func (m *MockRepository) Drop() error {
 	return args.Error(0)
 }
 
-func (m *MockRepository) CreateTransaction(_ context.Context, transaction tests.Transaction) (tests.Transaction, error) {
+func (m *MockRepository) CreateTransaction(_ context.Context, transaction transactions.Transaction) (transactions.Transaction, error) {
 	args := m.Called(transaction)
-	return args.Get(0).(tests.Transaction), args.Error(1)
+	return args.Get(0).(transactions.Transaction), args.Error(1)
 }
 
-func (m *MockRepository) UpdateTransaction(_ context.Context, transaction tests.Transaction) (tests.Transaction, error) {
+func (m *MockRepository) UpdateTransaction(_ context.Context, transaction transactions.Transaction) (transactions.Transaction, error) {
 	args := m.Called(transaction)
-	return args.Get(0).(tests.Transaction), args.Error(1)
+	return args.Get(0).(transactions.Transaction), args.Error(1)
 }
 
-func (m *MockRepository) DeleteTransaction(_ context.Context, transaction tests.Transaction) error {
+func (m *MockRepository) DeleteTransaction(_ context.Context, transaction transactions.Transaction) error {
 	args := m.Called(transaction)
 	return args.Error(1)
 }
 
-func (m *MockRepository) GetLatestTransactionVersion(_ context.Context, id id.ID) (tests.Transaction, error) {
+func (m *MockRepository) GetLatestTransactionVersion(_ context.Context, id id.ID) (transactions.Transaction, error) {
 	args := m.Called(id)
-	return args.Get(0).(tests.Transaction), args.Error(1)
+	return args.Get(0).(transactions.Transaction), args.Error(1)
 }
 
 func (m *MockRepository) TransactionIDExists(_ context.Context, id id.ID) (bool, error) {
@@ -154,51 +154,51 @@ func (m *MockRepository) TransactionIDExists(_ context.Context, id id.ID) (bool,
 	return args.Bool(0), args.Error(1)
 }
 
-func (m *MockRepository) GetTransactionVersion(_ context.Context, id id.ID, version int) (tests.Transaction, error) {
+func (m *MockRepository) GetTransactionVersion(_ context.Context, id id.ID, version int) (transactions.Transaction, error) {
 	args := m.Called(id, version)
-	return args.Get(0).(tests.Transaction), args.Error(1)
+	return args.Get(0).(transactions.Transaction), args.Error(1)
 }
 
-func (m *MockRepository) GetTransactions(_ context.Context, take, skip int32, query, sortBy, sortDirection string) (model.List[tests.Transaction], error) {
+func (m *MockRepository) GetTransactions(_ context.Context, take, skip int32, query, sortBy, sortDirection string) (model.List[transactions.Transaction], error) {
 	args := m.Called(take, skip, query, sortBy, sortDirection)
-	transactions := args.Get(0).([]tests.Transaction)
-	list := model.List[tests.Transaction]{
-		Items:      transactions,
-		TotalCount: len(transactions),
+	transactionsArray := args.Get(0).([]transactions.Transaction)
+	list := model.List[transactions.Transaction]{
+		Items:      transactionsArray,
+		TotalCount: len(transactionsArray),
 	}
 	return list, args.Error(1)
 }
 
 // DeleteTransactionRun implements model.Repository
-func (m *MockRepository) DeleteTransactionRun(ctx context.Context, run tests.TransactionRun) error {
+func (m *MockRepository) DeleteTransactionRun(ctx context.Context, run transactions.TransactionRun) error {
 	args := m.Called(ctx, run)
 	return args.Error(0)
 }
 
 // GetTransactionRun implements model.Repository
-func (m *MockRepository) GetTransactionRun(ctx context.Context, transactionID id.ID, runID int) (tests.TransactionRun, error) {
+func (m *MockRepository) GetTransactionRun(ctx context.Context, transactionID id.ID, runID int) (transactions.TransactionRun, error) {
 	args := m.Called(ctx, transactionID, runID)
-	return args.Get(0).(tests.TransactionRun), args.Error(1)
+	return args.Get(0).(transactions.TransactionRun), args.Error(1)
 }
 
-func (m *MockRepository) GetLatestRunByTransactionVersion(_ context.Context, transactionID id.ID, version int) (tests.TransactionRun, error) {
+func (m *MockRepository) GetLatestRunByTransactionVersion(_ context.Context, transactionID id.ID, version int) (transactions.TransactionRun, error) {
 	args := m.Called(transactionID, version)
-	return args.Get(0).(tests.TransactionRun), args.Error(1)
+	return args.Get(0).(transactions.TransactionRun), args.Error(1)
 }
 
 // GetTransactionsRuns implements model.Repository
-func (m *MockRepository) GetTransactionsRuns(ctx context.Context, transactionID id.ID, take, skip int32) ([]tests.TransactionRun, error) {
+func (m *MockRepository) GetTransactionsRuns(ctx context.Context, transactionID id.ID, take, skip int32) ([]transactions.TransactionRun, error) {
 	args := m.Called(ctx, transactionID, take, skip)
-	return args.Get(0).([]tests.TransactionRun), args.Error(1)
+	return args.Get(0).([]transactions.TransactionRun), args.Error(1)
 }
 
 // UpdateTransactionRun implements model.Repository
-func (m *MockRepository) UpdateTransactionRun(ctx context.Context, run tests.TransactionRun) error {
+func (m *MockRepository) UpdateTransactionRun(ctx context.Context, run transactions.TransactionRun) error {
 	args := m.Called(ctx, run)
 	return args.Error(0)
 }
 
-func (m *MockRepository) CreateTransactionRun(ctx context.Context, run tests.TransactionRun) error {
+func (m *MockRepository) CreateTransactionRun(ctx context.Context, run transactions.TransactionRun) error {
 	args := m.Called(ctx, run)
 	return args.Error(0)
 }

--- a/server/testdb/runs.go
+++ b/server/testdb/runs.go
@@ -13,7 +13,7 @@ import (
 	"github.com/kubeshop/tracetest/server/environment"
 	"github.com/kubeshop/tracetest/server/model"
 	"github.com/kubeshop/tracetest/server/pkg/id"
-	"github.com/kubeshop/tracetest/server/tests"
+	"github.com/kubeshop/tracetest/server/transactions"
 	"go.opentelemetry.io/otel/trace"
 )
 
@@ -583,7 +583,7 @@ func readRunRow(row scanner) (model.Run, error) {
 	}
 }
 
-func (td *postgresDB) GetTransactionRunSteps(ctx context.Context, tr tests.TransactionRun) ([]model.Run, error) {
+func (td *postgresDB) GetTransactionRunSteps(ctx context.Context, tr transactions.TransactionRun) ([]model.Run, error) {
 	query := selectRunQuery + `
 WHERE transaction_run_steps.transaction_run_id = $1 AND transaction_run_steps.transaction_run_transaction_id = $2
 ORDER BY test_runs.completed_at ASC

--- a/server/testdb/tests.go
+++ b/server/testdb/tests.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/kubeshop/tracetest/server/model"
 	"github.com/kubeshop/tracetest/server/pkg/id"
-	"github.com/kubeshop/tracetest/server/tests"
+	"github.com/kubeshop/tracetest/server/transactions"
 )
 
 var _ model.TestRepository = &postgresDB{}
@@ -372,7 +372,7 @@ func (td *postgresDB) readTestRow(ctx context.Context, row scanner) (model.Test,
 	}
 }
 
-func (td *postgresDB) GetTransactionSteps(ctx context.Context, transaction tests.Transaction) ([]model.Test, error) {
+func (td *postgresDB) GetTransactionSteps(ctx context.Context, transaction transactions.Transaction) ([]model.Test, error) {
 	stmt, err := td.db.Prepare(getTestSQL + testMaxVersionQuery + ` INNER JOIN transaction_steps ts ON t.id = ts.test_id
 	 WHERE ts.transaction_id = $1 AND ts.transaction_version = $2 ORDER BY ts.step_number ASC`)
 	if err != nil {

--- a/server/transactions/main_test.go
+++ b/server/transactions/main_test.go
@@ -1,4 +1,4 @@
-package tests_test
+package transactions_test
 
 import (
 	"os"

--- a/server/transactions/transaction_runs.go
+++ b/server/transactions/transaction_runs.go
@@ -1,4 +1,4 @@
-package tests
+package transactions
 
 import (
 	"context"

--- a/server/transactions/transactions.go
+++ b/server/transactions/transactions.go
@@ -1,4 +1,4 @@
-package tests
+package transactions
 
 import (
 	"context"

--- a/server/transactions/transactions_runs_test.go
+++ b/server/transactions/transactions_runs_test.go
@@ -1,4 +1,4 @@
-package tests_test
+package transactions_test
 
 import (
 	"context"
@@ -8,7 +8,7 @@ import (
 	"github.com/kubeshop/tracetest/server/pkg/id"
 	"github.com/kubeshop/tracetest/server/testdb"
 	"github.com/kubeshop/tracetest/server/testmock"
-	"github.com/kubeshop/tracetest/server/tests"
+	"github.com/kubeshop/tracetest/server/transactions"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -33,7 +33,7 @@ func createTestWithName(t *testing.T, db model.TestRepository, name string) mode
 	return updated
 }
 
-func getRepos() (*tests.TransactionsRepository, model.Repository) {
+func getRepos() (*transactions.TransactionsRepository, model.Repository) {
 	db := testmock.GetRawTestingDatabase()
 
 	testsRepo, err := testdb.Postgres(testdb.WithDB(db))
@@ -41,15 +41,15 @@ func getRepos() (*tests.TransactionsRepository, model.Repository) {
 		panic(err)
 	}
 
-	transactionRepo := tests.NewTransactionsRepository(db, testsRepo)
+	transactionRepo := transactions.NewTransactionsRepository(db, testsRepo)
 
 	return transactionRepo, testsRepo
 }
 
-func getTransaction(t *testing.T, transactionRepo *tests.TransactionsRepository, testsRepo model.TestRepository) (tests.Transaction, transactionFixture) {
+func getTransaction(t *testing.T, transactionRepo *transactions.TransactionsRepository, testsRepo model.TestRepository) (transactions.Transaction, transactionFixture) {
 	f := setupTransactionFixture(t, transactionRepo.DB())
 
-	transaction := tests.Transaction{
+	transaction := transactions.Transaction{
 		ID:          id.NewRandGenerator().ID(),
 		Name:        "first test",
 		Description: "description",
@@ -76,7 +76,7 @@ func TestCreateTransactionRun(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t, tr.TransactionID, transaction.ID)
-	assert.Equal(t, tr.State, tests.TransactionRunStateCreated)
+	assert.Equal(t, tr.State, transactions.TransactionRunStateCreated)
 	assert.Len(t, tr.Steps, 0)
 }
 
@@ -87,7 +87,7 @@ func TestUpdateTransactionRun(t *testing.T) {
 	tr, err := transactionRepo.CreateRun(context.TODO(), transaction.NewRun())
 	require.NoError(t, err)
 
-	tr.State = tests.TransactionRunStateExecuting
+	tr.State = transactions.TransactionRunStateExecuting
 	tr.Steps = []model.Run{fixture.testRun}
 	err = transactionRepo.UpdateRun(context.TODO(), tr)
 	require.NoError(t, err)
@@ -96,7 +96,7 @@ func TestUpdateTransactionRun(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t, tr.TransactionID, transaction.ID)
-	assert.Equal(t, tests.TransactionRunStateExecuting, updatedRun.State)
+	assert.Equal(t, transactions.TransactionRunStateExecuting, updatedRun.State)
 	assert.Len(t, tr.Steps, 1)
 }
 
@@ -114,7 +114,7 @@ func TestDeleteTransactionRun(t *testing.T) {
 	require.ErrorContains(t, err, "no rows in result set")
 }
 
-func createTransaction(t *testing.T, repo *tests.TransactionsRepository, tran tests.Transaction) tests.Transaction {
+func createTransaction(t *testing.T, repo *transactions.TransactionsRepository, tran transactions.Transaction) transactions.Transaction {
 	one := 1
 	tran.ID = id.GenerateID()
 	tran.Version = &one
@@ -133,7 +133,7 @@ func createTransaction(t *testing.T, repo *tests.TransactionsRepository, tran te
 func TestListTransactionRun(t *testing.T) {
 	transactionRepo, testsRepo := getRepos()
 
-	t1 := createTransaction(t, transactionRepo, tests.Transaction{
+	t1 := createTransaction(t, transactionRepo, transactions.Transaction{
 		Name:        "first test",
 		Description: "description",
 		Steps: []model.Test{
@@ -142,7 +142,7 @@ func TestListTransactionRun(t *testing.T) {
 		},
 	})
 
-	t2 := createTransaction(t, transactionRepo, tests.Transaction{
+	t2 := createTransaction(t, transactionRepo, transactions.Transaction{
 		Name:        "second transaction",
 		Description: "description",
 		Steps: []model.Test{
@@ -173,7 +173,7 @@ func TestBug(t *testing.T) {
 
 	ctx := context.TODO()
 
-	transaction := createTransaction(t, transactionRepo, tests.Transaction{
+	transaction := createTransaction(t, transactionRepo, transactions.Transaction{
 		Name:        "first test",
 		Description: "description",
 		Steps: []model.Test{

--- a/server/transactions/transactions_test.go
+++ b/server/transactions/transactions_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/kubeshop/tracetest/server/testdb"
 	"github.com/kubeshop/tracetest/server/testmock"
 	"github.com/kubeshop/tracetest/server/transactions"
-	tests "github.com/kubeshop/tracetest/server/transactions"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -195,7 +194,7 @@ func TestTransactions(t *testing.T) {
 			if err != nil {
 				panic(err)
 			}
-			transactionsRepo := tests.NewTransactionsRepository(db, testsDB)
+			transactionsRepo := transactions.NewTransactionsRepository(db, testsDB)
 
 			manager := resourcemanager.New[transactions.Transaction](
 				transactions.TransactionResourceName,

--- a/server/transactions/transactions_test.go
+++ b/server/transactions/transactions_test.go
@@ -1,4 +1,4 @@
-package tests_test
+package transactions_test
 
 import (
 	"context"
@@ -14,7 +14,8 @@ import (
 	rmtests "github.com/kubeshop/tracetest/server/resourcemanager/testutil"
 	"github.com/kubeshop/tracetest/server/testdb"
 	"github.com/kubeshop/tracetest/server/testmock"
-	"github.com/kubeshop/tracetest/server/tests"
+	"github.com/kubeshop/tracetest/server/transactions"
+	tests "github.com/kubeshop/tracetest/server/transactions"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -141,7 +142,7 @@ func TestDeleteTestsRelatedToTransactions(t *testing.T) {
 	if err != nil {
 		panic(err)
 	}
-	transactionRepo := tests.NewTransactionsRepository(db, testsDB)
+	transactionRepo := transactions.NewTransactionsRepository(db, testsDB)
 
 	transactionRepo.Create(context.TODO(), transactionSample)
 
@@ -157,7 +158,7 @@ func TestDeleteTestsRelatedToTransactions(t *testing.T) {
 
 }
 
-var transactionSample = tests.Transaction{
+var transactionSample = transactions.Transaction{
 	ID:          "NiWVnxP4R",
 	Name:        "Verify Import",
 	Description: "check the working of the import flow",
@@ -168,7 +169,7 @@ var transactionSample = tests.Transaction{
 }
 
 func TestTransactions(t *testing.T) {
-	// sample2 := tests.Transaction{
+	// sample2 := transactions.Transaction{
 	// 	ID:          "sample2",
 	// 	Name:        "Some Transaction",
 	// 	Description: "Do important stuff",
@@ -177,7 +178,7 @@ func TestTransactions(t *testing.T) {
 	// 	},
 	// }
 
-	// sample3 := tests.Transaction{
+	// sample3 := transactions.Transaction{
 	// 	ID:          "sample3",
 	// 	Name:        "Some Transaction",
 	// 	Description: "Do important stuff",
@@ -187,8 +188,8 @@ func TestTransactions(t *testing.T) {
 	// }
 
 	rmtests.TestResourceType(t, rmtests.ResourceTypeTest{
-		ResourceTypeSingular: tests.TransactionResourceName,
-		ResourceTypePlural:   tests.TransactionResourceNamePlural,
+		ResourceTypeSingular: transactions.TransactionResourceName,
+		ResourceTypePlural:   transactions.TransactionResourceNamePlural,
 		RegisterManagerFn: func(router *mux.Router, db *sql.DB) resourcemanager.Manager {
 			testsDB, err := testdb.Postgres(testdb.WithDB(db))
 			if err != nil {
@@ -196,9 +197,9 @@ func TestTransactions(t *testing.T) {
 			}
 			transactionsRepo := tests.NewTransactionsRepository(db, testsDB)
 
-			manager := resourcemanager.New[tests.Transaction](
-				tests.TransactionResourceName,
-				tests.TransactionResourceNamePlural,
+			manager := resourcemanager.New[transactions.Transaction](
+				transactions.TransactionResourceName,
+				transactions.TransactionResourceNamePlural,
 				transactionsRepo,
 				resourcemanager.CanBeAugmented(),
 			)
@@ -207,7 +208,7 @@ func TestTransactions(t *testing.T) {
 			return manager
 		},
 		Prepare: func(t *testing.T, op rmtests.Operation, manager resourcemanager.Manager) {
-			transactionRepo := manager.Handler().(*tests.TransactionsRepository)
+			transactionRepo := manager.Handler().(*transactions.TransactionsRepository)
 			testsDB, err := testdb.Postgres(testdb.WithDB(transactionRepo.DB()))
 			if err != nil {
 				panic(err)
@@ -392,7 +393,7 @@ func compareJSON(t require.TestingT, operation rmtests.Operation, firstValue, se
 	require.JSONEq(t, expected, actual)
 }
 
-func createTransactionRun(repo *tests.TransactionsRepository, tran tests.Transaction, run model.Run) {
+func createTransactionRun(repo *transactions.TransactionsRepository, tran transactions.Transaction, run model.Run) {
 	updated, err := repo.GetAugmented(context.TODO(), tran.ID)
 	if err != nil {
 		panic(err)


### PR DESCRIPTION
This PR moves the `transactions` files from the `tests` module into a new `transactions` module

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [x] added a test
