### PR TITLE
fix: image generator option

### DIFF
--- a/.github/workflows/deploy-main.yml
+++ b/.github/workflows/deploy-main.yml
@@ -38,7 +38,7 @@ jobs:
         run: |
           cd server
           mkdir -p ../dist/
-          /tmp/go-arch/go-arch ../dist/architecture.png
+          /tmp/go-arch/go-arch -o ../dist/architecture.png
       - name: Upload assets
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -46,7 +46,7 @@ jobs:
         run: |
           cd server
           mkdir -p ../dist/
-          /tmp/go-arch/go-arch ../dist/architecture.png
+          /tmp/go-arch/go-arch -o ../dist/architecture.png
       - name: Upload assets
         uses: actions/upload-artifact@v3
         with:


### PR DESCRIPTION
This PR updates the pipeline to use the new `-o` option in the architecture graph generator.


## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
