### PR TITLE
fix(frontend): fix analyzer config form for weight field

### DIFF
--- a/web/src/components/Settings/Linter/Rule.tsx
+++ b/web/src/components/Settings/Linter/Rule.tsx
@@ -29,7 +29,11 @@ const Rule = ({fieldKey, baseName, isDisabled}: IProps) => {
       </Col>
       <Col span="auto">-</Col>
       <Col span={11}>
-        <Form.Item name={[fieldKey, 'weight']} label="Weight input configuration">
+        <Form.Item
+          name={[fieldKey, 'weight']}
+          label="Weight input configuration"
+          normalize={value => parseInt(String(value ?? 0), 10)}
+        >
           <Input type="number" disabled={isDisabled} />
         </Form.Item>
       </Col>


### PR DESCRIPTION
This PR fixes a parse issue that was causing an error when trying to update the rule's weight.

## Changes

- add normalize prop on rule weight input

## Fixes

-

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
