### PR TITLE
feature: Improving Analyzer Failure State

### DIFF
--- a/api/linters.yaml
+++ b/api/linters.yaml
@@ -42,6 +42,8 @@ components:
     LinterResult:
       type: object
       properties:
+        minimumScore:
+          type: integer
         passed:
           type: boolean
         score:

--- a/cli/openapi/model_linter_result.go
+++ b/cli/openapi/model_linter_result.go
@@ -19,9 +19,10 @@ var _ MappedNullable = &LinterResult{}
 
 // LinterResult struct for LinterResult
 type LinterResult struct {
-	Passed  *bool                `json:"passed,omitempty"`
-	Score   *int32               `json:"score,omitempty"`
-	Plugins []LinterResultPlugin `json:"plugins,omitempty"`
+	MinimumScore *int32               `json:"minimumScore,omitempty"`
+	Passed       *bool                `json:"passed,omitempty"`
+	Score        *int32               `json:"score,omitempty"`
+	Plugins      []LinterResultPlugin `json:"plugins,omitempty"`
 }
 
 // NewLinterResult instantiates a new LinterResult object
@@ -39,6 +40,38 @@ func NewLinterResult() *LinterResult {
 func NewLinterResultWithDefaults() *LinterResult {
 	this := LinterResult{}
 	return &this
+}
+
+// GetMinimumScore returns the MinimumScore field value if set, zero value otherwise.
+func (o *LinterResult) GetMinimumScore() int32 {
+	if o == nil || isNil(o.MinimumScore) {
+		var ret int32
+		return ret
+	}
+	return *o.MinimumScore
+}
+
+// GetMinimumScoreOk returns a tuple with the MinimumScore field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *LinterResult) GetMinimumScoreOk() (*int32, bool) {
+	if o == nil || isNil(o.MinimumScore) {
+		return nil, false
+	}
+	return o.MinimumScore, true
+}
+
+// HasMinimumScore returns a boolean if a field has been set.
+func (o *LinterResult) HasMinimumScore() bool {
+	if o != nil && !isNil(o.MinimumScore) {
+		return true
+	}
+
+	return false
+}
+
+// SetMinimumScore gets a reference to the given int32 and assigns it to the MinimumScore field.
+func (o *LinterResult) SetMinimumScore(v int32) {
+	o.MinimumScore = &v
 }
 
 // GetPassed returns the Passed field value if set, zero value otherwise.
@@ -147,6 +180,9 @@ func (o LinterResult) MarshalJSON() ([]byte, error) {
 
 func (o LinterResult) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
+	if !isNil(o.MinimumScore) {
+		toSerialize["minimumScore"] = o.MinimumScore
+	}
 	if !isNil(o.Passed) {
 		toSerialize["passed"] = o.Passed
 	}

--- a/server/executor/linter_runner.go
+++ b/server/executor/linter_runner.go
@@ -134,12 +134,6 @@ func (e *defaultlinterRunner) onRequest(request LinterRequest) {
 		return
 	}
 
-	err = lintResource.ValidateResult(run.Linter)
-	if err != nil {
-		e.onError(ctx, request, run, err)
-		return
-	}
-
 	e.onFinish(ctx, request, run)
 }
 
@@ -173,7 +167,8 @@ func (e *defaultlinterRunner) onRun(ctx context.Context, request LinterRequest, 
 		return e.onError(ctx, request, run, err)
 	}
 
-	run = run.SuccessfullinterExecution(result)
+	result.MinimumScore = linterResource.MinimumScore
+	run = run.SuccessfulLinterExecution(result)
 	err = e.updater.Update(ctx, run)
 	if err != nil {
 		log.Printf("[linterRunner] Test %s Run %d: error updating run: %s\n", request.Test.ID, request.Run.ID, err.Error())

--- a/server/http/mappings/linter.go
+++ b/server/http/mappings/linter.go
@@ -12,9 +12,10 @@ func (m OpenAPI) LinterResult(in model.LinterResult) openapi.LinterResult {
 	}
 
 	return openapi.LinterResult{
-		Passed:  in.Passed,
-		Score:   int32(in.Score),
-		Plugins: plugins,
+		Passed:       in.Passed,
+		Score:        int32(in.Score),
+		Plugins:      plugins,
+		MinimumScore: int32(in.MinimumScore),
 	}
 }
 

