### PR TITLE
chore(cli): update cli e2e table tests validation

### DIFF
--- a/cli/formatters/polling.go
+++ b/cli/formatters/polling.go
@@ -85,7 +85,7 @@ func (f PollingFormatter) getTableHeader() *simpletable.Header {
 		Cells: []*simpletable.Cell{
 			{Text: "ID"},
 			{Text: "NAME"},
-			{Text: "STRAGETY"},
+			{Text: "STRATEGY"},
 		},
 	}
 }

--- a/testing/cli-e2etest/testscenarios/analyzer/get_analyzer_test.go
+++ b/testing/cli-e2etest/testscenarios/analyzer/get_analyzer_test.go
@@ -99,20 +99,15 @@ func TestGetAnalyzer(t *testing.T) {
 		// Then it should print a table with 4 lines printed: header, separator, a analyzer item and empty line
 		result := tracetestcli.Exec(t, "get analyzer --id current --output pretty", tracetestcli.WithCLIConfig(cliConfig))
 		helpers.RequireExitCodeEqual(t, result, 0)
-		require.Contains(result.StdOut, "current")
 
 		parsedTable := helpers.UnmarshalTable(t, result.StdOut)
 		require.Len(parsedTable, 1)
 
 		singleLine := parsedTable[0]
 
-		require.Equal("Qti5R3_VR", singleLine["ID"])
-		require.Equal("New Transaction", singleLine["NAME"])
-		require.Equal("1", singleLine["VERSION"])
-		require.Equal("2", singleLine["STEPS"])
-		require.Equal("0", singleLine["RUNS"])
-		require.Equal("", singleLine["LAST RUN TIME"])
-		require.Equal("0", singleLine["LAST RUN SUCCESSES"])
-		require.Equal("0", singleLine["LAST RUN FAILURES"])
+		require.Equal("current", singleLine["ID"])
+		require.Equal("analyzer", singleLine["NAME"])
+		require.Equal("true", singleLine["ENABLED"])
+		require.Equal("95", singleLine["MINIMUM SCORE"])
 	})
 }

--- a/testing/cli-e2etest/testscenarios/analyzer/get_analyzer_test.go
+++ b/testing/cli-e2etest/testscenarios/analyzer/get_analyzer_test.go
@@ -2,7 +2,6 @@ package analyzer
 
 import (
 	"fmt"
-	"strings"
 	"testing"
 
 	"github.com/kubeshop/tracetest/cli-e2etest/environment"
@@ -102,7 +101,18 @@ func TestGetAnalyzer(t *testing.T) {
 		helpers.RequireExitCodeEqual(t, result, 0)
 		require.Contains(result.StdOut, "current")
 
-		lines := strings.Split(result.StdOut, "\n")
-		require.Len(lines, 4)
+		parsedTable := helpers.UnmarshalTable(t, result.StdOut)
+		require.Len(parsedTable, 1)
+
+		singleLine := parsedTable[0]
+
+		require.Equal("Qti5R3_VR", singleLine["ID"])
+		require.Equal("New Transaction", singleLine["NAME"])
+		require.Equal("1", singleLine["VERSION"])
+		require.Equal("2", singleLine["STEPS"])
+		require.Equal("0", singleLine["RUNS"])
+		require.Equal("", singleLine["LAST RUN TIME"])
+		require.Equal("0", singleLine["LAST RUN SUCCESSES"])
+		require.Equal("0", singleLine["LAST RUN FAILURES"])
 	})
 }

--- a/testing/cli-e2etest/testscenarios/analyzer/list_analyzer_test.go
+++ b/testing/cli-e2etest/testscenarios/analyzer/list_analyzer_test.go
@@ -112,9 +112,15 @@ func TestListAnalyzer(t *testing.T) {
 		// Then it should print a table with 4 lines printed: header, separator, analyzer item and empty line
 		result := tracetestcli.Exec(t, "list analyzer --sortBy name --output pretty", tracetestcli.WithCLIConfig(cliConfig))
 		helpers.RequireExitCodeEqual(t, result, 0)
-		require.Contains(result.StdOut, "current")
 
-		lines := strings.Split(result.StdOut, "\n")
-		require.Len(lines, 4)
+		parsedTable := helpers.UnmarshalTable(t, result.StdOut)
+		require.Len(parsedTable, 1)
+
+		singleLine := parsedTable[0]
+
+		require.Equal("current", singleLine["ID"])
+		require.Equal("analyzer", singleLine["NAME"])
+		require.Equal("true", singleLine["ENABLED"])
+		require.Equal("95", singleLine["MINIMUM SCORE"])
 	})
 }

