### PR TITLE
feat: support events in Jaeger, Tempo, and all OTLP datastores (both gRPC and HTTP variants)

### DIFF
--- a/server/model/spans.go
+++ b/server/model/spans.go
@@ -80,6 +80,10 @@ type Span struct {
 }
 
 func (s *Span) injectEventsIntoAttributes() {
+	if s.Events == nil {
+		s.Events = make([]SpanEvent, 0)
+	}
+
 	eventsJson, _ := json.Marshal(s.Events)
 	s.Attributes["span.events"] = string(eventsJson)
 }


### PR DESCRIPTION
This PR adds support to events in Jaeger and tempo datastores (both gRPC and HTTP variants)

![Screenshot from 2023-07-07 18-37-47](https://github.com/kubeshop/tracetest/assets/2704737/59d75dc2-2538-47d6-a5f1-78717e829ae7)



## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
