### PR TITLE
feat(cli): fixing deprecated environment flag

### DIFF
--- a/cli/cmd/resource_run_cmd.go
+++ b/cli/cmd/resource_run_cmd.go
@@ -74,7 +74,7 @@ func init() {
 
 	//deprecated
 	runCmd.Flags().StringVarP(&runParams.EnvID, "environment", "e", "", "environment file or ID to be used")
-	runCmd.Flags().MarkDeprecated("env", "use --vars instead")
+	runCmd.Flags().MarkDeprecated("environment", "use --vars instead")
 	runCmd.Flags().MarkShorthandDeprecated("e", "use --vars instead")
 
 	rootCmd.AddCommand(runCmd)

--- a/cli/cmd/resource_run_cmd.go
+++ b/cli/cmd/resource_run_cmd.go
@@ -73,7 +73,7 @@ func init() {
 	runCmd.Flags().StringSliceVar(&runParams.RequriedGates, "required-gates", []string{}, "override default required gate. "+validRequiredGatesMsg())
 
 	//deprecated
-	runCmd.Flags().StringVarP(&runParams.EnvID, "env", "e", "", "environment file or ID to be used")
+	runCmd.Flags().StringVarP(&runParams.EnvID, "environment", "e", "", "environment file or ID to be used")
 	runCmd.Flags().MarkDeprecated("env", "use --vars instead")
 	runCmd.Flags().MarkShorthandDeprecated("e", "use --vars instead")
 


### PR DESCRIPTION
This PR fixes the deprecated environment flag from `env` to `environment`

## Changes

-

## Fixes

-

## Checklist

- [ ] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