--- a/testing/cli-e2etest/testscenarios/config/get_config_test.go
+++ b/testing/cli-e2etest/testscenarios/config/get_config_test.go
@@ -2,7 +2,6 @@ package config
 
 import (
 	"fmt"
-	"strings"
 	"testing"
 
 	"github.com/kubeshop/tracetest/cli-e2etest/environment"
@@ -94,9 +93,14 @@ func TestGetConfig(t *testing.T) {
 		// Then it should print a table with 4 lines printed: header, separator, a config item and empty line
 		result := tracetestcli.Exec(t, "get config --id current --output pretty", tracetestcli.WithCLIConfig(cliConfig))
 		helpers.RequireExitCodeEqual(t, result, 0)
-		require.Contains(result.StdOut, "current")
 
-		lines := strings.Split(result.StdOut, "\n")
-		require.Len(lines, 4)
+		parsedTable := helpers.UnmarshalTable(t, result.StdOut)
+		require.Len(parsedTable, 1)
+
+		singleLine := parsedTable[0]
+
+		require.Equal("current", singleLine["ID"])
+		require.Equal("Config", singleLine["NAME"])
+		require.Equal("false", singleLine["ANALYTICS ENABLED"])
 	})
 }

--- a/testing/cli-e2etest/testscenarios/config/list_config_test.go
+++ b/testing/cli-e2etest/testscenarios/config/list_config_test.go
@@ -108,9 +108,14 @@ func TestListConfig(t *testing.T) {
 		// Then it should print a table with 4 lines printed: header, separator, config item and empty line
 		result := tracetestcli.Exec(t, "list config --sortBy name --output pretty", tracetestcli.WithCLIConfig(cliConfig))
 		helpers.RequireExitCodeEqual(t, result, 0)
-		require.Contains(result.StdOut, "current")
 
-		lines := strings.Split(result.StdOut, "\n")
-		require.Len(lines, 4)
+		parsedTable := helpers.UnmarshalTable(t, result.StdOut)
+		require.Len(parsedTable, 1)
+
+		singleLine := parsedTable[0]
+
+		require.Equal("current", singleLine["ID"])
+		require.Equal("Config", singleLine["NAME"])
+		require.Equal("false", singleLine["ANALYTICS ENABLED"])
 	})
 }

--- a/testing/cli-e2etest/testscenarios/datastore/get_datastore_test.go
+++ b/testing/cli-e2etest/testscenarios/datastore/get_datastore_test.go
@@ -2,7 +2,6 @@ package datastore
 
 import (
 	"fmt"
-	"strings"
 	"testing"
 
 	"github.com/kubeshop/tracetest/cli-e2etest/environment"
@@ -93,10 +92,14 @@ func TestGetDatastore(t *testing.T) {
 		// Then it should print a table with 4 lines printed: header, separator, data store item and empty line
 		result := tracetestcli.Exec(t, "get datastore --id current --output pretty", tracetestcli.WithCLIConfig(cliConfig))
 		helpers.RequireExitCodeEqual(t, result, 0)
-		require.Contains(result.StdOut, "current")
-		require.Contains(result.StdOut, env.Name())
 
-		lines := strings.Split(result.StdOut, "\n")
-		require.Len(lines, 4)
+		parsedTable := helpers.UnmarshalTable(t, result.StdOut)
+		require.Len(parsedTable, 1)
+
+		singleLine := parsedTable[0]
+
+		require.Equal("current", singleLine["ID"])
+		require.Equal(env.Name(), singleLine["NAME"])
+		require.Equal("*", singleLine["DEFAULT"])
 	})
 }

--- a/testing/cli-e2etest/testscenarios/datastore/list_datastore_test.go
+++ b/testing/cli-e2etest/testscenarios/datastore/list_datastore_test.go
@@ -2,7 +2,6 @@ package datastore
 
 import (
 	"fmt"
-	"strings"
 	"testing"
 
 	"github.com/kubeshop/tracetest/cli-e2etest/environment"
@@ -102,10 +101,14 @@ func TestListDatastore(t *testing.T) {
 		// Then it should print a table with 4 lines printed: header, separator, data store item and empty line
 		result := tracetestcli.Exec(t, "list datastore --sortBy name --output pretty", tracetestcli.WithCLIConfig(cliConfig))
 		helpers.RequireExitCodeEqual(t, result, 0)
-		require.Contains(result.StdOut, "current")
-		require.Contains(result.StdOut, env.Name())
 
-		lines := strings.Split(result.StdOut, "\n")
-		require.Len(lines, 4)
+		parsedTable := helpers.UnmarshalTable(t, result.StdOut)
+		require.Len(parsedTable, 1)
+
+		singleLine := parsedTable[0]
+
+		require.Equal("current", singleLine["ID"])
+		require.Equal(env.Name(), singleLine["NAME"])
+		require.Equal("*", singleLine["DEFAULT"])
 	})
 }

