### PR TITLE
fix(docs): fix deprecated test command

### DIFF
--- a/docs/docs/cli/configuring-your-cli.md
+++ b/docs/docs/cli/configuring-your-cli.md
@@ -29,7 +29,7 @@ Allows you to list all tests.
 **How to Use**:
 
 ```sh
-tracetest test list
+tracetest list test
 ```
 
 ### Run a Test


### PR DESCRIPTION
This PR fixes a deprecated test command in our docs.

## Changes

- fix deprecated command

## Fixes

- #2354 

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
