### PR TITLE
feat: add testrunner resource to cli e2e readme

### DIFF
--- a/testing/cli-e2etest/README.md
+++ b/testing/cli-e2etest/README.md
@@ -26,7 +26,7 @@ The main idea is to test every CLI command against the Tracetest server with dif
 | `--help`, `-h` | [HelpCommand](./testscenarios/help_test.go)       |
 | `--config`     | All scenarios                                     |
 
-### Tests and Test Runner
+### Run Tests and Transactions
 
 | CLI Command                                                        | Test scenarios |
 | ------------------------------------------------------------------ | -------------- |
@@ -111,6 +111,19 @@ The main idea is to test every CLI command against the Tracetest server with dif
 | `list pollingprofile --output pretty`                                 | [ListPollingProfile](./testscenarios/pollingprofile/list_pollingprofile_test.go) |
 | `list pollingprofile --output json`                                   | [ListPollingProfile](./testscenarios/pollingprofile/list_pollingprofile_test.go) |
 | `list pollingprofile --output yaml`                                   | [ListPollingProfile](./testscenarios/pollingprofile/list_pollingprofile_test.go) |
+
+### Resources: TestRunner
+
+| CLI Command                                                           | Test scenarios |
+| --------------------------------------------------------------------- | -------------- |
+| `apply testrunner -f [testrunner-file]`                               | [ApplyTestRunner](./testscenarios/testrunner/apply_testrunner_test.go) |
+| `delete testrunner --id current`                                      | [DeleteTestRunner](./testscenarios/testrunner/delete_testrunner_test.go) |
+| `get testrunner --id current --output pretty`                         | [GetTestRunner](./testscenarios/testrunner/get_testrunner_test.go) |
+| `get testrunner --id current --output json`                           | [GetTestRunner](./testscenarios/testrunner/get_testrunner_test.go) |
+| `get testrunner --id current --output yaml`                           | [GetTestRunner](./testscenarios/testrunner/get_testrunner_test.go) |
+| `list testrunner --output pretty`                                     | [ListTestRunner](./testscenarios/testrunner/list_testrunner_test.go) |
+| `list testrunner --output json`                                       | [ListTestRunner](./testscenarios/testrunner/list_testrunner_test.go) |
+| `list testrunner --output yaml`                                       | [ListTestRunner](./testscenarios/testrunner/list_testrunner_test.go) |
 
 ### Resources: Analyzer
 


### PR DESCRIPTION
This PR adds the testrunner resource to the cli e2e tests readme.

## Changes

- add testrunner resource to readme file

## Fixes

-

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
