### PR TITLE
chore(server): adding more logs for provisioning

### DIFF
--- a/server/provisioning/provisioning.go
+++ b/server/provisioning/provisioning.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log"
 	"os"
 
 	"github.com/goccy/go-yaml"
@@ -85,7 +86,7 @@ func (p Provisioner) do(data []byte) error {
 		}
 
 		if err != nil {
-			return fmt.Errorf("cannot unmarshal yaml: %w", err)
+			return fmt.Errorf("cannot unmarshal yaml for provisioning file: %w", err)
 		}
 
 		if rawYaml == nil {
@@ -99,13 +100,14 @@ func (p Provisioner) do(data []byte) error {
 				continue
 			}
 			if err != nil {
-				return fmt.Errorf("cannot provision resource from yaml: %w", err)
+				return fmt.Errorf("cannot provision resource from yaml for provisioner %T: %w", p, err)
 			}
+			log.Printf("[provisioning] provisioner %T executed with success", p)
 			success = true
 		}
 
 		if !success {
-			return fmt.Errorf("invalid resource type from yaml")
+			return fmt.Errorf("all resource types from provisioning yaml don't support provisioning")
 		}
 	}
 	return nil


### PR DESCRIPTION
This PR adds more logs for the resource provisioning action that happens on the first time that Tracetest server starts.

## Changes

- Adding logs for provisioning action

## Fixes

- https://github.com/kubeshop/tracetest/issues/3035

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
