### PR TITLE
fix(backend): fix analyzer rule error description

### DIFF
--- a/server/linter/analyzer/analyzer_metadata.go
+++ b/server/linter/analyzer/analyzer_metadata.go
@@ -127,7 +127,7 @@ var (
 		ID:               EnforceHttpsProtocolRuleID,
 		Name:             "Secure HTTPS Protocol",
 		Description:      "Enforce usage of secure protocol for HTTP server spans",
-		ErrorDescription: "The following spans are using insecure http protocol:",
+		ErrorDescription: "The following attributes are using insecure http protocol:",
 		Tips:             []string{},
 		Weight:           30,
 		ErrorLevel:       "error",

--- a/server/linter/analyzer/analyzer_repository_test.go
+++ b/server/linter/analyzer/analyzer_repository_test.go
@@ -112,7 +112,7 @@ func TestLinterResource(t *testing.T) {
 								"weight": 30,
 								"errorLevel": "error",
 								"name": "Secure HTTPS Protocol",
-								"errorDescription": "The following spans are using insecure http protocol:",
+								"errorDescription": "The following attributes are using insecure http protocol:",
 								"description": "Enforce usage of secure protocol for HTTP server spans",
 								"tips": []
 							},


### PR DESCRIPTION
This PR fixes an incorrect errorDescription for the `secure-https-protocol` analyzer rule.

## Changes

- fix errorDescription in metadata file

## Fixes

-

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
