### PR TITLE
fix(frontend): fix trace panel size

### DIFF
--- a/web/src/components/RunDetailTrace/AnalyzerPanel.tsx
+++ b/web/src/components/RunDetailTrace/AnalyzerPanel.tsx
@@ -10,7 +10,7 @@ interface IProps {
 
 const panel = {
   name: 'ANALYZER',
-  maxSize: 650,
+  maxSize: window.innerWidth / 2 || 650,
   minSize: 25,
   isDefaultOpen: true,
 };


### PR DESCRIPTION
This PR fixes the size of the panels for the Trace tab in order to have the same sizes for all the tabs (Trigger, Trace, Test and Automate)

## Changes

- fix panel size

## Fixes

- fixes #2936 

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Screenshot

![2023-07-14 14 55 31](https://github.com/kubeshop/tracetest/assets/3879892/9bfeceb5-679d-4047-bfcc-297c88c9c198)