### PR TITLE
fix(frontend): fixing select spans visual bug

### DIFF
--- a/web/src/components/CurrentSpanSelector/CurrentSpanSelector.styled.ts
+++ b/web/src/components/CurrentSpanSelector/CurrentSpanSelector.styled.ts
@@ -1,6 +1,8 @@
 import styled from 'styled-components';
 
 export const Container = styled.div`
+  position: absolute;
+  left: 20%;
   display: flex;
   justify-content: center;
   margin-top: 2px;

--- a/web/src/components/CurrentSpanSelector/CurrentSpanSelector.tsx
+++ b/web/src/components/CurrentSpanSelector/CurrentSpanSelector.tsx
@@ -29,7 +29,6 @@ const CurrentSpanSelector = ({spanId}: IProps) => {
 
   const handleOnClick = useCallback(() => {
     const selector = SpanService.getSelectorInformation(span!);
-
     if (isTestSpecFormOpen)
       open({
         isEditing: false,
@@ -42,8 +41,8 @@ const CurrentSpanSelector = ({spanId}: IProps) => {
   }, [isTestSpecFormOpen, onOpen, open, span]);
 
   return (
-    <S.Container className="matched">
-      <S.FloatingText onClick={() => !isTriggerSelectorLoading && handleOnClick()}>
+    <S.Container className="matched" onClick={() => !isTriggerSelectorLoading && handleOnClick()}>
+      <S.FloatingText>
         {isTriggerSelectorLoading ? (
           <>
             Updating selected span <LoadingOutlined />


### PR DESCRIPTION
This PR fixes a bug when displaying the switch span button while the test spec form is open that caused the prev checks to go out of bounds.

## Changes

- Updates container to have position absolute
- Updates listener to wrap container

## Fixes

- #2492 

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

<img width="715" alt="Screenshot 2023-06-09 at 12 29 34" src="https://github.com/kubeshop/tracetest/assets/11051031/62ef5226-b0ff-473d-b65a-4f20abf943d4">


