### PR TITLE
fix(frontend): Improving attribute menu tooltip

### DIFF
--- a/web/src/components/PulseButton/PulseButton.styled.ts
+++ b/web/src/components/PulseButton/PulseButton.styled.ts
@@ -1,9 +1,9 @@
-import styled, {DefaultTheme, keyframes} from 'styled-components';
+import styled, {DefaultTheme, css, keyframes} from 'styled-components';
 
-const getPulseAnimation = (theme: DefaultTheme) =>
+export const getPulseAnimation = (theme: DefaultTheme) =>
   keyframes`
   0% {
-    transform: scale(.7);
+    transform: scale(.9);
     box-shadow: 0 0 0 0 ${theme.color.primaryLight};
   }
   70% {
@@ -11,9 +11,15 @@ const getPulseAnimation = (theme: DefaultTheme) =>
     box-shadow: 0 0 0 2px ${theme.color.primaryLight};
   }
   100% {
-    transform: scale(.7);
+    transform: scale(.9);
     box-shadow: 0 0 0 0 ${theme.color.primaryLight};
   }
+`;
+
+export const withPulseAnimation = (theme: DefaultTheme) => css`
+  animation-name: ${getPulseAnimation(theme)};
+  animation-duration: 1.5s;
+  animation-iteration-count: infinite;
 `;
 
 export const PulseButton = styled.button`
@@ -25,7 +31,5 @@ export const PulseButton = styled.button`
   cursor: pointer;
   background: ${({theme}) => theme.color.primary};
 