--- a/testing/cli-e2etest/testscenarios/demo/get_demo_test.go
+++ b/testing/cli-e2etest/testscenarios/demo/get_demo_test.go
@@ -2,7 +2,6 @@ package demo
 
 import (
 	"fmt"
-	"strings"
 	"testing"
 
 	"github.com/kubeshop/tracetest/cli-e2etest/environment"
@@ -109,9 +108,15 @@ func TestGetDemo(t *testing.T) {
 		command := fmt.Sprintf("get demo --id %s --output pretty", registeredDemoId)
 		result := tracetestcli.Exec(t, command, tracetestcli.WithCLIConfig(cliConfig))
 		helpers.RequireExitCodeEqual(t, result, 0)
-		require.Contains(result.StdOut, "dev")
 
-		lines := strings.Split(result.StdOut, "\n")
-		require.Len(lines, 4)
+		parsedTable := helpers.UnmarshalTable(t, result.StdOut)
+		require.Len(parsedTable, 1)
+
+		singleLine := parsedTable[0]
+
+		require.NotEmpty(singleLine["ID"]) // demo resource generates a random ID each time
+		require.Equal("dev", singleLine["NAME"])
+		require.Equal("otelstore", singleLine["TYPE"])
+		require.Equal("true", singleLine["ENABLED"])
 	})
 }

