### PR TITLE
feature(frontend): Adding Docker Host Url Prompt

### DIFF
--- a/web/src/components/CreateTestPlugins/Rest/steps/RequestDetails/RequestDetailsUrlInput.tsx
+++ b/web/src/components/CreateTestPlugins/Rest/steps/RequestDetails/RequestDetailsUrlInput.tsx
@@ -3,6 +3,7 @@ import {HTTP_METHOD} from 'constants/Common.constants';
 import {SupportedEditors} from 'constants/Editor.constants';
 import Editor from 'components/Editor';
 import * as S from './RequestDetails.styled';
+import UrlDockerTipInput from './UrlDockerTipInput';
 
 interface IProps {
   showMethodSelector?: boolean;
@@ -39,6 +40,9 @@ const RequestDetailsUrlInput = ({showMethodSelector = true}: IProps) => {
           <Editor type={SupportedEditors.Interpolation} placeholder="Enter request url" />
         </Form.Item>
       </S.URLInputContainer>
+      <Form.Item name="url">
+        <UrlDockerTipInput />
+      </Form.Item>
     </div>
   );
 };

--- a/web/src/components/CreateTestPlugins/Rest/steps/RequestDetails/UrlDockerTipInput.styled.ts
+++ b/web/src/components/CreateTestPlugins/Rest/steps/RequestDetails/UrlDockerTipInput.styled.ts
@@ -1,0 +1,13 @@
+import {Typography} from 'antd';
+import styled from 'styled-components';
+
+export const Paragraph = styled(Typography.Paragraph)`
+  && {
+    margin-top: 10px;
+    font-weight: 600;
+
+    span {
+      font-weight: 400;
+    }
+  }
+`;

--- a/web/src/components/CreateTestPlugins/Rest/steps/RequestDetails/UrlDockerTipInput.tsx
+++ b/web/src/components/CreateTestPlugins/Rest/steps/RequestDetails/UrlDockerTipInput.tsx
@@ -1,0 +1,43 @@
+import {useCallback, useMemo} from 'react';
+import {Typography} from 'antd';
+import {noop} from 'lodash';
+import {getIsValidUrl, getParsedURL} from 'utils/Common';
+import * as S from './UrlDockerTipInput.styled';
+
+interface IProps {
+  onChange?(value: string): void;
+  value?: string;
+}
+
+const localhostDns = ['localhost', '127.0.0.1'];
+const dockerHostDns = 'host.docker.internal';
+
+const UrlDockerTipInput = ({onChange = noop, value = ''}: IProps) => {
+  const hostname = useMemo(() => {
+    try {
+      return getParsedURL(value).hostname;
+    } catch (e) {
+      return '';
+    }
+  }, [value]);
+
+  const handleReplaceUrl = useCallback(() => {
+    if (getIsValidUrl(value)) {
+      const url = getParsedURL(value);
+      url.hostname = dockerHostDns;
+      onChange(url?.toString());
+    }
+  }, [onChange, value]);
+
+  return !!hostname && localhostDns.includes(hostname) ? (
+    <S.Paragraph>
+      Are you running Tracetest on Docker?{' '}
+      <Typography.Text type="secondary">
+        Try replacing <code>{hostname}</code> with <code>host.docker.internal</code> by clicking{'  '}
+        <a onClick={() => handleReplaceUrl()}>here.</a>
+      </Typography.Text>
+    </S.Paragraph>
+  ) : null;
+};
+
+export default UrlDockerTipInput;

--- a/web/src/utils/Common.ts
+++ b/web/src/utils/Common.ts
@@ -66,3 +66,28 @@ export const getServerBaseUrl = () => {
 
   return `${protocol}//${host}${prefix}`;
 };
+
+export const getIsValidUrl = (url: string): boolean => {
+  try {
+    return !!getParsedURL(url);
+  } catch (e) {
+    return false;
+  }
+};
+
+const regex =
+  '(?:\\S+(?::\\S*)?@)?(?:(?:(?:[1-9]\\d?|1\\d\\d|2[01]\\d|22[0-3])(?:\\.(?:1?\\d{1,2}|2[0-4]\\d|25[0-5])){2}(?:\\.(?:[0-9]\\d?|1\\d\\d|2[0-4]\\d|25[0-4]))|(?:(?:[a-z\\u00a1-\\uffff0-9]+-?)*[a-z\\u00a1-\\uffff0-9]+)(?:\\.(?:[a-z\\u00a1-\\uffff0-9]+-?)*[a-z\\u00a1-\\uffff0-9]+)*(?:\\.(?:[a-z\\u00a1-\\uffff]{2,})))|localhost)(?::\\d{2,5})?(?:(/|\\?|#)[^\\s]*)?$';
+
+export const getParsedURL = (rawUrl: string): URL => {
+  const urlRegex = new RegExp(regex, 'i');
+
+  const [matchedUrl = ''] = rawUrl.match(urlRegex) || [];
+
+  if (!matchedUrl) throw new Error('Invalid URL');
+
+  if (!!matchedUrl && !matchedUrl.startsWith('http')) {
+    return new URL(`http://${matchedUrl}`);
+  }
+
+  return new URL(matchedUrl);
+};


### PR DESCRIPTION
This PR updates the request url component to include an extra input for the localhost vs docker host prompt

## Changes

- Adds new docker url component
- Includes logic for validating and parsing urls

## Fixes

- #2910 

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

https://www.loom.com/share/4ddc663c26934a118175107f01b323cd