### PR TITLE
fix(cli): preprocess test and transaction files when running and applying

### DIFF
--- a/cli/cmd/config.go
+++ b/cli/cmd/config.go
@@ -16,8 +16,8 @@ import (
 )
 
 var (
+	cliLogger      = &zap.Logger{}
 	cliConfig      config.Config
-	cliLogger      *zap.Logger
 	versionText    string
 	isVersionMatch bool
 )
@@ -140,8 +140,7 @@ func setupLogger(cmd *cobra.Command, args []string) {
 		zapcore.Lock(os.Stdout),
 		atom,
 	))
-
-	cliLogger = logger
+	*cliLogger = *logger
 }
 
 func teardownCommand(cmd *cobra.Command, args []string) {

--- a/cli/cmd/resources.go
+++ b/cli/cmd/resources.go
@@ -9,165 +9,171 @@ import (
 	"github.com/Jeffail/gabs/v2"
 	"github.com/kubeshop/tracetest/cli/analytics"
 	"github.com/kubeshop/tracetest/cli/pkg/resourcemanager"
+	"github.com/kubeshop/tracetest/cli/preprocessor"
 )
 
 var resourceParams = &resourceParameters{}
-var httpClient = &resourcemanager.HTTPClient{}
+var (
+	httpClient = &resourcemanager.HTTPClient{}
 
-var resources = resourcemanager.NewRegistry().
-	Register(
-		resourcemanager.NewClient(
-			httpClient,
-			"config", "configs",
-			resourcemanager.WithTableConfig(resourcemanager.TableConfig{
-				Cells: []resourcemanager.TableCellConfig{
-					{Header: "ID", Path: "spec.id"},
-					{Header: "NAME", Path: "spec.name"},
-					{Header: "ANALYTICS ENABLED", Path: "spec.analyticsEnabled"},
-				},
-			}),
-		),
-	).
-	Register(
-		resourcemanager.NewClient(
-			httpClient,
-			"analyzer", "analyzers",
-			resourcemanager.WithTableConfig(resourcemanager.TableConfig{
-				Cells: []resourcemanager.TableCellConfig{
-					{Header: "ID", Path: "spec.id"},
-					{Header: "NAME", Path: "spec.name"},
-					{Header: "ENABLED", Path: "spec.enabled"},
-					{Header: "MINIMUM SCORE", Path: "spec.minimumScore"},
-				},
-			}),
-		),
-	).
-	Register(
-		resourcemanager.NewClient(
-			httpClient,
-			"pollingprofile", "pollingprofiles",
-			resourcemanager.WithTableConfig(resourcemanager.TableConfig{
-				Cells: []resourcemanager.TableCellConfig{
-					{Header: "ID", Path: "spec.id"},
-					{Header: "NAME", Path: "spec.name"},
-					{Header: "STRATEGY", Path: "spec.strategy"},
-				},
-			}),
-		),
-	).
-	Register(
-		resourcemanager.NewClient(
-			httpClient,
-			"demo", "demos",
-			resourcemanager.WithTableConfig(resourcemanager.TableConfig{
-				Cells: []resourcemanager.TableCellConfig{
-					{Header: "ID", Path: "spec.id"},
-					{Header: "NAME", Path: "spec.name"},
-					{Header: "TYPE", Path: "spec.type"},
-					{Header: "ENABLED", Path: "spec.enabled"},
-				},
-			}),
-		),
-	).
-	Register(
-		resourcemanager.NewClient(
-			httpClient,
-			"datastore", "datastores",
-			resourcemanager.WithTableConfig(resourcemanager.TableConfig{
-				Cells: []resourcemanager.TableCellConfig{
-					{Header: "ID", Path: "spec.id"},
-					{Header: "NAME", Path: "spec.name"},
-					{Header: "DEFAULT", Path: "spec.default"},
-				},
-				ItemModifier: func(item *gabs.Container) error {
-					isDefault := item.Path("spec.default").Data().(bool)
-					if !isDefault {
-						item.SetP("", "spec.default")
-					} else {
-						item.SetP("*", "spec.default")
-					}
-					return nil
-				},
-			}),
-			resourcemanager.WithDeleteSuccessMessage("DataStore removed. Defaulting back to no-tracing mode"),
-		),
-	).
-	Register(
-		resourcemanager.NewClient(
-			httpClient,
-			"environment", "environments",
-			resourcemanager.WithTableConfig(resourcemanager.TableConfig{
-				Cells: []resourcemanager.TableCellConfig{
-					{Header: "ID", Path: "spec.id"},
-					{Header: "NAME", Path: "spec.name"},
-					{Header: "DESCRIPTION", Path: "spec.description"},
-				},
-			}),
-		),
-	).
-	Register(
-		resourcemanager.NewClient(
-			httpClient,
-			"transaction", "transactions",
-			resourcemanager.WithTableConfig(resourcemanager.TableConfig{
-				Cells: []resourcemanager.TableCellConfig{
-					{Header: "ID", Path: "spec.id"},
-					{Header: "NAME", Path: "spec.name"},
-					{Header: "VERSION", Path: "spec.version"},
-					{Header: "STEPS", Path: "spec.summary.steps"},
-					{Header: "RUNS", Path: "spec.summary.runs"},
-					{Header: "LAST RUN TIME", Path: "spec.summary.lastRun.time"},
-					{Header: "LAST RUN SUCCESSES", Path: "spec.summary.lastRun.passes"},
-					{Header: "LAST RUN FAILURES", Path: "spec.summary.lastRun.fails"},
-				},
-				ItemModifier: func(item *gabs.Container) error {
-					// set spec.summary.steps to the number of steps in the transaction
-					item.SetP(len(item.Path("spec.steps").Children()), "spec.summary.steps")
+	testPreprocessor = preprocessor.Test(cliLogger)
 
-					if err := formatItemDate(item, "spec.summary.lastRun.time"); err != nil {
-						return err
-					}
+	resources = resourcemanager.NewRegistry().
+			Register(
+			resourcemanager.NewClient(
+				httpClient,
+				"config", "configs",
+				resourcemanager.WithTableConfig(resourcemanager.TableConfig{
+					Cells: []resourcemanager.TableCellConfig{
+						{Header: "ID", Path: "spec.id"},
+						{Header: "NAME", Path: "spec.name"},
+						{Header: "ANALYTICS ENABLED", Path: "spec.analyticsEnabled"},
+					},
+				}),
+			),
+		).
+		Register(
+			resourcemanager.NewClient(
+				httpClient,
+				"analyzer", "analyzers",
+				resourcemanager.WithTableConfig(resourcemanager.TableConfig{
+					Cells: []resourcemanager.TableCellConfig{
+						{Header: "ID", Path: "spec.id"},
+						{Header: "NAME", Path: "spec.name"},
+						{Header: "ENABLED", Path: "spec.enabled"},
+						{Header: "MINIMUM SCORE", Path: "spec.minimumScore"},
+					},
+				}),
+			),
+		).
+		Register(
+			resourcemanager.NewClient(
+				httpClient,
+				"pollingprofile", "pollingprofiles",
+				resourcemanager.WithTableConfig(resourcemanager.TableConfig{
+					Cells: []resourcemanager.TableCellConfig{
+						{Header: "ID", Path: "spec.id"},
+						{Header: "NAME", Path: "spec.name"},
+						{Header: "STRATEGY", Path: "spec.strategy"},
+					},
+				}),
+			),
+		).
+		Register(
+			resourcemanager.NewClient(
+				httpClient,
+				"demo", "demos",
+				resourcemanager.WithTableConfig(resourcemanager.TableConfig{
+					Cells: []resourcemanager.TableCellConfig{
+						{Header: "ID", Path: "spec.id"},
+						{Header: "NAME", Path: "spec.name"},
+						{Header: "TYPE", Path: "spec.type"},
+						{Header: "ENABLED", Path: "spec.enabled"},
+					},
+				}),
+			),
+		).
+		Register(
+			resourcemanager.NewClient(
+				httpClient,
+				"datastore", "datastores",
+				resourcemanager.WithTableConfig(resourcemanager.TableConfig{
+					Cells: []resourcemanager.TableCellConfig{
+						{Header: "ID", Path: "spec.id"},
+						{Header: "NAME", Path: "spec.name"},
+						{Header: "DEFAULT", Path: "spec.default"},
+					},
+					ItemModifier: func(item *gabs.Container) error {
+						isDefault := item.Path("spec.default").Data().(bool)
+						if !isDefault {
+							item.SetP("", "spec.default")
+						} else {
+							item.SetP("*", "spec.default")
+						}
+						return nil
+					},
+				}),
+				resourcemanager.WithDeleteSuccessMessage("DataStore removed. Defaulting back to no-tracing mode"),
+			),
+		).
+		Register(
+			resourcemanager.NewClient(
+				httpClient,
+				"environment", "environments",
+				resourcemanager.WithTableConfig(resourcemanager.TableConfig{
+					Cells: []resourcemanager.TableCellConfig{
+						{Header: "ID", Path: "spec.id"},
+						{Header: "NAME", Path: "spec.name"},
+						{Header: "DESCRIPTION", Path: "spec.description"},
+					},
+				}),
+			),
+		).
+		Register(
+			resourcemanager.NewClient(
+				httpClient,
+				"transaction", "transactions",
+				resourcemanager.WithTableConfig(resourcemanager.TableConfig{
+					Cells: []resourcemanager.TableCellConfig{
+						{Header: "ID", Path: "spec.id"},
+						{Header: "NAME", Path: "spec.name"},
+						{Header: "VERSION", Path: "spec.version"},
+						{Header: "STEPS", Path: "spec.summary.steps"},
+						{Header: "RUNS", Path: "spec.summary.runs"},
+						{Header: "LAST RUN TIME", Path: "spec.summary.lastRun.time"},
+						{Header: "LAST RUN SUCCESSES", Path: "spec.summary.lastRun.passes"},
+						{Header: "LAST RUN FAILURES", Path: "spec.summary.lastRun.fails"},
+					},
+					ItemModifier: func(item *gabs.Container) error {
+						// set spec.summary.steps to the number of steps in the transaction
+						item.SetP(len(item.Path("spec.steps").Children()), "spec.summary.steps")
 
-					return nil
-				},
-			}),
-		),
-	).
-	Register(
-		resourcemanager.NewClient(
-			httpClient,
-			"test", "tests",
-			resourcemanager.WithTableConfig(resourcemanager.TableConfig{
-				Cells: []resourcemanager.TableCellConfig{
-					{Header: "ID", Path: "spec.id"},
-					{Header: "NAME", Path: "spec.name"},
-					{Header: "VERSION", Path: "spec.version"},
-					{Header: "TRIGGER TYPE", Path: "spec.trigger.type"},
-					{Header: "RUNS", Path: "spec.summary.runs"},
-					{Header: "LAST RUN TIME", Path: "spec.summary.lastRun.time"},
-					{Header: "LAST RUN SUCCESSES", Path: "spec.summary.lastRun.passes"},
-					{Header: "LAST RUN FAILURES", Path: "spec.summary.lastRun.fails"},
-					{Header: "URL", Path: "spec.url"},
-				},
-				ItemModifier: func(item *gabs.Container) error {
-					// set spec.summary.steps to the number of steps in the transaction
-					id, ok := item.Path("spec.id").Data().(string)
-					if !ok {
-						return fmt.Errorf("test id '%s' is not a string", id)
-					}
+						if err := formatItemDate(item, "spec.summary.lastRun.time"); err != nil {
+							return err
+						}
 
-					url := cliConfig.URL() + "/test/" + id
-					item.SetP(url, "spec.url")
+						return nil
+					},
+				}),
+			),
+		).
+		Register(
+			resourcemanager.NewClient(
+				httpClient,
+				"test", "tests",
+				resourcemanager.WithTableConfig(resourcemanager.TableConfig{
+					Cells: []resourcemanager.TableCellConfig{
+						{Header: "ID", Path: "spec.id"},
+						{Header: "NAME", Path: "spec.name"},
+						{Header: "VERSION", Path: "spec.version"},
+						{Header: "TRIGGER TYPE", Path: "spec.trigger.type"},
+						{Header: "RUNS", Path: "spec.summary.runs"},
+						{Header: "LAST RUN TIME", Path: "spec.summary.lastRun.time"},
+						{Header: "LAST RUN SUCCESSES", Path: "spec.summary.lastRun.passes"},
+						{Header: "LAST RUN FAILURES", Path: "spec.summary.lastRun.fails"},
+						{Header: "URL", Path: "spec.url"},
+					},
+					ItemModifier: func(item *gabs.Container) error {
+						// set spec.summary.steps to the number of steps in the transaction
+						id, ok := item.Path("spec.id").Data().(string)
+						if !ok {
+							return fmt.Errorf("test id '%s' is not a string", id)
+						}
 
-					if err := formatItemDate(item, "spec.summary.lastRun.time"); err != nil {
-						return err
-					}
+						url := cliConfig.URL() + "/test/" + id
+						item.SetP(url, "spec.url")
 
-					return nil
-				},
-			}),
-		),
-	)
+						if err := formatItemDate(item, "spec.summary.lastRun.time"); err != nil {
+							return err
+						}
+
+						return nil
+					},
+				}),
+				resourcemanager.WithApplyPreProcessor(testPreprocessor.Preprocess),
+			),
+		)
+)
 
 func resourceList() string {
 	return strings.Join(resources.List(), "|")

--- a/cli/cmd/resources.go
+++ b/cli/cmd/resources.go
@@ -89,7 +89,7 @@ var resources = resourcemanager.NewRegistry().
 					return nil
 				},
 			}),
