### PR TITLE
fix(frontend): fix missing dep in useEffect in TestSpec form

### DIFF
--- a/web/src/components/TestSpecForm/TestSpecForm.tsx
+++ b/web/src/components/TestSpecForm/TestSpecForm.tsx
@@ -76,14 +76,12 @@ const TestSpecForm = ({
   }, []);
 
   useEffect(() => {
-    if (!isEditing) {
-      form.setFieldsValue({
-        selector,
-        name,
-        assertions,
-      });
-    }
-  }, [form, isEditing, name, selector]);
+    form.setFieldsValue({
+      selector,
+      name,
+      assertions,
+    });
+  }, [assertions, form, name, selector]);
 
   const selectorSuggestions = useAppSelector(TestSpecsSelectors.selectSelectorSuggestions);
   const prevSelector = useAppSelector(TestSpecsSelectors.selectPrevSelector);


### PR DESCRIPTION
This PR fixes a missing dependency in our `TestSpec` form that was causing a bug when trying to create a new spec from the attribute list using the same selector.

## Changes

- add missing dependency

## Fixes

- fixes #2484 

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
