### PR TITLE
feature(frontend): adding enable switch for ingestor for Otel DataStores

### DIFF
--- a/web/src/components/AnalyzerResult/AnalyzerResult.styled.ts
+++ b/web/src/components/AnalyzerResult/AnalyzerResult.styled.ts
@@ -50,7 +50,7 @@ export const RuleContainer = styled.div`
   border-bottom: ${({theme}) => `1px dashed ${theme.color.borderLight}`};
   padding-bottom: 16px;
   margin-bottom: 16px;
-  margin-left: 32px;
+  margin-left: 43px;
 `;
 
 export const RuleHeader = styled.div`

--- a/web/src/components/DocsBanner/DocsBanner.styled.ts
+++ b/web/src/components/DocsBanner/DocsBanner.styled.ts
@@ -1,7 +1,7 @@
 import { Typography } from 'antd';
 import styled from 'styled-components';
 
-export const DataStoreDocsBannerContainer = styled.div`
+export const DocsBannerContainer = styled.div`
   display: flex;
   gap: 8px;
   align-items: center;

--- a/web/src/components/DocsBanner/DocsBanner.tsx
+++ b/web/src/components/DocsBanner/DocsBanner.tsx
@@ -1,0 +1,13 @@
+import {ReadOutlined} from '@ant-design/icons';
+import * as S from './DocsBanner.styled';
+
+const DocsBanner: React.FC = ({children}) => {
+  return (
+    <S.DocsBannerContainer>
+      <ReadOutlined />
+      <S.Text>{children}</S.Text>
+    </S.DocsBannerContainer>
+  );
+};
+
+export default DocsBanner;

--- a/web/src/components/DocsBanner/index.ts
+++ b/web/src/components/DocsBanner/index.ts
@@ -1,0 +1,2 @@
+// eslint-disable-next-line no-restricted-exports
+export {default} from './DocsBanner';

--- a/web/src/components/Settings/DataStoreDocsBanner/DataStoreDocsBanner.tsx
+++ b/web/src/components/Settings/DataStoreDocsBanner/DataStoreDocsBanner.tsx
@@ -1,7 +1,6 @@
-import {ReadOutlined} from '@ant-design/icons';
 import {SupportedDataStoresToDocsLink, SupportedDataStoresToName} from 'constants/DataStore.constants';
 import {SupportedDataStores} from 'types/DataStore.types';
-import * as S from './DataStoreDocsBanner.styled';
+import DocsBanner from 'components/DocsBanner/DocsBanner';
 
 interface IProps {
   dataStoreType: SupportedDataStores;
@@ -9,15 +8,12 @@ interface IProps {
 
 const DataStoreDocsBanner = ({dataStoreType}: IProps) => {
   return (
-    <S.DataStoreDocsBannerContainer>
-      <ReadOutlined />
-      <S.Text>
-        Need more information about setting up {SupportedDataStoresToName[dataStoreType]}?{' '}
-        <a href={SupportedDataStoresToDocsLink[dataStoreType]} target="_blank">
-          Go to our docs
-        </a>
-      </S.Text>
-    </S.DataStoreDocsBannerContainer>
+    <DocsBanner>
+      Need more information about setting up {SupportedDataStoresToName[dataStoreType]}?{' '}
+      <a href={SupportedDataStoresToDocsLink[dataStoreType]} target="_blank">
+        Go to our docs
+      </a>
+    </DocsBanner>
   );
 };
 

--- a/web/src/components/Settings/DataStoreForm/DataStoreForm.styled.ts
+++ b/web/src/components/Settings/DataStoreForm/DataStoreForm.styled.ts
@@ -78,13 +78,6 @@ export const Title = styled(Typography.Title)`
   }
 `;
 
-export const Explanation = styled(Typography.Text)`
-  && {
-    color: ${({theme}) => theme.color.textSecondary};
-    font-size: ${({theme}) => theme.size.md};
-  }
-`;
-
 export const Description = styled(Typography.Text)`
   && {
     color: ${({theme}) => theme.color.textSecondary};

--- a/web/src/components/Settings/DataStoreForm/DataStoreForm.tsx
+++ b/web/src/components/Settings/DataStoreForm/DataStoreForm.tsx
@@ -44,7 +44,7 @@ const DataStoreForm = ({
 
   useEffect(() => {
     form.setFieldsValue({
-      dataStore: {name: '', type: SupportedDataStores.JAEGER, isIngestorEnabled: false, ...initialValues.dataStore},
+      dataStore: {name: '', type: SupportedDataStores.JAEGER, ...initialValues.dataStore},
     });
   }, [dataStoreType, form, initialValues.dataStore]);
 

--- a/web/src/components/Settings/DataStoreForm/DataStoreForm.tsx
+++ b/web/src/components/Settings/DataStoreForm/DataStoreForm.tsx
@@ -2,9 +2,8 @@ import {Button, Form} from 'antd';
 import {useCallback, useEffect, useMemo} from 'react';
 import DataStoreService from 'services/DataStore.service';
 import {TDraftDataStore, TDataStoreForm, SupportedDataStores} from 'types/DataStore.types';
-import {SupportedDataStoresToExplanation, SupportedDataStoresToName} from 'constants/DataStore.constants';
+import {SupportedDataStoresToName} from 'constants/DataStore.constants';
 import DataStoreConfig from 'models/DataStoreConfig.model';
-import DataStoreDocsBanner from '../DataStoreDocsBanner/DataStoreDocsBanner';
 import DataStoreComponentFactory from '../DataStorePlugin/DataStoreComponentFactory';
 import * as S from './DataStoreForm.styled';
 import DataStoreSelectionInput from './DataStoreSelectionInput';
@@ -36,11 +35,17 @@ const DataStoreForm = ({
   isLoading,
   isFormValid,
 }: IProps) => {
-  const initialValues = useMemo(() => DataStoreService.getInitialValues(dataStoreConfig), [dataStoreConfig]);
+  const configuredDataStoreType = dataStoreConfig.defaultDataStore.type as SupportedDataStores;
+  const initialValues = useMemo(
+    () => DataStoreService.getInitialValues(dataStoreConfig, configuredDataStoreType),
+    [configuredDataStoreType, dataStoreConfig]
+  );
   const dataStoreType = Form.useWatch('dataStoreType', form);
 
   useEffect(() => {
-    form.setFieldsValue({dataStore: {name: '', type: SupportedDataStores.JAEGER, ...initialValues.dataStore}});
+    form.setFieldsValue({
+      dataStore: {name: '', type: SupportedDataStores.JAEGER, isIngestorEnabled: false, ...initialValues.dataStore},
+    });
   }, [dataStoreType, form, initialValues.dataStore]);
 
   const onValidation = useCallback(
@@ -50,7 +55,6 @@ const DataStoreForm = ({
     },
     [onIsFormValid]
   );
-  const explanation = SupportedDataStoresToExplanation[dataStoreType!];
 
   return (
     <Form<TDraftDataStore>
@@ -72,12 +76,6 @@ const DataStoreForm = ({
               Tracetest needs configuration information to be able to retrieve your trace from your distributed tracing
               solution. Select your tracing data store and enter the configuration info.
             </S.Description>
-            {explanation ? (
-              <S.Explanation>{explanation}</S.Explanation>
-            ) : (
-              <S.Title>Provide the connection info for {SupportedDataStoresToName[dataStoreType!]}</S.Title>
-            )}
-            <DataStoreDocsBanner dataStoreType={dataStoreType!} />
             {dataStoreType && <DataStoreComponentFactory dataStoreType={dataStoreType} />}
           </S.TopContainer>
           <S.ButtonsContainer>
@@ -93,7 +91,7 @@ const DataStoreForm = ({
                 Test Connection
               </Button>
               <Button disabled={!isFormValid} loading={isLoading} type="primary" onClick={() => form.submit()}>
-                Save
+                Save and Set as DataStore
               </Button>
             </S.SaveContainer>
           </S.ButtonsContainer>

--- a/web/src/components/Settings/DataStorePlugin/forms/AwsXRay/AwsXRay.tsx
+++ b/web/src/components/Settings/DataStorePlugin/forms/AwsXRay/AwsXRay.tsx
@@ -1,5 +1,8 @@
 import {Checkbox, Col, Form, Input, Row} from 'antd';
 import {SupportedDataStores, TDraftDataStore} from 'types/DataStore.types';
+import DataStoreDocsBanner from '../../../DataStoreDocsBanner/DataStoreDocsBanner';
+import * as S from '../../DataStorePluginForm.styled';
+import { SupportedDataStoresToName } from '../../../../../constants/DataStore.constants';
 
 const AwsXRay = () => {
   const baseName = ['dataStore', SupportedDataStores.AWSXRay];
@@ -8,6 +11,8 @@ const AwsXRay = () => {
 
   return (
     <>
+      <S.Title>Provide the connection info for {SupportedDataStoresToName[SupportedDataStores.AWSXRay]}</S.Title>
+      <DataStoreDocsBanner dataStoreType={SupportedDataStores.AWSXRay} />
       <Row gutter={[16, 16]}>
         <Col span={12}>
           <Form.Item name={[...baseName, 'useDefaultAuth']} valuePropName="checked">

--- a/web/src/components/Settings/DataStorePlugin/forms/AzureAppInsights/AzureAppInsights.tsx
+++ b/web/src/components/Settings/DataStorePlugin/forms/AzureAppInsights/AzureAppInsights.tsx
@@ -1,8 +1,9 @@
 import {Checkbox, Col, Form, Input, Radio, Row} from 'antd';
 import {ConnectionTypes, SupportedDataStores, TDraftDataStore} from 'types/DataStore.types';
-import * as S from 'components/Settings/DataStoreForm/DataStoreForm.styled';
-import {collectorExplanation} from 'constants/DataStore.constants';
+import {SupportedDataStoresToName} from 'constants/DataStore.constants';
 import OpenTelemetryCollector from '../OpenTelemetryCollector/OpenTelemetryCollector';
+import * as S from '../../DataStorePluginForm.styled';
+import DataStoreDocsBanner from '../../../DataStoreDocsBanner/DataStoreDocsBanner';
 
 const AzureAppInsights = () => {
   const baseName = ['dataStore', SupportedDataStores.AzureAppInsights];
@@ -23,8 +24,12 @@ const AzureAppInsights = () => {
           </Form.Item>
         </Col>
       </Row>
-      {(connectionType === ConnectionTypes.Direct && (
+      {(connectionType === ConnectionTypes.Collector && <OpenTelemetryCollector />) || (
         <>
+          <S.Title>
+            Provide the connection info for {SupportedDataStoresToName[SupportedDataStores.AzureAppInsights]}
+          </S.Title>
+          <DataStoreDocsBanner dataStoreType={SupportedDataStores.AzureAppInsights} />
           <Row gutter={[16, 16]}>
             <Col span={16}>
               <Form.Item
@@ -52,20 +57,6 @@ const AzureAppInsights = () => {
               >
                 <Input disabled={useAzureActiveDirectoryAuth} type="password" placeholder="your access token" />
               </Form.Item>
-            </Col>
-          </Row>
-        </>
-      )) || (
-        <>
-          <Row gutter={[16, 16]}>
-            <Col span={16}>
-              <S.Explanation>{collectorExplanation}</S.Explanation>
-            </Col>
-          </Row>
-
-          <Row gutter={[16, 16]}>
-            <Col span={16}>
-              <OpenTelemetryCollector />
             </Col>
           </Row>
         </>

--- a/web/src/components/Settings/DataStorePlugin/forms/BaseClient/BaseClient.tsx
+++ b/web/src/components/Settings/DataStorePlugin/forms/BaseClient/BaseClient.tsx
@@ -1,5 +1,5 @@
 import {Col, Form, Radio, Row} from 'antd';
-import {SupportedClientTypes, TDraftDataStore} from 'types/DataStore.types';
+import {SupportedClientTypes, SupportedDataStores, TDraftDataStore} from 'types/DataStore.types';
 import GrpcClient from '../GrpcClient';
 import HttpClient from '../HttpClient';
 
@@ -10,7 +10,7 @@ const FieldsFormMap = {
 
 const BaseClient = () => {
   const form = Form.useFormInstance<TDraftDataStore>();
-  const dataStoreType = form.getFieldValue('dataStoreType');
+  const dataStoreType = form.getFieldValue('dataStoreType') as SupportedDataStores;
   const baseName = ['dataStore', dataStoreType];
   const type = (Form.useWatch([...baseName, 'type'], form) || SupportedClientTypes.GRPC) as SupportedClientTypes;
   const Component = FieldsFormMap[type];

--- a/web/src/components/Settings/DataStorePlugin/forms/ElasticSearch/ElasticSearch.tsx
+++ b/web/src/components/Settings/DataStorePlugin/forms/ElasticSearch/ElasticSearch.tsx
@@ -1,10 +1,11 @@
 import {Checkbox, Col, Form, Input, Row} from 'antd';
 
 import RequestDetailsFileInput from 'components/CreateTestPlugins/Grpc/steps/RequestDetails/RequestDetailsFileInput';
-import {SupportedDataStoresToDefaultEndpoint} from 'constants/DataStore.constants';
+import {SupportedDataStoresToDefaultEndpoint, SupportedDataStoresToName} from 'constants/DataStore.constants';
 import {SupportedDataStores, TDraftDataStore} from 'types/DataStore.types';
 import * as S from '../../DataStorePluginForm.styled';
 import AddressesList from './AddressesList';
+import DataStoreDocsBanner from '../../../DataStoreDocsBanner/DataStoreDocsBanner';
 
 const OpenSearch = () => {
   const form = Form.useFormInstance<TDraftDataStore>();
@@ -14,6 +15,8 @@ const OpenSearch = () => {
 
   return (
     <>
+      <S.Title>Provide the connection info for {SupportedDataStoresToName[dataStoreType]}</S.Title>
+      <DataStoreDocsBanner dataStoreType={dataStoreType} />
       <Row gutter={[16, 16]}>
         <Col span={12}>
           <Form.Item

--- a/web/src/components/Settings/DataStorePlugin/forms/GrpcClient/GrpcClient.tsx
+++ b/web/src/components/Settings/DataStorePlugin/forms/GrpcClient/GrpcClient.tsx
@@ -1,12 +1,13 @@
 import {Checkbox, Col, Form, Input, Row, Select, Space, Switch} from 'antd';
 import {useCallback} from 'react';
-import {SupportedDataStoresToDefaultEndpoint} from 'constants/DataStore.constants';
+import {SupportedDataStoresToDefaultEndpoint, SupportedDataStoresToName} from 'constants/DataStore.constants';
 import {useDataStore} from 'providers/DataStore/DataStore.provider';
 import DataStoreService from 'services/DataStore.service';
 import {SupportedDataStores, TDraftDataStore} from 'types/DataStore.types';
 import * as FS from '../../DataStorePluginForm.styled';
 import * as S from './GrcpClient.styled';
 import GrpcClientSecure from './GrpcClientSecure';
+import DataStoreDocsBanner from '../../../DataStoreDocsBanner/DataStoreDocsBanner';
 
 const COMPRESSION_LIST = [
   {name: 'none', value: 'none'},
@@ -36,6 +37,8 @@ const GrpcClient = () => {
 
   return (
     <>
+      <FS.Title>Provide the connection info for {SupportedDataStoresToName[dataStoreType]}</FS.Title>
+      <DataStoreDocsBanner dataStoreType={dataStoreType} />
       <Row gutter={[16, 16]}>
         <Col span={12}>
           <Form.Item

--- a/web/src/components/Settings/DataStorePlugin/forms/HttpClient/HttpClient.tsx
+++ b/web/src/components/Settings/DataStorePlugin/forms/HttpClient/HttpClient.tsx
@@ -1,18 +1,22 @@
 import {Checkbox, Col, Form, Input, Row, Space, Switch} from 'antd';
-import {TDraftDataStore} from 'types/DataStore.types';
+import {SupportedDataStores, TDraftDataStore} from 'types/DataStore.types';
+import {SupportedDataStoresToName} from 'constants/DataStore.constants';
 import GrpcClientSecure from '../GrpcClient/GrpcClientSecure';
 import * as S from '../../DataStorePluginForm.styled';
+import DataStoreDocsBanner from '../../../DataStoreDocsBanner/DataStoreDocsBanner';
 
 const HEADER_DEFAULT_VALUES = [{key: '', value: ''}];
 
 const HttpClient = () => {
   const form = Form.useFormInstance<TDraftDataStore>();
-  const dataStoreType = form.getFieldValue('dataStoreType');
+  const dataStoreType = form.getFieldValue('dataStoreType') as SupportedDataStores;
   const baseName = ['dataStore', dataStoreType, 'http'];
   const insecureValue = Form.useWatch([...baseName, 'tls', 'insecure'], form) ?? true;
 
   return (
     <>
+      <S.Title>Provide the connection info for {SupportedDataStoresToName[dataStoreType]}</S.Title>
+      <DataStoreDocsBanner dataStoreType={dataStoreType} />
       <Row gutter={[16, 16]}>
         <Col span={12}>
           <Form.Item label="URL" name={[...baseName, 'url']} rules={[{required: true, message: 'URL is required'}]}>

--- a/web/src/components/Settings/DataStorePlugin/forms/OpenTelemetryCollector/Configuration.tsx
+++ b/web/src/components/Settings/DataStorePlugin/forms/OpenTelemetryCollector/Configuration.tsx
@@ -4,9 +4,9 @@ import {arduinoLight} from 'react-syntax-highlighter/dist/cjs/styles/hljs';
 import useCopy from 'hooks/useCopy';
 import {CollectorConfigMap} from 'constants/CollectorConfig.constants';
 import {TCollectorDataStores, TDraftDataStore} from 'types/DataStore.types';
-import DocsBanner from 'components/DocsBanner/DocsBanner';
 import * as S from '../../DataStorePluginForm.styled';
 import * as OtelCollectorStyles from './OpenTelemetryCollector.styled';
+import DataStoreDocsBanner from '../../../DataStoreDocsBanner/DataStoreDocsBanner';
 
 const Configuration = () => {
   const copy = useCopy();
@@ -36,9 +36,7 @@ const Configuration = () => {
           </OtelCollectorStyles.CodeContainer>
         </S.FormColumn>
       </S.FormContainer>
-      <DocsBanner>
-        Need more information about setting up OpenTelemetry Collector? <a href="">Go to our docs</a>
-      </DocsBanner>
+      <DataStoreDocsBanner dataStoreType={dataStoreType} />
     </>
   );
 };

--- a/web/src/components/Settings/DataStorePlugin/forms/OpenTelemetryCollector/Configuration.tsx
+++ b/web/src/components/Settings/DataStorePlugin/forms/OpenTelemetryCollector/Configuration.tsx
@@ -1,0 +1,46 @@
+import {Form} from 'antd';
+import SyntaxHighlighter from 'react-syntax-highlighter';
+import {arduinoLight} from 'react-syntax-highlighter/dist/cjs/styles/hljs';
+import useCopy from 'hooks/useCopy';
+import {CollectorConfigMap} from 'constants/CollectorConfig.constants';
+import {TCollectorDataStores, TDraftDataStore} from 'types/DataStore.types';
+import DocsBanner from 'components/DocsBanner/DocsBanner';
+import * as S from '../../DataStorePluginForm.styled';
+import * as OtelCollectorStyles from './OpenTelemetryCollector.styled';
+
+const Configuration = () => {
+  const copy = useCopy();
+  const form = Form.useFormInstance<TDraftDataStore>();
+  const dataStoreType = Form.useWatch('dataStoreType', form) as TCollectorDataStores;
+  const example = CollectorConfigMap[dataStoreType!];
+
+  return (
+    <>
+      <OtelCollectorStyles.SubtitleContainer>
+        <OtelCollectorStyles.Title>OpenTelemetry Collector Configuration</OtelCollectorStyles.Title>
+        <OtelCollectorStyles.Description>
+          The OpenTelemetry Collector configuration below is a sample. Your config file layout should look the same.
+          Make sure to use your own API keys or tokens as explained. Copy the config sample below, paste it into your
+          own OpenTelemetry Collector config and apply it.
+        </OtelCollectorStyles.Description>
+      </OtelCollectorStyles.SubtitleContainer>
+      <S.FormContainer>
+        <S.FormColumn>
+          <OtelCollectorStyles.CodeContainer data-cy="file-viewer-code-container">
+            <OtelCollectorStyles.CopyIconContainer onClick={() => copy(example)}>
+              <OtelCollectorStyles.CopyIcon />
+            </OtelCollectorStyles.CopyIconContainer>
+            <SyntaxHighlighter language="yaml" style={arduinoLight}>
+              {example}
+            </SyntaxHighlighter>
+          </OtelCollectorStyles.CodeContainer>
+        </S.FormColumn>
+      </S.FormContainer>
+      <DocsBanner>
+        Need more information about setting up OpenTelemetry Collector? <a href="">Go to our docs</a>
+      </DocsBanner>
+    </>
+  );
+};
+
+export default Configuration;

--- a/web/src/components/Settings/DataStorePlugin/forms/OpenTelemetryCollector/Ingestor.tsx
+++ b/web/src/components/Settings/DataStorePlugin/forms/OpenTelemetryCollector/Ingestor.tsx
@@ -1,0 +1,31 @@
+import {Form, Switch} from 'antd';
+import DocsBanner from 'components/DocsBanner/DocsBanner';
+import * as S from './OpenTelemetryCollector.styled';
+
+const Ingestor = () => {
+  return (
+    <S.Container>
+      <S.Description>
+        Tracetest easily integrates with any distributed tracing solution via the OpenTelemetry Collector. It allows
+        your current tracing system to send only Tracetest spans while the rest go to your chosen backend.
+      </S.Description>
+      <S.Title>Ingestor Endpoint</S.Title>
+      <S.Description>
+        Tracetest exposes trace ingestion endpoints on ports 4317 for gRPC and 4318 for HTTP. Turn on the Tracetest
+        ingestion endpoint to start sending traces. Use the Tracetest Server’s hostname and port to connect.For example,
+        with Docker use tracetest:4317 for gRPC.
+      </S.Description>
+      <S.SwitchContainer>
+        <Form.Item name={['dataStore', 'isIngestorEnabled']} valuePropName="checked">
+          <Switch />
+        </Form.Item>
+        Enable Tracetest ingestion endpoint
+      </S.SwitchContainer>
+      <DocsBanner>
+        Need more information about setting up ingestion endpoint? <a href="">Go to our docs</a>
+      </DocsBanner>
+    </S.Container>
+  );
+};
+
+export default Ingestor;

--- a/web/src/components/Settings/DataStorePlugin/forms/OpenTelemetryCollector/Ingestor.tsx
+++ b/web/src/components/Settings/DataStorePlugin/forms/OpenTelemetryCollector/Ingestor.tsx
@@ -1,9 +1,14 @@
 import {Form, Switch} from 'antd';
 import DocsBanner from 'components/DocsBanner/DocsBanner';
 import {INGESTOR_ENDPOINT_URL} from 'constants/Common.constants';
+import {TCollectorDataStores, TDraftDataStore} from 'types/DataStore.types';
 import * as S from './OpenTelemetryCollector.styled';
 
 const Ingestor = () => {
+  const form = Form.useFormInstance<TDraftDataStore>();
+  const dataStoreType = Form.useWatch('dataStoreType', form) as TCollectorDataStores;
+  const baseName = ['dataStore', dataStoreType];
+
   return (
     <S.Container>
       <S.Description>
@@ -17,7 +22,7 @@ const Ingestor = () => {
         with Docker use tracetest:4317 for gRPC.
       </S.Description>
       <S.SwitchContainer>
-        <Form.Item name={['dataStore', 'isIngestorEnabled']} valuePropName="checked">
+        <Form.Item name={[...baseName, 'isIngestorEnabled']} valuePropName="checked">
           <Switch />
         </Form.Item>
         Enable Tracetest ingestion endpoint

--- a/web/src/components/Settings/DataStorePlugin/forms/OpenTelemetryCollector/Ingestor.tsx
+++ b/web/src/components/Settings/DataStorePlugin/forms/OpenTelemetryCollector/Ingestor.tsx
@@ -1,5 +1,6 @@
 import {Form, Switch} from 'antd';
 import DocsBanner from 'components/DocsBanner/DocsBanner';
+import {INGESTOR_ENDPOINT_URL} from 'constants/Common.constants';
 import * as S from './OpenTelemetryCollector.styled';
 
 const Ingestor = () => {
@@ -22,7 +23,10 @@ const Ingestor = () => {
         Enable Tracetest ingestion endpoint
       </S.SwitchContainer>
       <DocsBanner>
-        Need more information about setting up ingestion endpoint? <a href="">Go to our docs</a>
+        Need more information about setting up ingestion endpoint?{' '}
+        <a target="_blank" href={INGESTOR_ENDPOINT_URL}>
+          Go to our docs
+        </a>
       </DocsBanner>
     </S.Container>
   );

--- a/web/src/components/Settings/DataStorePlugin/forms/OpenTelemetryCollector/OpenTelemetryCollector.styled.ts
+++ b/web/src/components/Settings/DataStorePlugin/forms/OpenTelemetryCollector/OpenTelemetryCollector.styled.ts
@@ -1,13 +1,14 @@
 import {CopyOutlined} from '@ant-design/icons';
-import {Modal} from 'antd';
+import {Modal, Typography} from 'antd';
 import styled from 'styled-components';
 
 export const CodeContainer = styled.div`
   position: relative;
   border: ${({theme}) => `1px solid ${theme.color.border}`};
-  max-height: 370px;
-  width: 600px;
+  max-height: 215px;
+  width: 470px;
   overflow-y: scroll;
+  margin-bottom: 18px;
 
   pre {
     margin: 0;
@@ -38,4 +39,26 @@ export const CopyIconContainer = styled.div`
 
 export const SubtitleContainer = styled.div`
   margin-bottom: 8px;
+`;
+
+export const Container = styled.div``;
+
+export const Title = styled(Typography.Title)`
+  && {
+    font-size: ${({theme}) => theme.size.md};
+  }
+`;
+
+export const Description = styled(Typography.Paragraph)`
+  && {
+    color: ${({theme}) => theme.color.textSecondary};
+    font-size: ${({theme}) => theme.size.md};
+  }
+`;
+
+export const SwitchContainer = styled.div`
+  align-items: center;
+  display: flex;
+  gap: 8px;
+  margin-bottom: 18px;
 `;

--- a/web/src/components/Settings/DataStorePlugin/forms/OpenTelemetryCollector/OpenTelemetryCollector.tsx
+++ b/web/src/components/Settings/DataStorePlugin/forms/OpenTelemetryCollector/OpenTelemetryCollector.tsx
@@ -1,34 +1,21 @@
-import {Form} from 'antd';
-import SyntaxHighlighter from 'react-syntax-highlighter';
-import {arduinoLight} from 'react-syntax-highlighter/dist/cjs/styles/hljs';
-import {TCollectorDataStores, TDraftDataStore} from 'types/DataStore.types';
-import {CollectorConfigMap} from 'constants/CollectorConfig.constants';
-import useCopy from 'hooks/useCopy';
-import * as S from '../../DataStorePluginForm.styled';
-import * as OtelCollectorStyles from './OpenTelemetryCollector.styled';
+import {Col, Row} from 'antd';
+import Ingestor from './Ingestor';
+import Configuration from './Configuration';
 
 const OpenTelemetryCollector = () => {
-  const form = Form.useFormInstance<TDraftDataStore>();
-  const copy = useCopy();
-  const dataStoreType = Form.useWatch('dataStoreType', form) as TCollectorDataStores;
-  const example = CollectorConfigMap[dataStoreType!];
-
   return (
-    <S.FormContainer>
-      <S.FormColumn>
-        <OtelCollectorStyles.SubtitleContainer>
-          <S.Title>Sample Configuration</S.Title>
-        </OtelCollectorStyles.SubtitleContainer>
-        <OtelCollectorStyles.CodeContainer data-cy="file-viewer-code-container">
-          <OtelCollectorStyles.CopyIconContainer onClick={() => copy(example)}>
-            <OtelCollectorStyles.CopyIcon />
-          </OtelCollectorStyles.CopyIconContainer>
-          <SyntaxHighlighter language="yaml" style={arduinoLight}>
-            {example}
-          </SyntaxHighlighter>
-        </OtelCollectorStyles.CodeContainer>
-      </S.FormColumn>
-    </S.FormContainer>
+    <>
+      <Row gutter={[16, 16]}>
+        <Col span={16}>
+          <Ingestor />
+        </Col>
+      </Row>
+      <Row gutter={[16, 16]}>
+        <Col span={16}>
+          <Configuration />
+        </Col>
+      </Row>
+    </>
   );
 };
 

--- a/web/src/components/Settings/DataStorePlugin/forms/SignalFx/SignalFx.tsx
+++ b/web/src/components/Settings/DataStorePlugin/forms/SignalFx/SignalFx.tsx
@@ -1,22 +1,37 @@
 import {Col, Form, Input, Row} from 'antd';
 import {SupportedDataStores} from 'types/DataStore.types';
+import {SupportedDataStoresToName} from 'constants/DataStore.constants';
+import * as S from '../../DataStorePluginForm.styled';
+import DataStoreDocsBanner from '../../../DataStoreDocsBanner/DataStoreDocsBanner';
 
 const SignalFx = () => {
   const baseName = ['dataStore', SupportedDataStores.SignalFX];
 
   return (
-    <Row gutter={[16, 16]}>
-      <Col span={12}>
-        <Form.Item label="Realm" name={[...baseName, 'realm']} rules={[{required: true, message: 'Realm is required'}]}>
-          <Input placeholder="us1" />
-        </Form.Item>
-      </Col>
-      <Col span={12}>
-        <Form.Item label="Token" name={[...baseName, 'token']} rules={[{required: true, message: 'Token is required'}]}>
-          <Input placeholder="Your token" type="password" />
-        </Form.Item>
-      </Col>
-    </Row>
+    <>
+      <S.Title>Provide the connection info for {SupportedDataStoresToName[SupportedDataStores.SignalFX]}</S.Title>
+      <DataStoreDocsBanner dataStoreType={SupportedDataStores.SignalFX} />
+      <Row gutter={[16, 16]}>
+        <Col span={12}>
+          <Form.Item
+            label="Realm"
+            name={[...baseName, 'realm']}
+            rules={[{required: true, message: 'Realm is required'}]}
+          >
+            <Input placeholder="us1" />
+          </Form.Item>
+        </Col>
+        <Col span={12}>
+          <Form.Item
+            label="Token"
+            name={[...baseName, 'token']}
+            rules={[{required: true, message: 'Token is required'}]}
+          >
+            <Input placeholder="Your token" type="password" />
+          </Form.Item>
+        </Col>
+      </Row>
+    </>
   );
 };
 

--- a/web/src/constants/Common.constants.ts
+++ b/web/src/constants/Common.constants.ts
@@ -9,6 +9,8 @@ export const GITHUB_ISSUES_URL = 'https://github.com/kubeshop/tracetest/issues/n
 export const DISCORD_URL = 'https://discord.gg/6zupCZFQbe';
 export const OCTOLIINT_ISSUE_URL = 'https://github.com/kubeshop/tracetest/issues/2615';
 
+export const INGESTOR_ENDPOINT_URL = 'https://docs.tracetest.io/configuration/ingestor-endpoint';
+
 export const TRACE_SEMANTIC_CONVENTIONS_URL =
   'https://github.com/open-telemetry/opentelemetry-specification/tree/main/specification/trace/semantic_conventions';
 export const RESOURCE_SEMANTIC_CONVENTIONS_URL =

--- a/web/src/constants/DataStore.constants.tsx
+++ b/web/src/constants/DataStore.constants.tsx
@@ -28,7 +28,8 @@ export const SupportedDataStoresToDocsLink = {
   [SupportedDataStores.OtelCollector]:
     'https://docs.tracetest.io/configuration/connecting-to-data-stores/opentelemetry-collector',
   [SupportedDataStores.Honeycomb]: 'https://docs.tracetest.io/configuration/connecting-to-data-stores/honeycomb',
-  [SupportedDataStores.AzureAppInsights]: 'https://docs.tracetest.io/configuration/connecting-to-data-stores/azure-app-insights',
+  [SupportedDataStores.AzureAppInsights]:
+    'https://docs.tracetest.io/configuration/connecting-to-data-stores/azure-app-insights',
 } as const;
 
 export const SupportedDataStoresToDefaultEndpoint = {
@@ -45,21 +46,3 @@ export const SupportedDataStoresToDefaultEndpoint = {
   [SupportedDataStores.Honeycomb]: '',
   [SupportedDataStores.AzureAppInsights]: '',
 } as const;
-
-export const collectorExplanation = (
-  <>
-    Tracetest can work with any distributed tracing solution that is utilizing the{' '}
-    <a href="https://opentelemetry.io/docs/collector/" target="_blank">
-      OpenTelemetry Collector
-    </a>{' '}
-    via a second pipeline. The second pipeline enables your current tracing system to send only Tracetest spans to
-    Tracetest, while all other spans continue to go to the backend of your choice.
-  </>
-);
-
-export const SupportedDataStoresToExplanation: Record<string, React.ReactElement> = {
-  [SupportedDataStores.OtelCollector]: collectorExplanation,
-  [SupportedDataStores.NewRelic]: collectorExplanation,
-  [SupportedDataStores.Lightstep]: collectorExplanation,
-  [SupportedDataStores.Datadog]: collectorExplanation,
-};

--- a/web/src/models/DataStore.model.ts
+++ b/web/src/models/DataStore.model.ts
@@ -2,13 +2,16 @@ import {SupportedDataStores} from 'types/DataStore.types';
 import {Model, TDataStoreSchemas} from 'types/Common.types';
 
 export type TRawDataStore = TDataStoreSchemas['DataStoreResource'];
+export type TRawAzureAppInsightsDataStore = TDataStoreSchemas['AzureAppInsights'];
+
+export type TRawOtlpDataStore = {isIngestorEnabled?: boolean};
 type DataStore = Model<TRawDataStore, {}>['spec'] & {
-  isIngestorEnabled?: boolean;
-  otlp?: {};
-  newrelic?: {};
-  lightstep?: {};
-  datadog?: {};
-  honeycomb?: {};
+  otlp?: TRawOtlpDataStore;
+  newrelic?: TRawOtlpDataStore;
+  lightstep?: TRawOtlpDataStore;
+  datadog?: TRawOtlpDataStore;
+  honeycomb?: TRawOtlpDataStore;
+  azureappinsights?: TRawAzureAppInsightsDataStore & TRawOtlpDataStore;
 };
 
 const DataStore = ({
@@ -39,7 +42,6 @@ const DataStore = ({
   tempo,
   awsxray,
   azureappinsights,
-  isIngestorEnabled: false,
 });
 
 export default DataStore;

--- a/web/src/models/DataStore.model.ts
+++ b/web/src/models/DataStore.model.ts
@@ -3,6 +3,7 @@ import {Model, TDataStoreSchemas} from 'types/Common.types';
 
 export type TRawDataStore = TDataStoreSchemas['DataStoreResource'];
 type DataStore = Model<TRawDataStore, {}>['spec'] & {
+  isIngestorEnabled?: boolean;
   otlp?: {};
   newrelic?: {};
   lightstep?: {};
@@ -38,6 +39,7 @@ const DataStore = ({
   tempo,
   awsxray,
   azureappinsights,
+  isIngestorEnabled: false,
 });
 
 export default DataStore;

--- a/web/src/services/DataStore.service.ts
+++ b/web/src/services/DataStore.service.ts
@@ -26,7 +26,7 @@ const dataStoreServiceMap = {
 
 interface IDataStoreService {
   getRequest(draft: TDraftDataStore, defaultDataStore: DataStore): Promise<TRawDataStore>;
-  getInitialValues(config: DataStoreConfig): TDraftDataStore;
+  getInitialValues(config: DataStoreConfig, configuredDataStore?: SupportedDataStores): TDraftDataStore;
   validateDraft(config: TDraftDataStore): Promise<boolean>;
   shouldTestConnection(draft: TDraftDataStore): boolean;
   _getDataStore(type?: SupportedDataStores): TDataStoreService;
@@ -57,12 +57,12 @@ const DataStoreService = (): IDataStoreService => ({
     } as TRawDataStore;
   },
 
-  getInitialValues(dataStoreConfig) {
+  getInitialValues(dataStoreConfig, configuredDataStore) {
     const {defaultDataStore} = dataStoreConfig;
     const type = (defaultDataStore.type || SupportedDataStores.JAEGER) as SupportedDataStores;
     const dataStore = this._getDataStore(type);
 
-    return {...dataStore.getInitialValues(dataStoreConfig, type), dataStoreType: type};
+    return {...dataStore.getInitialValues(dataStoreConfig, type, configuredDataStore), dataStoreType: type};
   },
 
   validateDraft(draft) {

--- a/web/src/services/DataStores/AzureAppInsights.service.ts
+++ b/web/src/services/DataStores/AzureAppInsights.service.ts
@@ -24,12 +24,12 @@ const AzureAppInsightsService = (): TDataStoreService => ({
   },
   validateDraft({
     dataStore: {
-      isIngestorEnabled = false,
       azureappinsights: {
         resourceArmId = '',
         connectionType = ConnectionTypes.Direct,
         accessToken = '',
         useAzureActiveDirectoryAuth = true,
+        isIngestorEnabled = false,
       } = {},
     } = {},
   }) {
@@ -52,9 +52,15 @@ const AzureAppInsightsService = (): TDataStoreService => ({
       dataStore: {
         name: SupportedDataStores.AzureAppInsights,
         type: SupportedDataStores.AzureAppInsights,
-        azureappinsights: {resourceArmId, connectionType, accessToken, useAzureActiveDirectoryAuth},
-        isIngestorEnabled:
-          configuredDataStore === SupportedDataStores.AzureAppInsights && connectionType === ConnectionTypes.Collector,
+        azureappinsights: {
+          resourceArmId,
+          connectionType,
+          accessToken,
+          useAzureActiveDirectoryAuth,
+          isIngestorEnabled:
+            configuredDataStore === SupportedDataStores.AzureAppInsights &&
+            connectionType === ConnectionTypes.Collector,
+        },
       },
       dataStoreType: SupportedDataStores.AzureAppInsights,
     };

--- a/web/src/services/DataStores/AzureAppInsights.service.ts
+++ b/web/src/services/DataStores/AzureAppInsights.service.ts
@@ -24,6 +24,7 @@ const AzureAppInsightsService = (): TDataStoreService => ({
   },
   validateDraft({
     dataStore: {
+      isIngestorEnabled = false,
       azureappinsights: {
         resourceArmId = '',
         connectionType = ConnectionTypes.Direct,
@@ -35,10 +36,11 @@ const AzureAppInsightsService = (): TDataStoreService => ({
     if (connectionType === ConnectionTypes.Direct && !resourceArmId) return Promise.resolve(false);
     if (connectionType === ConnectionTypes.Direct && !useAzureActiveDirectoryAuth && !accessToken)
       return Promise.resolve(false);
+    if (connectionType === ConnectionTypes.Collector && !isIngestorEnabled) return Promise.resolve(false);
 
     return Promise.resolve(true);
   },
-  getInitialValues({defaultDataStore: {azureappinsights = {}} = {}}) {
+  getInitialValues({defaultDataStore: {azureappinsights = {}} = {}}, dataStoreType, configuredDataStore) {
     const {
       resourceArmId = '',
       connectionType = ConnectionTypes.Direct,
@@ -51,6 +53,8 @@ const AzureAppInsightsService = (): TDataStoreService => ({
         name: SupportedDataStores.AzureAppInsights,
         type: SupportedDataStores.AzureAppInsights,
         azureappinsights: {resourceArmId, connectionType, accessToken, useAzureActiveDirectoryAuth},
+        isIngestorEnabled:
+          configuredDataStore === SupportedDataStores.AzureAppInsights && connectionType === ConnectionTypes.Collector,
       },
       dataStoreType: SupportedDataStores.AzureAppInsights,
     };

--- a/web/src/services/DataStores/OtelCollector.service.ts
+++ b/web/src/services/DataStores/OtelCollector.service.ts
@@ -7,14 +7,19 @@ const OtelCollectorService = (): TDataStoreService => ({
       name: dataStoreType,
     });
   },
-  validateDraft() {
-    return Promise.resolve(true);
+  validateDraft({dataStore: {isIngestorEnabled = false} = {}}) {
+    return Promise.resolve(isIngestorEnabled);
   },
-  getInitialValues(draft, dataStoreType = SupportedDataStores.OtelCollector) {
+  getInitialValues(
+    draft,
+    dataStoreType = SupportedDataStores.OtelCollector,
+    configuredDataStore = SupportedDataStores.OtelCollector
+  ) {
     return {
       dataStore: {
         name: dataStoreType,
         type: dataStoreType,
+        isIngestorEnabled: configuredDataStore === dataStoreType,
       },
       dataStoreType,
     };

--- a/web/src/services/DataStores/OtelCollector.service.ts
+++ b/web/src/services/DataStores/OtelCollector.service.ts
@@ -1,4 +1,5 @@
-import {SupportedDataStores, TDataStoreService} from 'types/DataStore.types';
+import {IDataStore, SupportedDataStores, TDataStoreService} from 'types/DataStore.types';
+import {TRawOtlpDataStore} from 'models/DataStore.model';
 
 const OtelCollectorService = (): TDataStoreService => ({
   getRequest(draft, dataStoreType = SupportedDataStores.OtelCollector) {
@@ -7,7 +8,10 @@ const OtelCollectorService = (): TDataStoreService => ({
       name: dataStoreType,
     });
   },
-  validateDraft({dataStore: {isIngestorEnabled = false} = {}}) {
+  validateDraft({dataStore = {} as IDataStore, dataStoreType = SupportedDataStores.OtelCollector}) {
+    const {isIngestorEnabled = false} =
+      (dataStore[dataStoreType || SupportedDataStores.OtelCollector] as TRawOtlpDataStore) ?? {};
+
     return Promise.resolve(isIngestorEnabled);
   },
   getInitialValues(
@@ -19,7 +23,9 @@ const OtelCollectorService = (): TDataStoreService => ({
       dataStore: {
         name: dataStoreType,
         type: dataStoreType,
-        isIngestorEnabled: configuredDataStore === dataStoreType,
+        [dataStoreType]: {
+          isIngestorEnabled: configuredDataStore === dataStoreType,
+        },
       },
       dataStoreType,
     };

--- a/web/src/types/DataStore.types.ts
+++ b/web/src/types/DataStore.types.ts
@@ -1,7 +1,7 @@
 import {FormInstance} from 'antd';
 import {Model, TDataStoreSchemas, TConfigSchemas} from 'types/Common.types';
 import ConnectionTestStep from 'models/ConnectionResultStep.model';
-import DataStore from 'models/DataStore.model';
+import DataStore, { TRawOtlpDataStore } from 'models/DataStore.model';
 import DataStoreConfig from 'models/DataStoreConfig.model';
 import {THeader} from './Test.types';
 
@@ -83,16 +83,16 @@ export interface IElasticSearch extends TRawElasticSearch {
   certificateFile?: File;
 }
 
-type IDataStore = DataStore & {
+export type IDataStore = DataStore & {
   jaeger?: IBaseClientSettings;
   tempo?: IBaseClientSettings;
   opensearch?: IElasticSearch;
   elasticapm?: IElasticSearch;
-  otlp?: {};
-  lightstep?: {};
-  newrelic?: {};
-  datadog?: {};
-  honeycomb?: {};
+  otlp?: TRawOtlpDataStore;
+  lightstep?: TRawOtlpDataStore;
+  newrelic?: TRawOtlpDataStore;
+  datadog?: TRawOtlpDataStore;
+  honeycomb?: TRawOtlpDataStore;
 };
 
 export type TDraftDataStore = {

--- a/web/src/types/DataStore.types.ts
+++ b/web/src/types/DataStore.types.ts
@@ -105,7 +105,11 @@ export type TDataStoreForm = FormInstance<TDraftDataStore>;
 export type TDataStoreService = {
   getRequest(values: TDraftDataStore, dataStoreType?: SupportedDataStores): Promise<DataStore>;
   validateDraft(draft: TDraftDataStore): Promise<boolean>;
-  getInitialValues(draft: DataStoreConfig, dataStoreType?: SupportedDataStores): TDraftDataStore;
+  getInitialValues(
+    draft: DataStoreConfig,
+    dataStoreType?: SupportedDataStores,
+    configuredDataStore?: SupportedDataStores
+  ): TDraftDataStore;
   shouldTestConnection(draft: TDraftDataStore): boolean;
 };
 


### PR DESCRIPTION
This PR updates the otlp data store designs and adds a switch to enable the ingestor

## Changes

- Updates the otlp datastore component
- Moves explanation and title to each datastore form
- Adds logic to handle new field

## Fixes

- #2509 

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test


https://www.loom.com/share/ed6fc3cbfd204cb09090b6d4c7324ff1