-			resourcemanager.WithDeleteEnabled("DataStore removed. Defaulting back to no-tracing mode"),
+			resourcemanager.WithDeleteSuccessMessage("DataStore removed. Defaulting back to no-tracing mode"),
 		),
 	).
 	Register(

--- a/cli/pkg/resourcemanager/apply.go
+++ b/cli/pkg/resourcemanager/apply.go
@@ -12,7 +12,10 @@ import (
 
 const VerbApply Verb = "apply"
 
+type applyPreProcessorFn func(fileutil.File) fileutil.File
+
 func (c Client) Apply(ctx context.Context, inputFile fileutil.File, requestedFormat Format) (string, error) {
+
 	url := c.client.url(c.resourceNamePlural)
 	req, err := http.NewRequestWithContext(ctx, http.MethodPut, url.String(), inputFile.Reader())
 	if err != nil {
@@ -90,5 +93,5 @@ func (c Client) Apply(ctx context.Context, inputFile fileutil.File, requestedFor
 
 	}
 
-	return requestedFormat.Format(string(body), c.tableConfig)
+	return requestedFormat.Format(string(body), c.options.tableConfig)
 }

--- a/cli/pkg/resourcemanager/apply.go
+++ b/cli/pkg/resourcemanager/apply.go
@@ -12,9 +12,17 @@ import (
 
 const VerbApply Verb = "apply"
 
-type applyPreProcessorFn func(fileutil.File) fileutil.File
+type applyPreProcessorFn func(context.Context, fileutil.File) (fileutil.File, error)
 
 func (c Client) Apply(ctx context.Context, inputFile fileutil.File, requestedFormat Format) (string, error) {
+
+	if c.options.applyPreProcessor != nil {
+		var err error
+		inputFile, err = c.options.applyPreProcessor(ctx, inputFile)
+		if err != nil {
+			return "", fmt.Errorf("cannot preprocess Apply request: %w", err)
+		}
+	}
 
 	url := c.client.url(c.resourceNamePlural)
 	req, err := http.NewRequestWithContext(ctx, http.MethodPut, url.String(), inputFile.Reader())

--- a/cli/pkg/resourcemanager/client.go
+++ b/cli/pkg/resourcemanager/client.go
@@ -15,8 +15,7 @@ type Client struct {
 	client             *HTTPClient
 	resourceName       string
 	resourceNamePlural string
-	deleteSuccessMsg   string
-	tableConfig        TableConfig
+	options            options
 }
 
 type HTTPClient struct {
@@ -56,27 +55,13 @@ func (c HTTPClient) do(req *http.Request) (*http.Response, error) {
 	return c.client.Do(req)
 }
 
-type options func(c *Client)
-
-func WithDeleteEnabled(deleteSuccessMssg string) options {
-	return func(c *Client) {
-		c.deleteSuccessMsg = deleteSuccessMssg
-	}
-}
-
-func WithTableConfig(tableConfig TableConfig) options {
-	return func(c *Client) {
-		c.tableConfig = tableConfig
-	}
-}
-
 // NewClient creates a new client for a resource managed by the resourceamanger.
 // The tableConfig parameter configures how the table view should be rendered.
 // This configuration work both for a single resource from a Get, or a ResourceList from a List
 func NewClient(
 	httpClient *HTTPClient,
 	resourceName, resourceNamePlural string,
-	opts ...options) Client {
+	opts ...option) Client {
 	c := Client{
 		client:             httpClient,
 		resourceName:       resourceName,
@@ -84,11 +69,10 @@ func NewClient(
 	}
 
 	for _, opt := range opts {
-		opt(&c)
+		opt(&c.options)
 	}
 
 	return c
-
 }
 
 type requestError struct {

--- a/cli/pkg/resourcemanager/delete.go
+++ b/cli/pkg/resourcemanager/delete.go
@@ -38,8 +38,8 @@ func (c Client) Delete(ctx context.Context, id string, format Format) (string, e
 	}
 
 	msg := ""
-	if c.deleteSuccessMsg != "" {
-		msg = c.deleteSuccessMsg
+	if c.options.deleteSuccessMsg != "" {
+		msg = c.options.deleteSuccessMsg
 	} else {
 		ucfirst := strings.ToUpper(string(c.resourceName[0])) + c.resourceName[1:]
 		msg = fmt.Sprintf("%s successfully deleted", ucfirst)

--- a/cli/pkg/resourcemanager/get.go
+++ b/cli/pkg/resourcemanager/get.go
@@ -42,5 +42,5 @@ func (c Client) Get(ctx context.Context, id string, format Format) (string, erro
 		return "", fmt.Errorf("cannot read Get response: %w", err)
 	}
 
-	return format.Format(string(body), c.tableConfig)
+	return format.Format(string(body), c.options.tableConfig)
 }

--- a/cli/pkg/resourcemanager/list.go
+++ b/cli/pkg/resourcemanager/list.go
@@ -55,5 +55,5 @@ func (c Client) List(ctx context.Context, opt ListOption, format Format) (string
 		return "", fmt.Errorf("cannot read List response: %w", err)
 	}
 
-	return format.Format(string(body), c.tableConfig)
+	return format.Format(string(body), c.options.tableConfig)
 }

--- a/cli/pkg/resourcemanager/options.go
+++ b/cli/pkg/resourcemanager/options.go
@@ -1,0 +1,27 @@
+package resourcemanager
+
+type options struct {
+	applyPreProcessor applyPreProcessorFn
+	tableConfig       TableConfig
+	deleteSuccessMsg  string
+}
+
+type option func(*options)
+
+func WithApplyPreProcessor(preProcessor applyPreProcessorFn) option {
+	return func(o *options) {
+		o.applyPreProcessor = preProcessor
+	}
+}
+
+func WithDeleteSuccessMessage(deleteSuccessMssg string) option {
+	return func(o *options) {
+		o.deleteSuccessMsg = deleteSuccessMssg
+	}
+}
+
+func WithTableConfig(tableConfig TableConfig) option {
+	return func(o *options) {
+		o.tableConfig = tableConfig
+	}
+}

--- a/cli/preprocessor/test.go
+++ b/cli/preprocessor/test.go
@@ -1,0 +1,68 @@
+package preprocessor
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/goccy/go-yaml"
+	"github.com/kubeshop/tracetest/cli/openapi"
+	"github.com/kubeshop/tracetest/cli/pkg/fileutil"
+	"go.uber.org/zap"
+)
+
+type test struct {
+	logger *zap.Logger
+}
+
+func Test(logger *zap.Logger) test {
+	return test{
+		logger: logger,
+	}
+}
+
+func (t test) Preprocess(ctx context.Context, input fileutil.File) (fileutil.File, error) {
+	var test openapi.TestResource
+	err := yaml.Unmarshal(input.Contents(), &test)
+	if err != nil {
+		t.logger.Error("error parsing test", zap.String("content", string(input.Contents())), zap.Error(err))
+		return input, fmt.Errorf("could not unmarshal test yaml: %w", err)
+	}
+
+	test, err = t.consolidateGRPCFile(input, test)
+	if err != nil {
+		return input, fmt.Errorf("could not consolidate grpc file: %w", err)
+	}
+
+	marshalled, err := yaml.Marshal(test)
+	if err != nil {
+		return input, fmt.Errorf("could not marshal test yaml: %w", err)
+	}
+
+	return fileutil.New(input.AbsPath(), marshalled), nil
+}
+
+func (t test) consolidateGRPCFile(input fileutil.File, test openapi.TestResource) (openapi.TestResource, error) {
+	if test.Spec.Trigger.GetType() != "grpc" {
+		t.logger.Debug("test does not use grpc", zap.String("triggerType", test.Spec.Trigger.GetType()))
+		return test, nil
+	}
+
+	definedPBFile := test.Spec.Trigger.Grpc.GetProtobufFile()
+	if !fileutil.LooksLikeFilePath(definedPBFile) {
+		t.logger.Debug("protobuf file is not a file path", zap.String("protobufFile", definedPBFile))
+		return test, nil
+	}
+
+	pbFilePath := input.RelativeFile(definedPBFile)
+	t.logger.Debug("protobuf file", zap.String("path", pbFilePath))
+
+	pbFile, err := fileutil.Read(pbFilePath)
+	if err != nil {
+		return test, fmt.Errorf(`cannot read protobuf file: %w`, err)
+	}
+	t.logger.Debug("protobuf file contents", zap.String("contents", string(pbFile.Contents())))
+
+	test.Spec.Trigger.Grpc.SetProtobufFile(string(pbFile.Contents()))
+
+	return test, nil
+}

--- a/cli/preprocessor/transaction.go
+++ b/cli/preprocessor/transaction.go
@@ -1,0 +1,87 @@
+package preprocessor
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/goccy/go-yaml"
+	"github.com/kubeshop/tracetest/cli/openapi"
+	"github.com/kubeshop/tracetest/cli/pkg/fileutil"
+	"go.uber.org/zap"
+)
+
+type applyTestFunc func(context.Context, fileutil.File) (fileutil.File, error)
+
+type transaction struct {
+	logger      *zap.Logger
+	applyTestFn applyTestFunc
+}
+
+func Transaction(logger *zap.Logger, applyTestFn applyTestFunc) transaction {
+	return transaction{
+		logger:      logger,
+		applyTestFn: applyTestFn,
+	}
+}
+
+func (t transaction) Preprocess(ctx context.Context, input fileutil.File) (fileutil.File, error) {
+	var tran openapi.TransactionResource
+	err := yaml.Unmarshal(input.Contents(), &tran)
+	if err != nil {
+		t.logger.Error("error parsing transaction", zap.String("content", string(input.Contents())), zap.Error(err))
+		return input, fmt.Errorf("could not unmarshal transaction yaml: %w", err)
+	}
+
+	tran, err = t.mapTransactionSteps(ctx, input, tran)
+	if err != nil {
+		return input, fmt.Errorf("could not map transaction steps: %w", err)
+	}
+
+	marshalled, err := yaml.Marshal(tran)
+	if err != nil {
+		return input, fmt.Errorf("could not marshal test yaml: %w", err)
+	}
+	return fileutil.New(input.AbsPath(), marshalled), nil
+}
+
+func (t transaction) mapTransactionSteps(ctx context.Context, input fileutil.File, tran openapi.TransactionResource) (openapi.TransactionResource, error) {
+	for i, step := range tran.Spec.GetSteps() {
+		t.logger.Debug("mapping transaction step",
+			zap.Int("index", i),
+			zap.String("step", step),
+		)
+		if !fileutil.LooksLikeFilePath(step) {
+			t.logger.Debug("does not look like a file path",
+				zap.Int("index", i),
+				zap.String("step", step),
+			)
+			continue
+		}
+
+		f, err := fileutil.Read(input.RelativeFile(step))
+		if err != nil {
+			return openapi.TransactionResource{}, fmt.Errorf("cannot read test file: %w", err)
+		}
+
+		testFile, err := t.applyTestFn(ctx, f)
+		if err != nil {
+			return openapi.TransactionResource{}, fmt.Errorf("cannot apply test '%s': %w", step, err)
+		}
+
+		var test openapi.TestResource
+		err = yaml.Unmarshal(testFile.Contents(), &test)
+		if err != nil {
+			return openapi.TransactionResource{}, fmt.Errorf("cannot unmarshal updated test '%s': %w", step, err)
+		}
+
+		t.logger.Debug("mapped transaction step",
+			zap.Int("index", i),
+			zap.String("step", step),
+			zap.String("mapped step", test.Spec.GetId()),
+		)
+
+		tran.Spec.Steps[i] = test.Spec.GetId()
+	}
+
+	return tran, nil
+}

--- a/testing/cli-e2etest/testscenarios/test/apply_test_test.go
+++ b/testing/cli-e2etest/testscenarios/test/apply_test_test.go
@@ -2,51 +2,91 @@ package test
 
 import (
 	"fmt"
+	"os"
 	"testing"
 
-	"atomicgo.dev/assert"
 	"github.com/kubeshop/tracetest/cli-e2etest/environment"
 	"github.com/kubeshop/tracetest/cli-e2etest/helpers"
 	"github.com/kubeshop/tracetest/cli-e2etest/testscenarios/types"
 	"github.com/kubeshop/tracetest/cli-e2etest/tracetestcli"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func TestApplyTest(t *testing.T) {
-	// instantiate require with testing helper
-	require := require.New(t)
+	t.Run("Basic", func(t *testing.T) {
+		// instantiate require with testing helper
+		require := require.New(t)
+		assert := assert.New(t)
 
-	// setup isolated e2e environment
-	env := environment.CreateAndStart(t)
-	defer env.Close(t)
+		// setup isolated e2e environment
+		env := environment.CreateAndStart(t)
+		defer env.Close(t)
 
-	cliConfig := env.GetCLIConfigPath(t)
+		cliConfig := env.GetCLIConfigPath(t)
 
-	// Given I am a Tracetest CLI user
-	// And I have my server recently created
+		// Given I am a Tracetest CLI user
+		// And I have my server recently created
 
-	// When I try to set up a new test
-	// Then it should be applied with success
-	testPath := env.GetTestResourcePath(t, "list")
+		// When I try to set up a new test
+		// Then it should be applied with success
+		testPath := env.GetTestResourcePath(t, "list")
 
-	result := tracetestcli.Exec(t, fmt.Sprintf("apply test --file %s", testPath), tracetestcli.WithCLIConfig(cliConfig))
-	helpers.RequireExitCodeEqual(t, result, 0)
+		result := tracetestcli.Exec(t, fmt.Sprintf("apply test --file %s", testPath), tracetestcli.WithCLIConfig(cliConfig))
+		helpers.RequireExitCodeEqual(t, result, 0)
 
-	// When I try to get a test
-	// Then it should return the test applied on the last step
-	result = tracetestcli.Exec(t, "get test --id fH_8AulVR", tracetestcli.WithCLIConfig(cliConfig))
-	helpers.RequireExitCodeEqual(t, result, 0)
+		// When I try to get a test
+		// Then it should return the test applied on the last step
+		result = tracetestcli.Exec(t, "get test --id fH_8AulVR", tracetestcli.WithCLIConfig(cliConfig))
+		helpers.RequireExitCodeEqual(t, result, 0)
 
-	listTest := helpers.UnmarshalYAML[types.TestResource](t, result.StdOut)
-	assert.Equal("Test", listTest.Type)
-	assert.Equal("fH_8AulVR", listTest.Spec.ID)
-	assert.Equal("Pokeshop - List", listTest.Spec.Name)
-	assert.Equal("List Pokemon", listTest.Spec.Description)
-	assert.Equal("http", listTest.Spec.Trigger.Type)
-	assert.Equal("http://demo-api:8081/pokemon?take=20&skip=0", listTest.Spec.Trigger.HTTPRequest.URL)
-	assert.Equal("GET", listTest.Spec.Trigger.HTTPRequest.Method)
-	assert.Equal("", listTest.Spec.Trigger.HTTPRequest.Body)
-	require.Len(listTest.Spec.Trigger.HTTPRequest.Headers, 1)
-	assert.Equal("Content-Type", listTest.Spec.Trigger.HTTPRequest.Headers[0].Key)
-	assert.Equal("application/json", listTest.Spec.Trigger.HTTPRequest.Headers[0].Value)
+		listTest := helpers.UnmarshalYAML[types.TestResource](t, result.StdOut)
+		assert.Equal("Test", listTest.Type)
+		assert.Equal("fH_8AulVR", listTest.Spec.ID)
+		assert.Equal("Pokeshop - List", listTest.Spec.Name)
+		assert.Equal("List Pokemon", listTest.Spec.Description)
+		assert.Equal("http", listTest.Spec.Trigger.Type)
+		assert.Equal("http://demo-api:8081/pokemon?take=20&skip=0", listTest.Spec.Trigger.HTTPRequest.URL)
+		assert.Equal("GET", listTest.Spec.Trigger.HTTPRequest.Method)
+		assert.Equal("", listTest.Spec.Trigger.HTTPRequest.Body)
+		require.Len(listTest.Spec.Trigger.HTTPRequest.Headers, 1)
+		assert.Equal("Content-Type", listTest.Spec.Trigger.HTTPRequest.Headers[0].Key)
+		assert.Equal("application/json", listTest.Spec.Trigger.HTTPRequest.Headers[0].Value)
+	})
+
+	t.Run("EmbeddingProtobufFile", func(t *testing.T) {
+		// instantiate require with testing helper
+		require := require.New(t)
+		assert := assert.New(t)
+
+		proto, err := os.ReadFile("./resources/api.proto")
+		require.NoError(err)
+
+		// setup isolated e2e environment
+		env := environment.CreateAndStart(t)
+		defer env.Close(t)
+
+		cliConfig := env.GetCLIConfigPath(t)
+
+		// Given I am a Tracetest CLI user
+		// And I have my server recently created
+
+		// When I try to set up a new test
+		// Then it should be applied with success
+		testPath := env.GetTestResourcePath(t, "grpc-trigger-reference-protobuf")
+
+		result := tracetestcli.Exec(t, fmt.Sprintf("apply test --file %s", testPath), tracetestcli.WithCLIConfig(cliConfig))
+		helpers.RequireExitCodeEqual(t, result, 0)
+
+		// When I try to get a test
+		// Then it should return the test applied on the last step
+		result = tracetestcli.Exec(t, "get test --id create-pokemon", tracetestcli.WithCLIConfig(cliConfig))
+		helpers.RequireExitCodeEqual(t, result, 0)
+
+		listTest := helpers.UnmarshalYAML[types.TestResource](t, result.StdOut)
+		assert.Equal("Test", listTest.Type)
+		assert.Equal("create-pokemon", listTest.Spec.ID)
+		assert.Equal("grpc", listTest.Spec.Trigger.Type)
+		assert.Equal(string(proto), listTest.Spec.Trigger.GRPCRequest.ProtobufFile)
+	})
 }

--- a/testing/cli-e2etest/testscenarios/transaction/resources/another-transaction.yaml
+++ b/testing/cli-e2etest/testscenarios/transaction/resources/another-transaction.yaml
@@ -4,7 +4,7 @@ spec:
   name: Another Transaction
   description: another transaction
   steps:
-  - 9wtAH2_Vg
-  - 9wtAH2_Vg
-  - ajksdkasjbd
-  - ajksdkasjbd
+  - ./transaction-step-1.yaml
+  - ./transaction-step-1.yaml
+  - ./transaction-step-2.yaml
+  - ./transaction-step-2.yaml

--- a/testing/cli-e2etest/testscenarios/transaction/resources/new-transaction.yaml
+++ b/testing/cli-e2etest/testscenarios/transaction/resources/new-transaction.yaml
@@ -4,5 +4,5 @@ spec:
   name: New Transaction
   description: a transaction
   steps:
-  - 9wtAH2_Vg
-  - ajksdkasjbd
+  - ./transaction-step-1.yaml
+  - ./transaction-step-2.yaml

--- a/testing/cli-e2etest/testscenarios/transaction/resources/one-more-transaction.yaml
+++ b/testing/cli-e2etest/testscenarios/transaction/resources/one-more-transaction.yaml
@@ -4,6 +4,6 @@ spec:
   name: One More Transaction
   description: one more transaction
   steps:
-  - 9wtAH2_Vg
-  - 9wtAH2_Vg
-  - ajksdkasjbd
+  - ./transaction-step-1.yaml
+  - ./transaction-step-1.yaml
+  - ./transaction-step-2.yaml

--- a/testing/cli-e2etest/testscenarios/transaction/resources/updated-new-transaction.yaml
+++ b/testing/cli-e2etest/testscenarios/transaction/resources/updated-new-transaction.yaml
@@ -4,6 +4,6 @@ spec:
   name: Updated Transaction
   description: an updated transaction
   steps:
-  - 9wtAH2_Vg
-  - ajksdkasjbd
-  - ajksdkasjbd
+  - ./transaction-step-1.yaml
+  - ./transaction-step-2.yaml
+  - ./transaction-step-2.yaml

--- a/testing/cli-e2etest/testscenarios/types/test.go
+++ b/testing/cli-e2etest/testscenarios/types/test.go
@@ -23,8 +23,13 @@ type Test struct {
 }
 
 type Trigger struct {
-	Type        string      `json:"type"`
-	HTTPRequest HTTPRequest `json:"httpRequest"`
+	Type        string       `json:"type"`
+	HTTPRequest *HTTPRequest `json:"httpRequest"`
+	GRPCRequest *GRPCRequest `json:"grpc"`
+}
+
+type GRPCRequest struct {
+	ProtobufFile string `json:"protobufFile,omitempty"`
 }
 
 type HTTPRequest struct {
@@ -45,14 +50,9 @@ type Output struct {
 }
 
 type TestSpec struct {
-	Selector   Selector `json:"selector"`
+	Selector   string   `json:"selector"`
 	Name       string   `json:"name,omitempty"`
 	Assertions []string `json:"assertions"`
-}
-
-type Selector struct {
-	Query          string       `json:"query"`
-	ParsedSelector SpanSelector `json:"parsedSelector"`
 }
 
 type SpanSelector struct {


### PR DESCRIPTION
The new cli resources client introduced a bug:
When a test or transaction is run with `tracetest test run ...` command, the files gets preprocessed: tests files embed protobuf files if needed, and transactions map test file references to test IDs.

The original behaviour was to preprocess files both on `test run` and `apply transaction` (`apply test` wasn't implemented beofre).

This PR adds e2e tests to cover this behavior and fixes it.

In order to implement this in a generic way, we introdiuce a `preprocessor` concept to the resource manager client.

Resources can define an optional `applyPreProcessorFn` function when registering. This func can alter the file that gets submitted to the server before submitting it.