-  animation-name: ${({theme}) => getPulseAnimation(theme)};
-  animation-duration: 1.5s;
-  animation-iteration-count: infinite;
+  ${({theme}) => withPulseAnimation(theme)}
 `;

--- a/web/src/components/PulseButton/index.ts
+++ b/web/src/components/PulseButton/index.ts
@@ -1,3 +1,4 @@
-import {PulseButton} from './PulseButton.styled';
+import {PulseButton, withPulseAnimation} from './PulseButton.styled';
 
 export default PulseButton;
+export {withPulseAnimation};

--- a/web/src/components/ResizablePanels/LeftPanel.tsx
+++ b/web/src/components/ResizablePanels/LeftPanel.tsx
@@ -1,4 +1,6 @@
 import * as Spaces from 'react-spaces';
+import {useLayoutEffect} from 'react';
+import {noop} from 'lodash';
 import useResizablePanel, {TPanel, TSize} from '../ResizablePanels/hooks/useResizablePanel';
 import Splitter from '../ResizablePanels/Splitter';
 
@@ -7,10 +9,16 @@ interface IProps {
   order?: number;
   children(size: TSize): React.ReactNode;
   tooltip?: string;
+  isToolTipVisible?: boolean;
+  onOpen?(): void;
 }
 
-const LeftPanel = ({panel, order = 1, tooltip, children}: IProps) => {
+const LeftPanel = ({panel, order = 1, tooltip, isToolTipVisible = false, children, onOpen = noop}: IProps) => {
   const {size, toggle, onStopResize} = useResizablePanel({panel});
+
+  useLayoutEffect(() => {
+    if (size.isOpen) onOpen();
+  }, [onOpen, size.isOpen]);
 
   return (
     <Spaces.LeftResizable
@@ -25,8 +33,9 @@ const LeftPanel = ({panel, order = 1, tooltip, children}: IProps) => {
           {...props}
           name={size.name}
           isOpen={size.isOpen}
-          onClick={() => toggle()}
-          tooltip={!size.isOpen ? tooltip : ''}
+          onClick={toggle}
+          tooltip={tooltip}
+          isToolTipVisible={isToolTipVisible}
           tooltipPlacement="right"
         />
       )}

--- a/web/src/components/ResizablePanels/ResizablePanels.styled.ts
+++ b/web/src/components/ResizablePanels/ResizablePanels.styled.ts
@@ -1,5 +1,6 @@
 import {Button} from 'antd';
 import styled, {createGlobalStyle, css} from 'styled-components';
+import {withPulseAnimation} from '../PulseButton';
 
 export const GlobalStyle = createGlobalStyle`
   .spaces-resize-handle {
@@ -24,7 +25,7 @@ export const ButtonContainer = styled.div`
   z-index: 100;
 `;
 
-export const SplitterButton = styled(Button)`
+export const SplitterButton = styled(Button)<{$isPulsing: boolean}>`
   && {
     border: 3px solid ${({theme}) => theme.color.primaryLight};
     background-clip: padding-box;
@@ -32,6 +33,8 @@ export const SplitterButton = styled(Button)`
       font-size: ${({theme}) => theme.size.md};
     }
   }
+
+  ${({theme, $isPulsing}) => $isPulsing && withPulseAnimation(theme)}
 `;
 
 export const SplitterContainer = styled.div``;

--- a/web/src/components/ResizablePanels/Splitter.tsx
+++ b/web/src/components/ResizablePanels/Splitter.tsx
@@ -8,6 +8,7 @@ interface IProps {
   id?: string;
   className?: string;
   name: string;
+  isToolTipVisible?: boolean;
   tooltip?: string;
   tooltipPlacement?: TooltipProps['placement'];
   onMouseDown(e: React.MouseEvent<HTMLElement, MouseEvent>): void;
@@ -24,24 +25,36 @@ const Splitter = ({
   onTouchStart,
   tooltip,
   tooltipPlacement = 'right',
-}: IProps) => (
-  <S.SplitterContainer id={id} key={id} className={className} onMouseDown={onMouseDown} onTouchStart={onTouchStart}>
-    <S.ButtonContainer>
-      <Tooltip title={tooltip} trigger="hover" placement={tooltipPlacement} overlayClassName="splitter">
-        <S.SplitterButton
-          data-cy={`toggle-drawer-${name}`}
-          icon={isOpen ? <DoubleLeftOutlined /> : <DoubleRightOutlined />}
-          onClick={event => {
-            event.stopPropagation();
-            onClick();
-          }}
-          onMouseDown={event => event.stopPropagation()}
-          shape="circle"
-          type="primary"
-        />
-      </Tooltip>
-    </S.ButtonContainer>
-  </S.SplitterContainer>
-);
+  isToolTipVisible = false,
+}: IProps) => {
+  const button = (
+    <S.SplitterButton
+      $isPulsing={isToolTipVisible}
+      data-cy={`toggle-drawer-${name}`}
+      icon={isOpen ? <DoubleLeftOutlined /> : <DoubleRightOutlined />}
+      onClick={event => {
+        event.stopPropagation();
+        onClick();
+      }}
+      onMouseDown={event => event.stopPropagation()}
+      shape="circle"
+      type="primary"
+    />
+  );
+
+  return (
+    <S.SplitterContainer id={id} key={id} className={className} onMouseDown={onMouseDown} onTouchStart={onTouchStart}>
+      <S.ButtonContainer>
+        {isToolTipVisible ? (
+          <Tooltip title={tooltip} visible trigger={[]} placement={tooltipPlacement} overlayClassName="splitter">
+            {button}
+          </Tooltip>
+        ) : (
+          button
+        )}
+      </S.ButtonContainer>
+    </S.SplitterContainer>
+  );
+};
 
 export default Splitter;

--- a/web/src/components/RunDetailTest/SpanDetailsPanel.tsx
+++ b/web/src/components/RunDetailTest/SpanDetailsPanel.tsx
@@ -1,5 +1,6 @@
 import SpanDetail, {TestAttributeRow, TestSubHeader} from 'components/SpanDetail';
 import {useSpan} from 'providers/Span/Span.provider';
+import useAttributePanelTooltip from 'hooks/useAttributePanelTooltip';
 import {LeftPanel, PanelContainer} from '../ResizablePanels';
 
 const panel = {
@@ -10,12 +11,10 @@ const panel = {
 
 const SpanDetailsPanel = () => {
   const {selectedSpan} = useSpan();
+  const {tooltip, isVisible, onClose} = useAttributePanelTooltip();
 
   return (
-    <LeftPanel
-      panel={panel}
-      tooltip="A certain span contains an attribute and this attribute has a specific value. You can check it here."
-    >
+    <LeftPanel panel={panel} tooltip={tooltip} isToolTipVisible={isVisible} onOpen={onClose}>
       {size => (
         <PanelContainer $isOpen={size.isOpen}>
           <SpanDetail span={selectedSpan} AttributeRowComponent={TestAttributeRow} SubHeaderComponent={TestSubHeader} />

--- a/web/src/components/RunDetailTrace/SpanDetailsPanel.tsx
+++ b/web/src/components/RunDetailTrace/SpanDetailsPanel.tsx
@@ -5,6 +5,7 @@ import TestRun from 'models/TestRun.model';
 import {useDashboard} from 'providers/Dashboard/Dashboard.provider';
 import SpanSelectors from 'selectors/Span.selectors';
 import TraceSelectors from 'selectors/Trace.selectors';
+import useAttributePanelTooltip from 'hooks/useAttributePanelTooltip';
 import {LeftPanel, PanelContainer} from '../ResizablePanels';
 
 interface IProps {
@@ -23,16 +24,14 @@ const SpanDetailsPanel = ({run, testId}: IProps) => {
   const selectedSpan = useAppSelector(TraceSelectors.selectSelectedSpan);
   const {navigate} = useDashboard();
   const span = useAppSelector(state => SpanSelectors.selectSpanById(state, selectedSpan, testId, run.id));
+  const {onClose, tooltip, isVisible} = useAttributePanelTooltip();
 
   const handleOnCreateSpec = useCallback(() => {
     navigate(`/test/${testId}/run/${run.id}/test`);
   }, [navigate, run.id, testId]);
 
   return (
-    <LeftPanel
-      panel={panel}
-      tooltip="A certain span contains an attribute and this attribute has a specific value. You can check it here."
-    >
+    <LeftPanel panel={panel} tooltip={tooltip} onOpen={onClose} isToolTipVisible={isVisible}>
       {size => (
         <PanelContainer $isOpen={size.isOpen}>
           <SpanDetail

--- a/web/src/hooks/useAttributePanelTooltip.ts
+++ b/web/src/hooks/useAttributePanelTooltip.ts
@@ -1,0 +1,21 @@
+import {useCallback} from 'react';
+import {useAppDispatch, useAppSelector} from 'redux/hooks';
+import UserSelectors from 'selectors/User.selectors';
+import {setUserPreference} from '../redux/slices/User.slice';
+
+const tooltip = 'A certain span contains an attribute and this attribute has a specific value. You can check it here.';
+
+const useAttributePanelTooltip = () => {
+  const dispatch = useAppDispatch();
+  const showAttributeTooltip = useAppSelector(
+    state => UserSelectors.selectUserPreference(state, 'showAttributeTooltip') as boolean
+  );
+
+  const onClose = useCallback(() => {
+    dispatch(setUserPreference({key: 'showAttributeTooltip', value: false}));
+  }, [dispatch]);
+
+  return {isVisible: showAttributeTooltip, tooltip, onClose};
+};
+
+export default useAttributePanelTooltip;

--- a/web/src/services/UserPreferences.service.ts
+++ b/web/src/services/UserPreferences.service.ts
@@ -11,6 +11,7 @@ const initialUserPreferences: IUserPreferences = {
   initConfigSetup: true,
   initConfigSetupFromTest: true,
   showGuidedTourNotification: true,
+  showAttributeTooltip: true,
 };
 
 const UserPreferencesService = () => ({

--- a/web/src/types/User.types.ts
+++ b/web/src/types/User.types.ts
@@ -4,6 +4,7 @@ export interface IUserPreferences {
   initConfigSetup: boolean;
   initConfigSetupFromTest: boolean;
   showGuidedTourNotification: boolean;
+  showAttributeTooltip: boolean;
 }
 
 export type TUserPreferenceKey = keyof IUserPreferences;


### PR DESCRIPTION
This PR updates the behavior for the attribute list tooltip, showing it when users get to a test run for the first time and saving a flag to the user preferences (local storage) afterwards

## Changes

- Updates tooltip behavior
- Adds localstorage flag
- Fixex the tooltip animation

## Fixes

- #2902 

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test


https://www.loom.com/share/7b8227121ce54d8bb2abc816cb367b27