### PR TITLE
fix(frontend): add AttributeActions icon to status and duration fields

### DIFF
--- a/web/src/components/RunDetailTriggerResponse/RunDetailTriggerResponse.styled.ts
+++ b/web/src/components/RunDetailTriggerResponse/RunDetailTriggerResponse.styled.ts
@@ -42,7 +42,6 @@ export const TabsContainer = styled.div`
 
 export const StatusText = styled(Typography.Text)`
   && {
-    margin-left: 14px;
     font-size: ${({theme}) => theme.size.md};
   }
 `;

--- a/web/src/components/RunDetailTriggerResponse/RunDetailTriggerResponse.tsx
+++ b/web/src/components/RunDetailTriggerResponse/RunDetailTriggerResponse.tsx
@@ -1,4 +1,4 @@
-import {Tabs} from 'antd';
+import {Divider, Space, Tabs} from 'antd';
 import {useCallback} from 'react';
 import {useNavigate, useSearchParams} from 'react-router-dom';
 
@@ -90,29 +90,31 @@ const RunDetailTriggerResponse = ({
     <S.Container>
       <S.TitleContainer>
         <S.Title>Response Data</S.Title>
-        <div>
-          <AttributeActions
-            attribute={{key: 'tracetest.response.status', value: `${statusCode}`}}
-            onCreateTestOutput={handleCreateTestOutput}
-            onCreateTestSpec={handleCreateTestSpec}
-          >
+        <Space split={<Divider type="vertical" />}>
+          <Space align="center">
             <S.StatusText>
               Status: <S.StatusSpan $isError={statusCode >= 400}>{statusCode}</S.StatusSpan>
             </S.StatusText>
-          </AttributeActions>
-          <AttributeActions
-            attribute={{key: 'tracetest.span.duration', value: `${triggerTime}ms`}}
-            onCreateTestOutput={handleCreateTestOutput}
-            onCreateTestSpec={handleCreateTestSpec}
-          >
+            <AttributeActions
+              attribute={{key: 'tracetest.response.status', value: `${statusCode}`}}
+              onCreateTestOutput={handleCreateTestOutput}
+              onCreateTestSpec={handleCreateTestSpec}
+            />
+          </Space>
+          <Space align="center">
             <S.StatusText>
               Time:{' '}
               <S.StatusSpan $isError={triggerTime > 1000}>
                 {state === TestState.CREATED || state === TestState.EXECUTING ? '-' : `${triggerTime}ms`}
               </S.StatusSpan>
             </S.StatusText>
-          </AttributeActions>
-        </div>
+            <AttributeActions
+              attribute={{key: 'tracetest.span.duration', value: `${triggerTime}ms`}}
+              onCreateTestOutput={handleCreateTestOutput}
+              onCreateTestSpec={handleCreateTestSpec}
+            />
+          </Space>
+        </Space>
       </S.TitleContainer>
       <S.TabsContainer data-tour={StepsID.Response}>
         <Tabs


### PR DESCRIPTION
This PR adds the AttributeActions icon to the status and duration fields in the TriggerResponse data section.

## Changes

- add AttributeActions icon to status and duration

## Fixes

- fixes #2525

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Screenshot

<img width="1501" alt="Screenshot 2023-06-12 at 10 38 24" src="https://github.com/kubeshop/tracetest/assets/3879892/29d18d96-28a2-4421-a287-fac6d719d1b8">