### PR TITLE
fix(frontend): fix otel semantic conventions path

### DIFF
--- a/web/src/redux/apis/OtelRepo.api.ts
+++ b/web/src/redux/apis/OtelRepo.api.ts
@@ -19,7 +19,7 @@ const OtelRepoAPI = createApi({
     getConventions: build.query<OtelReference, {kind?: string; folder?: string}>({
       query: ({folder = 'trace', kind: file = 'http'}) => {
         return {
-          url: `semantic_conventions/${folder}/${file}.yaml`,
+          url: `model/${folder}/${file}.yaml`,
           responseHandler: 'text',
         };
       },


### PR DESCRIPTION
This PR fixes a broken URL for the OTel Semantic Conventions.
[This PR](https://github.com/open-telemetry/semantic-conventions/pull/166) in the official Semantic Conventions repository changed the folder semantic_conventions to model.

## Changes

- fix broken path

## Fixes

-

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
