### PR TITLE
feature(frontend): Automate Tab (#2753)

### DIFF
--- a/web/src/components/CodeBlock/CodeBlock.styled.ts
+++ b/web/src/components/CodeBlock/CodeBlock.styled.ts
@@ -1,13 +1,19 @@
 import styled from 'styled-components';
 
-export const Container = styled.div`
-  > div {
-    padding: 7px 14px;
-    border: 1px solid rgba(3, 24, 73, 0.1);
-    margin-top: 16px;
+export const CodeContainer = styled.div<{$maxHeight: string; $minHeight: string}>`
+  position: relative;
+  border: ${({theme}) => `1px solid ${theme.color.border}`};
+  min-height: ${({$minHeight}) => $minHeight || '370px'};
+  cursor: pointer;
 
-    .ͼ1.cm-editor.cm-focused {
-      outline: none;
+  pre {
+    margin: 0;
+    min-height: inherit;
+    max-height: ${({$maxHeight}) => $maxHeight || '340px'};
+    background: ${({theme}) => theme.color.background} !important;
+
+    &:hover {
+      background: ${({theme}) => theme.color.backgroundInteractive} !important;
     }
   }
 `;

--- a/web/src/components/CodeBlock/CodeBlock.tsx
+++ b/web/src/components/CodeBlock/CodeBlock.tsx
@@ -1,18 +1,21 @@
-import ReactCodeMirror from '@uiw/react-codemirror';
-import {loadLanguage, LanguageName, langNames} from '@uiw/codemirror-extensions-langs';
+import SyntaxHighlighter from 'react-syntax-highlighter';
+import {arduinoLight} from 'react-syntax-highlighter/dist/cjs/styles/hljs';
+import {LanguageName, langNames} from '@uiw/codemirror-extensions-langs';
+import useCopy from 'hooks/useCopy';
 import {useMemo} from 'react';
 import * as S from './CodeBlock.styled';
-import useEditorTheme from '../Editor/hooks/useEditorTheme';
 
 interface IProps {
   value: string;
-  mimeType: string;
+  language?: string;
+  mimeType?: string;
+  maxHeight?: string;
+  minHeight?: string;
 }
 
-const getInitialLang = (mimeType: string): LanguageName | undefined =>
-  langNames.find(lang => mimeType.includes(`/${lang}`));
+const getLang = (mimeType: string): LanguageName | undefined => langNames.find(lang => mimeType.includes(`/${lang}`));
 
-const formatValue = (value: string, lang: LanguageName | undefined): string => {
+const formatValue = (value: string, lang?: string): string => {
   switch (lang) {
     case 'json':
       try {
@@ -26,24 +29,16 @@ const formatValue = (value: string, lang: LanguageName | undefined): string => {
   }
 };
 
-const CodeBlock = ({value, mimeType}: IProps) => {
-  const lang = useMemo(() => getInitialLang(mimeType), [mimeType]);
-  const theme = useEditorTheme();
-  const extensionList = useMemo(() => (lang ? [theme, loadLanguage(lang)!] : []), [lang, theme]);
+const CodeBlock = ({value, language, mimeType = '', maxHeight = '', minHeight = ''}: IProps) => {
+  const copy = useCopy();
+  const lang = useMemo(() => language || getLang(mimeType), [language, mimeType]);
 
   return (
-    <S.Container>
-      <ReactCodeMirror
-        basicSetup={{lineNumbers: false, foldGutter: false}}
-        id="code-block"
-        data-cy="code-block"
-        value={formatValue(value, lang)}
-        readOnly
-        extensions={extensionList}
-        spellCheck={false}
-        autoFocus
-      />
-    </S.Container>
+    <S.CodeContainer data-cy="code-block" $maxHeight={maxHeight} $minHeight={minHeight} onClick={() => copy(value)}>
+      <SyntaxHighlighter language={lang} style={arduinoLight} wrapLongLines>
+        {formatValue(value, lang)}
+      </SyntaxHighlighter>
+    </S.CodeContainer>
   );
 };
 

--- a/web/src/components/FileViewerModal/FileViewerModal.provider.tsx
+++ b/web/src/components/FileViewerModal/FileViewerModal.provider.tsx
@@ -1,21 +1,18 @@
 import {capitalize, noop} from 'lodash';
 import {createContext, useCallback, useContext, useMemo, useState} from 'react';
 import FileViewerModal from 'components/FileViewerModal';
-import {
-  useLazyGetJUnitByRunIdQuery,
-  useLazyGetResourceDefinitionQuery,
-  useLazyGetResourceDefinitionV2Query,
-} from 'redux/apis/TraceTest.api';
 import {ResourceType} from 'types/Resource.type';
+import useDefinitionFile from 'hooks/useDefinitionFile';
+import useJUnitResult from 'hooks/useJUnitResult';
 
 interface IContext {
-  loadJUnit(testId: string, runId: string): void;
-  loadDefinition(resourceType: ResourceType, resourceId: string, version?: number): void;
+  onJUnit(testId: string, runId: string): void;
+  onDefinition(resourceType: ResourceType, resourceId: string, version?: number): void;
 }
 
 export const Context = createContext<IContext>({
-  loadJUnit: noop,
-  loadDefinition: noop,
+  onJUnit: noop,
+  onDefinition: noop,
 });
 
 interface IProps {
@@ -41,13 +38,8 @@ const propsMap = {
 
 const FileViewerModalProvider = ({children}: IProps) => {
   const [isFileViewerOpen, setIsFileViewerOpen] = useState(false);
-  const [fileViewerData, setFileViewerData] = useState<{data: string; type: 'definition' | 'junit'}>({
-    data: '',
-    type: 'definition',
-  });
-  const [getJUnit] = useLazyGetJUnitByRunIdQuery();
-  const [getResourceDefinition] = useLazyGetResourceDefinitionQuery();
-  const [getResourceDefinitionV2] = useLazyGetResourceDefinitionV2Query();
+  const {definition, loadDefinition} = useDefinitionFile();
+  const {jUnit, loadJUnit} = useJUnitResult();
   const [fileProps, setProps] = useState({
     title: '',
     language: '',
@@ -55,23 +47,19 @@ const FileViewerModalProvider = ({children}: IProps) => {
     fileName: '',
   });
 
-  const loadJUnit = useCallback(
+  const onJUnit = useCallback(
     async (testId: string, runId: string) => {
-      const data = await getJUnit({runId, testId}).unwrap();
+      loadJUnit(testId, runId);
       setIsFileViewerOpen(true);
-      setFileViewerData({data, type: 'junit'});
       setProps(propsMap.junit);
     },
-    [getJUnit]
+    [loadJUnit]
   );
 
-  const loadDefinition = useCallback(
+  const onDefinition = useCallback(
     async (resourceType: ResourceType, resourceId: string, version?: number) => {
-      const data = await (resourceType === ResourceType.Environment || resourceType === ResourceType.Transaction
-        ? getResourceDefinitionV2({resourceId, resourceType}).unwrap()
-        : getResourceDefinition({resourceId, version, resourceType}).unwrap());
       setIsFileViewerOpen(true);
-      setFileViewerData({data, type: 'definition'});
+      loadDefinition(resourceType, resourceId, version);
       setProps({
         title: `${capitalize(resourceType)} Definition`,
         language: 'yaml',
@@ -79,10 +67,10 @@ const FileViewerModalProvider = ({children}: IProps) => {
         fileName: `${resourceType}-${resourceId}-${version || 0}-definition.yaml`,
       });
     },
-    [getResourceDefinition, getResourceDefinitionV2]
+    [loadDefinition]
   );
 
-  const value: IContext = useMemo(() => ({loadJUnit, loadDefinition}), [loadJUnit, loadDefinition]);
+  const value: IContext = useMemo(() => ({onJUnit, onDefinition}), [onJUnit, onDefinition]);
 
   return (
     <>
@@ -90,7 +78,7 @@ const FileViewerModalProvider = ({children}: IProps) => {
       <FileViewerModal
         isOpen={isFileViewerOpen}
         {...fileProps}
-        data={fileViewerData.data}
+        data={definition || jUnit}
         onClose={() => setIsFileViewerOpen(false)}
       />
     </>

--- a/web/src/components/Header/Header.styled.tsx
+++ b/web/src/components/Header/Header.styled.tsx
@@ -10,7 +10,8 @@ export const Header = styled(Layout.Header)`
   justify-content: space-between;
   height: 48px;
   line-height: 48px;
-  padding: 0 24px;
+  padding: 0;
+  padding-left: 24px;
 
   .ant-dropdown-trigger {
     display: block;

--- a/web/src/components/RunActionsMenu/RunActionsMenu.tsx
+++ b/web/src/components/RunActionsMenu/RunActionsMenu.tsx
@@ -49,6 +49,15 @@ const RunActionsMenu = ({resultId, testId, transactionId, transactionRunId, isRu
               JUnit Results
             </Menu.Item>
             <Menu.Item
+              data-cy="automate-test-button"
+              key="automate-test"
+              onClick={() => {
+                navigate(`/test/${testId}/run/${resultId}/automate`);
+              }}
+            >
+              Automate
+            </Menu.Item>
+            <Menu.Item
               data-cy="test-edit-button"
               onClick={({domEvent}) => {
                 domEvent.stopPropagation();

--- a/web/src/components/RunActionsMenu/RunActionsMenu.tsx
+++ b/web/src/components/RunActionsMenu/RunActionsMenu.tsx
@@ -10,21 +10,13 @@ import * as S from './RunActionsMenu.styled';
 interface IProps {
   resultId: string;
   testId: string;
-  testVersion: number;
   isRunView?: boolean;
   transactionId?: string;
   transactionRunId: string;
 }
 
-const RunActionsMenu = ({
-  resultId,
-  testId,
-  testVersion,
-  transactionId,
-  transactionRunId,
-  isRunView = false,
-}: IProps) => {
-  const {loadJUnit, loadDefinition} = useFileViewerModal();
+const RunActionsMenu = ({resultId, testId, transactionId, transactionRunId, isRunView = false}: IProps) => {
+  const {onJUnit} = useFileViewerModal();
 
   const navigate = useNavigate();
 
@@ -51,20 +43,10 @@ const RunActionsMenu = ({
               key="view-junit"
               onClick={() => {
                 TestRunAnalyticsService.onLoadJUnitReport();
-                loadJUnit(testId, resultId);
+                onJUnit(testId, resultId);
               }}
             >
               JUnit Results
-            </Menu.Item>
-            <Menu.Item
-              data-cy="view-test-definition-button"
-              key="view-test-definition"
-              onClick={() => {
-                TestRunAnalyticsService.onLoadTestDefinition();
-                loadDefinition(ResourceType.Test, testId, testVersion);
-              }}
-            >
-              Test Definition
             </Menu.Item>
             <Menu.Item
               data-cy="test-edit-button"

--- a/web/src/components/RunCard/TestRunCard.tsx
+++ b/web/src/components/RunCard/TestRunCard.tsx
@@ -122,7 +122,6 @@ const TestRunCard = ({
           <RunActionsMenu
             resultId={runId}
             testId={testId}
-            testVersion={testVersion}
             transactionRunId={transactionRunId}
             transactionId={transactionId}
           />

--- a/web/src/components/RunDetailAutomate/RunDetailAutomate.styled.ts
+++ b/web/src/components/RunDetailAutomate/RunDetailAutomate.styled.ts
@@ -1,0 +1,28 @@
+import styled from 'styled-components';
+
+export const Container = styled.div`
+  display: flex;
+  height: 100%;
+  width: 100%;
+`;
+
+export const Section = styled.div`
+  flex: 1;
+`;
+
+export const SectionLeft = styled(Section)`
+  background-color: ${({theme}) => theme.color.white};
+  overflow-y: scroll;
+  z-index: 1;
+  flex-basis: 50%;
+  max-width: 50vw;
+`;
+
+export const SectionRight = styled(Section)`
+  background-color: ${({theme}) => theme.color.white};
+  border-left: 1px solid rgba(3, 24, 73, 0.1);
+  overflow-y: scroll;
+  z-index: 2;
+  flex-basis: 50%;
+  max-width: 50vw;
+`;

--- a/web/src/components/RunDetailAutomate/RunDetailAutomate.tsx
+++ b/web/src/components/RunDetailAutomate/RunDetailAutomate.tsx
@@ -1,6 +1,7 @@
 import Test from 'models/Test.model';
 import * as S from './RunDetailAutomate.styled';
-import TestDefinition from '../TestDefinition/TestDefinition';
+import TestDefinition from '../RunDetailAutomateDefinition';
+import RunDetailAutomateMethods from '../RunDetailAutomateMethods/RunDetailAutomateMethods';
 
 interface IProps {
   test: Test;
@@ -12,7 +13,9 @@ const RunDetailAutomate = ({test}: IProps) => {
       <S.SectionLeft>
         <TestDefinition test={test} />
       </S.SectionLeft>
-      <S.SectionRight>Test run Techniques</S.SectionRight>
+      <S.SectionRight>
+        <RunDetailAutomateMethods />
+      </S.SectionRight>
     </S.Container>
   );
 };

--- a/web/src/components/RunDetailAutomate/RunDetailAutomate.tsx
+++ b/web/src/components/RunDetailAutomate/RunDetailAutomate.tsx
@@ -1,9 +1,17 @@
+import Test from 'models/Test.model';
 import * as S from './RunDetailAutomate.styled';
+import TestDefinition from '../TestDefinition/TestDefinition';
 
-const RunDetailAutomate = () => {
+interface IProps {
+  test: Test;
+}
+
+const RunDetailAutomate = ({test}: IProps) => {
   return (
     <S.Container>
-      <S.SectionLeft>Test Definition</S.SectionLeft>
+      <S.SectionLeft>
+        <TestDefinition test={test} />
+      </S.SectionLeft>
       <S.SectionRight>Test run Techniques</S.SectionRight>
     </S.Container>
   );

--- a/web/src/components/RunDetailAutomate/RunDetailAutomate.tsx
+++ b/web/src/components/RunDetailAutomate/RunDetailAutomate.tsx
@@ -1,0 +1,12 @@
+import * as S from './RunDetailAutomate.styled';
+
+const RunDetailAutomate = () => {
+  return (
+    <S.Container>
+      <S.SectionLeft>Test Definition</S.SectionLeft>
+      <S.SectionRight>Test run Techniques</S.SectionRight>
+    </S.Container>
+  );
+};
+
+export default RunDetailAutomate;

--- a/web/src/components/RunDetailAutomate/index.ts
+++ b/web/src/components/RunDetailAutomate/index.ts
@@ -1,0 +1,2 @@
+// eslint-disable-next-line no-restricted-exports
+export {default} from './RunDetailAutomate';

--- a/web/src/components/RunDetailAutomateDefinition/RunDetailAutomateDefinition.styled.ts
+++ b/web/src/components/RunDetailAutomateDefinition/RunDetailAutomateDefinition.styled.ts
@@ -1,0 +1,24 @@
+import {Typography} from 'antd';
+import styled from 'styled-components';
+
+export const Container = styled.div`
+  padding: 24px;
+`;
+
+export const Title = styled(Typography.Title)`
+  && {
+    font-size: ${({theme}) => theme.size.lg};
+    margin-bottom: 16px;
+    font-weight: 700;
+  }
+`;
+
+export const SubtitleContainer = styled.div`
+  margin-bottom: 8px;
+`;
+
+export const Footer = styled.div`
+  display: flex;
+  justify-content: flex-end;
+  margin-top: 16px;
+`;

--- a/web/src/components/RunDetailAutomateDefinition/RunDetailAutomateDefinition.tsx
+++ b/web/src/components/RunDetailAutomateDefinition/RunDetailAutomateDefinition.tsx
@@ -1,0 +1,42 @@
+import {useCallback, useEffect} from 'react';
+import {DownloadOutlined} from '@ant-design/icons';
+import {Button, Typography} from 'antd';
+import {downloadFile} from 'utils/Common';
+import useDefinitionFile from 'hooks/useDefinitionFile';
+import {ResourceType} from 'types/Resource.type';
+import Test from 'models/Test.model';
+import * as S from './RunDetailAutomateDefinition.styled';
+import CodeBlock from '../CodeBlock/CodeBlock';
+
+interface IProps {
+  test: Test;
+}
+
+const RunDetailAutomateDefinition = ({test: {id, version}}: IProps) => {
+  const {definition, loadDefinition} = useDefinitionFile();
+
+  const onDownload = useCallback(() => {
+    downloadFile(definition, 'test_definition.yaml');
+  }, [definition]);
+
+  useEffect(() => {
+    loadDefinition(ResourceType.Test, id, version);
+  }, [id, loadDefinition, version]);
+
+  return (
+    <S.Container>
+      <S.Title>Test Definition</S.Title>
+      <S.SubtitleContainer>
+        <Typography.Text>Preview your YAML file</Typography.Text>
+      </S.SubtitleContainer>
+      <CodeBlock value={definition} language="yaml" />
+      <S.Footer>
+        <Button data-cy="file-viewer-download" icon={<DownloadOutlined />} onClick={onDownload} type="primary">
+          Download File
+        </Button>
+      </S.Footer>
+    </S.Container>
+  );
+};
+
+export default RunDetailAutomateDefinition;

--- a/web/src/components/RunDetailAutomateDefinition/index.ts
+++ b/web/src/components/RunDetailAutomateDefinition/index.ts
@@ -1,0 +1,2 @@
+// eslint-disable-next-line no-restricted-exports
+export {default} from './RunDetailAutomateDefinition';

--- a/web/src/components/RunDetailAutomateMethods/RunDetailAutomateMethods.styled.ts
+++ b/web/src/components/RunDetailAutomateMethods/RunDetailAutomateMethods.styled.ts
@@ -11,9 +11,9 @@ export const Container = styled.div`
 
 export const TitleContainer = styled.div`
   display: flex;
-  justify-content: space-between;
   align-items: center;
-  margin-bottom: 25px;
+  gap: 8px;
+  margin-bottom: 24px;
 `;
 
 export const Title = styled(Typography.Title)`
@@ -21,6 +21,12 @@ export const Title = styled(Typography.Title)`
     font-size: ${({theme}) => theme.size.lg};
     margin: 0;
     font-weight: 700;
+  }
+`;
+
+export const Subtitle = styled(Typography.Text)`
+  && {
+    color: ${({theme}) => theme.color.textLight};
   }
 `;
 
@@ -129,14 +135,12 @@ export const EmptyText = styled(Typography.Text)`
 export const EmptyTitle = styled(Typography.Title).attrs({level: 3})``;
 
 export const ResponseBodyContainer = styled.div`
-  display: grid;
-  grid-template-columns: 95% 5%;
+  display: flex;
   width: 100%;
 `;
 
 export const ResponseBodyContent = styled.div`
   flex: 1;
-  margin-top: 16px;
 `;
 
 export const ResponseBodyActions = styled.div`

--- a/web/src/components/RunDetailAutomateMethods/RunDetailAutomateMethods.tsx
+++ b/web/src/components/RunDetailAutomateMethods/RunDetailAutomateMethods.tsx
@@ -1,0 +1,36 @@
+import {Tabs} from 'antd';
+import {useSearchParams} from 'react-router-dom';
+import CliCommand from './methods/CLICommand';
+import * as S from './RunDetailAutomateMethods.styled';
+
+const TabsKeys = {
+  CLI: 'cli',
+};
+
+const RunDetailAutomateMethods = () => {
+  const [query, updateQuery] = useSearchParams();
+
+  return (
+    <S.Container>
+      <S.TitleContainer>
+        <S.Title>Running Techniques</S.Title> <S.Subtitle>Methods to automate the running of this test</S.Subtitle>
+      </S.TitleContainer>
+      <S.TabsContainer>
+        <Tabs
+          defaultActiveKey={query.get('tab') || TabsKeys.CLI}
+          data-cy="run-detail-automate-methods"
+          size="small"
+          onChange={newTab => {
+            updateQuery([['tab', newTab]]);
+          }}
+        >
+          <Tabs.TabPane key={TabsKeys.CLI} tab="CLI">
+            <CliCommand />
+          </Tabs.TabPane>
+        </Tabs>
+      </S.TabsContainer>
+    </S.Container>
+  );
+};
+
+export default RunDetailAutomateMethods;

--- a/web/src/components/RunDetailAutomateMethods/index.ts
+++ b/web/src/components/RunDetailAutomateMethods/index.ts
@@ -1,0 +1,2 @@
+// eslint-disable-next-line no-restricted-exports
+export {default} from './RunDetailAutomateMethods';

--- a/web/src/components/RunDetailAutomateMethods/methods/CLICommand/CliCommand.styled.ts
+++ b/web/src/components/RunDetailAutomateMethods/methods/CLICommand/CliCommand.styled.ts
@@ -1,0 +1,45 @@
+import {Typography} from 'antd';
+import styled from 'styled-components';
+
+export const Title = styled(Typography.Title).attrs({
+  level: 3,
+})`
+  && {
+    font-size: ${({theme}) => theme.size.md};
+    font-weight: 600;
+    margin-bottom: 16px;
+  }
+`;
+
+export const Subtitle = styled(Typography.Paragraph)`
+  && {
+    margin-bottom: 8px;
+  }
+`;
+
+export const TitleContainer = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+`;
+
+export const Container = styled.div`
+  margin: 16px 0;
+`;
+
+export const SwitchContainer = styled.div`
+  align-items: center;
+  display: flex;
+  gap: 8px;
+  margin-bottom: 12px;
+`;
+
+export const SwitchLabel = styled.label`
+  cursor: pointer;
+`;
+
+export const ControlsContainer = styled.div`
+  margin-top: 16px;
+`;
+export const OptionsContainer = styled.div``;
+export const FormatContainer = styled.div``;

--- a/web/src/components/RunDetailAutomateMethods/methods/CLICommand/CliCommand.tsx
+++ b/web/src/components/RunDetailAutomateMethods/methods/CLICommand/CliCommand.tsx
@@ -1,0 +1,26 @@
+import CodeBlock from 'components/CodeBlock/CodeBlock';
+import {ReadOutlined} from '@ant-design/icons';
+import {CLI_RUNNING_TESTS_URL} from 'constants/Common.constants';
+import * as S from './CliCommand.styled';
+import Controls from './Controls';
+import useCliCommand from './hooks/useCliCommand';
+
+const CLiCommand = () => {
+  const {command, onGetCommand} = useCliCommand();
+
+  return (
+    <S.Container>
+      <S.TitleContainer>
+        <S.Title>CLI Configuration</S.Title>
+        <a href={CLI_RUNNING_TESTS_URL} target="_blank">
+          <ReadOutlined />
+        </a>
+      </S.TitleContainer>
+      <S.Subtitle>Tracetest CLI command:</S.Subtitle>
+      <CodeBlock language="bash" value={command} minHeight="80px" maxHeight="80px" />
+      <Controls onChange={onGetCommand} />
+    </S.Container>
+  );
+};
+
+export default CLiCommand;

--- a/web/src/components/RunDetailAutomateMethods/methods/CLICommand/Controls.tsx
+++ b/web/src/components/RunDetailAutomateMethods/methods/CLICommand/Controls.tsx
@@ -1,0 +1,74 @@
+import {useCallback, useEffect, useState} from 'react';
+import {toUpper} from 'lodash';
+import {Radio, Typography} from 'antd';
+import {
+  CliCommandFormat,
+  CliCommandOption,
+  TCliCommandConfig,
+  TCliCommandEnabledOptions,
+} from 'services/CliCommand.service';
+import * as S from './CliCommand.styled';
+import SwitchControl from './SwitchControl';
+
+const optionToText: Record<CliCommandOption, string> = {
+  [CliCommandOption.Wait]: 'Wait for test to complete',
+  [CliCommandOption.UseHostname]: 'Specify Tracetest server hostname',
+  [CliCommandOption.UseCurrentEnvironment]: 'Use current environment',
+  // [CliCommandOption.UseId]: 'Use file or test id',
+  [CliCommandOption.GeneratesJUnit]: 'Generate JUnit report',
+  [CliCommandOption.useDocker]: 'Run CLI via Docker image',
+};
+
+const defaultOptions: TCliCommandEnabledOptions = {
+  [CliCommandOption.Wait]: false,
+  [CliCommandOption.UseHostname]: false,
+  [CliCommandOption.UseCurrentEnvironment]: true,
+  // [CliCommandOption.UseId]: true,
+  [CliCommandOption.GeneratesJUnit]: false,
+  [CliCommandOption.useDocker]: false,
+};
+
+interface IProps {
+  onChange(cmdConfig: TCliCommandConfig): void;
+}
+
+const Controls = ({onChange}: IProps) => {
+  const [enabledOptions, setEnabledOptions] = useState<Record<CliCommandOption, boolean>>(defaultOptions);
+  const [format, setFormat] = useState<CliCommandFormat>(CliCommandFormat.Pretty);
+
+  const onSwitchChange = useCallback((name: CliCommandOption, isEnabled: boolean) => {
+    setEnabledOptions(prev => ({...prev, [name]: isEnabled}));
+  }, []);
+
+  useEffect(() => {
+    onChange({options: enabledOptions, format});
+  }, [format, enabledOptions, onChange]);
+
+  return (
+    <S.ControlsContainer>
+      <S.OptionsContainer>
+        {Object.entries(optionToText).map(([name, text]) => (
+          <SwitchControl
+            id={name}
+            text={text}
+            key={name}
+            onChange={isEnabled => onSwitchChange(name as CliCommandOption, isEnabled)}
+            value={enabledOptions[name as CliCommandOption]}
+          />
+        ))}
+      </S.OptionsContainer>
+      <S.FormatContainer>
+        <Typography.Paragraph>Output Format:</Typography.Paragraph>
+        <Radio.Group defaultValue={format} value={format}>
+          {Object.values(CliCommandFormat).map(cmdFormat => (
+            <Radio key={cmdFormat} value={cmdFormat} onChange={() => setFormat(cmdFormat)}>
+              {toUpper(cmdFormat)}
+            </Radio>
+          ))}
+        </Radio.Group>
+      </S.FormatContainer>
+    </S.ControlsContainer>
+  );
+};
+
+export default Controls;

--- a/web/src/components/RunDetailAutomateMethods/methods/CLICommand/SwitchControl.tsx
+++ b/web/src/components/RunDetailAutomateMethods/methods/CLICommand/SwitchControl.tsx
@@ -1,0 +1,20 @@
+import {Switch} from 'antd';
+import * as S from './CliCommand.styled';
+
+interface IProps {
+  text: string;
+  value: boolean;
+  id: string;
+  onChange(value: boolean): void;
+}
+
+const SwitchControl = ({value, onChange, text, id}: IProps) => {
+  return (
+    <S.SwitchContainer>
+      <Switch onChange={onChange} checked={value} id={id} />
+      <S.SwitchLabel htmlFor={id}>{text}</S.SwitchLabel>
+    </S.SwitchContainer>
+  );
+};
+
+export default SwitchControl;

--- a/web/src/components/RunDetailAutomateMethods/methods/CLICommand/hooks/useCliCommand.ts
+++ b/web/src/components/RunDetailAutomateMethods/methods/CLICommand/hooks/useCliCommand.ts
@@ -1,0 +1,22 @@
+import {useCallback, useState} from 'react';
+import {useEnvironment} from 'providers/Environment/Environment.provider';
+import {useTest} from 'providers/Test/Test.provider';
+import CliCommandService, {TCliCommandConfig} from 'services/CliCommand.service';
+
+const useCliCommand = () => {
+  const {selectedEnvironment} = useEnvironment();
+  const {test} = useTest();
+  const [command, setCommand] = useState<string>('');
+
+  const onGetCommand = useCallback(
+    (config: TCliCommandConfig) => {
+      const cmd = CliCommandService.getCommand(config, test, selectedEnvironment?.id);
+      setCommand(cmd);
+    },
+    [selectedEnvironment?.id, test]
+  );
+
+  return {command, onGetCommand};
+};
+
+export default useCliCommand;

--- a/web/src/components/RunDetailAutomateMethods/methods/CLICommand/index.ts
+++ b/web/src/components/RunDetailAutomateMethods/methods/CLICommand/index.ts
@@ -1,0 +1,2 @@
+// eslint-disable-next-line no-restricted-exports
+export {default} from './CliCommand';

--- a/web/src/components/RunDetailLayout/HeaderRight.tsx
+++ b/web/src/components/RunDetailLayout/HeaderRight.tsx
@@ -14,10 +14,9 @@ import EventLogPopover from '../EventLogPopover/EventLogPopover';
 
 interface IProps {
   testId: string;
-  testVersion: number;
 }
 
-const HeaderRight = ({testId, testVersion}: IProps) => {
+const HeaderRight = ({testId}: IProps) => {
   const {isDraftMode: isTestSpecsDraftMode} = useTestSpecs();
   const {isDraftMode: isTestOutputsDraftMode} = useTestOutput();
   const isDraftMode = isTestSpecsDraftMode || isTestOutputsDraftMode;
@@ -57,7 +56,6 @@ const HeaderRight = ({testId, testVersion}: IProps) => {
         isRunView
         resultId={run.id}
         testId={testId}
-        testVersion={testVersion}
         transactionId={run.transactionId}
         transactionRunId={run.transactionRunId}
       />

--- a/web/src/components/RunDetailLayout/RunDetailLayout.styled.ts
+++ b/web/src/components/RunDetailLayout/RunDetailLayout.styled.ts
@@ -36,6 +36,14 @@ export const ContainerHeader = styled.div`
       display: none;
     }
 
+    .ant-tabs-nav-wrap {
+      overflow: visible;
+    }
+
+    .ant-tabs-nav-more {
+      display: none;
+    }
+
     ::before {
       display: none;
     }
@@ -86,7 +94,7 @@ export const Section = styled.div<{$justifyContent: string}>`
   display: flex;
   gap: 14px;
   justify-content: ${({$justifyContent}) => $justifyContent};
-  width: calc((100vw / 2) - 150px);
+  width: calc((100vw / 2) - 200px);
 `;
 
 export const StateContainer = styled.div`
@@ -118,7 +126,7 @@ export const Text = styled(Typography.Text).attrs({
 export const Title = styled(Typography.Title).attrs({ellipsis: true, level: 2})`
   && {
     margin: 0;
-    max-width: calc((100vw / 2) - 150px - 54px);
+    max-width: calc((100vw / 2) - 200px - 54px);
   }
 `;
 

--- a/web/src/components/RunDetailLayout/RunDetailLayout.tsx
+++ b/web/src/components/RunDetailLayout/RunDetailLayout.tsx
@@ -16,6 +16,7 @@ import {ConfigMode} from 'types/DataStore.types';
 import HeaderLeft from './HeaderLeft';
 import HeaderRight from './HeaderRight';
 import * as S from './RunDetailLayout.styled';
+import RunDetailAutomate from '../RunDetailAutomate/RunDetailAutomate';
 
 interface IProps {
   test: Test;
@@ -84,6 +85,9 @@ const RunDetailLayout = ({test: {id, name, trigger, version = 1}, test}: IProps)
         </Tabs.TabPane>
         <Tabs.TabPane tab={renderTab('Test', id, run.id, mode)} key={RunDetailModes.TEST}>
           <RunDetailTest run={run} runEvents={runEvents} testId={id} />
+        </Tabs.TabPane>
+        <Tabs.TabPane tab={renderTab('Automate', id, run.id, mode)} key={RunDetailModes.AUTOMATE}>
+          <RunDetailAutomate />
         </Tabs.TabPane>
       </Tabs>
     </S.Container>

--- a/web/src/components/RunDetailLayout/RunDetailLayout.tsx
+++ b/web/src/components/RunDetailLayout/RunDetailLayout.tsx
@@ -34,7 +34,7 @@ const renderTab = (title: string, testId: string, runId: string, mode: string) =
   </S.TabLink>
 );
 
-const RunDetailLayout = ({test: {id, name, trigger, version = 1}, test}: IProps) => {
+const RunDetailLayout = ({test: {id, name, trigger}, test}: IProps) => {
   const {mode = RunDetailModes.TRIGGER} = useParams();
   const {showNotification} = useNotification();
   const {isError, run, runEvents} = useTestRun();
@@ -60,9 +60,9 @@ const RunDetailLayout = ({test: {id, name, trigger, version = 1}, test}: IProps)
   const tabBarExtraContent = useMemo(
     () => ({
       left: <HeaderLeft name={name} triggerType={trigger.type.toUpperCase()} />,
-      right: <HeaderRight testId={id} testVersion={version} />,
+      right: <HeaderRight testId={id} />,
     }),
-    [id, name, trigger.type, version]
+    [id, name, trigger.type]
   );
 
   return (
@@ -75,7 +75,6 @@ const RunDetailLayout = ({test: {id, name, trigger, version = 1}, test}: IProps)
         }}
         renderTabBar={renderTabBar}
         tabBarExtraContent={tabBarExtraContent}
-        destroyInactiveTabPane
       >
         <Tabs.TabPane tab={renderTab('Trigger', id, run.id, mode)} key={RunDetailModes.TRIGGER}>
           <RunDetailTrigger test={test} run={run} runEvents={runEvents} isError={isError} />
@@ -87,7 +86,7 @@ const RunDetailLayout = ({test: {id, name, trigger, version = 1}, test}: IProps)
           <RunDetailTest run={run} runEvents={runEvents} testId={id} />
         </Tabs.TabPane>
         <Tabs.TabPane tab={renderTab('Automate', id, run.id, mode)} key={RunDetailModes.AUTOMATE}>
-          <RunDetailAutomate />
+          <RunDetailAutomate test={test} />
         </Tabs.TabPane>
       </Tabs>
     </S.Container>

--- a/web/src/components/RunDetailTriggerResponse/ResponseBody.tsx
+++ b/web/src/components/RunDetailTriggerResponse/ResponseBody.tsx
@@ -18,7 +18,7 @@ const ResponseBody = ({body = '', bodyMimeType = '', state, onCreateTestOutput, 
   isRunStateFinished(state) || !!body ? (
     <S.ResponseBodyContainer>
       <S.ResponseBodyContent>
-        <CodeBlock value={body} mimeType={bodyMimeType} />
+        <CodeBlock value={body} mimeType={bodyMimeType} maxHeight="540px" />
       </S.ResponseBodyContent>
       <S.ResponseBodyActions>
         <AttributeActions

--- a/web/src/components/TestDefinition/TestDefinition.styled.ts
+++ b/web/src/components/TestDefinition/TestDefinition.styled.ts
@@ -1,0 +1,58 @@
+import {Button, Typography} from 'antd';
+import styled from 'styled-components';
+
+export const CodeContainer = styled.div`
+  position: relative;
+  border: ${({theme}) => `1px solid ${theme.color.border}`};
+  min-height: 370px;
+
+  pre {
+    margin: 0;
+    min-height: inherit;
+    max-height: 340px;
+    background: ${({theme}) => theme.color.background} !important;
+  }
+`;
+
+export const Container = styled.div`
+  padding: 24px;
+`;
+
+export const Title = styled(Typography.Title)`
+  && {
+    font-size: ${({theme}) => theme.size.lg};
+    margin-bottom: 16px;
+    font-weight: 700;
+  }
+`;
+
+export const SubtitleContainer = styled.div`
+  margin-bottom: 8px;
+`;
+
+export const CopyButton = styled(Button)`
+  && {
+    background-color: ${({theme}) => theme.color.white};
+    padding-left: 8px;
+    padding-right: 8px;
+    font-size: ${({theme}) => theme.size.md};
+    font-weight: 600;
+  }
+`;
+
+export const CopyIconContainer = styled.div`
+  position: absolute;
+  right: 8px;
+  top: 9px;
+  padding: 0 2px;
+  border-radius: 2px;
+  cursor: pointer;
+  background-color: ${({theme}) => theme.color.textHighlight};
+  z-index: 101;
+`;
+
+export const Footer = styled.div`
+  display: flex;
+  justify-content: flex-end;
+  margin-top: 16px;
+`;

--- a/web/src/components/TestDefinition/TestDefinition.tsx
+++ b/web/src/components/TestDefinition/TestDefinition.tsx
@@ -1,0 +1,56 @@
+import {useCallback, useEffect} from 'react';
+import {snakeCase} from 'lodash';
+import {DownloadOutlined} from '@ant-design/icons';
+import {Button, Typography} from 'antd';
+import SyntaxHighlighter from 'react-syntax-highlighter';
+import {arduinoLight} from 'react-syntax-highlighter/dist/cjs/styles/hljs';
+import {downloadFile} from 'utils/Common';
+import useCopy from 'hooks/useCopy';
+import useDefinitionFile from 'hooks/useDefinitionFile';
+import {ResourceType} from 'types/Resource.type';
+import Test from 'models/Test.model';
+import * as S from './TestDefinition.styled';
+
+interface IProps {
+  test: Test;
+}
+
+const TestDefinition = ({test: {id, version, name}}: IProps) => {
+  const {definition, loadDefinition} = useDefinitionFile();
+
+  const onDownload = useCallback(() => {
+    downloadFile(definition, `${snakeCase(`${name} ${version} definition`)}.yaml`);
+  }, [definition, name, version]);
+
+  const copy = useCopy();
+
+  useEffect(() => {
+    loadDefinition(ResourceType.Test, id, version);
+  }, [id, loadDefinition, version]);
+
+  return (
+    <S.Container>
+      <S.Title>Test Definition</S.Title>
+      <S.SubtitleContainer>
+        <Typography.Text>Preview your YAML file</Typography.Text>
+      </S.SubtitleContainer>
+      <S.CodeContainer data-cy="test-definition-code-container">
+        <S.CopyIconContainer>
+          <S.CopyButton onClick={() => copy(definition)} ghost type="primary">
+            Copy
+          </S.CopyButton>
+        </S.CopyIconContainer>
+        <SyntaxHighlighter language="yaml" style={arduinoLight}>
+          {definition}
+        </SyntaxHighlighter>
+      </S.CodeContainer>
+      <S.Footer>
+        <Button data-cy="file-viewer-download" icon={<DownloadOutlined />} onClick={onDownload} type="primary">
+          Download File
+        </Button>
+      </S.Footer>
+    </S.Container>
+  );
+};
+
+export default TestDefinition;

--- a/web/src/components/TestDefinition/index.ts
+++ b/web/src/components/TestDefinition/index.ts
@@ -1,0 +1,2 @@
+// eslint-disable-next-line no-restricted-exports
+export {default} from './TestDefinition';

--- a/web/src/components/TransactionRunActionsMenu/TransactionRunActionsMenu.tsx
+++ b/web/src/components/TransactionRunActionsMenu/TransactionRunActionsMenu.tsx
@@ -14,10 +14,8 @@ interface IProps {
 }
 
 const TransactionRunActionsMenu = ({runId, transactionId, isRunView = false, transactionVersion}: IProps) => {
-  const {loadDefinition} = useFileViewerModal();
-
+  const {onDefinition} = useFileViewerModal();
   const navigate = useNavigate();
-
   const onDelete = useDeleteResourceRun({id: transactionId, isRunView, type: ResourceType.Transaction});
 
   return (
@@ -28,7 +26,7 @@ const TransactionRunActionsMenu = ({runId, transactionId, isRunView = false, tra
             <Menu.Item
               data-cy="view-transaction-definition-button"
               key="view-transaction-definition"
-              onClick={() => loadDefinition(ResourceType.Transaction, transactionId, transactionVersion)}
+              onClick={() => onDefinition(ResourceType.Transaction, transactionId, transactionVersion)}
             >
               Transaction Definition
             </Menu.Item>

--- a/web/src/constants/Common.constants.ts
+++ b/web/src/constants/Common.constants.ts
@@ -8,6 +8,7 @@ export const GITHUB_URL = 'https://github.com/kubeshop/tracetest';
 export const GITHUB_ISSUES_URL = 'https://github.com/kubeshop/tracetest/issues/new/choose';
 export const DISCORD_URL = 'https://discord.gg/6zupCZFQbe';
 export const OCTOLIINT_ISSUE_URL = 'https://github.com/kubeshop/tracetest/issues/2615';
+export const CLI_RUNNING_TESTS_URL = 'https://docs.tracetest.io/cli/running-tests';
 
 export const INGESTOR_ENDPOINT_URL = 'https://docs.tracetest.io/configuration/ingestor-endpoint';
 

--- a/web/src/constants/TestRun.constants.ts
+++ b/web/src/constants/TestRun.constants.ts
@@ -84,4 +84,5 @@ export enum RunDetailModes {
   TRIGGER = 'trigger',
   TRACE = 'trace',
   TEST = 'test',
+  AUTOMATE = 'automate',
 }

--- a/web/src/hooks/useDefinitionFile.ts
+++ b/web/src/hooks/useDefinitionFile.ts
@@ -1,0 +1,24 @@
+import {useCallback, useState} from 'react';
+import {useLazyGetResourceDefinitionQuery, useLazyGetResourceDefinitionV2Query} from 'redux/apis/TraceTest.api';
+import {ResourceType} from 'types/Resource.type';
+
+const useDefinitionFile = () => {
+  const [definition, setDefinition] = useState<string>('');
+  const [getResourceDefinition] = useLazyGetResourceDefinitionQuery();
+  const [getResourceDefinitionV2] = useLazyGetResourceDefinitionV2Query();
+
+  const loadDefinition = useCallback(
+    async (resourceType: ResourceType, resourceId: string, version?: number) => {
+      const data = await (resourceType === ResourceType.Environment || resourceType === ResourceType.Transaction
+        ? getResourceDefinitionV2({resourceId, resourceType}).unwrap()
+        : getResourceDefinition({resourceId, version, resourceType}).unwrap());
+
+      setDefinition(data);
+    },
+    [getResourceDefinition, getResourceDefinitionV2]
+  );
+
+  return {definition, loadDefinition};
+};
+
+export default useDefinitionFile;

--- a/web/src/hooks/useJUnitResult.ts
+++ b/web/src/hooks/useJUnitResult.ts
@@ -1,0 +1,20 @@
+import {useCallback, useState} from 'react';
+import {useLazyGetJUnitByRunIdQuery} from 'redux/apis/TraceTest.api';
+
+const useJUnitResult = () => {
+  const [getJUnit] = useLazyGetJUnitByRunIdQuery();
+  const [jUnit, setJUnit] = useState<string>('');
+
+  const loadJUnit = useCallback(
+    async (testId: string, runId: string) => {
+      const data = await getJUnit({runId, testId}).unwrap();
+
+      setJUnit(data);
+    },
+    [getJUnit]
+  );
+
+  return {jUnit, loadJUnit};
+};
+
+export default useJUnitResult;

--- a/web/src/pages/Environments/EnvironmentCard.tsx
+++ b/web/src/pages/Environments/EnvironmentCard.tsx
@@ -22,7 +22,7 @@ export const EnvironmentCard = ({
   onEdit,
 }: IProps) => {
   const [isCollapsed, setIsCollapsed] = useState(false);
-  const {loadDefinition} = useFileViewerModal();
+  const {onDefinition} = useFileViewerModal();
   const {selectedEnvironment} = useEnvironment();
   const isSelected = selectedEnvironment?.id === id;
 
@@ -62,7 +62,7 @@ export const EnvironmentCard = ({
                   label: <span data-cy="environment-actions-definition">Environment Definition</span>,
                   onClick: e => {
                     e.domEvent.stopPropagation();
-                    loadDefinition(ResourceType.Environment, id);
+                    onDefinition(ResourceType.Environment, id);
                   },
                 },
                 {

--- a/web/src/services/CliCommand.service.ts
+++ b/web/src/services/CliCommand.service.ts
@@ -1,0 +1,63 @@
+import Test from '../models/Test.model';
+import Env from '../utils/Env';
+
+export enum CliCommandOption {
+  Wait = 'wait',
+  UseHostname = 'useHostname',
+  UseCurrentEnvironment = 'useCurrentEnvironment',
+  // UseId = 'useId',
+  GeneratesJUnit = 'generateJUnit',
+  useDocker = 'useDocker',
+}
+
+export enum CliCommandFormat {
+  Pretty = 'pretty',
+  Json = 'json',
+}
+
+export type TCliCommandEnabledOptions = Record<CliCommandOption, boolean>;
+
+export type TCliCommandConfig = {
+  options: TCliCommandEnabledOptions;
+  format: CliCommandFormat;
+};
+
+type TApplyProps = {
+  command: string;
+  test: Test;
+  environmentId?: string;
+  enabled: boolean;
+};
+type TApplyOption = (props: TApplyProps) => string;
+
+const CliCommandService = () => ({
+  applyOptions: {
+    [CliCommandOption.Wait]: ({command, enabled}) => (enabled ? `${command} --wait-for-result` : command),
+    [CliCommandOption.UseHostname]: ({command, enabled}) => {
+      const {host, protocol} = window.location;
+      const prefix = Env.get('serverPathPrefix');
+      return enabled ? `${command} -s ${protocol}//${host}${prefix || ''}` : command;
+    },
+    [CliCommandOption.UseCurrentEnvironment]: ({command, enabled, environmentId}) =>
+      enabled && environmentId ? `${command} -e ${environmentId}` : command,
+    // [CliCommandOption.UseId]: ({enabled, command, test: {id}}) => `${command} -d ${enabled ? id : `${id}.yaml`}`,
+    [CliCommandOption.GeneratesJUnit]: ({command, enabled}) => (enabled ? `${command} --junit result.junit` : command),
+    [CliCommandOption.useDocker]: ({enabled, command}) =>
+      `${
+        enabled
+          ? 'docker run --rm -it -v$(pwd):$(pwd) -w $(pwd) --network host --entrypoint tracetest kubeshop/tracetest:latest -s http://localhost:11633/'
+          : 'tracetest'
+      } ${command}`,
+  } as Record<CliCommandOption, TApplyOption>,
+  getCommand({options, format}: TCliCommandConfig, test: Test, environmentId?: string) {
+    const command = Object.entries(options).reduce(
+      (acc, [option, enabled]) =>
+        this.applyOptions[option as CliCommandOption]({command: acc, enabled, test, environmentId}),
+      'test run -d test_definition.yaml'
+    );
+
+    return `${command} -o ${format}`;
+  },
+});
+
+export default CliCommandService();


### PR DESCRIPTION
This PR adds the Automate tab to the test run details, which includes the features for:
1. Display and download the test definition YAML
2. Allow users to generate and customize the tracetest CLI command to automate the execution

## Changes

- Adds automate tab
- Updates the code block component to be used everywhere
- Adds services and logic to support the customization of the CLI command

## Fixes

- #2693 

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
