### PR TITLE
fix: don't update transaction file other than adding id to it

### DIFF
--- a/cli/pkg/resourcemanager/apply.go
+++ b/cli/pkg/resourcemanager/apply.go
@@ -15,6 +15,7 @@ const VerbApply Verb = "apply"
 type applyPreProcessorFn func(context.Context, fileutil.File) (fileutil.File, error)
 
 func (c Client) Apply(ctx context.Context, inputFile fileutil.File, requestedFormat Format) (string, error) {
+	originalInputFile := inputFile
 
 	if c.options.applyPreProcessor != nil {
 		var err error
@@ -72,7 +73,7 @@ func (c Client) Apply(ctx context.Context, inputFile fileutil.File, requestedFor
 
 	// if the original file doesn't have an ID, we need to get the server generated ID from the response
 	// and write it to the original file
-	if !inputFile.HasID() {
+	if !originalInputFile.HasID() {
 
 		jsonBody, err := requestedFormat.ToJSON(body)
 		if err != nil {
@@ -89,12 +90,12 @@ func (c Client) Apply(ctx context.Context, inputFile fileutil.File, requestedFor
 			return "", fmt.Errorf("cannot get ID from Apply response")
 		}
 
-		inputFile, err = inputFile.SetID(id)
+		originalInputFile, err = originalInputFile.SetID(id)
 		if err != nil {
 			return "", fmt.Errorf("cannot set ID on input file: %w", err)
 		}
 
-		_, err = inputFile.Write()
+		_, err = originalInputFile.Write()
 		if err != nil {
 			return "", fmt.Errorf("cannot write updated input file: %w", err)
 		}

--- a/testing/cli-e2etest/helpers/common.go
+++ b/testing/cli-e2etest/helpers/common.go
@@ -97,3 +97,17 @@ func Copy(source, dst string) {
 		panic(err)
 	}
 }
+
+func RemoveIDFromTransactionFile(t *testing.T, filePath string) {
+	fileContent, err := os.ReadFile(filePath)
+	require.NoError(t, err)
+
+	transaction := UnmarshalYAML[types.TransactionResource](t, string(fileContent))
+	transaction.Spec.ID = ""
+
+	newFileContent, err := yaml.Marshal(transaction)
+	require.NoError(t, err)
+
+	err = os.WriteFile(filePath, newFileContent, os.ModeAppend)
+	require.NoError(t, err)
+}

--- a/testing/cli-e2etest/testscenarios/transaction/apply_transaction_test.go
+++ b/testing/cli-e2etest/testscenarios/transaction/apply_transaction_test.go
@@ -2,6 +2,7 @@ package transaction
 
 import (
 	"fmt"
+	"io/ioutil"
 	"testing"
 
 	"github.com/kubeshop/tracetest/cli-e2etest/environment"
@@ -85,4 +86,25 @@ func TestApplyTransaction(t *testing.T) {
 	require.Equal("9wtAH2_Vg", updatedTransaction.Spec.Steps[0])
 	require.Equal("ajksdkasjbd", updatedTransaction.Spec.Steps[1])
 	require.Equal("ajksdkasjbd", updatedTransaction.Spec.Steps[2])
+
+	// When I try to set up a new transaction without any id
+	// Then it should be applied with success and it should not update
+	// the steps with its ids.
+	transactionWithoutIDPath := env.GetTestResourcePath(t, "new-transaction-without-id")
+
+	transactionWithoutIDResult := tracetestcli.Exec(t, fmt.Sprintf("apply transaction --file %s", transactionWithoutIDPath), tracetestcli.WithCLIConfig(cliConfig))
+	helpers.RequireExitCodeEqual(t, transactionWithoutIDResult, 0)
+
+	content, err := ioutil.ReadFile(transactionWithoutIDPath)
+	require.NoError(err)
+
+	transactionWithoutID := helpers.UnmarshalYAML[types.TransactionResource](t, string(content))
+
+	require.Equal("Transaction", transactionWithoutID.Type)
+	require.NotEmpty(transactionWithoutID.Spec.ID)
+	require.Equal("New Transaction", transactionWithoutID.Spec.Name)
+	require.Equal("a transaction", transactionWithoutID.Spec.Description)
+	require.Len(transactionWithoutID.Spec.Steps, 2)
+	require.Equal("./transaction-step-1.yaml", transactionWithoutID.Spec.Steps[0])
+	require.Equal("./transaction-step-2.yaml", transactionWithoutID.Spec.Steps[1])
 }

--- a/testing/cli-e2etest/testscenarios/transaction/apply_transaction_test.go
+++ b/testing/cli-e2etest/testscenarios/transaction/apply_transaction_test.go
@@ -2,7 +2,7 @@ package transaction
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/kubeshop/tracetest/cli-e2etest/environment"
@@ -92,10 +92,12 @@ func TestApplyTransaction(t *testing.T) {
 	// the steps with its ids.
 	transactionWithoutIDPath := env.GetTestResourcePath(t, "new-transaction-without-id")
 
+	helpers.RemoveIDFromTransactionFile(t, transactionWithoutIDPath)
+
 	transactionWithoutIDResult := tracetestcli.Exec(t, fmt.Sprintf("apply transaction --file %s", transactionWithoutIDPath), tracetestcli.WithCLIConfig(cliConfig))
 	helpers.RequireExitCodeEqual(t, transactionWithoutIDResult, 0)
 
-	content, err := ioutil.ReadFile(transactionWithoutIDPath)
+	content, err := os.ReadFile(transactionWithoutIDPath)
 	require.NoError(err)
 
 	transactionWithoutID := helpers.UnmarshalYAML[types.TransactionResource](t, string(content))

--- a/testing/cli-e2etest/testscenarios/transaction/resources/new-transaction-without-id.yaml
+++ b/testing/cli-e2etest/testscenarios/transaction/resources/new-transaction-without-id.yaml
@@ -1,0 +1,8 @@
+type: Transaction
+spec:
+  id: ccTdWur4R
+  name: New Transaction
+  description: a transaction
+  steps:
+  - ./transaction-step-1.yaml
+  - ./transaction-step-2.yaml

--- a/testing/cli-e2etest/testscenarios/transaction/resources/new-transaction-without-id.yaml
+++ b/testing/cli-e2etest/testscenarios/transaction/resources/new-transaction-without-id.yaml
@@ -1,6 +1,5 @@
 type: Transaction
 spec:
-  id: ccTdWur4R
   name: New Transaction
   description: a transaction
   steps:

--- a/testing/cli-e2etest/testscenarios/types/transaction.go
+++ b/testing/cli-e2etest/testscenarios/types/transaction.go
@@ -4,7 +4,7 @@ package types
 // however they are defined here to avoid bias with the current implementation
 
 type Transaction struct {
-	ID          string   `json:"id"`
+	ID          string   `json:"id,omitempty"`
 	Name        string   `json:"name"`
 	Description string   `json:"description"`
 	Steps       []string `json:"steps"`


### PR DESCRIPTION
This PR prevents the CLI from updating the transaction file from being updated with the pre-processed file content.

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
