### PR TITLE
fix(frontend): use Link component in transaction page

### DIFF
--- a/web/src/components/TransactionHeader/TransactionHeader.styled.ts
+++ b/web/src/components/TransactionHeader/TransactionHeader.styled.ts
@@ -1,7 +1,7 @@
 import {LeftOutlined} from '@ant-design/icons';
 import {Typography} from 'antd';
-import {Link as RRLink} from 'react-router-dom';
 import styled from 'styled-components';
+import RRLink from 'components/Link';
 
 export const BackIcon = styled(LeftOutlined)`
   cursor: pointer;

--- a/web/src/components/TransactionRunResult/ExecutionStep.tsx
+++ b/web/src/components/TransactionRunResult/ExecutionStep.tsx
@@ -69,9 +69,11 @@ const ExecutionStep = ({
         </S.AssertionResultContainer>
         <S.ExecutionStepStatus>
           <Tooltip title="Go to Run">
-            <S.ExecutionStepRunLink to={toLink} target="_blank" data-cy="execution-step-run-link">
-              <LinkOutlined />
-            </S.ExecutionStepRunLink>
+            <div>
+              <S.ExecutionStepRunLink to={toLink} target="_blank" data-cy="execution-step-run-link">
+                <LinkOutlined />
+              </S.ExecutionStepRunLink>
+            </div>
           </Tooltip>
         </S.ExecutionStepStatus>
       </S.Content>


### PR DESCRIPTION
This PR fixes a navigation issue in the Transaction page by using the proper Link component.

## Changes

- use Link component instead of the `react-router-dom` instance

## Fixes

-

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
