### PR TITLE
Documenting running cli in docker

### DIFF
--- a/docs/docs/ci-cd-automation/overview.md
+++ b/docs/docs/ci-cd-automation/overview.md
@@ -8,12 +8,23 @@ You can find guides for:
 - [Testkube](./testkube-pipeline)
 - [Tekton](./tekton-pipeline)
 
+:::note
+If you want to see more examples with other CI/CD tools, let us know by [opening an issue in GitHub](https://github.com/kubeshop/tracetest/issues/new/choose)!
+:::
+
 Tracetest is designed to work with all CI/CD platforms and automation tools. To enable Tracetest to run in CI/CD environments, make sure to [install the Tracetest CLI](../getting-started/installation.mdx) and configure it to access your [Tracetest server](../configuration/server.md).
+
+You can also directly execute the Tracetest CLI from a docker image rather than installing the CLI on your local machine. This is sometimes convienent when you wish to execute the CLI in a CI/CD environment.
+
+**How to Use**:
+
+```sh
+docker run --rm -it -v$(pwd):$(pwd) -w $(pwd) --entrypoint tracetest kubeshop/tracetest:latest -s http://host.docker.internal:11633/ test run  --definition <file-path> --wait-for-result
+```
 
 To read more about integrating Tracetest with CI/CD tools, check out tutorials in our blog:
 
 - [Integrating Tracetest with GitHub Actions in a CI pipeline](https://kubeshop.io/blog/integrating-tracetest-with-github-actions-in-a-ci-pipeline)
 
-:::note
-If you want to see more examples with other CI/CD tools, let us know by [opening an issue in GitHub](https://github.com/kubeshop/tracetest/issues/new/choose)!
-:::
+
+

--- a/docs/docs/ci-cd-automation/overview.md
+++ b/docs/docs/ci-cd-automation/overview.md
@@ -14,7 +14,7 @@ If you want to see more examples with other CI/CD tools, let us know by [opening
 
 Tracetest is designed to work with all CI/CD platforms and automation tools. To enable Tracetest to run in CI/CD environments, make sure to [install the Tracetest CLI](../getting-started/installation.mdx) and configure it to access your [Tracetest server](../configuration/server.md).
 
-You can also directly execute the Tracetest CLI from a docker image rather than installing the CLI on your local machine. This is sometimes convienent when you wish to execute the CLI in a CI/CD environment.
+You can also directly execute the Tracetest CLI from a Docker image rather than installing the CLI on your local machine. This can be convenient when you wish to execute the CLI in a CI/CD environment.
 
 **How to Use**:
 

--- a/docs/docs/cli/configuring-your-cli.md
+++ b/docs/docs/cli/configuring-your-cli.md
@@ -67,7 +67,8 @@ tracetest test run --definition <file-path>
 
 ### Running Tracetest CLI From Docker
 
-There are times where it is easier to directly execute the Tracetest CLI from a docker image rather than installing the CLI on your local machine. This is sometimes convienent when you wish to execute the CLI in a CI/CD environment.
+There are times when it is easier to directly execute the Tracetest CLI from a Docker image rather than installing the CLI on your local machine. This can be convenient when you wish to execute the CLI in a CI/CD environment.
+
 
 **How to Use**:
 

--- a/docs/docs/cli/configuring-your-cli.md
+++ b/docs/docs/cli/configuring-your-cli.md
@@ -64,3 +64,15 @@ tracetest test run --definition <file-path>
 **Options**:
 
 `--wait-for-result`: The CLI will only exit after the test run has completed (the trace was retrieved and assertions were executed).
+
+### Running Tracetest CLI From Docker
+
+There are times where it is easier to directly execute the Tracetest CLI from a docker image rather than installing the CLI on your local machine. This is sometimes convienent when you wish to execute the CLI in a CI/CD environment.
+
+**How to Use**:
+
+```sh
+docker run --rm -it -v$(pwd):$(pwd) -w $(pwd) --entrypoint tracetest kubeshop/tracetest:latest -s http://host.docker.internal:11633/ test run  --definition <file-path> --wait-for-result
+```
+
+

--- a/docs/docs/cli/configuring-your-cli.md
+++ b/docs/docs/cli/configuring-your-cli.md
@@ -73,7 +73,7 @@ There are times when it is easier to directly execute the Tracetest CLI from a D
 **How to Use**:
 
 ```sh
-docker run --rm -it -v$(pwd):$(pwd) -w $(pwd) --entrypoint tracetest kubeshop/tracetest:latest -s http://host.docker.internal:11633/ test run  --definition <file-path> --wait-for-result
+docker run --rm -it -v$(pwd):$(pwd) -w $(pwd) --network host --entrypoint tracetest kubeshop/tracetest:latest -s http://localhost:11633/ test run  --definition <file-path> --wait-for-result
 ```
 
 


### PR DESCRIPTION
Adding docs in two places per #2611 to document how to use the Tracetest image to run the CLI in docker without installing locally.
