### PR TITLE
feature(frontend): enabling first attribute check deletion

### DIFF
--- a/web/src/components/TestSpecForm/AssertionCheck.tsx
+++ b/web/src/components/TestSpecForm/AssertionCheck.tsx
@@ -115,14 +115,12 @@ export const AssertionCheck = ({
         />
       </S.FieldsContainer>
       <S.ActionContainer>
-        {index !== 0 && (
-          <S.DeleteCheckIcon
-            onClick={() => {
-              CreateAssertionModalAnalyticsService.onRemoveCheck();
-              remove(name);
-            }}
-          />
-        )}
+        <S.DeleteCheckIcon
+          onClick={() => {
+            CreateAssertionModalAnalyticsService.onRemoveCheck();
+            remove(name);
+          }}
+        />
       </S.ActionContainer>
     </S.Container>
   );


### PR DESCRIPTION
This PR enables users to delete all checks no matter if its the first or the last

## Changes

- Enables deletion for all checks from the test spec form

## Fixes

- #2678 

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

<img width="667" alt="Screenshot 2023-06-09 at 12 33 50" src="https://github.com/kubeshop/tracetest/assets/11051031/a4c0b9f5-fb85-4c34-a876-2aadf3cc6c39">
