### PR TITLE
eat(cli): refactor Delete to new resource manager client

### DIFF
--- a/cli/cmd/config.go
+++ b/cli/cmd/config.go
@@ -103,6 +103,7 @@ var resources = resourcemanager.NewRegistry().
 					{Header: "ENABLED", Path: "spec.enabled"},
 				},
 			}),
+			resourcemanager.WithDeleteEnabled("Demo successfully deleted"),
 		),
 	).
 	Register(
@@ -125,6 +126,7 @@ var resources = resourcemanager.NewRegistry().
 					return nil
 				},
 			}),
+			resourcemanager.WithDeleteEnabled("DataStore removed. Defaulting back to no-tracing mode"),
 		),
 	).
 	Register(
@@ -138,6 +140,7 @@ var resources = resourcemanager.NewRegistry().
 					{Header: "DESCRIPTION", Path: "spec.description"},
 				},
 			}),
+			resourcemanager.WithDeleteEnabled("Environment successfully deleted"),
 		),
 	).
 	Register(
@@ -175,6 +178,7 @@ var resources = resourcemanager.NewRegistry().
 					return nil
 				},
 			}),
+			resourcemanager.WithDeleteEnabled("Transaction successfully deleted"),
 		),
 	)
 

--- a/cli/cmd/config.go
+++ b/cli/cmd/config.go
@@ -55,61 +55,61 @@ var resources = resourcemanager.NewRegistry().
 		resourcemanager.NewClient(
 			httpClient,
 			"config", "configs",
-			resourcemanager.TableConfig{
+			resourcemanager.WithTableConfig(resourcemanager.TableConfig{
 				Cells: []resourcemanager.TableCellConfig{
 					{Header: "ID", Path: "spec.id"},
 					{Header: "NAME", Path: "spec.name"},
 					{Header: "ANALYTICS ENABLED", Path: "spec.analyticsEnabled"},
 				},
-			},
+			}),
 		),
 	).
 	Register(
 		resourcemanager.NewClient(
 			httpClient,
 			"analyzer", "analyzers",
-			resourcemanager.TableConfig{
+			resourcemanager.WithTableConfig(resourcemanager.TableConfig{
 				Cells: []resourcemanager.TableCellConfig{
 					{Header: "ID", Path: "spec.id"},
 					{Header: "NAME", Path: "spec.name"},
 					{Header: "ENABLED", Path: "spec.enabled"},
 					{Header: "MINIMUM SCORE", Path: "spec.minimumScore"},
 				},
-			},
+			}),
 		),
 	).
 	Register(
 		resourcemanager.NewClient(
 			httpClient,
 			"pollingprofile", "pollingprofiles",
-			resourcemanager.TableConfig{
+			resourcemanager.WithTableConfig(resourcemanager.TableConfig{
 				Cells: []resourcemanager.TableCellConfig{
 					{Header: "ID", Path: "spec.id"},
 					{Header: "NAME", Path: "spec.name"},
 					{Header: "STRATEGY", Path: "spec.strategy"},
 				},
-			},
+			}),
 		),
 	).
 	Register(
 		resourcemanager.NewClient(
 			httpClient,
 			"demo", "demos",
-			resourcemanager.TableConfig{
+			resourcemanager.WithTableConfig(resourcemanager.TableConfig{
 				Cells: []resourcemanager.TableCellConfig{
 					{Header: "ID", Path: "spec.id"},
 					{Header: "NAME", Path: "spec.name"},
 					{Header: "TYPE", Path: "spec.type"},
 					{Header: "ENABLED", Path: "spec.enabled"},
 				},
-			},
+			}),
 		),
 	).
 	Register(
 		resourcemanager.NewClient(
 			httpClient,
 			"datastore", "datastores",
-			resourcemanager.TableConfig{
+			resourcemanager.WithTableConfig(resourcemanager.TableConfig{
 				Cells: []resourcemanager.TableCellConfig{
 					{Header: "ID", Path: "spec.id"},
 					{Header: "NAME", Path: "spec.name"},
@@ -124,27 +124,27 @@ var resources = resourcemanager.NewRegistry().
 					}
 					return nil
 				},
-			},
+			}),
 		),
 	).
 	Register(
 		resourcemanager.NewClient(
 			httpClient,
 			"environment", "environments",
-			resourcemanager.TableConfig{
+			resourcemanager.WithTableConfig(resourcemanager.TableConfig{
 				Cells: []resourcemanager.TableCellConfig{
 					{Header: "ID", Path: "spec.id"},
 					{Header: "NAME", Path: "spec.name"},
 					{Header: "DESCRIPTION", Path: "spec.description"},
 				},
-			},
+			}),
 		),
 	).
 	Register(
 		resourcemanager.NewClient(
 			httpClient,
 			"transaction", "transactions",
-			resourcemanager.TableConfig{
+			resourcemanager.WithTableConfig(resourcemanager.TableConfig{
 				Cells: []resourcemanager.TableCellConfig{
 					{Header: "ID", Path: "spec.id"},
 					{Header: "NAME", Path: "spec.name"},
@@ -174,7 +174,7 @@ var resources = resourcemanager.NewRegistry().
 					}
 					return nil
 				},
-			},
+			}),
 		),
 	)
 

