### PR TITLE
Replace abbreviations in collector config

### DIFF
--- a/docs/docs/configuration/connecting-to-data-stores/datadog.md
+++ b/docs/docs/configuration/connecting-to-data-stores/datadog.md
@@ -10,7 +10,7 @@ Examples of configuring Tracetest with Datadog can be found in the [`examples` f
 
 In your OpenTelemetry Collector config file:
 
-- Set the `exporter` to `otlp/tt`
+- Set the `exporter` to `otlp/tracetest`
 - Set the `endpoint` to your Tracetest instance on port `4317`
 
 :::tip
@@ -46,7 +46,7 @@ exporters:
   # OTLP for Tracetest
   # Send traces to Tracetest.
   # Read more in docs here: https://docs.tracetest.io/configuration/connecting-to-data-stores/opentelemetry-collector
-  otlp/tt:
+  otlp/tracetest:
     endpoint: tracetest:4317
     tls:
       insecure: true
@@ -61,11 +61,11 @@ exporters:
 
 service:
   pipelines:
-    traces/tt:
+    traces/tracetest:
       receivers: [otlp]
       processors: [batch]
-      exporters: [otlp/tt] # exporter sending traces to your Tracetest instance
-    traces/dd:
+      exporters: [otlp/tracetest] # exporter sending traces to your Tracetest instance
+    traces/datadog:
       receivers: [otlp]
       processors: [batch]
       exporters: [datadog] # exporter sending traces to directly to Datadog

--- a/docs/docs/configuration/connecting-to-data-stores/lightstep.md
+++ b/docs/docs/configuration/connecting-to-data-stores/lightstep.md
@@ -10,7 +10,7 @@ Examples of configuring Tracetest with Lightstep can be found in the [`examples`
 
 In your OpenTelemetry Collector config file:
 
-- Set the `exporter` to `otlp/tt`
+- Set the `exporter` to `otlp/tracetest`
 - Set the `endpoint` to your Tracetest instance on port `4317`
 
 :::tip
@@ -19,7 +19,7 @@ If you are running Tracetest with Docker, and Tracetest's service name is `trace
 
 Additionally, add another config:
 
-- Set the `exporter` to `otlp/ls`
+- Set the `exporter` to `otlp/lightstep`
 - Set the `endpoint` pointing to your Lightstep account and the Lightstep ingest API
 - Set your Lightstep access token as a `header`
 
@@ -42,12 +42,12 @@ exporters:
   logging:
     logLevel: debug
   # OTLP for Tracetest
-  otlp/tt:
+  otlp/tracetest:
     endpoint: tracetest:4317 # Send traces to Tracetest. Read more in docs here:  https://docs.tracetest.io/configuration/connecting-to-data-stores/opentelemetry-collector
     tls:
       insecure: true
   # OTLP for Lightstep
-  otlp/ls:
+  otlp/lightstep:
     endpoint: ingest.lightstep.com:443
     headers:
       "lightstep-access-token": "<lightstep_access_token>" # Send traces to Lightstep. Read more in docs here: https://docs.lightstep.com/otel/otel-quick-start
@@ -57,14 +57,14 @@ service:
     # Your probably already have a traces pipeline, you don't have to change it.
     # Add these two to your configuration. Just make sure to not have two
     # pipelines with the same name
-    traces/tt:
+    traces/tracetest:
       receivers: [otlp] # your receiver
       processors: [batch]
-      exporters: [otlp/tt] # your exporter pointing to your tracetest instance
-    traces/ls:
+      exporters: [otlp/tracetest] # your exporter pointing to your tracetest instance
+    traces/lightstep:
       receivers: [otlp] # your receiver
       processors: [batch]
-      exporters: [logging, otlp/ls] # your exporter pointing to your lighstep account
+      exporters: [logging, otlp/lightstep] # your exporter pointing to your lighstep account
 ```
 
 ## Configure Tracetest to Use Lightstep as a Trace Data Store

--- a/docs/docs/configuration/connecting-to-data-stores/new-relic.md
+++ b/docs/docs/configuration/connecting-to-data-stores/new-relic.md
@@ -10,7 +10,7 @@ Examples of configuring Tracetest with New Relic can be found in the [`examples`
 
 In your OpenTelemetry Collector config file:
 
-- Set the `exporter` to `otlp/tt`
+- Set the `exporter` to `otlp/tracetest`
 - Set the `endpoint` to your Tracetest instance on port `4317`
 
 :::tip
@@ -19,7 +19,7 @@ If you are running Tracetest with Docker and Tracetest's service name is `tracet
 
 Additionally, add another config:
 
-- Set the `exporter` to `otlp/nr`.
+- Set the `exporter` to `otlp/newrelic`.
 - Set the `endpoint` pointing to your New Relic account and the New Relic ingest API.
 - Set your New Relic access token as a `header`.
 
@@ -42,12 +42,12 @@ exporters:
   logging:
     logLevel: debug
   # OTLP for Tracetest
-  otlp/tt:
+  otlp/tracetest:
     endpoint: tracetest:4317 # Send traces to Tracetest. Read more in docs here:  https://docs.tracetest.io/configuration/connecting-to-data-stores/opentelemetry-collector
     tls:
       insecure: true
   # OTLP for New Relic
-  otlp/nr:
+  otlp/newrelic:
     endpoint: otlp.nr-data.net:443
     headers:
       api-key: <new_relic_ingest_licence_key> # Send traces to New Relic.
@@ -59,14 +59,14 @@ service:
     # Your probably already have a traces pipeline, you don't have to change it.
     # Add these two to your configuration. Just make sure to not have two
     # pipelines with the same name
-    traces/tt:
+    traces/tracetest:
       receivers: [otlp] # your receiver
       processors: [batch]
-      exporters: [otlp/tt] # your exporter pointing to your tracetest instance
-    traces/nr:
+      exporters: [otlp/tracetest] # your exporter pointing to your tracetest instance
+    traces/newrelic:
       receivers: [otlp] # your receiver
       processors: [batch]
-      exporters: [logging, otlp/nr] # your exporter pointing to your lighstep account
+      exporters: [logging, otlp/newrelic] # your exporter pointing to your lighstep account
 ```
 
 ## Configure Tracetest to Use New Relic as a Trace Data Store

--- a/docs/docs/examples-tutorials/recipes/running-tracetest-with-aws-x-ray-adot.md
+++ b/docs/docs/examples-tutorials/recipes/running-tracetest-with-aws-x-ray-adot.md
@@ -194,18 +194,18 @@ processors:
 exporters:
   awsxray:
     region: ${AWS_REGION}
-  otlp/tt:
+  otlp/tracetest:
     endpoint: tracetest:4317
     tls:
       insecure: true
 
 service:
   pipelines:
-    traces/tt:
+    traces/tracetest:
       receivers: [awsxray]
       processors: [batch]
-      exporters: [otlp/tt]
-    traces/xr:
+      exporters: [otlp/tracetest]
+    traces/awsxray:
       receivers: [awsxray]
       exporters: [awsxray]
 ```

--- a/docs/docs/examples-tutorials/recipes/running-tracetest-with-datadog.md
+++ b/docs/docs/examples-tutorials/recipes/running-tracetest-with-datadog.md
@@ -216,7 +216,7 @@ processors:
 
 exporters:
   # OTLP for Tracetest
-  otlp/tt:
+  otlp/tracetest:
     endpoint: tracetest:4317
     # Send traces to Tracetest.
     # Read more in docs here: https://docs.tracetest.io/configuration/connecting-to-data-stores/opentelemetry-collector
@@ -232,11 +232,11 @@ exporters:
 
 service:
   pipelines:
-    traces/tt:
+    traces/tracetest:
       receivers: [otlp]
       processors: [batch]
-      exporters: [otlp/tt]
-    traces/dd:
+      exporters: [otlp/tracetest]
+    traces/datadog:
       receivers: [otlp]
       processors: [batch]
       exporters: [datadog]

--- a/docs/docs/examples-tutorials/recipes/running-tracetest-with-honeycomb.md
+++ b/docs/docs/examples-tutorials/recipes/running-tracetest-with-honeycomb.md
@@ -238,12 +238,12 @@ exporters:
   logging:
     logLevel: debug
   # OTLP for Tracetest
-  otlp/tt:
+  otlp/tracetest:
     endpoint: tracetest:4317 # Send traces to Tracetest. Read more in docs here:  https://docs.tracetest.io/configuration/connecting-to-data-stores/opentelemetry-collector
     tls:
       insecure: true
   # OTLP for Honeycomb
-  otlp/hc:
+  otlp/honeycomb:
     endpoint: "api.honeycomb.io:443"
     headers:
       "x-honeycomb-team": <HONEYCOMB_API_KEY>
@@ -251,14 +251,14 @@ exporters:
 
 service:
   pipelines:
-    traces/tt:
+    traces/tracetest:
       receivers: [otlp]
       processors: [batch]
-      exporters: [otlp/tt]
-    traces/hc:
+      exporters: [otlp/tracetest]
+    traces/honeycomb:
       receivers: [otlp]
       processors: [batch]
-      exporters: [logging, otlp/hc]
+      exporters: [logging, otlp/honeycomb]
 ```
 
 ## Run Both the Node.js App and Tracetest

--- a/docs/docs/examples-tutorials/recipes/running-tracetest-with-lightstep.md
+++ b/docs/docs/examples-tutorials/recipes/running-tracetest-with-lightstep.md
@@ -182,7 +182,7 @@ spec:
 
 The `collector.config.yaml` explains that. It receives traces via either `grpc` or `http`. Then, exports them to Tracetest's OTLP endpoint `tracetest:4317` in one pipeline, and to Lightstep in another.
 
-Make sure to add your Lightstep access token in the headers of the `otlp/ls` exporter.
+Make sure to add your Lightstep access token in the headers of the `otlp/lightstep` exporter.
 
 ```yaml
 receivers:
@@ -199,25 +199,26 @@ exporters:
   logging:
     logLevel: debug
   # OTLP for Tracetest
-  otlp/tt:
+  otlp/tracetest:
     endpoint: tracetest:4317 # Send traces to Tracetest. Read more in docs here: https://docs.tracetest.io/configuration/connecting-to-data-stores/opentelemetry-collector
     tls:
       insecure: true
   # OTLP for Lightstep
+  otlp/lightstep:
     endpoint: ingest.lightstep.com:443
     headers:
       "lightstep-access-token": "<your-lightstep-access-token>" # Send traces to Lightstep. Read more in docs here: https://docs.lightstep.com/otel/otel-quick-start
 
 service:
   pipelines:
-    traces/tt:
+    traces/tracetest:
       receivers: [otlp]
       processors: [batch]
-      exporters: [otlp/tt]
-    traces/ls:
+      exporters: [otlp/tracetest]
+    traces/lightstep:
       receivers: [otlp]
       processors: [batch]
-      exporters: [logging, otlp/ls]
+      exporters: [logging, otlp/lightstep]
 ```
 
 ## Run Both the OpenTelemetry Demo App and Tracetest

--- a/docs/docs/examples-tutorials/recipes/running-tracetest-with-new-relic.md
+++ b/docs/docs/examples-tutorials/recipes/running-tracetest-with-new-relic.md
@@ -222,7 +222,7 @@ service:
       receivers: [otlp]
       processors: [batch]
       exporters: [otlp/tracetest]
-    traces/lightstep:
+    traces/newrelic:
       receivers: [otlp]
       processors: [batch]
       exporters: [logging, otlp/newrelic]

--- a/docs/docs/examples-tutorials/recipes/running-tracetest-with-new-relic.md
+++ b/docs/docs/examples-tutorials/recipes/running-tracetest-with-new-relic.md
@@ -178,7 +178,7 @@ spec:
 
 The `collector.config.yaml` explains that. It receives traces via either `grpc` or `http`. Then, exports them to Tracetest's OTLP endpoint `tracetest:4317` in one pipeline, and to New Relic in another.
 
-Make sure to add your New Relic ingest licence key in the headers of the `otlp/nr` exporter.
+Make sure to add your New Relic ingest licence key in the headers of the `otlp/newrelic` exporter.
 You access the licence key in your New Relic account settings.
 
 ![](https://res.cloudinary.com/djwdcmwdz/image/upload/v1673009509/Blogposts/tracetest-new-relic-partnerships/screely-1673009504630_gko3up.png)
@@ -204,12 +204,12 @@ exporters:
   logging:
     logLevel: debug
   # OTLP for Tracetest
-  otlp/tt:
+  otlp/tracetest:
     endpoint: tracetest:4317 # Send traces to Tracetest. Read more in docs here: https://docs.tracetest.io/configuration/connecting-to-data-stores/opentelemetry-collector
     tls:
       insecure: true
   # OTLP for New Relic
-  otlp/nr:
+  otlp/newrelic:
     endpoint: otlp.nr-data.net:443
     headers:
       "api-key": "<new_relic_ingest_licence_key>" # Send traces to New Relic.
@@ -218,14 +218,14 @@ exporters:
 
 service:
   pipelines:
-    traces/tt:
+    traces/tracetest:
       receivers: [otlp]
       processors: [batch]
-      exporters: [otlp/tt]
-    traces/ls:
+      exporters: [otlp/tracetest]
+    traces/lightstep:
       receivers: [otlp]
       processors: [batch]
-      exporters: [logging, otlp/nr]
+      exporters: [logging, otlp/newrelic]
 ```
 
 **Important!** Take a closer look at the sampling configs in both the `collector.config.yaml` and `tracetest.config.yaml`. They both set sampling to 100%. This is crucial when running trace-based e2e and integration tests.

--- a/examples/quick-start-datadog-nodejs/tracetest/collector.config.yaml
+++ b/examples/quick-start-datadog-nodejs/tracetest/collector.config.yaml
@@ -12,7 +12,7 @@ processors:
 
 exporters:
   # OTLP for Tracetest
-  otlp/tt:
+  otlp/tracetest:
     endpoint: tracetest:4317 # Send traces to Tracetest. Read more in docs here:  https://docs.tracetest.io/configuration/connecting-to-data-stores/opentelemetry-collector
     tls:
       insecure: true
@@ -27,11 +27,11 @@ exporters:
 
 service:
   pipelines:
-    traces/tt:
+    traces/tracetest:
       receivers: [otlp]
       processors: [batch]
-      exporters: [otlp/tt]
-    traces/dd:
+      exporters: [otlp/tracetest]
+    traces/datadog:
       receivers: [otlp]
       processors: [batch]
       exporters: [datadog]

--- a/examples/tracetest-amazon-x-ray-adot/collector.config.yaml
+++ b/examples/tracetest-amazon-x-ray-adot/collector.config.yaml
@@ -8,17 +8,17 @@ processors:
 exporters:
   awsxray:
     region: ${AWS_REGION}
-  otlp/tt:
+  otlp/tracetest:
     endpoint: tracetest:4317
     tls:
       insecure: true
 
 service:
   pipelines:
-    traces/tt:
+    traces/tracetest:
       receivers: [awsxray]
       processors: [batch]
-      exporters: [otlp/tt]
-    traces/xr:
+      exporters: [otlp/tracetest]
+    traces/awsxray:
       receivers: [awsxray]
       exporters: [awsxray]

--- a/examples/tracetest-datadog/tracetest/collector.config.yaml
+++ b/examples/tracetest-datadog/tracetest/collector.config.yaml
@@ -41,7 +41,7 @@ processors:
 
 exporters:
   # OTLP for Tracetest
-  otlp/tt:
+  otlp/tracetest:
     endpoint: tracetest:4317 # Send traces to Tracetest.
                               # Read more in docs here: https://docs.tracetest.io/configuration/connecting-to-data-stores/opentelemetry-collector
     tls:
@@ -56,11 +56,11 @@ exporters:
 
 service:
   pipelines:
-    traces/tt:
+    traces/tracetest:
       receivers: [otlp]
       processors: [batch]
-      exporters: [otlp/tt]
-    traces/dd:
+      exporters: [otlp/tracetest]
+    traces/datadog:
       receivers: [otlp]
       processors: [batch]
       exporters: [datadog]

--- a/examples/tracetest-honeycomb/collector.config.yaml
+++ b/examples/tracetest-honeycomb/collector.config.yaml
@@ -12,12 +12,12 @@ exporters:
   logging:
     logLevel: debug
   # OTLP for Tracetest
-  otlp/tt:
+  otlp/tracetest:
     endpoint: tracetest:4317 # Send traces to Tracetest. Read more in docs here:  https://docs.tracetest.io/configuration/connecting-to-data-stores/opentelemetry-collector
     tls:
       insecure: true
   # OTLP for Honeycomb
-  otlp/hc:
+  otlp/honeycomb:
     endpoint: "api.honeycomb.io:443"
     headers:
       "x-honeycomb-team": <HONEYCOMB_API_KEY>
@@ -26,11 +26,11 @@ exporters:
 
 service:
   pipelines:
-    traces/tt:
+    traces/tracetest:
       receivers: [otlp]
       processors: [batch]
-      exporters: [otlp/tt]
-    traces/hc:
+      exporters: [otlp/tracetest]
+    traces/honeycomb:
       receivers: [otlp]
       processors: [batch]
-      exporters: [logging, otlp/hc]
+      exporters: [logging, otlp/honeycomb]

--- a/examples/tracetest-lightstep-otel-demo/README.md
+++ b/examples/tracetest-lightstep-otel-demo/README.md
@@ -158,7 +158,7 @@ dataStore:
 
 The `otelcol-config-extras.yml` explains that. But first, check the `otelcol-config.yml`. It receives traces via either `grpc` or `http`. Then, in the `otelcol-config-extras.yml` you see a `exporters` that exports traces to Tracetest's OTLP endpoint `tracetest:4317` in one pipeline, and to Lightstep in another.
 
-Make sure to add your Lightstep access token in the headers of the `otlp/ls` exporter.
+Make sure to add your Lightstep access token in the headers of the `otlp/lightstep` exporter.
 
 ```yaml
 # otelcol-config-extras.yml
@@ -172,26 +172,26 @@ processors:
 
 exporters:
   # OTLP for Tracetest
-  otlp/tt:
+  otlp/tracetest:
     endpoint: tracetest:4317 # Send traces to Tracetest. Read more in docs here:  https://docs.tracetest.io/configuration/connecting-to-data-stores/opentelemetry-collector
     tls:
       insecure: true
   # OTLP for Lightstep
-  otlp/ls:
+  otlp/lightstep:
     endpoint: ingest.lightstep.com:443
     headers:
       "lightstep-access-token": "<lightstep_access_token>" # Send traces to Lightstep. Read more in docs here: https://docs.lightstep.com/otel/otel-quick-start
 
 service:
   pipelines:
-    traces/tt:
+    traces/tracetest:
       receivers: [otlp]
       processors: [batch]
-      exporters: [otlp/tt]
-    traces/ls:
+      exporters: [otlp/tracetest]
+    traces/lightstep:
       receivers: [otlp]
       processors: [batch]
-      exporters: [logging, otlp/ls]
+      exporters: [logging, otlp/lightstep]
 ```
 
 ## Run the OpenTelemetry Demo with Tracetest

--- a/examples/tracetest-lightstep-otel-demo/otelcollector/otelcol-config-extras.yml
+++ b/examples/tracetest-lightstep-otel-demo/otelcollector/otelcol-config-extras.yml
@@ -7,23 +7,23 @@ processors:
 
 exporters:
   # OTLP for Tracetest
-  otlp/tt:
+  otlp/tracetest:
     endpoint: tracetest:4317 # Send traces to Tracetest. Read more in docs here:  https://docs.tracetest.io/configuration/connecting-to-data-stores/opentelemetry-collector
     tls:
       insecure: true
   # OTLP for Lightstep
-  otlp/ls:
+  otlp/lightstep:
     endpoint: ingest.lightstep.com:443
     headers:
       "lightstep-access-token": "<lightstep_access_token>" # Send traces to Lightstep. Read more in docs here: https://docs.lightstep.com/otel/otel-quick-start 
 
 service:
   pipelines:
-    traces/tt:
+    traces/tracetest:
       receivers: [otlp]
       processors: [batch]
-      exporters: [otlp/tt]
-    traces/ls:
+      exporters: [otlp/tracetest]
+    traces/lightstep:
       receivers: [otlp]
       processors: [batch]
-      exporters: [logging, otlp/ls]
+      exporters: [logging, otlp/lightstep]

--- a/examples/tracetest-lightstep/tracetest/collector.config.yaml
+++ b/examples/tracetest-lightstep/tracetest/collector.config.yaml
@@ -12,23 +12,23 @@ exporters:
   logging:
     logLevel: debug
   # OTLP for Tracetest
-  otlp/tt:
+  otlp/tracetest:
     endpoint: tracetest:4317 # Send traces to Tracetest. Read more in docs here:  https://docs.tracetest.io/configuration/connecting-to-data-stores/opentelemetry-collector
     tls:
       insecure: true
   # OTLP for Lightstep
-  otlp/ls:
+  otlp/lightstep:
     endpoint: ingest.lightstep.com:443
     headers:
       "lightstep-access-token": "<lightstep_access_token>" # Send traces to Lightstep. Read more in docs here: https://docs.lightstep.com/otel/otel-quick-start 
 
 service:
   pipelines:
-    traces/tt:
+    traces/tracetest:
       receivers: [otlp]
       processors: [batch]
-      exporters: [otlp/tt]
-    traces/ls:
+      exporters: [otlp/tracetest]
+    traces/lightstep:
       receivers: [otlp]
       processors: [batch]
-      exporters: [logging, otlp/ls]
+      exporters: [logging, otlp/lightstep]

--- a/examples/tracetest-new-relic-otel-demo/README.md
+++ b/examples/tracetest-new-relic-otel-demo/README.md
@@ -158,7 +158,7 @@ dataStore:
 
 The `otelcol-config-extras.yml` explains that. But first, check the `otelcol-config.yml`. It receives traces via either `grpc` or `http`. Then, in the `otelcol-config-extras.yml` you see a `exporters` that exports traces to Tracetest's OTLP endpoint `tracetest:4317` in one pipeline, and to New Relic in another.
 
-Make sure to add your New Relic access token in the headers of the `otlp/nr` exporter.
+Make sure to add your New Relic access token in the headers of the `otlp/newrelic` exporter.
 
 ```yaml
 # otelcol-config-extras.yml
@@ -172,11 +172,11 @@ processors:
 
 exporters:
   # OTLP for Tracetest
-  otlp/tt:
+  otlp/tracetest:
     endpoint: tracetest:4317 # Send traces to Tracetest. Read more in docs here:  https://docs.tracetest.io/configuration/connecting-to-data-stores/opentelemetry-collector
     tls:
       insecure: true
-  otlp/nr:
+  otlp/newrelic:
     endpoint: otlp.nr-data.net:443
     headers:
       api-key: <new_relic_ingest_licence_key> # Send traces to New Relic.
@@ -185,14 +185,14 @@ exporters:
 
 service:
   pipelines:
-    traces/tt:
+    traces/tracetest:
       receivers: [otlp]
       processors: [batch]
-      exporters: [otlp/tt]
-    traces/nr:
+      exporters: [otlp/tracetest]
+    traces/newrelic:
       receivers: [otlp]
       processors: [batch]
-      exporters: [logging, otlp/nr]
+      exporters: [logging, otlp/newrelic]
 ```
 
 ## Run the OpenTelemetry Demo with Tracetest and New Relic

--- a/examples/tracetest-new-relic-otel-demo/otelcollector/otelcol-config-extras.yml
+++ b/examples/tracetest-new-relic-otel-demo/otelcollector/otelcol-config-extras.yml
@@ -7,11 +7,11 @@ processors:
 
 exporters:
   # OTLP for Tracetest
-  otlp/tt:
+  otlp/tracetest:
     endpoint: tracetest:4317 # Send traces to Tracetest. Read more in docs here:  https://docs.tracetest.io/configuration/connecting-to-data-stores/opentelemetry-collector
     tls:
       insecure: true
-  otlp/nr:
+  otlp/newrelic:
     endpoint: otlp.nr-data.net:443
     headers:
       api-key: <new_relic_ingest_licence_key> # Send traces to New Relic.
@@ -20,11 +20,11 @@ exporters:
 
 service:
   pipelines:
-    traces/tt:
+    traces/tracetest:
       receivers: [otlp]
       processors: [batch]
-      exporters: [otlp/tt]
-    traces/nr:
+      exporters: [otlp/tracetest]
+    traces/newrelic:
       receivers: [otlp]
       processors: [batch]
-      exporters: [logging, otlp/nr]
+      exporters: [logging, otlp/newrelic]

--- a/examples/tracetest-new-relic/tracetest/collector.config.yaml
+++ b/examples/tracetest-new-relic/tracetest/collector.config.yaml
@@ -12,12 +12,12 @@ exporters:
   logging:
     logLevel: debug
   # OTLP for Tracetest
-  otlp/tt:
+  otlp/tracetest:
     endpoint: tracetest:4317 # Send traces to Tracetest. Read more in docs here:  https://docs.tracetest.io/configuration/connecting-to-data-stores/opentelemetry-collector
     tls:
       insecure: true
   # OTLP for New Relic
-  otlp/nr:
+  otlp/newrelic:
     endpoint: otlp.nr-data.net:443
     headers:
       api-key: <new_relic_ingest_licence_key> # Send traces to New Relic.
@@ -26,11 +26,11 @@ exporters:
 
 service:
   pipelines:
-    traces/tt:
+    traces/tracetest:
       receivers: [otlp]
       processors: [batch]
-      exporters: [otlp/tt]
-    traces/nr:
+      exporters: [otlp/tracetest]
+    traces/newrelic:
       receivers: [otlp]
       processors: [batch]
-      exporters: [logging, otlp/nr]
+      exporters: [logging, otlp/newrelic]

--- a/web/src/constants/CollectorConfig.constants.ts
+++ b/web/src/constants/CollectorConfig.constants.ts
@@ -14,26 +14,26 @@ exporters:
   logging:
     logLevel: debug
   # OTLP for Tracetest
-  otlp/tt:
+  otlp/tracetest:
     endpoint: tracetest:4317 # Send traces to Tracetest. Read more in docs here:  https://docs.tracetest.io/configuration/connecting-to-data-stores/opentelemetry-collector
     tls:
       insecure: true
   # OTLP for Lightstep
-  otlp/ls:
+  otlp/lightstep:
     endpoint: ingest.lightstep.com:443
     headers:
       "lightstep-access-token": "<lightstep_access_token>" # Send traces to Lightstep. Read more in docs here: https://docs.lightstep.com/otel/otel-quick-start
 
 service:
   pipelines:
-    traces/tt:
+    traces/tracetest:
       receivers: [otlp]
       processors: [batch]
-      exporters: [otlp/tt]
-    traces/ls:
+      exporters: [otlp/tracetest]
+    traces/lightstep:
       receivers: [otlp]
       processors: [batch]
-      exporters: [logging, otlp/ls]
+      exporters: [logging, otlp/lightstep]
 `;
 
 export const OtelCollector = `receivers:
@@ -74,12 +74,12 @@ exporters:
   logging:
     logLevel: debug
   # OTLP for Tracetest
-  otlp/tt:
+  otlp/tracetest:
     endpoint: tracetest:4317 # Send traces to Tracetest. Read more in docs here:  https://docs.tracetest.io/configuration/connecting-to-data-stores/opentelemetry-collector
     tls:
       insecure: true
   # OTLP for New Relic
-  otlp/nr:
+  otlp/newrelic:
     endpoint: otlp.nr-data.net:443
     headers:
       api-key: <new_relic_ingest_licence_key> # Send traces to New Relic.
@@ -88,14 +88,14 @@ exporters:
 
 service:
   pipelines:
-    traces/tt:
+    traces/tracetest:
       receivers: [otlp]
       processors: [batch]
-      exporters: [otlp/tt]
-    traces/nr:
+      exporters: [otlp/tracetest]
+    traces/newrelic:
       receivers: [otlp]
       processors: [batch]
-      exporters: [logging, otlp/nr]
+      exporters: [logging, otlp/newrelic]
 `;
 
 export const Datadog = `receivers:
@@ -112,7 +112,7 @@ processors:
 
 exporters:
   # OTLP for Tracetest
-  otlp/tt:
+  otlp/tracetest:
     endpoint: tracetest:4317 # Send traces to Tracetest. Read more in docs here:  https://docs.tracetest.io/configuration/connecting-to-data-stores/opentelemetry-collector
     tls:
       insecure: true
@@ -124,11 +124,11 @@ exporters:
       # Read more in docs here: https://docs.datadoghq.com/opentelemetry/otel_collector_datadog_exporter
 service:
   pipelines:
-    traces/tt:
+    traces/tracetest:
       receivers: [otlp]
       processors: [batch]
-      exporters: [otlp/tt]
-    traces/dd:
+      exporters: [otlp/tracetest]
+    traces/datadog:
       receivers: [otlp]
       processors: [batch]
       exporters: [datadog]
@@ -148,12 +148,12 @@ exporters:
   logging:
     logLevel: debug
   # OTLP for Tracetest
-  otlp/tt:
+  otlp/tracetest:
     endpoint: tracetest:4317 # Send traces to Tracetest. Read more in docs here:  https://docs.tracetest.io/configuration/connecting-to-data-stores/opentelemetry-collector
     tls:
       insecure: true
   # OTLP for Honeycomb
-  otlp/hc:
+  otlp/honeycomb:
     endpoint: "api.honeycomb.io:443"
     headers:
       "x-honeycomb-team": "YOUR_API_KEY"
@@ -161,14 +161,14 @@ exporters:
 
 service:
   pipelines:
-    traces/tt:
+    traces/tracetest:
       receivers: [otlp]
       processors: [batch]
-      exporters: [otlp/tt]
-    traces/hc:
+      exporters: [otlp/tracetest]
+    traces/honeycomb:
       receivers: [otlp]
       processors: [batch]
-      exporters: [logging, otlp/hc]
+      exporters: [logging, otlp/honeycomb]
 `;
 
 export const CollectorConfigMap = {


### PR DESCRIPTION
Replacing all the abbreviations for tracetest and the data store vendors names with full names to make the docs more clear.

We used the following in our collector configs:
tt for tracetest
nr for newrelic
hc for honeycomb
ls for lightstep
dd for datadog

This pr replaces the abbreviation with the full name. It helps make it clear what the different sections are as opposed to having users have to translate 'tt' into 'tracetest', hopefully making things more clear. This change was recommended by Alayshia at Honeycomb.