### PR TITLE
fix(frontend): fix analyzer score styles

### DIFF
--- a/web/src/components/AnalyzerScore/AnalyzerScore.styled.ts
+++ b/web/src/components/AnalyzerScore/AnalyzerScore.styled.ts
@@ -15,9 +15,9 @@ export const ScoreTexContainer = styled.div`
   height: 100%;
 `;
 
-export const Score = styled(Typography.Title)<{$isLarge?: boolean}>`
+export const Score = styled(Typography.Title)<{$fontSize?: number}>`
   && {
-    font-size: ${({$isLarge}) => ($isLarge ? '24px' : '12px')};
+    font-size: ${({$fontSize}) => $fontSize || 12}px;
     margin-bottom: 0;
   }
 `;

--- a/web/src/components/AnalyzerScore/AnalyzerScore.tsx
+++ b/web/src/components/AnalyzerScore/AnalyzerScore.tsx
@@ -2,23 +2,19 @@ import * as S from './AnalyzerScore.styled';
 
 interface IProps {
   score: number;
+  fontSize?: number;
   height?: string;
   width?: string;
 }
 
-const AnalyzerScore = ({score, height, width}: IProps) => (
+const AnalyzerScore = ({score, fontSize, height, width}: IProps) => (
   <S.ScoreWrapper>
     <S.ScoreTexContainer>
-      <S.Score level={1}>{score}</S.Score>
+      <S.Score level={1} $fontSize={fontSize}>
+        {score}
+      </S.Score>
     </S.ScoreTexContainer>
-    <S.ScoreProgress
-      $height={height}
-      $width={width}
-      format={() => ''}
-      percent={score || 100}
-      $score={score}
-      type="circle"
-    />
+    <S.ScoreProgress $height={height} $width={width} format={() => ''} percent={score} $score={score} type="circle" />
   </S.ScoreWrapper>
 );
 

--- a/web/src/components/AnalyzerScore/Percentage.tsx
+++ b/web/src/components/AnalyzerScore/Percentage.tsx
@@ -8,17 +8,10 @@ interface IProps {
 
 const Percentage = ({score, height, width}: IProps) => (
   <S.PercentageScoreWrapper>
-    <S.Score level={1} $isLarge>
+    <S.Score level={1} $fontSize={24}>
       {score}%
     </S.Score>
-    <S.ScoreProgress
-      $height={height}
-      $width={width}
-      $score={score}
-      format={() => ''}
-      percent={score || 100}
-      type="circle"
-    />
+    <S.ScoreProgress $height={height} $width={width} $score={score} format={() => ''} percent={score} type="circle" />
   </S.PercentageScoreWrapper>
 );
 

--- a/web/src/components/ResourceCard/ResourceCardSummary.tsx
+++ b/web/src/components/ResourceCard/ResourceCardSummary.tsx
@@ -18,7 +18,7 @@ const ResourceCardSummary = ({
       {!!analyzerScore && (
         <Tooltip title="Trace Analyzer score">
           <div>
-            <AnalyzerScore width="28px" height="28px" score={analyzerScore} />
+            <AnalyzerScore fontSize={10} width="28px" height="28px" score={analyzerScore} />
           </div>
         </Tooltip>
       )}

--- a/web/src/components/RunCard/TestRunCard.tsx
+++ b/web/src/components/RunCard/TestRunCard.tsx
@@ -96,7 +96,7 @@ const TestRunCard = ({
         {isRunStateFinished(state) && !!linter.plugins.length && (
           <Tooltip title="Trace Analyzer score">
             <div onClick={event => handleResultClick(event, TEST_RUN_TRACE_TAB)}>
-              <AnalyzerScore width="28px" height="28px" score={linter.score} />
+              <AnalyzerScore fontSize={10} width="28px" height="28px" score={linter.score} />
             </div>
           </Tooltip>
         )}


### PR DESCRIPTION
This PR fixes analyzer score component:
- Do not fill the progress circle if the score is 0
- Fix font size issue in the test run list

## Changes

- Do not fill the progress circle if the score is 0
- Fix font size issue in the test run list

## Fixes

- fixes #2848 

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Screenshots

<img width="1624" alt="Screenshot 2023-07-05 at 16 08 38" src="https://github.com/kubeshop/tracetest/assets/3879892/32a01d13-00d5-4880-b7a3-ddac02fe78a6">

<img width="1624" alt="Screenshot 2023-07-05 at 16 09 22" src="https://github.com/kubeshop/tracetest/assets/3879892/d442cf8c-4b68-4ba0-8878-c133f03ced5e">