### PR TITLE
chore(cli): add deprecation notice when running a transaction

### DIFF
--- a/cli/cmd/resources.go
+++ b/cli/cmd/resources.go
@@ -25,7 +25,7 @@ var (
 		formatters.TestSuiteRun(func() string { return cliConfig.URL() }, true),
 	)
 
-	runnerRegistry = runner.NewRegistry().
+	runnerRegistry = runner.NewRegistry(cliLogger).
 			Register(runner.TestRunner(
 			testClient,
 			openapiClient,


### PR DESCRIPTION
This PR adds a deprecation notice when running a transaction through the CLI

## Changes

-  Added deprecation logic into RunnerRegistry

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
