### PR TITLE
fix(cicd): make pull request pipeline work as expected for push to main

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -7,10 +7,10 @@ on:
     branches: [main]
 
 env:
-  VERSION: pr-${{ github.event.pull_request.number }}
-  TAG: pr-${{ github.event.pull_request.number }}
+  VERSION: ${{ github.sha }}
+  TAG: latest
 
-  TRACETEST_ENV: pr
+  TRACETEST_ENV: ci
   TRACETEST_DEV: true
   CYPRESS_BASE_URL: http://localhost:11633
   POKEMON_HTTP_ENDPOINT: http://demo-api:8081
@@ -199,7 +199,7 @@ jobs:
       - name: Export docker image
         if: steps.cache-docker-build.outputs.cache-hit != 'true'
         run: |
-          docker save --output dist/image.tar "kubeshop/tracetest:$VERSION"
+          docker save --output dist/image.tar "kubeshop/tracetest:$TAG"
       - name: Upload assets
         uses: actions/upload-artifact@v3
         with:
@@ -333,7 +333,6 @@ jobs:
 
           export TRACETEST_CLI=$PWD/dist/tracetest
           export TEST_ENVIRONMENT=jaeger
-          export TAG=pr-${{ github.event.pull_request.number }}
 
           cd ./testing/cli-e2etest
           make test

--- a/.goreleaser.dev.yaml
+++ b/.goreleaser.dev.yaml
@@ -16,6 +16,8 @@ before:
       cmd: go mod tidy
 env:
   - VERSION={{ if index .Env "VERSION"  }}{{ .Env.VERSION }}{{ else }}dev{{ end }}
+  # if TAG is defined, use it. Fallback to VERSION
+  - TAG={{ if index .Env "TAG"  }}{{ .Env.TAG }}{{ else }}{{ .Env.VERSION }}{{ end }}
   - TRACETEST_ENV={{ if index .Env "TRACETEST_ENV"  }}{{ .Env.TRACETEST_ENV }}{{ else }}dev{{ end }}
   - ANALYTICS_BE_KEY={{ if index .Env "ANALYTICS_BE_KEY"  }}{{ .Env.ANALYTICS_BE_KEY }}{{ else }}{{ end }}
   - ANALYTICS_FE_KEY={{ if index .Env "ANALYTICS_FE_KEY"  }}{{ .Env.ANALYTICS_FE_KEY }}{{ else }}{{ end }}
@@ -52,7 +54,7 @@ builds:
 dockers:
 - skip_push: true
   image_templates:
-  - 'kubeshop/tracetest:{{ .Env.VERSION }}'
+  - 'kubeshop/tracetest:{{ .Env.TAG }}'
   extra_files:
     - web/build
   build_flag_templates:


### PR DESCRIPTION
This PR updates the pull request pipeline so it can work as expected when triggered both by a PR or by a push to main.

When running on main, the images were exported with the tag `kubeshop/tracetest:pr-`. This is because the pipeline relies on the PR number to build that tag. The problem is that sometimes the cache can be picked by a PR that will try to run images with the tag `kubeshop/tracetest:pr-{the pr number}`. Since the image is exported with the wrong tag, the docker stack cannot start and everything fails.

This happens by removing the references to PR specific info, like PR number, and replacing it by the sha of whatever commit triggered the action.

