### PR TITLE
fix: allow empty selector in specs v1

### DIFF
--- a/server/test/test_json.go
+++ b/server/test/test_json.go
@@ -17,7 +17,14 @@ func (v1 testSpecV1) valid() bool {
 	valid := true
 	specs := maps.Ordered[SpanQuery, namedAssertions](v1)
 	specs.ForEach(func(key SpanQuery, val namedAssertions) error {
-		if key == "" {
+		anyEmptyAssertion := false
+		for _, assertion := range val.Assertions {
+			if assertion == "" {
+				anyEmptyAssertion = true
+			}
+		}
+
+		if key == "" && anyEmptyAssertion {
 			valid = false
 		}
 		return nil

--- a/server/test/test_json_test.go
+++ b/server/test/test_json_test.go
@@ -51,6 +51,23 @@ func TestSpecV1(t *testing.T) {
 	assert.Equal(t, test.Assertion("attr:http.status = 200"), testObject.Specs[1].Assertions[0])
 }
 
+func TestV1WithEmptySelector(t *testing.T) {
+	x := "[{\"Key\": \"\", \"Value\": {\"Name\": \"DURATION_CHECK\", \"Assertions\": [\"attr:tracetest.span.duration < 2s\"]}}, {\"Key\": \"span[tracetest.span.type=\\\"database\\\"]\", \"Value\": {\"Name\": \"All Database Spans: Processing time is less than 100ms\", \"Assertions\": [\"attr:tracetest.span.duration < 100ms\"]}}]"
+	testObject := test.Test{}
+	err := json.Unmarshal([]byte(x), &testObject.Specs)
+
+	require.NoError(t, err)
+	assert.Equal(t, test.SpanQuery(""), testObject.Specs[0].Selector)
+	assert.Equal(t, "DURATION_CHECK", testObject.Specs[0].Name)
+	assert.Len(t, testObject.Specs[0].Assertions, 1)
+	assert.Equal(t, test.Assertion("attr:tracetest.span.duration < 2s"), testObject.Specs[0].Assertions[0])
+
+	assert.Equal(t, test.SpanQuery("span[tracetest.span.type=\"database\"]"), testObject.Specs[1].Selector)
+	assert.Equal(t, "All Database Spans: Processing time is less than 100ms", testObject.Specs[1].Name)
+	assert.Len(t, testObject.Specs[1].Assertions, 1)
+	assert.Equal(t, test.Assertion("attr:tracetest.span.duration < 100ms"), testObject.Specs[1].Assertions[0])
+}
+
 func TestSpecV2(t *testing.T) {
 	specFormat := `
 	[

--- a/server/test/test_json_test.go
+++ b/server/test/test_json_test.go
@@ -52,9 +52,24 @@ func TestSpecV1(t *testing.T) {
 }
 
 func TestV1WithEmptySelector(t *testing.T) {
-	x := "[{\"Key\": \"\", \"Value\": {\"Name\": \"DURATION_CHECK\", \"Assertions\": [\"attr:tracetest.span.duration < 2s\"]}}, {\"Key\": \"span[tracetest.span.type=\\\"database\\\"]\", \"Value\": {\"Name\": \"All Database Spans: Processing time is less than 100ms\", \"Assertions\": [\"attr:tracetest.span.duration < 100ms\"]}}]"
+	specsJSONWithEmptySelector := `[
+		{
+			"Key": "",
+			"Value": {
+				"Name": "DURATION_CHECK",
+				"Assertions": ["attr:tracetest.span.duration < 2s"]
+			}
+		},
+		{
+			"Key": "span[tracetest.span.type=\"database\"]",
+			"Value": {
+				"Name": "All Database Spans: Processing time is less than 100ms",
+				"Assertions": ["attr:tracetest.span.duration < 100ms"]
+			}
+		}
+	]`
 	testObject := test.Test{}
-	err := json.Unmarshal([]byte(x), &testObject.Specs)
+	err := json.Unmarshal([]byte(specsJSONWithEmptySelector), &testObject.Specs)
 
 	require.NoError(t, err)
 	assert.Equal(t, test.SpanQuery(""), testObject.Specs[0].Selector)

--- a/server/test/test_repository.go
+++ b/server/test/test_repository.go
@@ -476,10 +476,6 @@ func testFieldHasChanged(oldField interface{}, newField interface{}) (bool, erro
 	return string(oldFieldJSON) != string(newFieldJSON), nil
 }
 
-func intPtr(in int) *int {
-	return &in
-}
-
 func (r *repository) Delete(ctx context.Context, id id.ID) error {
 	exists, err := r.Exists(ctx, id)
 	if err != nil {


### PR DESCRIPTION
This PR fixes the issue that didn't allow specs to have empty selectors (select all) in them.

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [x] added a test
