### PR TITLE
fix(cli): fixing CLI formatting for transactions

### DIFF
--- a/cli/cmd/get_cmd.go
+++ b/cli/cmd/get_cmd.go
@@ -29,7 +29,7 @@ var getCmd = &cobra.Command{
 			return "", err
 		}
 
-		if output == string(formatters.JSON) {
+		if output == string(formatters.JSON) || output == string(formatters.Pretty) {
 			ctx = context.WithValue(ctx, "X-Tracetest-Augmented", true)
 		}
 

--- a/cli/formatters/transaction.go
+++ b/cli/formatters/transaction.go
@@ -125,6 +125,7 @@ func (f TransactionFormatter) getTableHeader() *simpletable.Header {
 			{Text: "NAME"},
 			{Text: "VERSION"},
 			{Text: "STEPS"},
+			{Text: "RUNS"},
 			{Text: "LAST RUN TIME"},
 			{Text: "LAST RUN SUCCESSES"},
 			{Text: "LAST RUN FAILURES"},
@@ -134,10 +135,14 @@ func (f TransactionFormatter) getTableHeader() *simpletable.Header {
 
 func (f TransactionFormatter) getTableRow(t openapi.TransactionResource) ([]*simpletable.Cell, error) {
 	version := 1
+
 	runs := 0
 	lastRunTime := ""
 	passes := 0
 	fails := 0
+
+	steps := len(t.Spec.Steps)
+
 	if t.Spec.Version != nil {
 		version = int(*t.Spec.Version)
 	}
@@ -147,7 +152,7 @@ func (f TransactionFormatter) getTableRow(t openapi.TransactionResource) ([]*sim
 			runs = int(*t.Spec.Summary.Runs)
 		}
 
-		if t.Spec.Summary.LastRun != nil {
+		if t.Spec.Summary.LastRun != nil && !t.Spec.Summary.LastRun.GetTime().IsZero() {
 			lastRunTime = t.Spec.Summary.LastRun.GetTime().String()
 		}
 
@@ -161,6 +166,7 @@ func (f TransactionFormatter) getTableRow(t openapi.TransactionResource) ([]*sim
 		{Text: *t.Spec.Id},
 		{Text: *t.Spec.Name},
 		{Text: strconv.Itoa(version)},
+		{Text: fmt.Sprint(steps)},
 		{Text: fmt.Sprint(runs)},
 		{Text: lastRunTime},
 		{Text: fmt.Sprint(passes)},

--- a/testing/cli-e2etest/helpers/table_unmarshal.go
+++ b/testing/cli-e2etest/helpers/table_unmarshal.go
@@ -1,0 +1,67 @@
+package helpers
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+type tableColumnMetadata struct {
+	Name string
+	Len  int
+}
+
+func UnmarshalTable(t *testing.T, data string) []map[string]string {
+	lines := strings.Split(data, "\n")
+	require.GreaterOrEqual(t, len(lines), 2) // it should have at least two lines
+
+	columnsMetadata := inferTableColumns(lines)
+	result := []map[string]string{}
+
+	lastLineIndexToParse := len(lines) - 2 // minus two, one to convert to index and another because the last line is always an empty line
+	for i := 2; i <= lastLineIndexToParse; i++ {
+		parsedResult := parseTableLine(columnsMetadata, lines[i])
+		result = append(result, parsedResult)
+	}
+
+	return result
+}
+
+func inferTableColumns(tableLines []string) []tableColumnMetadata {
+	headerLine := tableLines[0]
+	separatorLine := tableLines[1]
+
+	columns := strings.Split(separatorLine, " ")
+
+	result := []tableColumnMetadata{}
+
+	parserStart := 0
+	for _, column := range columns {
+		columnLen := len(column)
+
+		columnName := strings.TrimSpace(headerLine[parserStart : parserStart+columnLen])
+		parserStart = parserStart + columnLen + 1 // we need to shift one item for the next start
+
+		result = append(result, tableColumnMetadata{
+			Len:  columnLen,
+			Name: columnName,
+		})
+	}
+
+	return result
+}
+
+func parseTableLine(columnsMetadata []tableColumnMetadata, line string) map[string]string {
+	result := map[string]string{}
+
+	parserStart := 0
+	for _, column := range columnsMetadata {
+		value := strings.TrimSpace(line[parserStart : parserStart+column.Len])
+		parserStart = parserStart + column.Len + 1
+
+		result[column.Name] = value
+	}
+
+	return result
+}

--- a/testing/cli-e2etest/testscenarios/transaction/list_transactions_test.go
+++ b/testing/cli-e2etest/testscenarios/transaction/list_transactions_test.go
@@ -2,7 +2,6 @@ package transaction
 
 import (
 	"fmt"
-	"strings"
 	"testing"
 
 	"github.com/kubeshop/tracetest/cli-e2etest/environment"
@@ -187,12 +186,38 @@ func TestListTransactions(t *testing.T) {
 		result := tracetestcli.Exec(t, "list transaction --sortBy name --sortDirection asc --output pretty", tracetestcli.WithCLIConfig(cliConfig))
 		helpers.RequireExitCodeEqual(t, result, 0)
 
-		lines := strings.Split(result.StdOut, "\n")
-		require.Len(lines, 6)
+		parsedTable := helpers.UnmarshalTable(t, result.StdOut)
+		require.Len(parsedTable, 3)
 
-		require.Contains(lines[2], "Another Transaction")
-		require.Contains(lines[3], "New Transaction")
-		require.Contains(lines[4], "One More Transaction")
+		firstLine := parsedTable[0]
+		require.Equal("asuhfdkj", firstLine["ID"])
+		require.Equal("Another Transaction", firstLine["NAME"])
+		require.Equal("1", firstLine["VERSION"])
+		require.Equal("4", firstLine["STEPS"])
+		require.Equal("0", firstLine["RUNS"])
+		require.Equal("", firstLine["LAST RUN TIME"])
+		require.Equal("0", firstLine["LAST RUN SUCCESSES"])
+		require.Equal("0", firstLine["LAST RUN FAILURES"])
+
+		secondLine := parsedTable[1]
+		require.Equal("Qti5R3_VR", secondLine["ID"])
+		require.Equal("New Transaction", secondLine["NAME"])
+		require.Equal("1", secondLine["VERSION"])
+		require.Equal("2", secondLine["STEPS"])
+		require.Equal("0", secondLine["RUNS"])
+		require.Equal("", secondLine["LAST RUN TIME"])
+		require.Equal("0", secondLine["LAST RUN SUCCESSES"])
+		require.Equal("0", secondLine["LAST RUN FAILURES"])
+
+		thirdLine := parsedTable[2]
+		require.Equal("i2ug34j", thirdLine["ID"])
+		require.Equal("One More Transaction", thirdLine["NAME"])
+		require.Equal("1", thirdLine["VERSION"])
+		require.Equal("3", thirdLine["STEPS"])
+		require.Equal("0", thirdLine["RUNS"])
+		require.Equal("", thirdLine["LAST RUN TIME"])
+		require.Equal("0", thirdLine["LAST RUN SUCCESSES"])
+		require.Equal("0", thirdLine["LAST RUN FAILURES"])
 	})
 
 	t.Run("list with YAML format skipping the first and taking two items", func(t *testing.T) {


### PR DESCRIPTION
This PR fixes the bugs reported on #2761 and #2760

Loom: https://www.loom.com/share/d3b9abf4134e41dfb46c8d6bc2a7e9c1?sid=d95b69b3-c11f-4515-937d-62e7bba69d3c

## Changes

- Fixed formatting for transactions on the flag `--output pretty`

## Fixes

- closes #2761
- closes #2760

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [x] added a test
