### PR TITLE
docs: Onboarding iteration v2

### DIFF
--- a/docs/docs/cli/cli-installation-reference.md
+++ b/docs/docs/cli/cli-installation-reference.md
@@ -2,15 +2,13 @@
 
 This page contains a reference of all options for installing Tracetest CLI.
 
-## Detailed Instructions on Installing Tracetest Using the CLI
-
 Tracetest has a command line interface (CLI) which includes an **install wizard** that helps to install the Tracetest server into Docker or Kubernetes. The CLI can also be used to run tests, download or upload tests, and manage much of the capability of Tracetest.
 
-## Installing the Tracetest Server via the CLI
+:::tip Want more info?
+Read more about the installation guide [here](../getting-started/installation.mdx).
+:::
 
-Use the CLI's install wizard to install a Tracetest server locally using Docker Compose or to a local or remote Kubernetes cluster.
-
-The wizard installs all the tools required to set up the desired environment and creates all the configurations, tailored to your case.
+## Installing the Tracetest CLI in different operating systems
 
 Every time we release a new version of Tracetest, we generate binaries for Linux, MacOS, and Windows. Supporting both amd64, and ARM64 architectures, in `tar.gz`, `deb`, `rpm` and `exe` formats.
 
@@ -75,3 +73,21 @@ choco source add --name=kubeshop_repo --source=https://chocolatey.kubeshop.io/ch
 #### From source
 
 Download one of the files from the latest tag, extract to your machine, and then [add the tracetest binary to your PATH variable](https://stackoverflow.com/a/41895179).
+
+## Installing a specific version of the Tracetest CLI
+
+You can request to install a specific version by appending `-s -- [version]` to the installation script.
+
+```bash
+curl -L https://raw.githubusercontent.com/kubeshop/tracetest/main/install-cli.sh | bash -s -- [version]
+```
+
+If you would want version `v0.13.0` you would run this command:
+
+```bash
+curl -L https://raw.githubusercontent.com/kubeshop/tracetest/main/install-cli.sh | bash -s -- v0.12.1
+```
+
+This method skips package managers and directly downloads the build from the release page.
+
+Due to this, if the Tracetest CLI was previously installed using a package manager, that version will still exist in the system, so depending on the `$PATH` environment variable configuration, that version might take precedence over the specific version you installed with the install script.

--- a/docs/docs/getting-started/installation.mdx
+++ b/docs/docs/getting-started/installation.mdx
@@ -32,10 +32,11 @@ Read the CLI installation reference [here](../cli/cli-installation-reference.md)
 
 Tracetest runs as a standalone container. It runs a Server and exposes a Web UI on port `11633`.
 
-You have two options to install Tracetest Server:
+You have three options to install Tracetest Server:
 
 - Using the Tracetest CLI to guide your installation in Docker and Kubernetes.
 - Using the official [Helm chart](https://github.com/kubeshop/helm-charts/tree/main/charts/tracetest).
+- Using the [Docker Compose Quick Start with the Pokeshop Sample App](https://github.com/kubeshop/tracetest/tree/main/examples/quick-start-pokeshop).
 
 <Tabs groupId="installation">
   <TabItem value="cli" label="Tracetest CLI" default>

--- a/docs/docs/getting-started/installation.mdx
+++ b/docs/docs/getting-started/installation.mdx
@@ -232,6 +232,64 @@ kubectl --kubeconfig <path-to-your-home>/.kube/config --context <your-cluster-co
 Access the Tracetest Web UI on [`http://localhost:11633`](http://localhost:11633).
 
   </TabItem>
+  <TabItem value="docker-compose" label="Docker Compose">
+
+First, be sure that you have [Docker](https://docker.com/) installed in your machine.
+
+The Quick Start with the Pokeshop Sample App is located [here](https://github.com/kubeshop/tracetest/tree/main/examples/quick-start-pokeshop).
+
+**The [`docker-compose.yaml`](https://github.com/kubeshop/tracetest/blob/main/examples/quick-start-pokeshop/docker-compose.yml) contains Tracetest, the OpenTelemetry Collector, and a sample app called [Pokeshop](../live-examples/pokeshop/overview.md). This allows you to create sample tests right away!**
+
+<details>
+  <summary>
+    <b>Click to view Pokeshop Sample App Architecture</b>
+  </summary>
+
+Here's the Architecture of the Pokeshop Sample App:
+
+- an **API** that serves client requests,
+- a **Worker** who deals with background processes.
+
+The communication between the API and Worker is made using a `RabbitMQ` queue, and both services emit telemetry data to OpenTelemetry Collector and communicate with a Postgres database.
+
+Tracetest triggers tests against the Node.js API.
+
+```mermaid
+flowchart TD
+    A[(Redis)]
+    B[(Postgres)]
+    C(Node.js API)
+    D(RabbitMQ)
+    E(Worker)
+    F(OpenTelemetry Collector)
+    G(Tracetest)
+
+    G --> C
+    F --> G
+    C --> A
+    C --> B
+    C --> D
+    D --> E
+    E --> B
+    C --> F
+    E --> F
+    
+    
+```
+</details>
+
+**Start Docker Compose.**
+
+<CodeBlock
+  language="bash"
+  title="Terminal"
+>
+{`docker compose -f docker-compose.yaml up -d`}
+</CodeBlock>
+
+This will start the Tracetest Server and expose the Web UI on [`http://localhost:11633`](http://localhost:11633).
+
+  </TabItem>
 </Tabs>
 
 :::tip Don't have OpenTelemetry installed?

--- a/docs/docs/getting-started/overview.mdx
+++ b/docs/docs/getting-started/overview.mdx
@@ -2,7 +2,7 @@
 id: overview
 title: Getting Started with Tracetest 🚀
 description: Tracetest allows you to quickly build integration and end-to-end tests, powered by your OpenTelemetry traces.
-hide_table_of_contents: true
+hide_table_of_contents: false
 keywords:
   - tracetest
   - trace-based testing
@@ -13,15 +13,6 @@ image: https://res.cloudinary.com/djwdcmwdz/image/upload/v1689693872/docs/Blog_T
 ---
 
 Tracetest is a cloud-native application, packaged and distributed a Docker image and designed to run in a containerized environment.
-
-You can get started with Tracetest in one of two ways.
-
-- Docker
-- Kubernetes
-
-We recommend using the Tracetest CLI to install a Tracetest Server in your environment.
-
-Alternatively, you can run Tracetest with Helm or set up a custom Docker Compose file.
 
 ```mdx-code-block
 import {GettingStartedGuideCardsRow} from '@site/src/components/GettingStartedGuide';

--- a/docs/docs/getting-started/overview.mdx
+++ b/docs/docs/getting-started/overview.mdx
@@ -1,0 +1,30 @@
+---
+id: overview
+title: Getting Started with Tracetest 🚀
+description: Tracetest allows you to quickly build integration and end-to-end tests, powered by your OpenTelemetry traces.
+hide_table_of_contents: true
+keywords:
+  - tracetest
+  - trace-based testing
+  - observability
+  - distributed tracing
+  - testing
+image: https://res.cloudinary.com/djwdcmwdz/image/upload/v1689693872/docs/Blog_Thumbnail_28_ugy2yy.png
+---
+
+Tracetest is a cloud-native application, packaged and distributed a Docker image and designed to run in a containerized environment.
+
+You can get started with Tracetest in one of two ways.
+
+- Docker
+- Kubernetes
+
+We recommend using the Tracetest CLI to install a Tracetest Server in your environment.
+
+Alternatively, you can run Tracetest with Helm or set up a custom Docker Compose file.
+
+```mdx-code-block
+import {GettingStartedGuideCardsRow} from '@site/src/components/GettingStartedGuide';
+
+<GettingStartedGuideCardsRow />
+```

--- a/docs/docs/index.mdx
+++ b/docs/docs/index.mdx
@@ -18,9 +18,9 @@ import CodeBlock from '@theme/CodeBlock';
 Tracetest is a trace-based testing tool for building integration and end-to-end tests in minutes using your [OpenTelemetry](https://opentelemetry.io/docs/getting-started/) traces. Assert against your trace data at every point of a request transaction.
 
 ```mdx-code-block
-import {GettingStartedGuideCardsRow} from '@site/src/components/GettingStartedGuide';
+import {WelcomeGuideCardsRow} from '@site/src/components/WelcomeGuide';
 
-<GettingStartedGuideCardsRow />
+<WelcomeGuideCardsRow />
 ```
 
 ## Why Tracetest?

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -221,6 +221,10 @@ const sidebars = {
     {
       type: "category",
       label: "Getting Started",
+      link: {
+        type: "doc",
+        id: "getting-started/overview"
+      },
       items: [
         {
           type: "doc",

--- a/docs/src/components/GettingStartedGuide/index.tsx
+++ b/docs/src/components/GettingStartedGuide/index.tsx
@@ -3,23 +3,49 @@
 import React from 'react';
 import clsx from 'clsx';
 import Link from '@docusaurus/Link';
+import Translate from '@docusaurus/Translate';
 import Heading from '@theme/Heading';
 
 const GettingStartedGuides = [
   {
     name: '👇 Install Tracetest',
     url: './installation',
+    description: (
+      <Translate >
+        Set up Tracetest and start trace-based testing your distributed system.
+      </Translate>
+    ),
     button: 'Set up Tracetest',
   },
   {
     name: '🙌 Open Tracetest',
     url: './open',
+    description: (
+      <Translate>
+        After installing it, open Tracetest start to creating trace-based tests.
+      </Translate>
+    ),
     button: 'Create tests',
   },
   {
     name: '🤔 Don\'t have OpenTelemetry?',
     url: './no-otel',
-    button: 'Set up tracing',
+    description: (
+      <Translate >
+        Install OpenTelemetry in 5 minutes without any code changes!
+      </Translate>
+    ),
+    button: 'Set up OTel',
+  },
+  {
+    name: '🤩 Open Source',
+    url: 'https://github.com/kubeshop/tracetest',
+    description: (
+      <Translate>
+        Check out the Tracetest GitHub repo! Please consider giving us a star! ⭐️
+      </Translate>
+    ),
+    button: 'Go to GitHub',
   },
 ];
 
@@ -27,14 +53,16 @@ interface Props {
   name: string;
   url: string;
   button: string;
+  description: JSX.Element;
 }
 
-function GettingStartedGuideCard({name, url, button}: Props) {
+function GettingStartedGuideCard({name, url, description, button}: Props) {
   return (
-    <div className="col col--4 margin-bottom--lg">
+    <div className="col col--6 margin-bottom--lg">
       <div className={clsx('card')}>
         <div className="card__body">
-          <Heading as="h4" style={{ margin: 0 }}>{name}</Heading>
+          <Heading as="h3">{name}</Heading>
+          <p>{description}</p>
         </div>
         <div className="card__footer">
           <div className="button-group button-group--block">

--- a/docs/src/components/GettingStartedGuide/index.tsx
+++ b/docs/src/components/GettingStartedGuide/index.tsx
@@ -2,70 +2,24 @@
 
 import React from 'react';
 import clsx from 'clsx';
-import Translate from '@docusaurus/Translate';
 import Link from '@docusaurus/Link';
 import Heading from '@theme/Heading';
 
 const GettingStartedGuides = [
   {
     name: '👇 Install Tracetest',
-    url: './getting-started/installation',
-    description: (
-      <Translate >
-        Set up Tracetest and start trace-based testing your distributed system.
-      </Translate>
-    ),
+    url: './installation',
     button: 'Set up Tracetest',
   },
   {
     name: '🙌 Open Tracetest',
-    url: './getting-started/open',
-    description: (
-      <Translate>
-        After installing it, open Tracetest start to creating trace-based tests.
-      </Translate>
-    ),
+    url: './open',
     button: 'Create tests',
   },
   {
     name: '🤔 Don\'t have OpenTelemetry?',
-    url: './getting-started/no-otel',
-    description: (
-      <Translate >
-        Install OpenTelemetry in 5 minutes without any code changes!
-      </Translate>
-    ),
-    button: 'Set up OTel',
-  },
-  {
-    name: '🤩 Open Source',
-    url: 'https://github.com/kubeshop/tracetest',
-    description: (
-      <Translate>
-        Check out the Tracetest GitHub repo! Please consider giving us a star! ⭐️
-      </Translate>
-    ),
-    button: 'Go to GitHub',
-  },
-  {
-    name: '⚙️ Configure trace data stores',
-    url: '../configuration/overview#supported-trace-data-stores',
-    description: (
-      <Translate>
-        Connect your existing trace data store or send traces to Tracetest directly!
-      </Translate>
-    ),
-    button: 'Configure Tracetest',
-  },
-  {
-    name: '🙄 New to Trace-based Testing?',
-    url: '../concepts/what-is-trace-based-testing',
-    description: (
-      <Translate>
-        Read about the concepts of trace-based testing to learn more!
-      </Translate>
-    ),
-    button: 'View Concepts',
+    url: './no-otel',
+    button: 'Set up tracing',
   },
 ];
 
@@ -73,16 +27,14 @@ interface Props {
   name: string;
   url: string;
   button: string;
-  description: JSX.Element;
 }
 
-function GettingStartedGuideCard({name, url, description, button}: Props) {
+function GettingStartedGuideCard({name, url, button}: Props) {
   return (
-    <div className="col col--6 margin-bottom--lg">
+    <div className="col col--4 margin-bottom--lg">
       <div className={clsx('card')}>
         <div className="card__body">
-          <Heading as="h3">{name}</Heading>
-          <p>{description}</p>
+          <Heading as="h4" style={{ margin: 0 }}>{name}</Heading>
         </div>
         <div className="card__footer">
           <div className="button-group button-group--block">

--- a/docs/src/components/WelcomeGuide/index.tsx
+++ b/docs/src/components/WelcomeGuide/index.tsx
@@ -1,0 +1,107 @@
+/* eslint-disable global-require */
+
+import React from 'react';
+import clsx from 'clsx';
+import Translate from '@docusaurus/Translate';
+import Link from '@docusaurus/Link';
+import Heading from '@theme/Heading';
+
+const WelcomeGuides = [
+  {
+    name: '👇 Install Tracetest',
+    url: './getting-started/installation',
+    description: (
+      <Translate >
+        Set up Tracetest and start trace-based testing your distributed system.
+      </Translate>
+    ),
+    button: 'Set up Tracetest',
+  },
+  {
+    name: '🙌 Open Tracetest',
+    url: './getting-started/open',
+    description: (
+      <Translate>
+        After installing it, open Tracetest start to creating trace-based tests.
+      </Translate>
+    ),
+    button: 'Create tests',
+  },
+  {
+    name: '🤔 Don\'t have OpenTelemetry?',
+    url: './getting-started/no-otel',
+    description: (
+      <Translate >
+        Install OpenTelemetry in 5 minutes without any code changes!
+      </Translate>
+    ),
+    button: 'Set up OTel',
+  },
+  {
+    name: '🤩 Open Source',
+    url: 'https://github.com/kubeshop/tracetest',
+    description: (
+      <Translate>
+        Check out the Tracetest GitHub repo! Please consider giving us a star! ⭐️
+      </Translate>
+    ),
+    button: 'Go to GitHub',
+  },
+  {
+    name: '⚙️ Configure trace data stores',
+    url: '../configuration/overview#supported-trace-data-stores',
+    description: (
+      <Translate>
+        Connect your existing trace data store or send traces to Tracetest directly!
+      </Translate>
+    ),
+    button: 'Configure Tracetest',
+  },
+  {
+    name: '🙄 New to Trace-based Testing?',
+    url: '../concepts/what-is-trace-based-testing',
+    description: (
+      <Translate>
+        Read about the concepts of trace-based testing to learn more!
+      </Translate>
+    ),
+    button: 'View Concepts',
+  },
+];
+
+interface Props {
+  name: string;
+  url: string;
+  button: string;
+  description: JSX.Element;
+}
+
+function WelcomeGuideCard({name, url, description, button}: Props) {
+  return (
+    <div className="col col--6 margin-bottom--lg">
+      <div className={clsx('card')}>
+        <div className="card__body">
+          <Heading as="h3">{name}</Heading>
+          <p>{description}</p>
+        </div>
+        <div className="card__footer">
+          <div className="button-group button-group--block">
+            <Link className="button button--secondary" to={url}>
+              {button}
+            </Link>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export function WelcomeGuideCardsRow(): JSX.Element {
+  return (
+    <div className="row">
+      {WelcomeGuides.map((WelcomeGuide) => (
+        <WelcomeGuideCard key={WelcomeGuide.name} {...WelcomeGuide} />
+      ))}
+    </div>
+  );
+}

--- a/examples/quick-start-pokeshop/.gitignore
+++ b/examples/quick-start-pokeshop/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store

--- a/examples/quick-start-pokeshop/README.md
+++ b/examples/quick-start-pokeshop/README.md
@@ -1,0 +1,14 @@
+# Quick Start - Tracetest + Pokeshop
+
+> [Read the installation guide in our documentation.](https://docs.tracetest.io/getting-started/installation)
+
+This examples' objective is to show how you can:
+
+1. Configure your Tracetest instance to connect to receive traces from OpenTelemetry Collector.
+
+## Steps
+
+1. [Install the tracetest CLI](https://docs.tracetest.io/installing/)
+2. Run `tracetest configure --endpoint http://localhost:11633` on a terminal
+3. Run the project by using docker-compose: `docker-compose up -d` (Linux) or `docker compose up -d` (Mac)
+4. Test if it works by running: `tracetest run test -f tests/test.yaml`. This would trigger a test that will send and retrieve spans from the OpenTelemetry Collector instance. View the test on `http://localhost:11633`.

--- a/examples/quick-start-pokeshop/collector.config.yaml
+++ b/examples/quick-start-pokeshop/collector.config.yaml
@@ -1,0 +1,24 @@
+receivers:
+  otlp:
+    protocols:
+      grpc:
+      http:
+
+processors:
+  batch:
+    timeout: 100ms
+
+exporters:
+  logging:
+    loglevel: debug
+  otlp/tracetest:
+    endpoint: tracetest:4317
+    tls:
+      insecure: true
+
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [otlp/tracetest]

--- a/examples/quick-start-pokeshop/docker-compose.yml
+++ b/examples/quick-start-pokeshop/docker-compose.yml
@@ -1,0 +1,135 @@
+version: "3"
+services:
+
+  # Tracetest
+  tracetest:
+    image: kubeshop/tracetest
+    volumes:
+      - ./tracetest.config.yaml:/app/tracetest.yaml
+      - ./tracetest.provision.yaml:/app/provisioning.yaml
+    ports:
+      - 11633:11633
+    command: --provisioning-file /app/provisioning.yaml
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    depends_on:
+      postgres:
+        condition: service_healthy
+      otel-collector:
+        condition: service_started
+    environment:
+      TRACETEST_DEV: ${TRACETEST_DEV}
+
+  otel-collector:
+    image: otel/opentelemetry-collector-contrib:0.59.0
+    command:
+      - "--config"
+      - "/otel-local-config.yaml"
+    volumes:
+      - ./collector.config.yaml:/otel-local-config.yaml
+  # Tracetest End
+ 
+
+  # Demo
+  postgres:
+    image: postgres:14
+    environment:
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_USER: postgres
+    healthcheck:
+      test: pg_isready -U "$$POSTGRES_USER" -d "$$POSTGRES_DB"
+      interval: 1s
+      timeout: 5s
+      retries: 60
+    ports:
+      - 5432:5432
+
+  demo-cache:
+    image: redis:6
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 1s
+      timeout: 3s
+      retries: 60
+
+  demo-queue:
+    image: rabbitmq:3.8-management
+    restart: unless-stopped
+    healthcheck:
+      test: rabbitmq-diagnostics -q check_running
+      interval: 1s
+      timeout: 5s
+      retries: 60
+
+  demo-api:
+    image: kubeshop/demo-pokemon-api:latest
+    restart: unless-stopped
+    pull_policy: always
+    environment:
+      REDIS_URL: demo-cache
+      DATABASE_URL: postgresql://postgres:postgres@postgres:5432/postgres?schema=public
+      RABBITMQ_HOST: demo-queue
+      POKE_API_BASE_URL: https://pokeapi.co/api/v2
+      COLLECTOR_ENDPOINT: http://otel-collector:4317
+      NPM_RUN_COMMAND: api
+    ports:
+      - "8081:8081"
+    healthcheck:
+      test: ["CMD", "wget", "--spider", "localhost:8081"]
+      interval: 1s
+      timeout: 3s
+      retries: 60
+    depends_on:
+      postgres:
+        condition: service_healthy
+      demo-cache:
+        condition: service_healthy
+      demo-queue:
+        condition: service_healthy
+
+  demo-worker:
+    image: kubeshop/demo-pokemon-api:latest
+    restart: unless-stopped
+    pull_policy: always
+    environment:
+      REDIS_URL: demo-cache
+      DATABASE_URL: postgresql://postgres:postgres@postgres:5432/postgres?schema=public
+      RABBITMQ_HOST: demo-queue
+      POKE_API_BASE_URL: https://pokeapi.co/api/v2
+      COLLECTOR_ENDPOINT: http://otel-collector:4317
+      NPM_RUN_COMMAND: worker
+    depends_on:
+      postgres:
+        condition: service_healthy
+      demo-cache:
+        condition: service_healthy
+      demo-queue:
+        condition: service_healthy
+
+  demo-rpc:
+    image: kubeshop/demo-pokemon-api:latest
+    restart: unless-stopped
+    pull_policy: always
+    environment:
+      REDIS_URL: demo-cache
+      DATABASE_URL: postgresql://postgres:postgres@postgres:5432/postgres?schema=public
+      RABBITMQ_HOST: demo-queue
+      POKE_API_BASE_URL: https://pokeapi.co/api/v2
+      COLLECTOR_ENDPOINT: http://otel-collector:4317
+      NPM_RUN_COMMAND: rpc
+    ports:
+      - 8082:8082
+    healthcheck:
+      test: ["CMD", "lsof", "-i", "8082"]
+      interval: 1s
+      timeout: 3s
+      retries: 60
+    depends_on:
+      postgres:
+        condition: service_healthy
+      demo-cache:
+        condition: service_healthy
+      demo-queue:
+        condition: service_healthy
+  # Demo End

--- a/examples/quick-start-pokeshop/tests/test.yaml
+++ b/examples/quick-start-pokeshop/tests/test.yaml
@@ -1,0 +1,32 @@
+type: Test
+spec:
+  id: ZVJwkpC4g
+  name: Pokeshop - Import
+  description: Import a Pokemon
+  trigger:
+    type: http
+    httpRequest:
+      method: POST
+      url: http://demo-api:8081/pokemon/import
+      body: '{"id":6}'
+      headers:
+      - key: Content-Type
+        value: application/json
+  specs:
+  - selector: span[tracetest.span.type="http"]
+    name: "All HTTP Spans: Status  code is 200"
+    assertions:
+    - attr:http.status_code = 200
+  - selector: span[tracetest.span.type="general" name="import pokemon"]
+    name: Validate that this span always exists after the message queue
+    assertions:
+    - attr:tracetest.selected_spans.count  =  1
+    - attr:span.events not-contains "exception"
+  - selector: span[tracetest.span.type="database" name="get pokemon_6" db.system="redis" db.operation="get" db.redis.database_index="0"]
+    name: Validate that Redis is using Charizard.
+    assertions:
+    - attr:db.payload = '{"key":"pokemon_6"}'
+  - selector: span[tracetest.span.type="database" name="create postgres.pokemon" db.system="postgres" db.name="postgres" db.user="postgres" db.operation="create" db.sql.table="pokemon"]
+    name: Validate that the Postgres has Charizard.
+    assertions:
+    - attr:db.result contains "charizard"

--- a/examples/quick-start-pokeshop/tracetest.config.yaml
+++ b/examples/quick-start-pokeshop/tracetest.config.yaml
@@ -1,0 +1,8 @@
+---
+postgres:
+  host: postgres
+  user: postgres
+  password: postgres
+  port: 5432
+  dbname: postgres
+  params: sslmode=disable

--- a/examples/quick-start-pokeshop/tracetest.provision.yaml
+++ b/examples/quick-start-pokeshop/tracetest.provision.yaml
@@ -1,0 +1,17 @@
+---
+type: DataStore
+spec:
+  name: OpenTelemetry Collector pipeline
+  type: otlp
+  default: true
+
+---
+type: Demo
+spec:
+  type: pokeshop
+  enabled: true
+  name: pokeshop
+  opentelemetryStore: {}
+  pokeshop:
+    httpEndpoint: http://demo-api:8081
+    grpcEndpoint: demo-rpc:8082


### PR DESCRIPTION
This PR adds:

- overview page for getting started section
- Docker Compose installation instructions on the installation page
- install specific version of CLI in the CLI reference page

## Screenshots

### Getting started overview

![localhost_3000_getting-started_overview](https://github.com/kubeshop/tracetest/assets/15029531/c8d12a76-853e-44b8-9991-8c8a6fe7d266)

### docker compose install

![localhost_3000_getting-started_installation](https://github.com/kubeshop/tracetest/assets/15029531/1dcde61f-7352-4a16-ba43-6109093cd7d0)


### CLI reference

![localhost_3000_getting-started_overview (2)](https://github.com/kubeshop/tracetest/assets/15029531/a7a05975-bafd-4270-86b3-9bc10b40981f)

## Changes

-

## Fixes

-

## Checklist

- [ ] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