--- a/testing/cli-e2etest/testscenarios/demo/list_demos_test.go
+++ b/testing/cli-e2etest/testscenarios/demo/list_demos_test.go
@@ -2,7 +2,6 @@ package demo
 
 import (
 	"fmt"
-	"strings"
 	"testing"
 
 	"github.com/kubeshop/tracetest/cli-e2etest/environment"
@@ -140,11 +139,22 @@ func TestListDemos(t *testing.T) {
 		result := tracetestcli.Exec(t, "list demo --sortBy name --sortDirection asc --output pretty", tracetestcli.WithCLIConfig(cliConfig))
 		helpers.RequireExitCodeEqual(t, result, 0)
 
-		lines := strings.Split(result.StdOut, "\n")
-		require.Len(lines, 5)
+		parsedTable := helpers.UnmarshalTable(t, result.StdOut)
+		require.Len(parsedTable, 2)
 
-		require.Contains(lines[2], "another-dev")
-		require.Contains(lines[3], "dev")
+		firstLine := parsedTable[0]
+
+		require.NotEmpty(firstLine["ID"]) // demo resource generates a random ID each time
+		require.Equal("another-dev", firstLine["NAME"])
+		require.Equal("pokeshop", firstLine["TYPE"])
+		require.Equal("true", firstLine["ENABLED"])
+
+		secondLine := parsedTable[1]
+
+		require.NotEmpty(secondLine["ID"]) // demo resource generates a random ID each time
+		require.Equal("dev", secondLine["NAME"])
+		require.Equal("otelstore", secondLine["TYPE"])
+		require.Equal("true", secondLine["ENABLED"])
 	})
 
 	t.Run("list with YAML format skipping the first and taking one item", func(t *testing.T) {

--- a/testing/cli-e2etest/testscenarios/environment/get_environment_test.go
+++ b/testing/cli-e2etest/testscenarios/environment/get_environment_test.go
@@ -2,7 +2,6 @@ package environment
 
 import (
 	"fmt"
-	"strings"
 	"testing"
 
 	"github.com/kubeshop/tracetest/cli-e2etest/environment"
@@ -102,9 +101,14 @@ func TestGetEnvironment(t *testing.T) {
 		// Then it should print a table with 4 lines printed: header, separator, environment item and empty line
 		result := tracetestcli.Exec(t, "get environment --id .env --output pretty", tracetestcli.WithCLIConfig(cliConfig))
 		helpers.RequireExitCodeEqual(t, result, 0)
-		require.Contains(result.StdOut, ".env")
 
-		lines := strings.Split(result.StdOut, "\n")
-		require.Len(lines, 4)
+		parsedTable := helpers.UnmarshalTable(t, result.StdOut)
+		require.Len(parsedTable, 1)
+
+		singleLine := parsedTable[0]
+
+		require.Equal(".env", singleLine["ID"])
+		require.Equal(".env", singleLine["NAME"])
+		require.Equal("", singleLine["DESCRIPTION"])
 	})
 }

--- a/testing/cli-e2etest/testscenarios/environment/list_environments_test.go
+++ b/testing/cli-e2etest/testscenarios/environment/list_environments_test.go
@@ -2,7 +2,6 @@ package environment
 
 import (
 	"fmt"
-	"strings"
 	"testing"
 
 	"github.com/kubeshop/tracetest/cli-e2etest/environment"
@@ -173,14 +172,28 @@ func TestListEnvironments(t *testing.T) {
 		result := tracetestcli.Exec(t, "list environment --sortBy name --sortDirection asc --output pretty", tracetestcli.WithCLIConfig(cliConfig))
 		helpers.RequireExitCodeEqual(t, result, 0)
 
-		lines := strings.Split(result.StdOut, "\n")
-		require.Len(lines, 6)
-
 		// due our database sorting algorithm, "another-env" comes in the front of ".env"
 		// ref https://wiki.postgresql.org/wiki/FAQ#Why_do_my_strings_sort_incorrectly.3F
-		require.Contains(lines[2], "another-env")
-		require.Contains(lines[3], ".env")
-		require.Contains(lines[4], "one-more-env")
+		parsedTable := helpers.UnmarshalTable(t, result.StdOut)
+		require.Len(parsedTable, 3)
+
+		firstLine := parsedTable[0]
+
+		require.Equal("another-env", firstLine["ID"])
+		require.Equal("another-env", firstLine["NAME"])
+		require.Equal("", firstLine["DESCRIPTION"])
+
+		secondLine := parsedTable[1]
+
+		require.Equal(".env", secondLine["ID"])
+		require.Equal(".env", secondLine["NAME"])
+		require.Equal("", secondLine["DESCRIPTION"])
+
+		thirdLine := parsedTable[2]
+
+		require.Equal("one-more-env", thirdLine["ID"])
+		require.Equal("one-more-env", thirdLine["NAME"])
+		require.Equal("", thirdLine["DESCRIPTION"])
 	})
 
 	t.Run("list with YAML format skipping the first and taking two items", func(t *testing.T) {

--- a/testing/cli-e2etest/testscenarios/pollingprofile/get_pollingprofile_test.go
+++ b/testing/cli-e2etest/testscenarios/pollingprofile/get_pollingprofile_test.go
@@ -2,7 +2,6 @@ package pollingprofile
 
 import (
 	"fmt"
-	"strings"
 	"testing"
 
 	"github.com/kubeshop/tracetest/cli-e2etest/environment"
@@ -103,10 +102,14 @@ func TestGetPollingProfile(t *testing.T) {
 		// Then it should print a table with 4 lines printed: header, separator, a polling profile item and empty line
 		result := tracetestcli.Exec(t, "get pollingprofile --id current --output pretty", tracetestcli.WithCLIConfig(cliConfig))
 		helpers.RequireExitCodeEqual(t, result, 0)
-		require.Contains(result.StdOut, "current")
-		require.Contains(result.StdOut, "periodic")
 
-		lines := strings.Split(result.StdOut, "\n")
-		require.Len(lines, 4)
+		parsedTable := helpers.UnmarshalTable(t, result.StdOut)
+		require.Len(parsedTable, 1)
+
+		singleLine := parsedTable[0]
+
+		require.Equal("current", singleLine["ID"])
+		require.Equal("current", singleLine["NAME"])
+		require.Equal("periodic", singleLine["STRATEGY"])
 	})
 }

--- a/testing/cli-e2etest/testscenarios/pollingprofile/list_pollingprofile_test.go
+++ b/testing/cli-e2etest/testscenarios/pollingprofile/list_pollingprofile_test.go
@@ -116,10 +116,14 @@ func TestListPollingProfile(t *testing.T) {
 		// Then it should print a table with 4 lines printed: header, separator, polling profile item and empty line
 		result := tracetestcli.Exec(t, "list pollingprofile --sortBy name --output pretty", tracetestcli.WithCLIConfig(cliConfig))
 		helpers.RequireExitCodeEqual(t, result, 0)
-		require.Contains(result.StdOut, "current")  // id and name
-		require.Contains(result.StdOut, "periodic") // strategy
 
-		lines := strings.Split(result.StdOut, "\n")
-		require.Len(lines, 4)
+		parsedTable := helpers.UnmarshalTable(t, result.StdOut)
+		require.Len(parsedTable, 1)
+
+		singleLine := parsedTable[0]
+
+		require.Equal("current", singleLine["ID"])
+		require.Equal("current", singleLine["NAME"])
+		require.Equal("periodic", singleLine["STRATEGY"])
 	})
 }


### PR DESCRIPTION
This PR updates the CLI e2e tests for the flag `--output=pretty` to the resources: analyzer, config, datastore, demo, environment and pollingprofile.

Loom: https://www.loom.com/share/1c6717266f1b4e299baceb8429eb0980?sid=8ae4d69b-590e-4c13-b5f2-13d2f189bf99

## Changes

- Updated `get` and `list` tests for the `--output=pretty` scenario to the resources: analyzer, config, datastore, demo, environment and pollingprofile.

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
