### PR TITLE
fix(server): standardize demo resource names

### DIFF
--- a/server/app/app.go
+++ b/server/app/app.go
@@ -15,7 +15,7 @@ import (
 	"github.com/kubeshop/tracetest/server/analytics"
 	"github.com/kubeshop/tracetest/server/assertions/comparator"
 	"github.com/kubeshop/tracetest/server/config"
-	"github.com/kubeshop/tracetest/server/config/demoresource"
+	"github.com/kubeshop/tracetest/server/config/demo"
 	datastore "github.com/kubeshop/tracetest/server/datastore"
 	"github.com/kubeshop/tracetest/server/environment"
 	"github.com/kubeshop/tracetest/server/executor"
@@ -263,7 +263,7 @@ func (app *App) Start(opts ...appOption) error {
 	registerPollingProfilesResource(pollingProfileRepo, apiRouter, db, provisioner, tracer)
 	registerEnvironmentResource(environmentRepo, apiRouter, db, provisioner, tracer)
 
-	demoRepo := demoresource.NewRepository(db)
+	demoRepo := demo.NewRepository(db)
 	registerDemosResource(demoRepo, apiRouter, db, provisioner, tracer)
 
 	registerDataStoreResource(dataStoreRepo, apiRouter, db, provisioner, tracer)
@@ -415,12 +415,12 @@ func registerEnvironmentResource(repository *environment.Repository, router *mux
 	provisioner.AddResourceProvisioner(manager)
 }
 
-func registerDemosResource(repository *demoresource.Repository, router *mux.Router, db *sql.DB, provisioner *provisioning.Provisioner, tracer trace.Tracer) {
-	manager := resourcemanager.New[demoresource.Demo](
-		demoresource.ResourceName,
-		demoresource.ResourceNamePlural,
+func registerDemosResource(repository *demo.Repository, router *mux.Router, db *sql.DB, provisioner *provisioning.Provisioner, tracer trace.Tracer) {
+	manager := resourcemanager.New[demo.Demo](
+		demo.ResourceName,
+		demo.ResourceNamePlural,
 		repository,
-		resourcemanager.WithOperations(demoresource.Operations...),
+		resourcemanager.WithOperations(demo.Operations...),
 		resourcemanager.WithTracer(tracer),
 	)
 	manager.RegisterRoutes(router)

--- a/server/config/demo/demo_entities.go
+++ b/server/config/demo/demo_entities.go
@@ -1,0 +1,59 @@
+package demo
+
+import (
+	"github.com/kubeshop/tracetest/server/pkg/id"
+	"github.com/kubeshop/tracetest/server/resourcemanager"
+)
+
+type DemoType string
+
+const (
+	DemoTypePokeshop           DemoType = "pokeshop"
+	DemoTypeOpentelemetryStore DemoType = "otelstore"
+)
+
+const (
+	ResourceName       = "Demo"
+	ResourceNamePlural = "Demos"
+)
+
+var Operations = []resourcemanager.Operation{
+	resourcemanager.OperationCreate,
+	resourcemanager.OperationDelete,
+	resourcemanager.OperationGet,
+	resourcemanager.OperationList,
+	resourcemanager.OperationUpdate,
+}
+
+type Demo struct {
+	ID                 id.ID                   `json:"id"`
+	Name               string                  `json:"name"`
+	Type               DemoType                `json:"type"`
+	Enabled            bool                    `json:"enabled"`
+	Pokeshop           *PokeshopDemo           `json:"pokeshop,omitempty"`
+	OpenTelemetryStore *OpenTelemetryStoreDemo `json:"opentelemetryStore,omitempty"`
+}
+
+func (d Demo) HasID() bool {
+	return d.ID != ""
+}
+
+func (d Demo) GetID() id.ID {
+	return d.ID
+}
+
+func (d Demo) Validate() error {
+	return nil
+}
+
+type PokeshopDemo struct {
+	HTTPEndpoint string `json:"httpEndpoint,omitempty"`
+	GRPCEndpoint string `json:"grpcEndpoint,omitempty"`
+}
+
+type OpenTelemetryStoreDemo struct {
+	FrontendEndpoint       string `json:"frontendEndpoint,omitempty"`
+	ProductCatalogEndpoint string `json:"productCatalogEndpoint,omitempty"`
+	CartEndpoint           string `json:"cartEndpoint,omitempty"`
+	CheckoutEndpoint       string `json:"checkoutEndpoint,omitempty"`
+}

--- a/server/config/demo/demo_repository.go
+++ b/server/config/demo/demo_repository.go
@@ -1,4 +1,4 @@
-package demoresource
+package demo
 
 import (
 	"context"
@@ -10,59 +10,6 @@ import (
 	"github.com/kubeshop/tracetest/server/pkg/id"
 	"github.com/kubeshop/tracetest/server/resourcemanager"
 )
-
-type DemoType string
-
-const (
-	DemoTypePokeshop           DemoType = "pokeshop"
-	DemoTypeOpentelemetryStore DemoType = "otelstore"
-)
-
-const (
-	ResourceName       = "Demo"
-	ResourceNamePlural = "Demos"
-)
-
-var Operations = []resourcemanager.Operation{
-	resourcemanager.OperationCreate,
-	resourcemanager.OperationDelete,
-	resourcemanager.OperationGet,
-	resourcemanager.OperationList,
-	resourcemanager.OperationUpdate,
-}
-
-type Demo struct {
-	ID                 id.ID                   `json:"id"`
-	Name               string                  `json:"name"`
-	Type               DemoType                `json:"type"`
-	Enabled            bool                    `json:"enabled"`
-	Pokeshop           *PokeshopDemo           `json:"pokeshop,omitempty"`
-	OpenTelemetryStore *OpenTelemetryStoreDemo `json:"opentelemetryStore,omitempty"`
-}
-
-func (d Demo) HasID() bool {
-	return d.ID != ""
-}
-
-func (d Demo) GetID() id.ID {
-	return d.ID
-}
-
-func (d Demo) Validate() error {
-	return nil
-}
-
-type PokeshopDemo struct {
-	HTTPEndpoint string `json:"httpEndpoint,omitempty"`
-	GRPCEndpoint string `json:"grpcEndpoint,omitempty"`
-}
-
-type OpenTelemetryStoreDemo struct {
-	FrontendEndpoint       string `json:"frontendEndpoint,omitempty"`
-	ProductCatalogEndpoint string `json:"productCatalogEndpoint,omitempty"`
-	CartEndpoint           string `json:"cartEndpoint,omitempty"`
-	CheckoutEndpoint       string `json:"checkoutEndpoint,omitempty"`
-}
 
 type Repository struct {
 	db *sql.DB

--- a/server/config/demo/demo_repository_test.go
+++ b/server/config/demo/demo_repository_test.go
@@ -1,4 +1,4 @@
-package demoresource_test
+package demo_test
 
 import (
 	"context"
@@ -6,55 +6,55 @@ import (
 	"testing"
 
 	"github.com/gorilla/mux"
-	"github.com/kubeshop/tracetest/server/config/demoresource"
+	"github.com/kubeshop/tracetest/server/config/demo"
 	"github.com/kubeshop/tracetest/server/pkg/id"
 	"github.com/kubeshop/tracetest/server/resourcemanager"
 	rmtests "github.com/kubeshop/tracetest/server/resourcemanager/testutil"
 )
 
 func TestPokeshopDemoResource(t *testing.T) {
-	sampleDemo := demoresource.Demo{
+	sampleDemo := demo.Demo{
 		ID:      "1",
 		Name:    "dev",
-		Type:    demoresource.DemoTypePokeshop,
+		Type:    demo.DemoTypePokeshop,
 		Enabled: true,
-		Pokeshop: &demoresource.PokeshopDemo{
+		Pokeshop: &demo.PokeshopDemo{
 			HTTPEndpoint: "http://dev-endpoint:1234",
 			GRPCEndpoint: "dev-grpc:9091",
 		},
 	}
 
-	secondSampleDemo := demoresource.Demo{
+	secondSampleDemo := demo.Demo{
 		ID:      "2",
 		Name:    "staging",
-		Type:    demoresource.DemoTypePokeshop,
+		Type:    demo.DemoTypePokeshop,
 		Enabled: true,
-		Pokeshop: &demoresource.PokeshopDemo{
+		Pokeshop: &demo.PokeshopDemo{
 			HTTPEndpoint: "http://stg-endpoint:1234",
 			GRPCEndpoint: "stg-grpc:9091",
 		},
 	}
 
-	thirdSampleDemo := demoresource.Demo{
+	thirdSampleDemo := demo.Demo{
 		ID:      "3",
 		Name:    "production",
-		Type:    demoresource.DemoTypePokeshop,
+		Type:    demo.DemoTypePokeshop,
 		Enabled: true,
-		Pokeshop: &demoresource.PokeshopDemo{
+		Pokeshop: &demo.PokeshopDemo{
 			HTTPEndpoint: "http://prod-endpoint:1234",
 			GRPCEndpoint: "prod-grpc:9091",
 		},
 	}
 
 	rmtests.TestResourceType(t, rmtests.ResourceTypeTest{
-		ResourceTypeSingular: demoresource.ResourceName,
-		ResourceTypePlural:   demoresource.ResourceNamePlural,
+		ResourceTypeSingular: demo.ResourceName,
+		ResourceTypePlural:   demo.ResourceNamePlural,
 		RegisterManagerFn: func(router *mux.Router, db *sql.DB) resourcemanager.Manager {
-			demoRepository := demoresource.NewRepository(db)
+			demoRepository := demo.NewRepository(db)
 
-			manager := resourcemanager.New[demoresource.Demo](
-				demoresource.ResourceName,
-				demoresource.ResourceNamePlural,
+			manager := resourcemanager.New[demo.Demo](
+				demo.ResourceName,
+				demo.ResourceNamePlural,
 				demoRepository,
 				resourcemanager.WithIDGen(id.GenerateID),
 			)
@@ -63,7 +63,7 @@ func TestPokeshopDemoResource(t *testing.T) {
 			return manager
 		},
 		Prepare: func(t *testing.T, op rmtests.Operation, manager resourcemanager.Manager) {
-			demoRepository := manager.Handler().(*demoresource.Repository)
+			demoRepository := manager.Handler().(*demo.Repository)
 			switch op {
 			case rmtests.OperationGetSuccess,
 				rmtests.OperationUpdateSuccess,
@@ -106,12 +106,12 @@ func TestPokeshopDemoResource(t *testing.T) {
 }
 
 func TestOpenTelemetryStoreDemoResource(t *testing.T) {
-	sampleDemo := demoresource.Demo{
+	sampleDemo := demo.Demo{
 		ID:      "1",
 		Name:    "dev",
-		Type:    demoresource.DemoTypeOpentelemetryStore,
+		Type:    demo.DemoTypeOpentelemetryStore,
 		Enabled: true,
-		OpenTelemetryStore: &demoresource.OpenTelemetryStoreDemo{
+		OpenTelemetryStore: &demo.OpenTelemetryStoreDemo{
 			FrontendEndpoint:       "http://dev-frontend:9000",
 			ProductCatalogEndpoint: "http://dev-product:8081",
 			CartEndpoint:           "http://dev-cart:8082",
@@ -119,12 +119,12 @@ func TestOpenTelemetryStoreDemoResource(t *testing.T) {
 		},
 	}
 
-	secondSampleDemo := demoresource.Demo{
+	secondSampleDemo := demo.Demo{
 		ID:      "2",
 		Name:    "staging",
-		Type:    demoresource.DemoTypePokeshop,
+		Type:    demo.DemoTypePokeshop,
 		Enabled: true,
-		OpenTelemetryStore: &demoresource.OpenTelemetryStoreDemo{
+		OpenTelemetryStore: &demo.OpenTelemetryStoreDemo{
 			FrontendEndpoint:       "http://stg-frontend:9000",
 			ProductCatalogEndpoint: "http://stg-product:8081",
 			CartEndpoint:           "http://stg-cart:8082",
@@ -132,12 +132,12 @@ func TestOpenTelemetryStoreDemoResource(t *testing.T) {
 		},
 	}
 
-	thirdSampleDemo := demoresource.Demo{
+	thirdSampleDemo := demo.Demo{
 		ID:      "3",
 		Name:    "production",
-		Type:    demoresource.DemoTypePokeshop,
+		Type:    demo.DemoTypePokeshop,
 		Enabled: true,
-		OpenTelemetryStore: &demoresource.OpenTelemetryStoreDemo{
+		OpenTelemetryStore: &demo.OpenTelemetryStoreDemo{
 			FrontendEndpoint:       "http://prod-frontend:9000",
 			ProductCatalogEndpoint: "http://prod-product:8081",
 			CartEndpoint:           "http://prod-cart:8082",
@@ -146,14 +146,14 @@ func TestOpenTelemetryStoreDemoResource(t *testing.T) {
 	}
 
 	rmtests.TestResourceType(t, rmtests.ResourceTypeTest{
-		ResourceTypeSingular: demoresource.ResourceName,
-		ResourceTypePlural:   demoresource.ResourceNamePlural,
+		ResourceTypeSingular: demo.ResourceName,
+		ResourceTypePlural:   demo.ResourceNamePlural,
 		RegisterManagerFn: func(router *mux.Router, db *sql.DB) resourcemanager.Manager {
-			demoRepository := demoresource.NewRepository(db)
+			demoRepository := demo.NewRepository(db)
 
-			manager := resourcemanager.New[demoresource.Demo](
-				demoresource.ResourceName,
-				demoresource.ResourceNamePlural,
+			manager := resourcemanager.New[demo.Demo](
+				demo.ResourceName,
+				demo.ResourceNamePlural,
 				demoRepository,
 				resourcemanager.WithIDGen(id.GenerateID),
 			)
@@ -162,7 +162,7 @@ func TestOpenTelemetryStoreDemoResource(t *testing.T) {
 			return manager
 		},
 		Prepare: func(t *testing.T, op rmtests.Operation, manager resourcemanager.Manager) {
-			demoRepository := manager.Handler().(*demoresource.Repository)
+			demoRepository := manager.Handler().(*demo.Repository)
 			switch op {
 			case rmtests.OperationGetSuccess,
 				rmtests.OperationUpdateSuccess,

--- a/server/config/demo/main_test.go
+++ b/server/config/demo/main_test.go
@@ -1,4 +1,4 @@
-package demoresource_test
+package demo_test
 
 import (
 	"os"

--- a/server/provisioning/provisioning_test.go
+++ b/server/provisioning/provisioning_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 
 	"github.com/kubeshop/tracetest/server/config"
-	"github.com/kubeshop/tracetest/server/config/demoresource"
+	"github.com/kubeshop/tracetest/server/config/demo"
 	"github.com/kubeshop/tracetest/server/datastore"
 	"github.com/kubeshop/tracetest/server/executor/pollingprofile"
 	"github.com/kubeshop/tracetest/server/provisioning"
@@ -94,14 +94,14 @@ type expectations struct {
 	dataStore      *datastore.DataStore
 	config         *config.Config
 	pollingprofile *pollingprofile.PollingProfile
-	demos          []demoresource.Demo
+	demos          []demo.Demo
 }
 
 type provisioningFixture struct {
 	provisioner     *provisioning.Provisioner
 	configs         *config.Repository
 	pollingProfiles *pollingprofile.Repository
-	demos           *demoresource.Repository
+	demos           *demo.Repository
 	dataStores      *datastore.Repository
 }
 
@@ -164,7 +164,7 @@ func setup(db *sql.DB) provisioningFixture {
 	f := provisioningFixture{
 		configs:         config.NewRepository(db),
 		pollingProfiles: pollingprofile.NewRepository(db),
-		demos:           demoresource.NewRepository(db),
+		demos:           demo.NewRepository(db),
 		dataStores:      datastore.NewRepository(db),
 	}
 
@@ -182,11 +182,11 @@ func setup(db *sql.DB) provisioningFixture {
 		resourcemanager.WithOperations(pollingprofile.Operations...),
 	)
 
-	demoManager := resourcemanager.New[demoresource.Demo](
-		demoresource.ResourceName,
-		demoresource.ResourceNamePlural,
+	demoManager := resourcemanager.New[demo.Demo](
+		demo.ResourceName,
+		demo.ResourceNamePlural,
 		f.demos,
-		resourcemanager.WithOperations(demoresource.Operations...),
+		resourcemanager.WithOperations(demo.Operations...),
 	)
 
 	dataStoreManager := resourcemanager.New[datastore.DataStore](
@@ -238,21 +238,21 @@ var cases = []struct {
 					RetryDelay: "30m",
 				},
 			},
-			demos: []demoresource.Demo{
+			demos: []demo.Demo{
 				{
 					Name:    "pokeshop",
-					Type:    demoresource.DemoTypePokeshop,
+					Type:    demo.DemoTypePokeshop,
 					Enabled: true,
-					Pokeshop: &demoresource.PokeshopDemo{
+					Pokeshop: &demo.PokeshopDemo{
 						HTTPEndpoint: "http://localhost/api",
 						GRPCEndpoint: "localhost:8080",
 					},
 				},
 				{
 					Name:    "otel",
-					Type:    demoresource.DemoTypeOpentelemetryStore,
+					Type:    demo.DemoTypeOpentelemetryStore,
 					Enabled: true,
-					OpenTelemetryStore: &demoresource.OpenTelemetryStoreDemo{
+					OpenTelemetryStore: &demo.OpenTelemetryStoreDemo{
 						FrontendEndpoint: "http://frontend:8080/",
 					},
 				},


### PR DESCRIPTION
This PR updates the names of the demo resource files to a common standard we defined with Tracetest Core contributors.

## Changes

- Updating demo resource file names and references

## Fixes

-

## Checklist

- [c] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
