### PR TITLE
fix: add resource requests to collector manifest

### DIFF
--- a/k8s/collector.yml
+++ b/k8s/collector.yml
@@ -56,6 +56,10 @@ spec:
           volumeMounts:
             - mountPath: /conf
               name: collector-config
+          resources:
+            requests:
+              cpu: 250m
+              memory: 512Mi
       volumes:
         - configMap:
             items:


### PR DESCRIPTION
This PR adds the `resources.requests` config into the collector manifest

## Checklist

- [ ] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
