### PR TITLE
fix(cli): remove cli analytics

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -30,7 +30,7 @@ jobs:
       - name: Setup go
         uses: actions/setup-go@v3
         with:
-          go-version-file: 'go.work'
+          go-version-file: "go.work"
           cache: true
           cache-dependency-path: go.work
       - name: install graph tool
@@ -65,7 +65,7 @@ jobs:
       - name: Setup go
         uses: actions/setup-go@v3
         with:
-          go-version-file: 'go.work'
+          go-version-file: "go.work"
           cache: true
           cache-dependency-path: go.work
       - name: Run unit tests
@@ -75,7 +75,7 @@ jobs:
     name: API Server unit tests
     runs-on: ubuntu-latest
 
-# git log --pretty=tformat:"%H" -n1 web
+    # git log --pretty=tformat:"%H" -n1 web
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -84,7 +84,7 @@ jobs:
       - name: Setup go
         uses: actions/setup-go@v3
         with:
-          go-version-file: 'go.work'
+          go-version-file: "go.work"
           cache: true
           cache-dependency-path: go.work
       - name: Run unit tests
@@ -181,7 +181,7 @@ jobs:
         if: steps.cache-docker-build.outputs.cache-hit != 'true'
         uses: actions/setup-go@v3
         with:
-          go-version-file: 'go.work'
+          go-version-file: "go.work"
           cache: true
           cache-dependency-path: go.work
       - uses: goreleaser/goreleaser-action@v4
@@ -208,7 +208,7 @@ jobs:
 
   test-examples:
     name: Test examples
-    needs:  [build-docker]
+    needs: [build-docker]
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -242,12 +242,12 @@ jobs:
 
           ./scripts/wait-for-port.sh 11633
 
-          ./dist/tracetest configure -g --endpoint http://localhost:11633 --analytics=false
+          ./dist/tracetest configure -g --endpoint http://localhost:11633
           ./dist/tracetest test run -d examples/${{ matrix.example_dir }}/tests/list-tests.yaml --wait-for-result || (cat /tmp/docker-log; exit 1)
 
   smoke-test-cli:
     name: CLI smoke tests
-    needs:  [build-docker]
+    needs: [build-docker]
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -314,7 +314,7 @@ jobs:
 
   e2e-cli:
     name: CLI e2e tests
