### PR TITLE
fix(ui): kafka trigger with null header blocks test render on WebUI

### DIFF
--- a/.goreleaser.demo.yaml
+++ b/.goreleaser.demo.yaml
@@ -49,8 +49,7 @@ builds:
     - amd64
 
 dockers:
-- skip_push: '{{ .Env.PUBLISH_DOCKER }}'
-  image_templates:
+- image_templates:
   - 'kubeshop/tracetest:{{ .Env.VERSION }}'
   extra_files:
     - web/build

--- a/web/src/models/KafkaRequest.model.ts
+++ b/web/src/models/KafkaRequest.model.ts
@@ -19,10 +19,6 @@ const KafkaRequest = ({
   messageKey = '',
   messageValue = '',
 }: TRawKafkaRequest): KafkaRequest => {
-  if (!headers) {
-    headers = []; // guard clause to avoid null header
-  }
-
   return {
     brokerUrls,
     topic,
@@ -30,7 +26,7 @@ const KafkaRequest = ({
     sslVerification,
     messageKey,
     messageValue,
-    headers: headers.map(({key = '', value = ''}) => ({
+    headers: (headers || []).map(({key = '', value = ''}) => ({
       key,
       value,
     })),

--- a/web/src/models/KafkaRequest.model.ts
+++ b/web/src/models/KafkaRequest.model.ts
@@ -19,6 +19,10 @@ const KafkaRequest = ({
   messageKey = '',
   messageValue = '',
 }: TRawKafkaRequest): KafkaRequest => {
+  if (!headers) {
+    headers = []; // guard clause to avoid null header
+  }
+
   return {
     brokerUrls,
     topic,


### PR DESCRIPTION
This PR fixes a UI bug caused by tests with Kafka trigger and no headers.

Loom: https://www.loom.com/share/f246f488f58d4aefa2fe34a67bb6b6e4?sid=8753e331-70b6-4462-92a5-b1116ed0c23a

## Changes

- Add guard clause on KafkaRequest model
- Removed unused field that is blocking `demo` deploy

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
