### PR TITLE
feat(frontend): improve attribute selection in test outputs form

### DIFF
--- a/web/src/components/TestOutputForm/TestOutputForm.tsx
+++ b/web/src/components/TestOutputForm/TestOutputForm.tsx
@@ -1,4 +1,7 @@
+import {startCompletion} from '@codemirror/autocomplete';
+import {EditorView} from '@codemirror/view';
 import {Button, Form, Input, Tag} from 'antd';
+import {delay} from 'lodash';
 import {useEffect} from 'react';
 
 import Editor from 'components/Editor';
@@ -57,6 +60,10 @@ const TestOutputForm = ({
     };
   }, []);
 
+  const onAttributeFocus = (view: EditorView) => {
+    if (!view?.state.doc.length) delay(() => startCompletion(view!), 0);
+  };
+
   return (
     <S.Container>
       <S.Title>{isEditing ? 'Edit Test Output' : 'Add Test Output'}</S.Title>
@@ -105,6 +112,7 @@ const TestOutputForm = ({
               }}
               placeholder="Attribute"
               type={SupportedEditors.Expression}
+              onFocus={onAttributeFocus}
             />
           </Form.Item>
         </S.FormSection>


### PR DESCRIPTION
This PR improves the attribute selection in the TestOutput form by opening the Suggestions menu when the field has focus.

## Changes

- add onFocus listener for attribute field in test output form

## Fixes

- fixes #2900 

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Screenshot

![2023-07-14 13 36 35](https://github.com/kubeshop/tracetest/assets/3879892/51a3c322-acb7-41e3-87cd-cb139f9a1fe3)