### PR TITLE
fix(cicd): fix default value for TAG env var

### DIFF
--- a/.goreleaser.dev.yaml
+++ b/.goreleaser.dev.yaml
@@ -17,7 +17,7 @@ before:
 env:
   - VERSION={{ if index .Env "VERSION"  }}{{ .Env.VERSION }}{{ else }}dev{{ end }}
   # if TAG is defined, use it. Fallback to VERSION
-  - TAG={{ if index .Env "TAG"  }}{{ .Env.TAG }}{{ else }}{{ .Env.VERSION }}{{ end }}
+  - TAG={{ if index .Env "TAG"  }}{{ .Env.TAG }}{{ else }}{{ if index .Env "VERSION"  }}{{ .Env.VERSION }}{{ else }}dev{{ end }}{{ end }}
   - TRACETEST_ENV={{ if index .Env "TRACETEST_ENV"  }}{{ .Env.TRACETEST_ENV }}{{ else }}dev{{ end }}
   - ANALYTICS_BE_KEY={{ if index .Env "ANALYTICS_BE_KEY"  }}{{ .Env.ANALYTICS_BE_KEY }}{{ else }}{{ end }}
   - ANALYTICS_FE_KEY={{ if index .Env "ANALYTICS_FE_KEY"  }}{{ .Env.ANALYTICS_FE_KEY }}{{ else }}{{ end }}

--- a/Makefile
+++ b/Makefile
@@ -108,4 +108,4 @@ clean: ## cleans the build artifacts
 	rm -rf dist
 	rm -rf web/build
 	rm -rf web/node_modules
-	docker rm image "kubeshop/tracetest:$(TAG)"
+	docker image rm "kubeshop/tracetest:$(TAG)"


### PR DESCRIPTION
This PR fixes an incorrect default value for the `TAG` env var in `goreleaser.dev.yaml`, causing the following build error:

![Screenshot 2023-06-21 at 12 15 30](https://github.com/kubeshop/tracetest/assets/314548/a6de23dc-594d-4dcc-b114-9c49ac9135f8)
