### PR TITLE
feature(frontend): Adding Automate Tab Skeleton

### DIFF
--- a/web/src/components/Header/Header.styled.tsx
+++ b/web/src/components/Header/Header.styled.tsx
@@ -10,7 +10,8 @@ export const Header = styled(Layout.Header)`
   justify-content: space-between;
   height: 48px;
   line-height: 48px;
-  padding: 0 24px;
+  padding: 0;
+  padding-left: 24px;
 
   .ant-dropdown-trigger {
     display: block;

--- a/web/src/components/RunDetailAutomate/RunDetailAutomate.styled.ts
+++ b/web/src/components/RunDetailAutomate/RunDetailAutomate.styled.ts
@@ -1,0 +1,28 @@
+import styled from 'styled-components';
+
+export const Container = styled.div`
+  display: flex;
+  height: 100%;
+  width: 100%;
+`;
+
+export const Section = styled.div`
+  flex: 1;
+`;
+
+export const SectionLeft = styled(Section)`
+  background-color: ${({theme}) => theme.color.white};
+  overflow-y: scroll;
+  z-index: 1;
+  flex-basis: 50%;
+  max-width: 50vw;
+`;
+
+export const SectionRight = styled(Section)`
+  background-color: ${({theme}) => theme.color.white};
+  border-left: 1px solid rgba(3, 24, 73, 0.1);
+  overflow-y: scroll;
+  z-index: 2;
+  flex-basis: 50%;
+  max-width: 50vw;
+`;

--- a/web/src/components/RunDetailAutomate/RunDetailAutomate.tsx
+++ b/web/src/components/RunDetailAutomate/RunDetailAutomate.tsx
@@ -1,0 +1,27 @@
+import TestRun from 'models/TestRun.model';
+import TestRunEvent from 'models/TestRunEvent.model';
+import * as S from './RunDetailAutomate.styled';
+
+interface IProps {
+  run: TestRun;
+  runEvents: TestRunEvent[];
+  testId: string;
+}
+
+export enum VisualizationType {
+  Dag,
+  Timeline,
+}
+
+const RunDetailAutomate = ({run, runEvents, testId}: IProps) => {
+  console.log('@@@props', run, runEvents, testId);
+
+  return (
+    <S.Container>
+      <S.SectionLeft>Test Definition</S.SectionLeft>
+      <S.SectionRight>Test run Techniques</S.SectionRight>
+    </S.Container>
+  );
+};
+
+export default RunDetailAutomate;

--- a/web/src/components/RunDetailAutomate/RunDetailAutomate.tsx
+++ b/web/src/components/RunDetailAutomate/RunDetailAutomate.tsx
@@ -1,21 +1,6 @@
-import TestRun from 'models/TestRun.model';
-import TestRunEvent from 'models/TestRunEvent.model';
 import * as S from './RunDetailAutomate.styled';
 
-interface IProps {
-  run: TestRun;
-  runEvents: TestRunEvent[];
-  testId: string;
-}
-
-export enum VisualizationType {
-  Dag,
-  Timeline,
-}
-
-const RunDetailAutomate = ({run, runEvents, testId}: IProps) => {
-  console.log('@@@props', run, runEvents, testId);
-
+const RunDetailAutomate = () => {
   return (
     <S.Container>
       <S.SectionLeft>Test Definition</S.SectionLeft>

--- a/web/src/components/RunDetailAutomate/index.ts
+++ b/web/src/components/RunDetailAutomate/index.ts
@@ -1,0 +1,2 @@
+// eslint-disable-next-line no-restricted-exports
+export {default} from './RunDetailAutomate';

--- a/web/src/components/RunDetailLayout/RunDetailLayout.styled.ts
+++ b/web/src/components/RunDetailLayout/RunDetailLayout.styled.ts
@@ -36,6 +36,14 @@ export const ContainerHeader = styled.div`
       display: none;
     }
 
+    .ant-tabs-nav-wrap {
+      overflow: visible;
+    }
+
+    .ant-tabs-nav-more {
+      display: none;
+    }
+
     ::before {
       display: none;
     }
@@ -86,7 +94,7 @@ export const Section = styled.div<{$justifyContent: string}>`
   display: flex;
   gap: 14px;
   justify-content: ${({$justifyContent}) => $justifyContent};
-  width: calc((100vw / 2) - 150px);
+  width: calc((100vw / 2) - 200px);
 `;
 
 export const StateContainer = styled.div`
@@ -118,7 +126,7 @@ export const Text = styled(Typography.Text).attrs({
 export const Title = styled(Typography.Title).attrs({ellipsis: true, level: 2})`
   && {
     margin: 0;
-    max-width: calc((100vw / 2) - 150px - 54px);
+    max-width: calc((100vw / 2) - 200px - 54px);
   }
 `;
 

--- a/web/src/components/RunDetailLayout/RunDetailLayout.tsx
+++ b/web/src/components/RunDetailLayout/RunDetailLayout.tsx
@@ -16,6 +16,7 @@ import {ConfigMode} from 'types/DataStore.types';
 import HeaderLeft from './HeaderLeft';
 import HeaderRight from './HeaderRight';
 import * as S from './RunDetailLayout.styled';
+import RunDetailAutomate from '../RunDetailAutomate/RunDetailAutomate';
 
 interface IProps {
   test: Test;
@@ -84,6 +85,9 @@ const RunDetailLayout = ({test: {id, name, trigger, version = 1}, test}: IProps)
         </Tabs.TabPane>
         <Tabs.TabPane tab={renderTab('Test', id, run.id, mode)} key={RunDetailModes.TEST}>
           <RunDetailTest run={run} runEvents={runEvents} testId={id} />
+        </Tabs.TabPane>
+        <Tabs.TabPane tab={renderTab('Automate', id, run.id, mode)} key={RunDetailModes.AUTOMATE}>
+          <RunDetailAutomate run={run} runEvents={runEvents} testId={id} />
         </Tabs.TabPane>
       </Tabs>
     </S.Container>

--- a/web/src/components/RunDetailLayout/RunDetailLayout.tsx
+++ b/web/src/components/RunDetailLayout/RunDetailLayout.tsx
@@ -87,7 +87,7 @@ const RunDetailLayout = ({test: {id, name, trigger, version = 1}, test}: IProps)
           <RunDetailTest run={run} runEvents={runEvents} testId={id} />
         </Tabs.TabPane>
         <Tabs.TabPane tab={renderTab('Automate', id, run.id, mode)} key={RunDetailModes.AUTOMATE}>
-          <RunDetailAutomate run={run} runEvents={runEvents} testId={id} />
+          <RunDetailAutomate />
         </Tabs.TabPane>
       </Tabs>
     </S.Container>

--- a/web/src/constants/TestRun.constants.ts
+++ b/web/src/constants/TestRun.constants.ts
@@ -84,4 +84,5 @@ export enum RunDetailModes {
   TRIGGER = 'trigger',
   TRACE = 'trace',
   TEST = 'test',
+  AUTOMATE = 'automate',
 }


### PR DESCRIPTION
This PR adds the base skeleton for the automate tab

## Changes

- Adds new tab to the test run detail header
- Adds new pane for the automate feature

## Fixes

- #2749 

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

![Screenshot 2023-06-16 at 16 15 43](https://github.com/kubeshop/tracetest/assets/11051031/050838f4-f2f0-4472-80fc-15a5fabcf5e3)
