### PR TITLE
feat(cli): update export command with new resourcemanager client

### DIFF
--- a/cli/cmd/datastore_legacy_cmd.go
+++ b/cli/cmd/datastore_legacy_cmd.go
@@ -47,8 +47,8 @@ var dataStoreExportCmd = &cobra.Command{
 	PreRun:     setupCommand(),
 	Run: func(cmd *cobra.Command, args []string) {
 		// call new export command
-		exportResourceID = "current"
-		exportResourceFile = exportOutputFile
+		exportParams.ResourceID = "current"
+		exportParams.OutputFile = exportOutputFile
 		exportCmd.Run(exportCmd, []string{"datastore"})
 	},
 	PostRun: teardownCommand,

--- a/cli/cmd/delete_cmd.go
+++ b/cli/cmd/delete_cmd.go
@@ -30,7 +30,7 @@ func init() {
 				return "", err
 			}
 
-			resultFormat, err := resourcemanager.Formats.Get(output, "yaml")
+			resultFormat, err := resourcemanager.Formats.GetWithFallback(output, "yaml")
 			if err != nil {
 				return "", err
 			}

--- a/cli/cmd/export_cmd.go
+++ b/cli/cmd/export_cmd.go
@@ -3,44 +3,55 @@ package cmd
 import (
 	"context"
 	"fmt"
-	"strings"
+	"os"
 
 	"github.com/kubeshop/tracetest/cli/parameters"
+	"github.com/kubeshop/tracetest/cli/pkg/resourcemanager"
 	"github.com/spf13/cobra"
 )
 
 var (
-	exportResourceID   string
-	exportResourceFile string
+	exportParams = &parameters.ExportParams{}
+	exportCmd    *cobra.Command
 )
 
-var exportCmd = &cobra.Command{
-	GroupID: cmdGroupResources.ID,
-	Use:     fmt.Sprintf("export %s", strings.Join(parameters.ValidResources, "|")),
-	Long:    "Export a resource from your Tracetest server",
-	Short:   "Export resource",
-	PreRun:  setupCommand(),
-	Run: WithResultHandler(func(_ *cobra.Command, args []string) (string, error) {
-		resourceType := resourceParams.ResourceName
-		ctx := context.Background()
-
-		resourceActions, err := resourceRegistry.Get(resourceType)
-		if err != nil {
-			return "", err
-		}
-
-		err = resourceActions.Export(ctx, exportResourceID, exportResourceFile)
-		if err != nil {
-			return "", err
-		}
-
-		return fmt.Sprintf("✔  Definition exported successfully for resource type: %s", resourceType), nil
-	}),
-	PostRun: teardownCommand,
-}
-
 func init() {
-	exportCmd.Flags().StringVar(&exportResourceID, "id", "", "id of the resource to export")
-	exportCmd.Flags().StringVarP(&exportResourceFile, "file", "f", "resource.yaml", "file path with name where to export the resource")
+	exportCmd = &cobra.Command{
+		GroupID: cmdGroupResources.ID,
+		Use:     "export " + resourceList(),
+		Long:    "Export a resource from your Tracetest server",
+		Short:   "Export resource",
+		PreRun:  setupCommand(),
+		Run: WithResourceMiddleware(func(_ *cobra.Command, args []string) (string, error) {
+			resourceType := resourceParams.ResourceName
+			ctx := context.Background()
+
+			resourceClient, err := resources.Get(resourceType)
+			if err != nil {
+				return "", err
+			}
+
+			resultFormat, err := resourcemanager.Formats.Get("yaml")
+			if err != nil {
+				return "", err
+			}
+
+			result, err := resourceClient.Get(ctx, exportParams.ResourceID, resultFormat)
+			if err != nil {
+				return "", err
+			}
+
+			err = os.WriteFile(exportParams.OutputFile, []byte(result), 0644)
+			if err != nil {
+				return "", fmt.Errorf("could not write file: %w", err)
+			}
+
+			return fmt.Sprintf("✔  Definition exported successfully for resource type: %s", resourceType), nil
+		}, exportParams),
+		PostRun: teardownCommand,
+	}
+
+	exportCmd.Flags().StringVar(&exportParams.ResourceID, "id", "", "id of the resource to export")
+	exportCmd.Flags().StringVarP(&exportParams.OutputFile, "file", "f", "resource.yaml", "file path with name where to export the resource")
 	rootCmd.AddCommand(exportCmd)
 }

--- a/cli/cmd/export_cmd.go
+++ b/cli/cmd/export_cmd.go
@@ -31,6 +31,7 @@ func init() {
 				return "", err
 			}
 
+			// export is ALWAYS yaml, so we can hardcode it here
 			resultFormat, err := resourcemanager.Formats.Get("yaml")
 			if err != nil {
 				return "", err

--- a/cli/cmd/get_cmd.go
+++ b/cli/cmd/get_cmd.go
@@ -29,7 +29,7 @@ func init() {
 				return "", err
 			}
 
-			resultFormat, err := resourcemanager.Formats.Get(output, "yaml")
+			resultFormat, err := resourcemanager.Formats.GetWithFallback(output, "yaml")
 			if err != nil {
 				return "", err
 			}

--- a/cli/cmd/list_cmd.go
+++ b/cli/cmd/list_cmd.go
@@ -29,7 +29,7 @@ func init() {
 				return "", err
 			}
 
-			resultFormat, err := resourcemanager.Formats.Get(output, "pretty")
+			resultFormat, err := resourcemanager.Formats.GetWithFallback(output, "pretty")
 			if err != nil {
 				return "", err
 			}

--- a/cli/parameters/resources.go
+++ b/cli/parameters/resources.go
@@ -59,6 +59,24 @@ func (p *ResourceIdParams) Validate(cmd *cobra.Command, args []string) []error {
 	return errors
 }
 
+type ExportParams struct {
+	ResourceIdParams
+	OutputFile string
+}
+
+func (p *ExportParams) Validate(cmd *cobra.Command, args []string) []error {
+	errors := p.ResourceIdParams.Validate(cmd, args)
+
+	if p.OutputFile == "" {
+		errors = append(errors, paramError{
+			Parameter: "file",
+			Message:   "output file must be provided",
+		})
+	}
+
+	return errors
+}
+
 type ApplyParams struct {
 	DefinitionFile string
 }

--- a/cli/pkg/resourcemanager/format.go
+++ b/cli/pkg/resourcemanager/format.go
@@ -20,15 +20,19 @@ type Format interface {
 
 type formatRegistry []Format
 
-func (f formatRegistry) Get(format, fallback string) (Format, error) {
+func (f formatRegistry) GetWithFallback(format, fallback string) (Format, error) {
 	if format == "" && fallback == "" {
 		return nil, fmt.Errorf("format and fallback cannot be empty at the same time")
 	}
 
 	if format == "" {
-		return f.Get(fallback, "")
+		return f.Get(fallback)
 	}
 
+	return f.Get(format)
+}
+
+func (f formatRegistry) Get(format string) (Format, error) {
 	for _, fr := range f {
 		if fr.String() == format {
 			return fr, nil


### PR DESCRIPTION
This PR follows up on https://github.com/kubeshop/tracetest/pull/2829, adding support for the Export verb in the same manner.
