### PR TITLE
fix: typo in variable set ui and comments

### DIFF
--- a/testing/cli-e2etest/testscenarios/test/run_test_test.go
+++ b/testing/cli-e2etest/testscenarios/test/run_test_test.go
@@ -117,7 +117,7 @@ func TestRunTestWithHttpTriggerAndVariableSetFile(t *testing.T) {
 		// And I have my server recently created
 		// And the datasource is already set
 
-		// When I create an variable set
+		// When I create a variable set
 		// Then it should be created correctly
 		environmentFile := env.GetTestResourcePath(t, "variableSet-file")
 

--- a/testing/cli-e2etest/testscenarios/variableset/delete_variableset_test.go
+++ b/testing/cli-e2etest/testscenarios/variableset/delete_variableset_test.go
@@ -24,7 +24,7 @@ func TestDeleteVariableSet(t *testing.T) {
 	// Given I am a Tracetest CLI user
 	// And I have my server recently created
 
-	// When I try to delete an variable set that don't exist
+	// When I try to delete a variable set that don't exist
 	// Then it should return an error and say that this resource does not exist
 	result := tracetestcli.Exec(t, "delete variableset --id .env", tracetestcli.WithCLIConfig(cliConfig))
 	helpers.RequireExitCodeEqual(t, result, 1)

--- a/testing/cli-e2etest/testscenarios/variableset/get_variableset_test.go
+++ b/testing/cli-e2etest/testscenarios/variableset/get_variableset_test.go
@@ -51,9 +51,9 @@ func TestGetVariableSet(t *testing.T) {
 	t.Run("get with YAML format", func(t *testing.T) {
 		// Given I am a Tracetest CLI user
 		// And I have my server recently created
-		// And I have an variable set already set
+		// And I have a variable set already set
 
-		// When I try to get an variable set on yaml mode
+		// When I try to get a variable set on yaml mode
 		// Then it should print a YAML
 		result := tracetestcli.Exec(t, "get variableset --id .env --output yaml", tracetestcli.WithCLIConfig(cliConfig))
 		helpers.RequireExitCodeEqual(t, result, 0)
@@ -73,9 +73,9 @@ func TestGetVariableSet(t *testing.T) {
 	t.Run("get with JSON format", func(t *testing.T) {
 		// Given I am a Tracetest CLI user
 		// And I have my server recently created
-		// And I have an variable set already set
+		// And I have a variable set already set
 
-		// When I try to get an variable set on json mode
+		// When I try to get a variable set on json mode
 		// Then it should print a json
 		result := tracetestcli.Exec(t, "get variableset --id .env --output json", tracetestcli.WithCLIConfig(cliConfig))
 		helpers.RequireExitCodeEqual(t, result, 0)
@@ -95,9 +95,9 @@ func TestGetVariableSet(t *testing.T) {
 	t.Run("get with pretty format", func(t *testing.T) {
 		// Given I am a Tracetest CLI user
 		// And I have my server recently created
-		// And I have an variable set already set
+		// And I have a variable set already set
 
-		// When I try to get an variable set on pretty mode
+		// When I try to get a variable set on pretty mode
 		// Then it should print a table with 4 lines printed: header, separator, variable set item and empty line
 		result := tracetestcli.Exec(t, "get variableset --id .env --output pretty", tracetestcli.WithCLIConfig(cliConfig))
 		helpers.RequireExitCodeEqual(t, result, 0)

--- a/web/src/components/RunDetailAutomateMethods/methods/CLICommand/Controls.tsx
+++ b/web/src/components/RunDetailAutomateMethods/methods/CLICommand/Controls.tsx
@@ -29,7 +29,7 @@ function getOptionsMetadata({
     [CliCommandOption.UseHostname]: {label: 'Specify Tracetest server hostname'},
     [CliCommandOption.UseCurrentVariableSet]: {
       label: 'Use selected variable set',
-      help: !isVariableSetSelected ? 'This option is only available when an variable set is selected' : undefined,
+      help: !isVariableSetSelected ? 'This option is only available when a variable set is selected' : undefined,
       disabled: !isVariableSetSelected,
     },
     [CliCommandOption.GeneratesJUnit]: {label: 'Generate JUnit report'},


### PR DESCRIPTION
This PR fixes typos related to `variable sets` in some comments and the web app ui.

## Changes

- fix typo

## Fixes

-

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