-    needs:  [build-docker]
+    needs: [build-docker]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/cli/actions/configure_action.go
+++ b/cli/actions/configure_action.go
@@ -20,8 +20,7 @@ type ConfigureConfig struct {
 }
 
 type ConfigureConfigSetValues struct {
-	Endpoint         *string
-	AnalyticsEnabled *bool
+	Endpoint *string
 }
 
 type configureAction struct {
@@ -55,23 +54,14 @@ func (a configureAction) Run(ctx context.Context, args ConfigureConfig) error {
 		return err
 	}
 
-	var analyticsEnabled bool
-
-	if args.SetValues.AnalyticsEnabled != nil {
-		analyticsEnabled = *args.SetValues.AnalyticsEnabled
-	} else {
-		analyticsEnabled = ui.Confirm("Enable analytics?", true)
-	}
-
 	scheme, endpoint, err := config.ParseServerURL(serverURL)
 	if err != nil {
 		return err
 	}
 
 	config := config.Config{
-		Scheme:           scheme,
-		Endpoint:         endpoint,
-		AnalyticsEnabled: analyticsEnabled,
+		Scheme:   scheme,
+		Endpoint: endpoint,
 	}
 
 	err = a.saveConfiguration(ctx, config, args)

--- a/cli/analytics/analytics.go
+++ b/cli/analytics/analytics.go
@@ -1,88 +1,22 @@
 package analytics
 
 import (
-	"os"
-
 	"github.com/denisbrodbeck/machineid"
-	"github.com/kubeshop/tracetest/cli/config"
-	segment "github.com/segmentio/analytics-go/v3"
 )
 
 var (
-	SecretKey = ""
-	client    segment.Client
-	mid       string
+	mid string
 )
 
 func ClientID() string {
 	return mid
 }
 
-func Init(conf config.Config) {
-	if !conf.AnalyticsEnabled || os.Getenv("TRACETEST_DEV") != "" {
-		// non-empty TRACETEST_DEV variable means it's running by a dev,
-		// and we should totally ignore analytics
-		return
-	}
-
-	client, _ = segment.NewWithConfig(SecretKey, segment.Config{
-		BatchSize: 1,
-	})
-
+func Init() {
 	id, err := machineid.ProtectedID("tracetest")
 	if err == nil {
 		// only use id if available.
 		mid = id
 	} // ignore errors and continue with an empty ID if necessary
 
-	client.Enqueue(segment.Identify{
-		UserId: mid,
-		Traits: segment.NewTraits().
-			Set("source", "cli").
-			Set("clientID", mid).
-			Set("env", config.Env).
-			Set("appVersion", config.Version),
-		Context: &segment.Context{
-			Direct: true,
-		},
-	})
-}
-
-func Track(name, category string, props map[string]string) error {
-	if client == nil {
-		return nil
-	}
-
-	p := segment.NewProperties().
-		Set("source", "cli").
-		Set("clientID", mid).
-		Set("env", config.Env).
-		Set("appVersion", config.Version).
-		Set("category", category)
-
-	for k, v := range props {
-		p = p.Set(k, v)
-	}
-
-	err := client.Enqueue(segment.Track{
-		Event:      name,
-		UserId:     mid,
-		Properties: p,
-		Context: &segment.Context{
-			Direct: true,
-		},
-	})
-
-	return err
-}
-
-func Close() {
-	if client == nil {
-		return
-	}
-
-	err := client.Close()
-	if err != nil {
-		panic(err)
-	}
 }

--- a/cli/cmd/apply_cmd.go
+++ b/cli/cmd/apply_cmd.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 
 	"github.com/kubeshop/tracetest/cli/actions"
-	"github.com/kubeshop/tracetest/cli/analytics"
 	"github.com/kubeshop/tracetest/cli/formatters"
 	"github.com/kubeshop/tracetest/cli/parameters"
 	"github.com/spf13/cobra"
@@ -23,10 +22,6 @@ var applyCmd = &cobra.Command{
 	Run: WithResourceMiddleware(func(_ *cobra.Command, args []string) (string, error) {
 		resourceType := args[0]
 		ctx := context.Background()
-
-		analytics.Track("Resource Apply", "cmd", map[string]string{
-			resourceType: resourceType,
-		})
 
 		resourceActions, err := resourceRegistry.Get(resourceType)
 

--- a/cli/cmd/config.go
+++ b/cli/cmd/config.go
@@ -121,7 +121,7 @@ func setupCommand(options ...setupOption) func(cmd *cobra.Command, args []string
 			validateVersionMismatch()
 		}
 
-		analytics.Init(cliConfig)
+		analytics.Init()
 	}
 }
 
@@ -201,7 +201,6 @@ func setupLogger(cmd *cobra.Command, args []string) {
 
 func teardownCommand(cmd *cobra.Command, args []string) {
 	cliLogger.Sync()
-	analytics.Close()
 }
 
 func setupVersion() {

--- a/cli/cmd/configure_cmd.go
+++ b/cli/cmd/configure_cmd.go
@@ -4,7 +4,6 @@ import (
 	"context"
 
 	"github.com/kubeshop/tracetest/cli/actions"
-	"github.com/kubeshop/tracetest/cli/analytics"
 	"github.com/kubeshop/tracetest/cli/parameters"
 	"github.com/kubeshop/tracetest/cli/utils"
 	"github.com/spf13/cobra"
@@ -19,8 +18,6 @@ var configureCmd = &cobra.Command{
 	Long:    "Configure your tracetest CLI",
 	PreRun:  setupLogger,
 	Run: WithResultHandler(WithParamsHandler(configParams)(func(cmd *cobra.Command, _ []string) (string, error) {
-		analytics.Track("Configure", "cmd", map[string]string{})
-
 		ctx := context.Background()
 		client := utils.GetAPIClient(cliConfig)
 		action := actions.NewConfigureAction(cliConfig, cliLogger, client)
@@ -32,10 +29,6 @@ var configureCmd = &cobra.Command{
 
 		if flagProvided(cmd, "endpoint") {
 			actionConfig.SetValues.Endpoint = &configParams.Endpoint
-		}
-
-		if flagProvided(cmd, "analytics") {
-			actionConfig.SetValues.AnalyticsEnabled = &configParams.AnalyticsEnabled
 		}
 
 		err := action.Run(ctx, actionConfig)
@@ -51,6 +44,5 @@ func flagProvided(cmd *cobra.Command, name string) bool {
 func init() {
 	configureCmd.PersistentFlags().BoolVarP(&configParams.Global, "global", "g", false, "configuration will be saved in your home dir")
 	configureCmd.PersistentFlags().StringVarP(&configParams.Endpoint, "endpoint", "e", "", "set the value for the endpoint, so the CLI won't ask for this value")
-	configureCmd.PersistentFlags().BoolVarP(&configParams.AnalyticsEnabled, "analytics", "a", true, "configure the analytic state, so the CLI won't ask for this value")
 	rootCmd.AddCommand(configureCmd)
 }

--- a/cli/cmd/dashboard_cmd.go
+++ b/cli/cmd/dashboard_cmd.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"fmt"
 
-	"github.com/kubeshop/tracetest/cli/analytics"
 	"github.com/kubeshop/tracetest/cli/utils"
 	"github.com/spf13/cobra"
 )
@@ -15,8 +14,6 @@ var dashboardCmd = &cobra.Command{
 	Long:    "Opens the Tracetest Dashboard URL",
 	PreRun:  setupCommand(),
 	Run: WithResultHandler(func(_ *cobra.Command, _ []string) (string, error) {
-		analytics.Track("Dashboard", "cmd", map[string]string{})
-
 		if cliConfig.IsEmpty() {
 			return "", fmt.Errorf("missing Tracetest endpoint configuration")
 		}

--- a/cli/cmd/delete_cmd.go
+++ b/cli/cmd/delete_cmd.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/kubeshop/tracetest/cli/analytics"
 	"github.com/kubeshop/tracetest/cli/parameters"
 	"github.com/spf13/cobra"
 )
@@ -21,10 +20,6 @@ var deleteCmd = &cobra.Command{
 	Run: WithResourceMiddleware(func(_ *cobra.Command, args []string) (string, error) {
 		resourceType := args[0]
 		ctx := context.Background()
-
-		analytics.Track("Resource Delete", "cmd", map[string]string{
-			resourceType: resourceType,
-		})
 
 		resourceActions, err := resourceRegistry.Get(resourceType)
 		if err != nil {

--- a/cli/cmd/export_cmd.go
+++ b/cli/cmd/export_cmd.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/kubeshop/tracetest/cli/analytics"
 	"github.com/kubeshop/tracetest/cli/parameters"
 	"github.com/spf13/cobra"
 )
@@ -24,10 +23,6 @@ var exportCmd = &cobra.Command{
 	Run: WithResultHandler(func(_ *cobra.Command, args []string) (string, error) {
 		resourceType := args[0]
 		ctx := context.Background()
-
-		analytics.Track("Resource Export", "cmd", map[string]string{
-			resourceType: resourceType,
-		})
 
 		resourceActions, err := resourceRegistry.Get(resourceType)
 		if err != nil {

--- a/cli/cmd/get_cmd.go
+++ b/cli/cmd/get_cmd.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/kubeshop/tracetest/cli/analytics"
 	"github.com/kubeshop/tracetest/cli/formatters"
 	"github.com/kubeshop/tracetest/cli/parameters"
 	"github.com/kubeshop/tracetest/cli/utils"
@@ -24,10 +23,6 @@ var getCmd = &cobra.Command{
 	Run: WithResourceMiddleware(func(_ *cobra.Command, args []string) (string, error) {
 		resourceType := args[0]
 		ctx := context.Background()
-
-		analytics.Track("Resource Get", "cmd", map[string]string{
-			resourceType: resourceType,
-		})
 
 		resourceActions, err := resourceRegistry.Get(resourceType)
 		if err != nil {

--- a/cli/cmd/list_cmd.go
+++ b/cli/cmd/list_cmd.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/kubeshop/tracetest/cli/analytics"
 	"github.com/kubeshop/tracetest/cli/formatters"
 	"github.com/kubeshop/tracetest/cli/parameters"
 	"github.com/kubeshop/tracetest/cli/utils"
@@ -23,10 +22,6 @@ var listCmd = &cobra.Command{
 	Run: WithResourceMiddleware(func(_ *cobra.Command, args []string) (string, error) {
 		resourceType := args[0]
 		ctx := context.Background()
-
-		analytics.Track("Resource List", "cmd", map[string]string{
-			resourceType: resourceType,
-		})
 
 		resourceActions, err := resourceRegistry.Get(resourceType)
 		if err != nil {

--- a/cli/cmd/server_install_cmd.go
+++ b/cli/cmd/server_install_cmd.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"github.com/kubeshop/tracetest/cli/analytics"
 	"github.com/kubeshop/tracetest/cli/installer"
 	"github.com/kubeshop/tracetest/cli/parameters"
 	"github.com/spf13/cobra"
@@ -25,7 +24,6 @@ var serverInstallCmd = &cobra.Command{
 		installer.InstallationMode = installerParams.InstallationMode
 		installer.KubernetesContext = installerParams.KubernetesContext
 
-		analytics.Track("Server Install", "cmd", map[string]string{})
 		installer.Start()
 	},
 	PostRun: teardownCommand,

--- a/cli/cmd/test_export_cmd.go
+++ b/cli/cmd/test_export_cmd.go
@@ -4,7 +4,6 @@ import (
 	"context"
 
 	"github.com/kubeshop/tracetest/cli/actions"
-	"github.com/kubeshop/tracetest/cli/analytics"
 	"github.com/kubeshop/tracetest/cli/utils"
 	"github.com/spf13/cobra"
 	"go.uber.org/zap"
@@ -22,8 +21,6 @@ var testExportCmd = &cobra.Command{
 	Long:   "Exports a test into a file",
 	PreRun: setupCommand(),
 	Run: WithResultHandler(func(cmd *cobra.Command, args []string) (string, error) {
-		analytics.Track("Test Export", "cmd", map[string]string{})
-
 		ctx := context.Background()
 		cliLogger.Debug("Exporting test", zap.String("testID", exportTestId))
 		client := utils.GetAPIClient(cliConfig)

--- a/cli/cmd/test_list_cmd.go
+++ b/cli/cmd/test_list_cmd.go
@@ -4,7 +4,6 @@ import (
 	"context"
 
 	"github.com/kubeshop/tracetest/cli/actions"
-	"github.com/kubeshop/tracetest/cli/analytics"
 	"github.com/kubeshop/tracetest/cli/utils"
 	"github.com/spf13/cobra"
 	"go.uber.org/zap"
@@ -16,8 +15,6 @@ var testListCmd = &cobra.Command{
 	Long:   "List all tests",
 	PreRun: setupCommand(),
 	Run: WithResultHandler(func(_ *cobra.Command, _ []string) (string, error) {
-		analytics.Track("Test List", "cmd", map[string]string{})
-
 		ctx := context.Background()
 		cliLogger.Debug("Retrieving list of tests", zap.String("endpoint", cliConfig.Endpoint))
 		client := utils.GetAPIClient(cliConfig)

--- a/cli/cmd/test_run_cmd.go
+++ b/cli/cmd/test_run_cmd.go
@@ -4,7 +4,6 @@ import (
 	"context"
 
 	"github.com/kubeshop/tracetest/cli/actions"
-	"github.com/kubeshop/tracetest/cli/analytics"
 	"github.com/kubeshop/tracetest/cli/utils"
 	"github.com/spf13/cobra"
 )
@@ -22,8 +21,6 @@ var testRunCmd = &cobra.Command{
 	Long:   "Run a test on your Tracetest server",
 	PreRun: setupCommand(),
 	Run: WithResultHandler(func(_ *cobra.Command, _ []string) (string, error) {
-		analytics.Track("Test Run", "cmd", map[string]string{})
-
 		ctx := context.Background()
 		client := utils.GetAPIClient(cliConfig)
 

--- a/cli/cmd/version_cmd.go
+++ b/cli/cmd/version_cmd.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"github.com/kubeshop/tracetest/cli/analytics"
 	"github.com/spf13/cobra"
 )
 
@@ -12,8 +11,6 @@ var versionCmd = &cobra.Command{
 	Long:    "Display this CLI tool version",
 	PreRun:  setupCommand(),
 	Run: WithResultHandler(func(_ *cobra.Command, _ []string) (string, error) {
-		analytics.Track("Version", "cmd", map[string]string{})
-
 		return versionText, nil
 	}),
 	PostRun: teardownCommand,

--- a/cli/config/config.go
+++ b/cli/config/config.go
@@ -16,10 +16,9 @@ var (
 )
 
 type Config struct {
-	Scheme           string  `yaml:"scheme"`
-	Endpoint         string  `yaml:"endpoint"`
-	ServerPath       *string `yaml:"serverPath,omitempty"`
-	AnalyticsEnabled bool    `yaml:"analyticsEnabled"`
+	Scheme     string  `yaml:"scheme"`
+	Endpoint   string  `yaml:"endpoint"`
+	ServerPath *string `yaml:"serverPath,omitempty"`
 }
 
 func (c Config) URL() string {

--- a/cli/installer/docker_compose.go
+++ b/cli/installer/docker_compose.go
@@ -57,7 +57,6 @@ const (
 )
 
 func dockerComposeInstaller(config configuration, ui cliUI.UI) {
-	trackInstall("docker-compose", config, nil)
 	dir := config.String("output.dir")
 
 	err := os.RemoveAll(dir)

--- a/cli/installer/installer.go
+++ b/cli/installer/installer.go
@@ -1,9 +1,6 @@
 package installer
 
 import (
-	"fmt"
-
-	"github.com/kubeshop/tracetest/cli/analytics"
 	cliUI "github.com/kubeshop/tracetest/cli/ui"
 )
 
@@ -17,7 +14,6 @@ var (
 const createIssueMsg = "If you need help, please create an issue: https://github.com/kubeshop/tracetest/issues/new/choose"
 
 func Start() {
-	analytics.Track("Start", "installer", map[string]string{})
 	ui := cliUI.DefaultUI
 
 	ui.Banner()
@@ -85,10 +81,8 @@ func (i installer) Configure(ui cliUI.UI) configuration {
 }
 
 func (i installer) Install(ui cliUI.UI) {
-	analytics.Track("PreCheck", "installer", map[string]string{})
 	i.PreCheck(ui)
 
-	analytics.Track("Configure", "installer", map[string]string{})
 	conf := i.Configure(ui)
 
 	ui.Title("Thanks! We are ready to install TraceTest now")
@@ -123,21 +117,4 @@ func setInstallationType(ui cliUI.UI, config configuration) {
 	}, 0)
 
 	option.Fn(ui)
-}
-
-func trackInstall(name string, config configuration, extra map[string]string) {
-	props := map[string]string{
-		"type":                    name,
-		"install_backend":         fmt.Sprintf("%t", config.Bool("tracetest.backend.install")),
-		"install_demo_pokeshop":   fmt.Sprintf("%t", config.Bool("demo.enable.pokeshop")),
-		"install_demo_otel":       fmt.Sprintf("%t", config.Bool("demo.enable.otel")),
-		"enable_server_analytics": fmt.Sprintf("%t", config.Bool("tracetest.analytics")),
-		"backend_type":            config.String("tracetest.backend.type"),
-	}
-
-	for k, v := range extra {
-		props[k] = v
-	}
-
-	analytics.Track("Apply", "installer", props)
 }

--- a/cli/installer/kubernetes.go
+++ b/cli/installer/kubernetes.go
@@ -65,8 +65,6 @@ func installSed(ui cliUI.UI) {
 }
 
 func kubernetesInstaller(config configuration, ui cliUI.UI) {
-	trackInstall("kubernetes", config, nil)
-
 	execCmdIgnoreErrors(kubectlCmd(config, "create namespace "+config.String("k8s.namespace")))
 
 	if !config.Bool("installer.only_tracetest") {

--- a/cli/parameters/configure.go
+++ b/cli/parameters/configure.go
@@ -7,9 +7,8 @@ import (
 )
 
 type ConfigureParams struct {
-	AnalyticsEnabled bool
-	Endpoint         string
-	Global           bool
+	Endpoint string
+	Global   bool
 }
 
 var _ Params = &ConfigureParams{}

--- a/docs/docs/ci-cd-automation/tekton-pipeline.md
+++ b/docs/docs/ci-cd-automation/tekton-pipeline.md
@@ -242,7 +242,7 @@ spec:
       image: kubeshop/tracetest:v0.11.9 # The official Tracetest image comes with the Tracetest CLI installed
       script: |
         # Configure and Run Tracetest CLI
-        tracetest configure -g --endpoint http://tracetest.tracetest.svc.cluster.local:11633/ --analytics=false
+        tracetest configure -g --endpoint http://tracetest.tracetest.svc.cluster.local:11633/
         tracetest test run -d /workspace/test-api.yaml -w
       volumeMounts:
       - name: custom

--- a/docs/docs/cli/configuring-your-cli.md
+++ b/docs/docs/cli/configuring-your-cli.md
@@ -18,18 +18,11 @@ Configure your CLI to connect to your Tracetest server.
 tracetest configure
 ```
 
-If you want to set values without having to answer questions from a prompt, you can provide the flags `--endpoint` to define the server endpoint and `--analytics` to turn the analytics on and off.
+If you want to set values without having to answer questions from a prompt, you can provide the flag `--endpoint` to define the server endpoint.
 
 
 ```sh
-# This will prompt a question to ask if you want to enable or not analytics
 tracetest configure --endpoint http://my-tracetest-server:11633
-
-# Analytics enabled
-tracetest configure --endpoint http://my-tracetest-server:11633 --analytics
-
-# Analytics disabled
-tracetest configure --endpoint http://my-tracetest-server:11633 --analytics=false
 ```
 
 ### **Test List**

--- a/docs/docs/examples-tutorials/recipes/running-tracetest-with-datadog.md
+++ b/docs/docs/examples-tutorials/recipes/running-tracetest-with-datadog.md
@@ -276,7 +276,7 @@ First, [install the CLI](https://docs.tracetest.io/getting-started/installation#
 Then, configure the CLI:
 
 ```bash
-tracetest configure --endpoint http://localhost:11633 --analytics
+tracetest configure --endpoint http://localhost:11633
 ```
 
 Once configured, you can run a test against the Tracetest instance via the terminal.

--- a/docs/docs/examples-tutorials/recipes/running-tracetest-with-honeycomb.md
+++ b/docs/docs/examples-tutorials/recipes/running-tracetest-with-honeycomb.md
@@ -279,7 +279,7 @@ First, [install the CLI](https://docs.tracetest.io/getting-started/installation#
 Then, configure the CLI:
 
 ```bash
-tracetest configure --endpoint http://localhost:11633 --analytics
+tracetest configure --endpoint http://localhost:11633
 ```
 
 Once configured, you can run a test against the Tracetest instance via the terminal.

--- a/docs/docs/examples-tutorials/recipes/running-tracetest-with-lightstep.md
+++ b/docs/docs/examples-tutorials/recipes/running-tracetest-with-lightstep.md
@@ -255,7 +255,7 @@ First, [install the CLI](https://docs.tracetest.io/getting-started/installation#
 Then, configure the CLI:
 
 ```bash
-tracetest configure --endpoint http://localhost:11633 --analytics
+tracetest configure --endpoint http://localhost:11633
 ```
 
 Once configured, you can run a test against the Tracetest instance via the terminal.

--- a/docs/docs/examples-tutorials/recipes/running-tracetest-with-new-relic.md
+++ b/docs/docs/examples-tutorials/recipes/running-tracetest-with-new-relic.md
@@ -264,7 +264,7 @@ First, [install the CLI](https://docs.tracetest.io/getting-started/installation#
 Then, configure the CLI:
 
 ```bash
-tracetest configure --endpoint http://localhost:11633 --analytics
+tracetest configure --endpoint http://localhost:11633
 ```
 
 Once configured, you can run a test against the Tracetest instance via the terminal.

--- a/docs/docs/examples-tutorials/recipes/running-tracetest-with-tekton.md
+++ b/docs/docs/examples-tutorials/recipes/running-tracetest-with-tekton.md
@@ -240,7 +240,7 @@ spec:
       image: kubeshop/tracetest:v0.11.9 # The official Tracetest image comes with the Tracetest CLI installed
       script: |
         # Configure and Run Tracetest CLI
-        tracetest configure -g --endpoint http://tracetest.tracetest.svc.cluster.local:11633/ --analytics=false
+        tracetest configure -g --endpoint http://tracetest.tracetest.svc.cluster.local:11633/
         tracetest test run -d /workspace/test-api.yaml -w
       volumeMounts:
       - name: custom

--- a/docs/docs/examples-tutorials/recipes/running-tracetest-without-a-trace-data-store-with-manual-instrumentation.md
+++ b/docs/docs/examples-tutorials/recipes/running-tracetest-without-a-trace-data-store-with-manual-instrumentation.md
@@ -317,7 +317,7 @@ First, [install the CLI](https://docs.tracetest.io/getting-started/installation#
 Then, configure the CLI:
 
 ```bash
-tracetest configure --endpoint http://localhost:11633 --analytics
+tracetest configure --endpoint http://localhost:11633
 ```
 
 Once configured, you can run a test against the Tracetest instance via the terminal.

--- a/examples/quick-start-tekton/install-and-run-tracetest.yaml
+++ b/examples/quick-start-tekton/install-and-run-tracetest.yaml
@@ -35,7 +35,7 @@ spec:
       image: kubeshop/tracetest:v0.11.9 # The official Tracetest image comes with the Tracetest CLI installed
       script: |
         # Configure and Run Tracetest CLI
-        tracetest configure -g --endpoint http://tracetest.tracetest.svc.cluster.local:11633/ --analytics=false
+        tracetest configure -g --endpoint http://tracetest.tracetest.svc.cluster.local:11633/
         tracetest test run -d /workspace/test-api.yaml -w
       volumeMounts:
       - name: custom

--- a/examples/tracetest-lightstep-otel-demo/README.md
+++ b/examples/tracetest-lightstep-otel-demo/README.md
@@ -228,7 +228,7 @@ First, [install the CLI](https://docs.tracetest.io/getting-started/installation#
 Then, configure the CLI:
 
 ```bash
-tracetest configure --endpoint http://localhost:11633 --analytics
+tracetest configure --endpoint http://localhost:11633
 ```
 
 Once configured, you can run a test against the Tracetest instance via the terminal.

--- a/examples/tracetest-new-relic-otel-demo/README.md
+++ b/examples/tracetest-new-relic-otel-demo/README.md
@@ -229,7 +229,7 @@ First, [install the CLI](https://docs.tracetest.io/getting-started/installation#
 Then, configure the CLI:
 
 ```bash
-tracetest configure --endpoint http://localhost:11633 --analytics
+tracetest configure --endpoint http://localhost:11633
 ```
 
 Once configure, you can run a test against the Tracetest instance via the terminal.

--- a/examples/tracetest-synthetic-monitoring/.github/workflows/synthetic-monitoring.yaml
+++ b/examples/tracetest-synthetic-monitoring/.github/workflows/synthetic-monitoring.yaml
@@ -38,8 +38,7 @@ jobs:
         run: curl -L https://raw.githubusercontent.com/kubeshop/tracetest/main/install-cli.sh | bash
 
       - name: Configure Tracetest CLI
-        # if you want to disable analytics, change --analytics=true to --analytics=false
-        run: tracetest configure -g --endpoint http://localhost:11633 --analytics=true
+        run: tracetest configure -g --endpoint http://localhost:11633
 
       - name: Run syntethic monitoring tests
         id: monitoring


### PR DESCRIPTION
This PR removes the CLI analytics, including the `--analytics` flag from the `configure` command and the tracking of events.

## Changes

- remove `--analytics` flag from `configure` command
- remove `analytics.Track` event
- fix docs and examples

## Fixes

-

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
