### PR TITLE
feat(cli): show trace ID on failed tests

### DIFF
--- a/cli/formatters/test_run.go
+++ b/cli/formatters/test_run.go
@@ -106,7 +106,7 @@ func (f testRun) formatSuccessfulTest(test openapi.Test, run openapi.TestRun) st
 	var buffer bytes.Buffer
 
 	link := f.GetRunLink(test.GetId(), run.GetId())
-	message := f.formatMessage("%s %s (%s)\n", PASSED_TEST_ICON, *test.Name, link)
+	message := f.formatMessage("%s %s (%s) - trace id: %s\n", PASSED_TEST_ICON, *test.Name, link, run.GetTraceId())
 	message = f.getColoredText(true, message)
 	buffer.WriteString(message)
 

--- a/cli/formatters/test_run.go
+++ b/cli/formatters/test_run.go
@@ -141,7 +141,7 @@ func (f testRun) formatFailedTest(test openapi.Test, run openapi.TestRun) string
 	var buffer bytes.Buffer
 
 	link := f.GetRunLink(test.GetId(), run.GetId())
-	message := f.formatMessage("%s %s (%s)\n", FAILED_TEST_ICON, *test.Name, link)
+	message := f.formatMessage("%s %s (%s) - trace id: %s\n", FAILED_TEST_ICON, test.GetName(), link, run.GetTraceId())
 	message = f.getColoredText(false, message)
 	buffer.WriteString(message)
 	for i, specResult := range run.Result.Results {

--- a/cli/formatters/test_run_test.go
+++ b/cli/formatters/test_run_test.go
@@ -126,7 +126,8 @@ func TestFailingTestOutput(t *testing.T) {
 			},
 		},
 		Run: openapi.TestRun{
-			Id: openapi.PtrString("1"),
+			Id:      openapi.PtrString("1"),
+			TraceId: openapi.PtrString("cb5e80748cc06f8a63f6b96c056defec"),
 			Result: &openapi.AssertionResults{
 				AllPassed: openapi.PtrBool(false),
 				Results: []openapi.AssertionResultsResultsInner{
@@ -187,7 +188,7 @@ func TestFailingTestOutput(t *testing.T) {
 
 	formatter := formatters.TestRun(baseURL, false)
 	output := formatter.Format(in, formatters.Pretty)
-	expectedOutput := `✘ Testcase 2 (http://localhost:11633/test/9876543/run/1/test)
+	expectedOutput := `✘ Testcase 2 (http://localhost:11633/test/9876543/run/1/test) - trace id: cb5e80748cc06f8a63f6b96c056defec
 	✔ Validate span duration
 		✔ #123456
 			✔ attr:tracetest.span.duration <= 200ms (157ms)
@@ -217,7 +218,8 @@ func TestFailingTestOutputWithPadding(t *testing.T) {
 			},
 		},
 		Run: openapi.TestRun{
-			Id: openapi.PtrString("1"),
+			Id:      openapi.PtrString("1"),
+			TraceId: openapi.PtrString("cb5e80748cc06f8a63f6b96c056defec"),
 			Result: &openapi.AssertionResults{
 				AllPassed: openapi.PtrBool(false),
 				Results: []openapi.AssertionResultsResultsInner{
@@ -278,7 +280,7 @@ func TestFailingTestOutputWithPadding(t *testing.T) {
 
 	formatter := formatters.TestRun(baseURL, false, formatters.WithPadding(1))
 	output := formatter.Format(in, formatters.Pretty)
-	expectedOutput := `	✘ Testcase 2 (http://localhost:11633/test/9876543/run/1/test)
+	expectedOutput := `	✘ Testcase 2 (http://localhost:11633/test/9876543/run/1/test) - trace id: cb5e80748cc06f8a63f6b96c056defec
 		✔ Validate span duration
 			✔ #123456
 				✔ attr:tracetest.span.duration <= 200ms (157ms)

--- a/cli/formatters/test_run_test.go
+++ b/cli/formatters/test_run_test.go
@@ -43,8 +43,9 @@ func TestSuccessfulTestRunOutput(t *testing.T) {
 			Name: openapi.PtrString("Testcase 1"),
 		},
 		Run: openapi.TestRun{
-			Id:    openapi.PtrString("1"),
-			State: openapi.PtrString("FINISHED"),
+			Id:      openapi.PtrString("1"),
+			State:   openapi.PtrString("FINISHED"),
+			TraceId: openapi.PtrString("cb5e80748cc06f8a63f6b96c056defec"),
 			Result: &openapi.AssertionResults{
 				AllPassed: openapi.PtrBool(true),
 			},
@@ -53,7 +54,7 @@ func TestSuccessfulTestRunOutput(t *testing.T) {
 	formatter := formatters.TestRun(baseURL, false)
 	output := formatter.Format(in, formatters.Pretty)
 
-	assert.Equal(t, "✔ Testcase 1 (http://localhost:11633/test/9876543/run/1/test)\n", output)
+	assert.Equal(t, "✔ Testcase 1 (http://localhost:11633/test/9876543/run/1/test) - trace id: cb5e80748cc06f8a63f6b96c056defec\n", output)
 }
 
 func TestSuccessfulTestRunOutputWithResult(t *testing.T) {
@@ -71,8 +72,9 @@ func TestSuccessfulTestRunOutputWithResult(t *testing.T) {
 			},
 		},
 		Run: openapi.TestRun{
-			Id:    openapi.PtrString("1"),
-			State: openapi.PtrString("FINISHED"),
+			Id:      openapi.PtrString("1"),
+			TraceId: openapi.PtrString("cb5e80748cc06f8a63f6b96c056defec"),
+			State:   openapi.PtrString("FINISHED"),
 			Result: &openapi.AssertionResults{
 				AllPassed: openapi.PtrBool(true),
 				Results: []openapi.AssertionResultsResultsInner{
@@ -101,7 +103,7 @@ func TestSuccessfulTestRunOutputWithResult(t *testing.T) {
 	}
 	formatter := formatters.TestRun(baseURL, false)
 	output := formatter.Format(in, formatters.Pretty)
-	expectedOutput := `✔ Testcase 1 (http://localhost:11633/test/9876543/run/1/test)
+	expectedOutput := `✔ Testcase 1 (http://localhost:11633/test/9876543/run/1/test) - trace id: cb5e80748cc06f8a63f6b96c056defec
 	✔ Validate span duration
 `
 

--- a/testing/server-tracetesting/features/environment/01_create_environment.yml
+++ b/testing/server-tracetesting/features/environment/01_create_environment.yml
@@ -32,7 +32,7 @@ spec:
   specs:
     - selector: span[name = "Tracetest trigger"]
       assertions:
-        - attr:tracetest.selected_spans.count = 1
+        - attr:tracetest.selected_spans.count = 10
         - attr:tracetest.response.status = 201
         # ensure we can reference outputs declared in the same test
         - attr:tracetest.response.body | json_path '$.spec.id' = env:ENVIRONMENT_ID

--- a/testing/server-tracetesting/features/environment/01_create_environment.yml
+++ b/testing/server-tracetesting/features/environment/01_create_environment.yml
@@ -32,7 +32,7 @@ spec:
   specs:
     - selector: span[name = "Tracetest trigger"]
       assertions:
-        - attr:tracetest.selected_spans.count = 10
+        - attr:tracetest.selected_spans.count = 1
         - attr:tracetest.response.status = 201
         # ensure we can reference outputs declared in the same test
         - attr:tracetest.response.body | json_path '$.spec.id' = env:ENVIRONMENT_ID


### PR DESCRIPTION
This PR makes the CLI show the related TraceID for tests that are failing. Example:

On Success:
![Screenshot 2023-07-27 at 17 52 27](https://github.com/kubeshop/tracetest/assets/314548/61fb5472-2634-4c90-9d6e-972f2f8f359f)


On failure:
![Screenshot 2023-07-27 at 16 07 03](https://github.com/kubeshop/tracetest/assets/314548/44056fb8-0c3b-482b-abc4-bdf900808624)

Transactions:
![Screenshot 2023-07-27 at 17 53 51](https://github.com/kubeshop/tracetest/assets/314548/33783c54-7421-42ad-ae9d-2c21f41b45dd)


## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [x] added a test
