### PR TITLE
fix(frontend): fix container in OTel settings page

### DIFF
--- a/web/src/components/Settings/DataStorePlugin/forms/OpenTelemetryCollector/Configuration.tsx
+++ b/web/src/components/Settings/DataStorePlugin/forms/OpenTelemetryCollector/Configuration.tsx
@@ -1,4 +1,4 @@
-import {Form} from 'antd';
+import {Col, Form, Row} from 'antd';
 import {CollectorConfigMap} from 'constants/CollectorConfig.constants';
 import {TCollectorDataStores, TDraftDataStore} from 'types/DataStore.types';
 import {FramedCodeBlock} from 'components/CodeBlock';
@@ -20,9 +20,15 @@ const Configuration = () => {
           own OpenTelemetry Collector config and apply it.
         </S.Description>
       </S.SubtitleContainer>
-      <S.CodeContainer data-cy="file-viewer-code-container">
-        <FramedCodeBlock value={example} language="yaml" title="Collector Configuration" />
-      </S.CodeContainer>
+
+      <Row>
+        <Col span={16}>
+          <S.CodeContainer data-cy="file-viewer-code-container">
+            <FramedCodeBlock value={example} language="yaml" title="Collector Configuration" />
+          </S.CodeContainer>
+        </Col>
+      </Row>
+
       <DataStoreDocsBanner dataStoreType={dataStoreType} />
     </>
   );

--- a/web/src/components/Settings/DataStorePlugin/forms/OpenTelemetryCollector/OpenTelemetryCollector.tsx
+++ b/web/src/components/Settings/DataStorePlugin/forms/OpenTelemetryCollector/OpenTelemetryCollector.tsx
@@ -6,12 +6,12 @@ const OpenTelemetryCollector = () => {
   return (
     <>
       <Row gutter={[16, 16]}>
-        <Col span={16}>
+        <Col span={24}>
           <Ingestor />
         </Col>
       </Row>
       <Row gutter={[16, 16]}>
-        <Col span={16}>
+        <Col span={24}>
           <Configuration />
         </Col>
       </Row>


### PR DESCRIPTION
This PR fixes the container for the OTel data store in the Settings page.

## Changes

- fix container size

## Fixes

- fixes #2899

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Screenshot

<img width="1624" alt="Screenshot 2023-07-12 at 16 05 29" src="https://github.com/kubeshop/tracetest/assets/3879892/114bf34e-efe1-4f6b-a6f5-b62d0f967080">