### PR TITLE
feature(frontend): adding auto scroll to assertion result

### DIFF
--- a/web/src/components/TestSpecDetail/Content.tsx
+++ b/web/src/components/TestSpecDetail/Content.tsx
@@ -1,4 +1,4 @@
-import {useMemo} from 'react';
+import {useEffect, useMemo} from 'react';
 
 import {SemanticGroupNames} from 'constants/SemanticGroupNames.constants';
 import {useTestRun} from 'providers/TestRun/TestRun.provider';
@@ -7,6 +7,7 @@ import TestSpecsSelectors from 'selectors/TestSpecs.selectors';
 import AssertionService from 'services/Assertion.service';
 import {TAssertionResultEntry} from 'models/AssertionResults.model';
 import {useTest} from 'providers/Test/Test.provider';
+import useScrollTo from 'hooks/useScrollTo';
 import Assertion from './Assertion';
 import Header from './Header';
 import SpanHeader from './SpanHeader';
@@ -46,6 +47,11 @@ const Content = ({
   } = useAppSelector(state => TestSpecsSelectors.selectSpecBySelector(state, selector)) || {};
   const totalPassedChecks = useMemo(() => AssertionService.getTotalPassedChecks(resultList), [resultList]);
   const results = useMemo(() => AssertionService.getResultsHashedBySpanId(resultList), [resultList]);
+  const scrollTo = useScrollTo();
+
+  useEffect(() => {
+    scrollTo(`assertion-result-${selectedSpan}`);
+  }, [scrollTo, selectedSpan]);
 
   return (
     <>
@@ -81,6 +87,7 @@ const Content = ({
             type="inner"
             $isSelected={spanId === selectedSpan}
             $type={span?.type ?? SemanticGroupNames.General}
+            id={`assertion-result-${spanId}`}
           >
             <S.AssertionsContainer onClick={() => onSelectSpan(span?.id ?? '')}>
               {checkResults.map(checkResult => (

--- a/web/src/hooks/useScrollTo.ts
+++ b/web/src/hooks/useScrollTo.ts
@@ -1,0 +1,15 @@
+const useScrollTo = () => {
+  const scrollTo = (id: string) => {
+    const element = document.getElementById(id);
+
+    if (element) {
+      element.scrollIntoView({
+        behavior: 'smooth',
+      });
+    }
+  };
+
+  return scrollTo;
+};
+
+export default useScrollTo;


### PR DESCRIPTION
This PR adds a way to auto-scroll to any element in the UI and uses it for the assertion results

## Changes

- Assertion results content scrolls to result when selected span changes

## Fixes

- #2602 

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test


https://www.loom.com/share/82c5917a28f14794b9b9914a7dc3c5bf