### PR TITLE
chore(cicd): allow running cypress without paralellization if licence key is not present

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -337,15 +337,31 @@ jobs:
           cd ./testing/cli-e2etest
           make test
 
+  config-e2e:
+    runs-on: ubuntu-latest
+    outputs:
+      CYPRESS_CONTAINERS: ${{ steps.configure-cypress-containers.outputs.CYPRESS_CONTAINERS }}
+    steps:
+    - name: Configure Cypress containers
+      id: configure-cypress-containers
+      run: |
+        # env.CYPRESS_RECORD_KEY is required for parallelization, so if it's empty run a single container
+        if [ "${{env.CYPRESS_RECORD_KEY}}" = "" ]; then
+          echo "CYPRESS_CONTAINERS=[1]" >> $GITHUB_OUTPUT
+        else
+          echo "CYPRESS_CONTAINERS=[1,2,3,4,5,6,7,8]" >> $GITHUB_OUTPUT
+        fi
+
   e2e:
-    needs: [build-docker]
+    needs: [build-docker, config-e2e]
     name: WebUI End-to-end tests
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
         # run copies of the current job in parallel
-        containers: [1, 2, 3, 4, 5, 6, 7, 8]
+
+        containers: ${{fromJson(needs.config-e2e.outputs.CYPRESS_CONTAINERS)}}
 
     steps:
       - name: Checkout
@@ -381,12 +397,15 @@ jobs:
         run: |
           docker load --input dist/image.tar
 
-      - name: Start services
+      - name: Run integration tests
         run: |
           ./run.sh down up
           ./run.sh logstt > /tmp/docker-log &
           ./scripts/wait-for-port.sh 11633
 
-      - name: Run integration tests
-        run: |
-          ./run.sh cypress-ci || (cat /tmp/docker-log; exit 1)
+          if [ "${{env.CYPRESS_RECORD_KEY}}" = "" ]; then
+            # if this is not container #1, the script won't get here, so don't need for additional checks
+            ./run.sh cypress
+          else
+            ./run.sh cypress-ci
+          fi


### PR DESCRIPTION
This PR allows running cypress in non-parallel mode if the licence key is not present. This is needed for extrnal users and forks to be able to run this pipeline
