### PR TITLE
Minor typos in Docs › CLI

### DIFF
--- a/docs/docs/cli/creating-transactions.md
+++ b/docs/docs/cli/creating-transactions.md
@@ -18,7 +18,7 @@ spec:
   steps:
     - ./tests/create-product.yaml
     - ./tests/add-product-to-cart.yaml
-    - ./tests/complete-purschase.yaml
+    - ./tests/complete-purchase.yaml
     - testID # you can also reference tests by their ids instead of referencing the definition file
 ```
 

--- a/docs/docs/cli/running-tests.md
+++ b/docs/docs/cli/running-tests.md
@@ -44,7 +44,7 @@ tracetest test run -d path/to/test.yaml -w
 Running the same command with the '-o json' option would change the output from the default of human readable 'pretty' to 'json'. This can be useful when you wish to extract particular data from the response. This would look like:
 
 ```sh
-tracetest test run -d path/to/test.yaml -w - o json
+tracetest test run -d path/to/test.yaml -w -o json
 ```
 
 ```json title="Output:"


### PR DESCRIPTION
This PR corrects two minor typos in the CLI section of the docs.

## Changes

- [Docs › CLI › Configuring Transactions › Creating Transactions](https://docs.tracetest.io/cli/creating-transactions):
`complete-purchase.yaml` instead of `complete-purschase.yaml` ([commit 6866bcf](https://github.com/kubeshop/tracetest/commit/6866bcfd6a3a59bd1863ac350b98374b50dcebae))
- [Docs › CLI › Configuring Tests › Running Tests](https://docs.tracetest.io/cli/running-tests):
`-o json` instead of `- o json` ([commit b29acc3](https://github.com/kubeshop/tracetest/commit/b29acc360cde2cf729caf40ac390e3607dd8bf36))

## Checklist

- [ ] tested locally
- [ ] added new dependencies
- [x] updated the docs
- [ ] added a test
