### PR TITLE
fix(cli): wait-for-result never exists if test ends with analyzer error

### DIFF
--- a/cli/utils/run_state.go
+++ b/cli/utils/run_state.go
@@ -8,5 +8,6 @@ func RunStateIsFailed(state string) bool {
 	return state == "TRIGGER_FAILED" ||
 		state == "TRACE_FAILED" ||
 		state == "ASSERTION_FAILED" ||
+		state == "ANALYZING_ERROR" ||
 		state == "FAILED" // this one is for backwards compatibility
 }


### PR DESCRIPTION
This PR fixes the CLI to correctly support analyzer errors when waiting for results.

## Fixes

- https://github.com/kubeshop/tracetest/issues/2685

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