--- a/server/linter/resource/model.go
+++ b/server/linter/resource/model.go
@@ -3,9 +3,7 @@ package linter_resource
 import (
 	"fmt"
 
-	"github.com/kubeshop/tracetest/server/model"
 	"github.com/kubeshop/tracetest/server/pkg/id"
-	"golang.org/x/exp/slices"
 )
 
 type (
@@ -44,37 +42,4 @@ func (l Linter) HasID() bool {
 
 func (l Linter) GetID() id.ID {
 	return l.ID
-}
-
-func (l Linter) ValidateResult(result model.LinterResult) error {
-	if l.MinimumScore != 0 && result.Score < l.MinimumScore {
-		return fmt.Errorf("linter score validation failed. Minimum %d, Actual: %d", l.MinimumScore, result.Score)
-	}
-
-	failedPlugins := make([]string, 0)
-	for _, plugin := range result.Plugins {
-		if !plugin.Passed {
-			failedPlugins = append(failedPlugins, plugin.Name)
-		}
-	}
-
-	if len(failedPlugins) == 0 {
-		return nil
-	}
-
-	requiredPlugins := make([]string, 0)
-	for _, plugin := range l.Plugins {
-		if plugin.Required {
-			requiredPlugins = append(requiredPlugins, plugin.Name)
-		}
-	}
-
-	for _, plugin := range requiredPlugins {
-		index := slices.IndexFunc(failedPlugins, func(failedPlugin string) bool { return failedPlugin == plugin })
-		if index >= 0 {
-			return fmt.Errorf("linter failed. Required plugin %s failed", plugin)
-		}
-	}
-
-	return nil
 }

--- a/server/model/linter.go
+++ b/server/model/linter.go
@@ -43,9 +43,10 @@ type Rule interface {
 }
 
 type LinterResult struct {
-	Plugins []PluginResult `json:"plugins"`
-	Score   int            `json:"score"`
-	Passed  bool           `json:"passed"`
+	Plugins      []PluginResult `json:"plugins"`
+	Score        int            `json:"score"`
+	MinimumScore int            `json:"minimumScore"`
+	Passed       bool           `json:"passed"`
 }
 
 type BaseRule struct {

--- a/server/model/run.go
+++ b/server/model/run.go
@@ -152,7 +152,7 @@ func (r Run) LinterError(err error) Run {
 	return r.Finish()
 }
 
-func (r Run) SuccessfullinterExecution(linter LinterResult) Run {
+func (r Run) SuccessfulLinterExecution(linter LinterResult) Run {
 	r.State = RunStateAwaitingTestResults
 	r.Linter = linter
 

--- a/server/openapi/model_linter_result.go
+++ b/server/openapi/model_linter_result.go
@@ -10,6 +10,8 @@
 package openapi
 
 type LinterResult struct {
+	MinimumScore int32 `json:"minimumScore,omitempty"`
+
 	Passed bool `json:"passed,omitempty"`
 
 	Score int32 `json:"score,omitempty"`

--- a/web/src/components/AnalyzerResult/AnalyzerResult.styled.ts
+++ b/web/src/components/AnalyzerResult/AnalyzerResult.styled.ts
@@ -23,31 +23,27 @@ export const Description = styled(Typography.Paragraph).attrs({
   }
 `;
 
-export const ScoreWrapper = styled.div`
-  position: relative;
+export const GlobalResultWrapper = styled.div`
+  display: grid;
+  grid-template-columns: auto 1fr;
+  margin-bottom: 28px;
+  gap: 45px;
 `;
 
-export const ScoreTexContainer = styled.div`
-  position: absolute;
+export const GlobalScoreWrapper = styled.div`
   display: flex;
   flex-direction: column;
-  justify-content: center;
   align-items: center;
-  width: 100%;
-  height: 100%;
 `;
 
-export const Score = styled(Typography.Title)`
-  && {
-    font-size: 12px;
-    margin-bottom: 0;
-  }
+export const ScoreResultWrapper = styled(GlobalScoreWrapper)`
+  align-items: flex-start;
 `;
 
-export const ScoreContainer = styled.div`
-  margin-bottom: 24px;
-  text-align: center;
-  cursor: pointer;
+export const GlobalScoreContainer = styled.div`
+  display: flex;
+  flex-direction: row;
+  justify-content: center;
 `;
 
 export const RuleContainer = styled.div`
@@ -76,6 +72,12 @@ export const RuleBody = styled(Column)`
 export const Subtitle = styled(Typography.Title)`
   && {
     margin-bottom: 8px;
+  }
+`;
+
+export const ResultText = styled(Typography.Text)<{$passed: boolean}>`
+  && {
+    color: ${({theme, $passed}) => ($passed ? theme.color.success : theme.color.error)};
   }
 `;
 

--- a/web/src/components/AnalyzerResult/AnalyzerResult.tsx
+++ b/web/src/components/AnalyzerResult/AnalyzerResult.tsx
@@ -1,21 +1,20 @@
 import {Link} from 'react-router-dom';
-import {Col, Row, Tooltip} from 'antd';
 import LinterResult from 'models/LinterResult.model';
 import Trace from 'models/Trace.model';
 import {DISCORD_URL, OCTOLIINT_ISSUE_URL} from 'constants/Common.constants';
 import {useSettingsValues} from 'providers/SettingsValues/SettingsValues.provider';
 import * as S from './AnalyzerResult.styled';
-import LintScore from '../LintScore/LintScore';
 import BetaBadge from '../BetaBadge/BetaBadge';
 import Empty from './Empty';
 import Plugins from './Plugins';
+import GlobalResult from './GlobalResult';
 
 interface IProps {
   result: LinterResult;
   trace: Trace;
 }
 
-const AnalyzerResult = ({result: {score, passed, plugins = []}, trace}: IProps) => {
+const AnalyzerResult = ({result: {score, minimumScore, plugins = []}, trace}: IProps) => {
   const {linter} = useSettingsValues();
 
   return (
@@ -40,25 +39,7 @@ const AnalyzerResult = ({result: {score, passed, plugins = []}, trace}: IProps) 
 
       {plugins.length ? (
         <>
-          <Row gutter={[16, 16]}>
-            <Col span={8} key="avg_result">
-              <Tooltip title="Tracetest core system supports analyzer evaluation as part of the testing capabilities.">
-                <S.ScoreContainer>
-                  <S.Subtitle level={3}>Trace Analyzer Result</S.Subtitle> <LintScore score={score} passed={passed} />
-                </S.ScoreContainer>
-              </Tooltip>
-            </Col>
-            {plugins.map(plugin => (
-              <Col span={8} key={plugin.name}>
-                <Tooltip title={plugin.description}>
-                  <S.ScoreContainer key={plugin.name}>
-                    <S.Subtitle level={3}>{plugin.name}</S.Subtitle>
-                    <LintScore score={plugin.score} passed={plugin.passed} />
-                  </S.ScoreContainer>
-                </Tooltip>
-              </Col>
-            ))}
-          </Row>
+          <GlobalResult score={score} minimumScore={minimumScore} />
           <Plugins plugins={plugins} trace={trace} />
         </>
       ) : (

--- a/web/src/components/AnalyzerResult/GlobalResult.tsx
+++ b/web/src/components/AnalyzerResult/GlobalResult.tsx
@@ -1,0 +1,36 @@
+import * as S from './AnalyzerResult.styled';
+import PercentageScore from '../LintScore/PercentageScore';
+import {TooltipQuestion} from '../TooltipQuestion/TooltipQuestion';
+
+interface IProps {
+  score: number;
+  minimumScore: number;
+}
+
+const GlobalResult = ({score, minimumScore}: IProps) => {
+  const passedScore = score >= minimumScore;
+
+  return (
+    <S.GlobalResultWrapper>
+      <S.GlobalScoreWrapper>
+        <S.Subtitle level={3}>
+          Overall Trace Analyzer Score
+          <TooltipQuestion title="Tracetest core system supports analyzer evaluation as part of the testing capabilities." />
+        </S.Subtitle>
+        <S.GlobalScoreContainer>
+          <PercentageScore score={score} />
+        </S.GlobalScoreContainer>
+      </S.GlobalScoreWrapper>
+      {!!minimumScore && (
+        <S.ScoreResultWrapper>
+          <S.Subtitle level={3}>Minimum Acceptable Score: {minimumScore}</S.Subtitle>
+          <S.Subtitle level={3}>
+            Result: <S.ResultText $passed={passedScore}>{passedScore ? 'Passed' : 'Failed'}</S.ResultText>
+          </S.Subtitle>
+        </S.ScoreResultWrapper>
+      )}
+    </S.GlobalResultWrapper>
+  );
+};
+
+export default GlobalResult;

--- a/web/src/components/AnalyzerResult/Plugins.tsx
+++ b/web/src/components/AnalyzerResult/Plugins.tsx
@@ -36,7 +36,7 @@ const Plugins = ({plugins, trace}: IProps) => {
         <S.PluginPanel
           header={
             <Space>
-              <LintScore width="35px" height="35px" score={plugin.score} passed={plugin.passed} />
+              <LintScore width="35px" height="35px" score={plugin.score} />
               <Typography.Text strong>{plugin.name}</Typography.Text>
               <Typography.Text type="secondary">{plugin.description}</Typography.Text>
             </Space>

--- a/web/src/components/LintScore/LintScore.styled.ts
+++ b/web/src/components/LintScore/LintScore.styled.ts
@@ -1,5 +1,5 @@
 import {Progress, Typography} from 'antd';
-import styled from 'styled-components';
+import styled, {DefaultTheme} from 'styled-components';
 
 export const ScoreWrapper = styled.div`
   position: relative;
@@ -22,15 +22,49 @@ export const Score = styled(Typography.Title)`
   }
 `;
 
+export const PercentageScoreWrapper = styled.div`
+  position: relative;
+  display: flex;
+  gap: 8px;
+  align-items: center;
+`;
+
+export const PercentageScore = styled(Typography.Title)`
+  && {
+    font-size: ${({theme}) => theme.size.xxxl};
+    margin-bottom: 0;
+  }
+`;
+
 export const ScoreContainer = styled.div`
   margin-bottom: 24px;
   text-align: center;
 `;
 
-export const ScoreProgress = styled(Progress)<{$height?: string, $width?: string }>`
+const getScoreColor = (score: number, theme: DefaultTheme) => {
+  if (score >= 90) {
+    return theme.color.success;
+  }
+
+  if (score >= 60) {
+    return theme.color.warningYellow;
+  }
+
+  return theme.color.error;
+};
+
+interface IScoreProgressProps {
+  $height?: string;
+  $width?: string;
+  $score: number;
+}
+
+export const ScoreProgress = styled(Progress).attrs<IScoreProgressProps>(({$score, theme}) => ({
+  strokeColor: getScoreColor($score, theme),
+}))<IScoreProgressProps>`
   .ant-progress-inner {
-    height: ${({$height = "50px"}) => $height} !important;
-    width: ${({$width = "50px"}) => $width} !important;
+    height: ${({$height = '50px'}) => $height} !important;
+    width: ${({$width = '50px'}) => $width} !important;
   }
 
   .ant-progress-circle-trail,

--- a/web/src/components/LintScore/LintScore.tsx
+++ b/web/src/components/LintScore/LintScore.tsx
@@ -2,12 +2,11 @@ import * as S from './LintScore.styled';
 
 interface IProps {
   score: number;
-  passed: boolean;
   height?: string;
   width?: string;
 }
 
-const LintScore = ({score, passed, height, width}: IProps) => {
+const LintScore = ({score, height, width}: IProps) => {
   return (
     <S.ScoreWrapper>
       <S.ScoreTexContainer>
@@ -17,8 +16,8 @@ const LintScore = ({score, passed, height, width}: IProps) => {
         $height={height}
         $width={width}
         format={() => ''}
-        percent={score}
-        status={passed ? 'success' : 'exception'}
+        percent={score || 100}
+        $score={score}
         type="circle"
       />
     </S.ScoreWrapper>

--- a/web/src/components/LintScore/PercentageScore.tsx
+++ b/web/src/components/LintScore/PercentageScore.tsx
@@ -1,0 +1,18 @@
+import * as S from './LintScore.styled';
+
+interface IProps {
+  score: number;
+  height?: string;
+  width?: string;
+}
+
+const Percentage = ({score, height, width}: IProps) => {
+  return (
+    <S.PercentageScoreWrapper>
+      <S.Score level={1}>{score}%</S.Score>
+      <S.ScoreProgress $height={height} $width={width} $score={score} format={() => ''} percent={score || 100} type="circle" />
+    </S.PercentageScoreWrapper>
+  );
+};
+
+export default Percentage;

--- a/web/src/components/RunCard/TestRunCard.tsx
+++ b/web/src/components/RunCard/TestRunCard.tsx
@@ -12,14 +12,14 @@ interface IProps {
   linkTo: string;
 }
 
-function getIcon(state: TestRun['state'], failedAssertions: number) {
+function getIcon(state: TestRun['state'], failedAssertions: number, isFailedAnalyzer: boolean) {
   if (!isRunStateFinished(state)) {
     return null;
   }
   if (isRunStateStopped(state)) {
     return <S.IconInfo />;
   }
-  if (isRunStateFailed(state) || failedAssertions > 0) {
+  if (isRunStateFailed(state) || failedAssertions > 0 || isFailedAnalyzer) {
     return <S.IconFail />;
   }
   return <S.IconSuccess />;
@@ -37,6 +37,7 @@ const TestRunCard = ({
     metadata,
     transactionId,
     transactionRunId,
+    linter,
   },
   testId,
   linkTo,
@@ -49,7 +50,7 @@ const TestRunCard = ({
   return (
     <Link to={linkTo}>
       <S.Container $isWhite data-cy={`run-card-${runId}`}>
-        <S.IconContainer>{getIcon(state, failedAssertionCount)}</S.IconContainer>
+        <S.IconContainer>{getIcon(state, failedAssertionCount, linter.isFailed)}</S.IconContainer>
 
         <S.Info>
           <div>

--- a/web/src/components/TransactionRunResult/ExecutionStep.tsx
+++ b/web/src/components/TransactionRunResult/ExecutionStep.tsx
@@ -10,12 +10,17 @@ import Test from 'models/Test.model';
 import TestRun from 'models/TestRun.model';
 import * as S from './TransactionRunResult.styled';
 
-const iconBasedOnResult = (state: TTestRunState, failedAssertions: number, index: number) => {
+const iconBasedOnResult = (
+  state: TTestRunState,
+  failedAssertions: number,
+  index: number,
+  isFailedAnalyzer: boolean
+) => {
   if (state !== TestState.FAILED && state !== TestState.FINISHED) {
     return null;
   }
 
-  if (state === TestState.FAILED || failedAssertions > 0) {
+  if (state === TestState.FAILED || failedAssertions > 0 || isFailedAnalyzer) {
     return <S.IconFail />;
   }
   if (state === TestState.FINISHED || failedAssertions === 0) {
@@ -36,7 +41,7 @@ const ExecutionStep = ({
   index,
   test: {name, trigger, id: testId},
   hasRunFailed,
-  testRun: {id: runId, state, testVersion, passedAssertionCount, failedAssertionCount, outputs} = TestRun({
+  testRun: {id: runId, state, testVersion, passedAssertionCount, failedAssertionCount, outputs, linter} = TestRun({
     state: hasRunFailed ? TestState.SKIPPED : TestState.WAITING,
   }),
 }: IProps) => {
@@ -47,7 +52,9 @@ const ExecutionStep = ({
   return (
     <S.Container data-cy={`transaction-execution-step-${name}`}>
       <S.Content>
-        <S.ExecutionStepStatus>{iconBasedOnResult(state, failedAssertionCount, index)}</S.ExecutionStepStatus>
+        <S.ExecutionStepStatus>
+          {iconBasedOnResult(state, failedAssertionCount, index, linter.isFailed)}
+        </S.ExecutionStepStatus>
         <Link to={toLink} target="_blank">
           <S.Info>
             <S.ItemName>{`${name} v${testVersion}`}</S.ItemName>

--- a/web/src/constants/Theme.constants.ts
+++ b/web/src/constants/Theme.constants.ts
@@ -25,6 +25,7 @@ export const theme: DefaultTheme = {
     md: '14px',
     lg: '16px',
     xl: '18px',
+    xxxl: '24px',
   },
   font: {
     family: 'SFPro',

--- a/web/src/models/LinterResult.model.ts
+++ b/web/src/models/LinterResult.model.ts
@@ -8,7 +8,7 @@ type TRawLinterResultPluginRuleResult = TLintersSchemas['LinterResultPluginRuleR
 type LinterResultPluginRuleResult = Model<TRawLinterResultPluginRuleResult, {}>;
 type LinterResultPluginRule = Model<TRawLinterResultPluginRule, {results: LinterResultPluginRuleResult[]}>;
 type LinterResultPlugin = Model<TRawLinterResultPlugin, {rules: LinterResultPluginRule[]}>;
-type LinterResult = Model<TRawLinterResult, {plugins: LinterResultPlugin[]}>;
+type LinterResult = Model<TRawLinterResult, {plugins: LinterResultPlugin[]; isFailed: boolean}>;
 
 function LinterResultPluginRuleResult({
   spanId = '',
@@ -47,11 +47,18 @@ function LinterResultPlugin({
   return {name, description, passed, score, rules: rules.map(rule => LinterResultPluginRule(rule))};
 }
 
-function LinterResult({passed = false, score = 0, plugins = []}: TRawLinterResult = {}): LinterResult {
+function LinterResult({
+  passed = false,
+  score = 0,
+  plugins = [],
+  minimumScore = 0,
+}: TRawLinterResult = {}): LinterResult {
   return {
     passed,
     score,
+    minimumScore,
     plugins: plugins.map(plugin => LinterResultPlugin(plugin)),
+    isFailed: score < minimumScore,
   };
 }
 

--- a/web/src/styled.d.ts
+++ b/web/src/styled.d.ts
@@ -36,6 +36,7 @@ declare module 'styled-components' {
       md: string;
       lg: string;
       xl: string;
+      xxxl: string;
     };
     /** Font defaults */
     font: {

--- a/web/src/types/Generated.types.ts
+++ b/web/src/types/Generated.types.ts
@@ -1656,6 +1656,7 @@ export interface external {
           required?: boolean;
         };
         LinterResult: {
+          minimumScore?: number;
           passed?: boolean;
           score?: number;
           plugins?: external["linters.yaml"]["components"]["schemas"]["LinterResultPlugin"][];


### PR DESCRIPTION
This PR improves the way we handle error states for the analyzer. Instead of stopping the test execution, now clients will be reading the linter results to validate if there was a failure or not, and show the proper results.

## Changes

- Removes stopping of test runs based on analyzer errors
- Updates analyzer errors UI to better showcase the minimum score error
- Updates transaction execution card and test run card to show the proper status

## Fixes

- #2682 

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

https://www.loom.com/share/6624b56c915b4c41a07f52179bbbdbf7