--- a/cli/cmd/delete_cmd.go
+++ b/cli/cmd/delete_cmd.go
@@ -22,7 +22,7 @@ func init() {
 		Long:    "Delete resources from your Tracetest server",
 		PreRun:  setupCommand(),
 		Run: WithResourceMiddleware(func(_ *cobra.Command, args []string) (string, error) {
-			resourceType := args[0]
+			resourceType := resourceParams.ResourceName
 			ctx := context.Background()
 
 			resourceClient, err := resources.Get(resourceType)

--- a/cli/cmd/delete_cmd.go
+++ b/cli/cmd/delete_cmd.go
@@ -3,40 +3,48 @@ package cmd
 import (
 	"context"
 	"fmt"
-	"strings"
 
 	"github.com/kubeshop/tracetest/cli/parameters"
+	"github.com/kubeshop/tracetest/cli/pkg/resourcemanager"
 	"github.com/spf13/cobra"
 )
 
-var deleteParams = &parameters.ResourceIdParams{}
-
-var deleteCmd = &cobra.Command{
-	GroupID: cmdGroupResources.ID,
-	Use:     fmt.Sprintf("delete %s", strings.Join(parameters.ValidResources, "|")),
-	Short:   "Delete resources",
-	Long:    "Delete resources from your Tracetest server",
-	PreRun:  setupCommand(),
-	Run: WithResourceMiddleware(func(_ *cobra.Command, args []string) (string, error) {
-		resourceType := resourceParams.ResourceName
-		ctx := context.Background()
-
-		resourceActions, err := resourceRegistry.Get(resourceType)
-		if err != nil {
-			return "", err
-		}
-
-		message, err := resourceActions.Delete(ctx, deleteParams.ResourceID)
-		if err != nil {
-			return "", err
-		}
-
-		return fmt.Sprintf("✔ %s", message), nil
-	}, deleteParams),
-	PostRun: teardownCommand,
-}
+var (
+	deleteParams = &parameters.ResourceIdParams{}
+	deleteCmd    *cobra.Command
+)
 
 func init() {
+	deleteCmd = &cobra.Command{
+		GroupID: cmdGroupResources.ID,
+		Use:     "delete " + resourceList(),
+		Short:   "Delete resources",
+		Long:    "Delete resources from your Tracetest server",
+		PreRun:  setupCommand(),
+		Run: WithResourceMiddleware(func(_ *cobra.Command, args []string) (string, error) {
+			resourceType := args[0]
+			ctx := context.Background()
+
+			resourceClient, err := resources.Get(resourceType)
+			if err != nil {
+				return "", err
+			}
+
+			resultFormat, err := resourcemanager.Formats.Get(output, "yaml")
+			if err != nil {
+				return "", err
+			}
+
+			result, err := resourceClient.Delete(ctx, deleteParams.ResourceID, resultFormat)
+			if err != nil {
+				return "", err
+			}
+
+			return fmt.Sprintf("✔ %s", result), nil
+		}, deleteParams),
+		PostRun: teardownCommand,
+	}
+
 	deleteCmd.Flags().StringVar(&deleteParams.ResourceID, "id", "", "id of the resource to delete")
 	rootCmd.AddCommand(deleteCmd)
 }

--- a/cli/pkg/resourcemanager/delete.go
+++ b/cli/pkg/resourcemanager/delete.go
@@ -4,11 +4,13 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"net/http/httputil"
 )
 
 const VerbDelete Verb = "delete"
 
 func (c client) Delete(ctx context.Context, id string, format Format) (string, error) {
+	fmt.Println(c.deleteSuccessMsg)
 	if c.deleteSuccessMsg == "" {
 		return "", ErrNotSupportedResourceAction
 	}
@@ -18,6 +20,9 @@ func (c client) Delete(ctx context.Context, id string, format Format) (string, e
 	if err != nil {
 		return "", fmt.Errorf("cannot build Delete request: %w", err)
 	}
+
+	d, _ := httputil.DumpRequestOut(req, true)
+	fmt.Println(string(d))
 
 	err = format.BuildRequest(req, VerbDelete)
 	if err != nil {

--- a/cli/pkg/resourcemanager/delete.go
+++ b/cli/pkg/resourcemanager/delete.go
@@ -1,0 +1,44 @@
+package resourcemanager
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+)
+
+const VerbDelete Verb = "delete"
+
+func (c client) Delete(ctx context.Context, id string, format Format) (string, error) {
+	if c.deleteSuccessMsg == "" {
+		return "", ErrNotSupportedResourceAction
+	}
+
+	url := c.client.url(c.resourceNamePlural, id)
+	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, url.String(), nil)
+	if err != nil {
+		return "", fmt.Errorf("cannot build Delete request: %w", err)
+	}
+
+	err = format.BuildRequest(req, VerbDelete)
+	if err != nil {
+		return "", fmt.Errorf("cannot build Delete request: %w", err)
+	}
+
+	resp, err := c.client.do(req)
+	if err != nil {
+		return "", fmt.Errorf("cannot execute Delete request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if !isSuccessResponse(resp) {
+		err := parseRequestError(resp, format)
+		reqErr, ok := err.(requestError)
+		if ok && reqErr.Code == http.StatusNotFound {
+			return "", fmt.Errorf("Resource %s with ID %s not found", c.resourceName, id)
+		}
+
+		return "", fmt.Errorf("could not Delete resource: %w", err)
+	}
+
+	return c.deleteSuccessMsg, nil
+}

--- a/cli/pkg/resourcemanager/get.go
+++ b/cli/pkg/resourcemanager/get.go
@@ -27,7 +27,7 @@ func (c client) Get(ctx context.Context, id string, format Format) (string, erro
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode != http.StatusOK {
+	if !isSuccessResponse(resp) {
 		err := parseRequestError(resp, format)
 		reqErr, ok := err.(requestError)
 		if ok && reqErr.Code == http.StatusNotFound {

--- a/cli/pkg/resourcemanager/list.go
+++ b/cli/pkg/resourcemanager/list.go
@@ -44,7 +44,7 @@ func (c client) List(ctx context.Context, opt ListOption, format Format) (string
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode != http.StatusOK {
+	if !isSuccessResponse(resp) {
 		err := parseRequestError(resp, format)
 
 		return "", fmt.Errorf("could not list resource: %w", err)

--- a/testing/cli-e2etest/testscenarios/demo/delete_demo_test.go
+++ b/testing/cli-e2etest/testscenarios/demo/delete_demo_test.go
@@ -28,7 +28,7 @@ func TestDeleteDemo(t *testing.T) {
 	// Then it should return an error and say that this resource does not exist
 	result := tracetestcli.Exec(t, "delete demo --id some-demo", tracetestcli.WithCLIConfig(cliConfig))
 	helpers.RequireExitCodeEqual(t, result, 1)
-	require.Contains(result.StdErr, "Resource demos with ID some-demo not found") // TODO: update this message to singular
+	require.Contains(result.StdErr, "Resource demo with ID some-demo not found") // TODO: update this message to singular
 
 	// When I try to set up a new demo
 	// Then it should be applied with success

--- a/testing/cli-e2etest/testscenarios/environment/delete_environment_test.go
+++ b/testing/cli-e2etest/testscenarios/environment/delete_environment_test.go
@@ -28,7 +28,7 @@ func TestDeleteEnvironment(t *testing.T) {
 	// Then it should return an error and say that this resource does not exist
 	result := tracetestcli.Exec(t, "delete environment --id .env", tracetestcli.WithCLIConfig(cliConfig))
 	helpers.RequireExitCodeEqual(t, result, 1)
-	require.Contains(result.StdErr, "Resource environments with ID .env not found") // TODO: update this message to singular
+	require.Contains(result.StdErr, "Resource environment with ID .env not found") // TODO: update this message to singular
 
 	// When I try to set up a new environment
 	// Then it should be applied with success

--- a/testing/cli-e2etest/testscenarios/transaction/delete_transaction_test.go
+++ b/testing/cli-e2etest/testscenarios/transaction/delete_transaction_test.go
@@ -27,7 +27,7 @@ func TestDeleteTransaction(t *testing.T) {
 	// Then it should return an error and say that this resource does not exist
 	result := tracetestcli.Exec(t, "delete transaction --id dont-exist", tracetestcli.WithCLIConfig(cliConfig))
 	helpers.RequireExitCodeEqual(t, result, 1)
-	require.Contains(result.StdErr, "Resource transactions with ID dont-exist not found") // TODO: update this message to singular
+	require.Contains(result.StdErr, "Resource transaction with ID dont-exist not found") // TODO: update this message to singular
 
 	// When I try to set up a new transaction
 	// Then it should be applied with success


### PR DESCRIPTION
This PR follows up on https://github.com/kubeshop/tracetest/pull/2829, adding support for the Delete verb in the same manner.
