### PR TITLE
feat(server): add analytics middleware

### DIFF
--- a/cli/analytics/analytics.go
+++ b/cli/analytics/analytics.go
@@ -33,7 +33,7 @@ func Init(conf config.Config) {
 	if err == nil {
 		// only use id if available.
 		mid = id
-	} // ignore errors and continue with an empty ID if neccesary
+	} // ignore errors and continue with an empty ID if necessary
 
 	client.Enqueue(segment.Identify{
 		UserId: mid,

--- a/cli/utils/api.go
+++ b/cli/utils/api.go
@@ -28,6 +28,7 @@ type ListArgs struct {
 func GetAPIClient(cliConfig config.Config) *openapi.APIClient {
 	config := openapi.NewConfiguration()
 	config.AddDefaultHeader("x-client-id", analytics.ClientID())
+	config.AddDefaultHeader("x-source", "cli")
 	config.Scheme = cliConfig.Scheme
 	config.Host = strings.TrimSuffix(cliConfig.Endpoint, "/")
 	if cliConfig.ServerPath != nil {
@@ -84,6 +85,7 @@ func (resourceClient ResourceClient) NewRequest(url, method, body, contentType s
 	}
 
 	request.Header.Set("x-client-id", analytics.ClientID())
+	request.Header.Set("x-source", "cli")
 	request.Header.Set("Content-Type", contentType)
 	request.Header.Set("Accept", contentType)
 	if augmented {

--- a/server/resourcemanager/resource_manager.go
+++ b/server/resourcemanager/resource_manager.go
@@ -130,7 +130,7 @@ func (m *manager[T]) RegisterRoutes(r *mux.Router) *mux.Router {
 	enabledOps := m.EnabledOperations()
 
 	if slices.Contains(enabledOps, OperationList) {
-		m.instrumentRoute(subrouter.HandleFunc("", m.list).Methods(http.MethodGet).Name("list"))
+		m.instrumentRoute(subrouter.HandleFunc("", m.list).Methods(http.MethodGet).Name(fmt.Sprintf("%s.List", m.resourceTypePlural)))
 	}
 
 	if slices.Contains(enabledOps, OperationCreate) {

--- a/web/src/redux/apis/TraceTest.api.ts
+++ b/web/src/redux/apis/TraceTest.api.ts
@@ -17,6 +17,9 @@ const TraceTestAPI = createApi({
   reducerPath: 'tests',
   baseQuery: fetchBaseQuery({
     baseUrl: PATH,
+    prepareHeaders: headers => {
+      headers.set('x-source', 'web');
+    },
   }),
   tagTypes: Object.values(TracetestApiTags),
   endpoints(builder: TTestApiEndpointBuilder) {


### PR DESCRIPTION
This PR adds an `analytics middleware` to the router in order to track/send events from the server.

## Changes

- add analytics middleware
- implements the `x-source` header
- remove route middleware in custom controller

## Fixes

- #2539 

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
