### PR TITLE
fix: disable csv fields count validation when listing contexts in k8s

### DIFF
--- a/cli/installer/kubernetes.go
+++ b/cli/installer/kubernetes.go
@@ -282,7 +282,10 @@ func getKubernetesContextArray(kubeconfig string) ([][]string, error) {
 	newStringBytes := spaceRegex.ReplaceAll([]byte(output), []byte(","))
 	output = string(newStringBytes)
 
-	records, err := csv.NewReader(strings.NewReader(output)).ReadAll()
+	csvReader := csv.NewReader(strings.NewReader(output))
+	// Related to issue: https://github.com/kubeshop/tracetest/issues/2723
+	csvReader.FieldsPerRecord = -1 // Disable fields length validation
+	records, err := csvReader.ReadAll()
 	if err != nil {
 		return [][]string{}, err
 	}


### PR DESCRIPTION
This PR fixes the error thrown by the csv reader when a CSV file contains different fields in each line.

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
