### PR TITLE
Clarify instructions for running the CLI from docker

### DIFF
--- a/docs/docs/ci-cd-automation/overview.md
+++ b/docs/docs/ci-cd-automation/overview.md
@@ -22,7 +22,7 @@ Many integrations with CI/CD tools can be accomplished by running the [Tracetest
 
 Use the command below, substituting the following placeholders:
 - <your-tracetest-server-url> - the URL to the running Tracetest server you wish to execute the test on. Example: http://localhost:11633/
-- <file-path> - the path to the saved Tracetest test. Example: ./mytest.yaml
+- <file-path> - The path to the saved Tracetest test. Example: ./mytest.yaml
 
 ```sh
 docker run --rm -it -v$(pwd):$(pwd) -w $(pwd) --network host --entrypoint tracetest kubeshop/tracetest:latest -s <your-tracetest-server-url> test run  --definition <file-path> --wait-for-result

--- a/docs/docs/ci-cd-automation/overview.md
+++ b/docs/docs/ci-cd-automation/overview.md
@@ -14,14 +14,14 @@ If you want to see more examples with other CI/CD tools, let us know by [opening
 
 Tracetest is designed to work with all CI/CD platforms and automation tools. To enable Tracetest to run in CI/CD environments, make sure to [install the Tracetest CLI](../getting-started/installation.mdx) and configure it to access your [Tracetest server](../configuration/server.md).
 
-### Running Tracetest CLI From Docker
+### Running Tracetest CLI from Docker
 
 Many integrations with CI/CD tools can be accomplished by running the [Tracetest CLI](../cli/configuring-your-cli) to execute a test against a remote Tracetest server. If you do not want to install the Tracetest CLI in your environment, you can choose to directly execute it from a Docker image. 
 
 **How to Use**:
 
 Use the command below, substituting the following placeholders:
-- <your-tracetest-server-url> - the url to the running Tracetest server you wish to execute the test on. Example: http://localhost:11633/
+- <your-tracetest-server-url> - the URL to the running Tracetest server you wish to execute the test on. Example: http://localhost:11633/
 - <file-path> - the path to the saved Tracetest test. Example: ./mytest.yaml
 
 ```sh

--- a/docs/docs/ci-cd-automation/overview.md
+++ b/docs/docs/ci-cd-automation/overview.md
@@ -14,12 +14,18 @@ If you want to see more examples with other CI/CD tools, let us know by [opening
 
 Tracetest is designed to work with all CI/CD platforms and automation tools. To enable Tracetest to run in CI/CD environments, make sure to [install the Tracetest CLI](../getting-started/installation.mdx) and configure it to access your [Tracetest server](../configuration/server.md).
 
-You can also directly execute the Tracetest CLI from a Docker image rather than installing the CLI on your local machine. This can be convenient when you wish to execute the CLI in a CI/CD environment.
+### Running Tracetest CLI From Docker
+
+Many integrations with CI/CD tools can be accomplished by running the [Tracetest CLI](../cli/configuring-your-cli) to execute a test against a remote Tracetest server. If you do not want to install the Tracetest CLI in your environment, you can choose to directly execute it from a Docker image. 
 
 **How to Use**:
 
+Use the command below, substituting the following placeholders:
+- <your-tracetest-server-url> - the url to the running Tracetest server you wish to execute the test on. Example: http://localhost:11633/
+- <file-path> - the path to the saved Tracetest test. Example: ./mytest.yaml
+
 ```sh
-docker run --rm -it -v$(pwd):$(pwd) -w $(pwd) --entrypoint tracetest kubeshop/tracetest:latest -s http://host.docker.internal:11633/ test run  --definition <file-path> --wait-for-result
+docker run --rm -it -v$(pwd):$(pwd) -w $(pwd) --network host --entrypoint tracetest kubeshop/tracetest:latest -s <your-tracetest-server-url> test run  --definition <file-path> --wait-for-result
 ```
 
 To read more about integrating Tracetest with CI/CD tools, check out tutorials in our blog:

--- a/docs/docs/cli/configuring-your-cli.md
+++ b/docs/docs/cli/configuring-your-cli.md
@@ -65,8 +65,12 @@ There are times when it is easier to directly execute the Tracetest CLI from a D
 
 **How to Use**:
 
+Use the command below, substituting the following placeholders:
+- <your-tracetest-server-url> - the url to the running Tracetest server you wish to execute the test on. Example: http://localhost:11633/
+- <file-path> - the path to the saved Tracetest test. Example: ./mytest.yaml
+
 ```sh
-docker run --rm -it -v$(pwd):$(pwd) -w $(pwd) --network host --entrypoint tracetest kubeshop/tracetest:latest -s http://localhost:11633/ test run  --definition <file-path> --wait-for-result
+docker run --rm -it -v$(pwd):$(pwd) -w $(pwd) --network host --entrypoint tracetest kubeshop/tracetest:latest -s <your-tracetest-server-url> test run  --definition <file-path> --wait-for-result
 ```
 
 

--- a/docs/docs/cli/configuring-your-cli.md
+++ b/docs/docs/cli/configuring-your-cli.md
@@ -66,7 +66,8 @@ There are times when it is easier to directly execute the Tracetest CLI from a D
 **How to Use**:
 
 Use the command below, substituting the following placeholders:
-- <your-tracetest-server-url> - the url to the running Tracetest server you wish to execute the test on. Example: http://localhost:11633/
+- <your-tracetest-server-url> - The URL to the running Tracetest server you wish to execute the test on. Example: http://localhost:11633/
+
 - <file-path> - the path to the saved Tracetest test. Example: ./mytest.yaml
 
 ```sh

--- a/docs/docs/cli/configuring-your-cli.md
+++ b/docs/docs/cli/configuring-your-cli.md
@@ -68,7 +68,8 @@ There are times when it is easier to directly execute the Tracetest CLI from a D
 Use the command below, substituting the following placeholders:
 - <your-tracetest-server-url> - The URL to the running Tracetest server you wish to execute the test on. Example: http://localhost:11633/
 
-- <file-path> - the path to the saved Tracetest test. Example: ./mytest.yaml
+- <file-path> - The path to the saved Tracetest test. Example: ./mytest.yaml
+
 
 ```sh
 docker run --rm -it -v$(pwd):$(pwd) -w $(pwd) --network host --entrypoint tracetest kubeshop/tracetest:latest -s <your-tracetest-server-url> test run  --definition <file-path> --wait-for-result


### PR DESCRIPTION
Clarified the instructions on how to run the CLI from docker, including explaining that it would need to connect to a remote Tracetest server.
