### PR TITLE
chore(e2e): add kafka tests for on our internal tracetesting/dogfood tests

### DIFF
--- a/testing/server-tracetesting/.gitignore
+++ b/testing/server-tracetesting/.gitignore
@@ -2,3 +2,4 @@ results/
 config.yml
 .env
 tracetesting-env.yaml
+tracetesting-vars.yaml

--- a/testing/server-tracetesting/features/kafka_test/01_create_kafka_test.yml
+++ b/testing/server-tracetesting/features/kafka_test/01_create_kafka_test.yml
@@ -1,8 +1,8 @@
 type: Test
 spec:
-  id: ojzHeDQ4gF
-  name: Create gRPC Test
-  description: Test step of 'gRPC Test Feature - Test Suite'
+  id: dvsf860sdv
+  name: Create Kafka Test
+  description: Test step of 'Kafka Test Feature - Test Suite'
   trigger:
     type: http
     httpRequest:
@@ -15,39 +15,50 @@ spec:
         {
           "type": "Test",
           "spec": {
-            "name": "gRPC pokemon list",
+            "name": "Import a Pokemon reading a Stream",
             "trigger": {
-              "type": "grpc",
-              "grpc": {
-                "protobufFile": "syntax = \"proto3\";\n\noption java_multiple_files = true;\noption java_outer_classname = \"PokeshopProto\";\noption objc_class_prefix = \"PKS\";\n\npackage pokeshop;\n\nservice Pokeshop {\n  rpc getPokemonList (GetPokemonRequest) returns (GetPokemonListResponse) {}\n  rpc createPokemon (Pokemon) returns (Pokemon) {}\n  rpc importPokemon (ImportPokemonRequest) returns (ImportPokemonRequest) {}\n}\n\nmessage ImportPokemonRequest {\n  int32 id = 1;\n  optional bool isFixed = 2;\n}\n\nmessage GetPokemonRequest {\n  optional int32 skip = 1;\n  optional int32 take = 2;\n  optional bool isFixed = 3;\n}\n\nmessage GetPokemonListResponse {\n  repeated Pokemon items = 1;\n  int32 totalCount = 2;\n}\n\nmessage Pokemon {\n  optional int32 id = 1;\n  string name = 2;\n  string type = 3;\n  bool isFeatured = 4;\n  optional string imageUrl = 5;\n}",
-                "address": "${var:DEMO_APP_GRPC_URL}",
-                "method": "pokeshop.Pokeshop.importPokemon",
-                "request": "{\"id\": 52}"
+              "type": "kafka",
+              "kafka": {
+                "brokerUrls": ["${var:DEMO_APP_KAFKA_BROKER}"],
+                "topic": "pokemon",
+                "headers": [],
+                "messageKey": "snorlax-key",
+                "messageValue": "{\"id\": 143}"
               }
             },
             "specs": [
               {
-                "selector":"span[name = \"queue.synchronizePokemon publish\"]",
-                "assertions": ["attr:tracetest.selected_spans.count > 0"]
+                "selector":"span[tracetest.span.type=\"messaging\" name=\"pokemon process\" messaging.system=\"kafka\" messaging.destination=\"pokemon\" messaging.destination_kind=\"topic\" messaging.operation=\"process\"]",
+                "assertions": ["attr:messaging.system = \"kafka\""],
+                "name": "A message was received from Kafka stream"
+              },
+              {
+                "selector":"span[tracetest.span.type=\"general\" name=\"import pokemon\"]",
+                "assertions": ["attr:name = \"import pokemon\""],
+                "name": "Import Pokemon use case was triggered"
               }
             ]
           }
         }
   specs:
-    - selector: span[name = "Tracetest trigger"]
+    - name: Tracetest API returned a valid HTTP code for test creation
+      selector: span[name = "Tracetest trigger"]
       assertions:
         - attr:tracetest.selected_spans.count = 1
         - attr:tracetest.response.status = 201
-    - selector: span[name="POST /api/tests" tracetest.span.type="http"]
+    - name: Tracetest API endpoint 'POST /api/tests' was called once
+      selector: span[name="POST /api/tests" tracetest.span.type="http"]
       assertions:
         - attr:tracetest.selected_spans.count = 1
-    - selector: span[name = "exec INSERT"]
+    - name: Just one test was added into the database
+      selector: span[name = "exec INSERT"]
       assertions:
         - attr:tracetest.selected_spans.count = 1
-    - selector: span[name = "exec INSERT"]:first
+    - name: The test was added on the correct database table
+      selector: span[name = "exec INSERT"]:first
       assertions:
         - attr:sql.query contains "INSERT INTO tests"
   outputs:
-    - name: GRPC_TEST_ID
+    - name: KAFKA_TEST_ID
       selector: span[name = "Tracetest trigger"]
       value: attr:tracetest.response.body | json_path '$.spec.id'

--- a/testing/server-tracetesting/features/kafka_test/01_create_kafka_test.yml
+++ b/testing/server-tracetesting/features/kafka_test/01_create_kafka_test.yml
@@ -1,0 +1,53 @@
+type: Test
+spec:
+  id: ojzHeDQ4gF
+  name: Create gRPC Test
+  description: Test step of 'gRPC Test Feature - Test Suite'
+  trigger:
+    type: http
+    httpRequest:
+      url: ${var:TARGET_URL}/api/tests
+      method: POST
+      headers:
+        - key: Content-Type
+          value: application/json
+      body: |
+        {
+          "type": "Test",
+          "spec": {
+            "name": "gRPC pokemon list",
+            "trigger": {
+              "type": "grpc",
+              "grpc": {
+                "protobufFile": "syntax = \"proto3\";\n\noption java_multiple_files = true;\noption java_outer_classname = \"PokeshopProto\";\noption objc_class_prefix = \"PKS\";\n\npackage pokeshop;\n\nservice Pokeshop {\n  rpc getPokemonList (GetPokemonRequest) returns (GetPokemonListResponse) {}\n  rpc createPokemon (Pokemon) returns (Pokemon) {}\n  rpc importPokemon (ImportPokemonRequest) returns (ImportPokemonRequest) {}\n}\n\nmessage ImportPokemonRequest {\n  int32 id = 1;\n  optional bool isFixed = 2;\n}\n\nmessage GetPokemonRequest {\n  optional int32 skip = 1;\n  optional int32 take = 2;\n  optional bool isFixed = 3;\n}\n\nmessage GetPokemonListResponse {\n  repeated Pokemon items = 1;\n  int32 totalCount = 2;\n}\n\nmessage Pokemon {\n  optional int32 id = 1;\n  string name = 2;\n  string type = 3;\n  bool isFeatured = 4;\n  optional string imageUrl = 5;\n}",
+                "address": "${var:DEMO_APP_GRPC_URL}",
+                "method": "pokeshop.Pokeshop.importPokemon",
+                "request": "{\"id\": 52}"
+              }
+            },
+            "specs": [
+              {
+                "selector":"span[name = \"queue.synchronizePokemon publish\"]",
+                "assertions": ["attr:tracetest.selected_spans.count > 0"]
+              }
+            ]
+          }
+        }
+  specs:
+    - selector: span[name = "Tracetest trigger"]
+      assertions:
+        - attr:tracetest.selected_spans.count = 1
+        - attr:tracetest.response.status = 201
+    - selector: span[name="POST /api/tests" tracetest.span.type="http"]
+      assertions:
+        - attr:tracetest.selected_spans.count = 1
+    - selector: span[name = "exec INSERT"]
+      assertions:
+        - attr:tracetest.selected_spans.count = 1
+    - selector: span[name = "exec INSERT"]:first
+      assertions:
+        - attr:sql.query contains "INSERT INTO tests"
+  outputs:
+    - name: GRPC_TEST_ID
+      selector: span[name = "Tracetest trigger"]
+      value: attr:tracetest.response.body | json_path '$.spec.id'

--- a/testing/server-tracetesting/features/kafka_test/02_list_kafka_test.yml
+++ b/testing/server-tracetesting/features/kafka_test/02_list_kafka_test.yml
@@ -1,8 +1,8 @@
 type: Test
 spec:
-  id: ojzHeDQ4Rc
-  name: List gRPC Test
-  description: Test step of 'gRPC Test Feature - Test Suite'
+  id: jkbd86ads
+  name: List Kafka Test
+  description: Test step of 'Kafka Test Feature - Test Suite'
   trigger:
     type: http
     httpRequest:
@@ -12,14 +12,17 @@ spec:
       - key: Content-Type
         value: application/json
   specs:
-  - selector: span[name = "Tracetest trigger"]
+  - name: Tracetest API listed the test last test created
+    selector: span[name = "Tracetest trigger"]
     assertions:
     - attr:tracetest.selected_spans.count = 1
     - attr:tracetest.response.status = 200
-    - attr:tracetest.response.body | json_path '$.items[*].spec.id' contains var:GRPC_TEST_ID # check if the test is listed
-  - selector: span[name="GET /api/tests" tracetest.span.type="http"]
+    - attr:tracetest.response.body | json_path '$.items[*].spec.id' contains var:KAFKA_TEST_ID # check if the test is listed
+  - name: Tracetest API endpoint 'GET /api/tests' was called once
+    selector: span[name="GET /api/tests" tracetest.span.type="http"]
     assertions:
     - attr:tracetest.selected_spans.count = 1
-  - selector: span[name = "query SELECT"]
+  - name: Two queries were executed on the database, one for counting and another for listing
+    selector: span[name = "query SELECT"]
     assertions:
     - attr:tracetest.selected_spans.count = 2

--- a/testing/server-tracetesting/features/kafka_test/02_list_kafka_test.yml
+++ b/testing/server-tracetesting/features/kafka_test/02_list_kafka_test.yml
@@ -1,0 +1,25 @@
+type: Test
+spec:
+  id: ojzHeDQ4Rc
+  name: List gRPC Test
+  description: Test step of 'gRPC Test Feature - Test Suite'
+  trigger:
+    type: http
+    httpRequest:
+      url: ${var:TARGET_URL}/api/tests
+      method: GET
+      headers:
+      - key: Content-Type
+        value: application/json
+  specs:
+  - selector: span[name = "Tracetest trigger"]
+    assertions:
+    - attr:tracetest.selected_spans.count = 1
+    - attr:tracetest.response.status = 200
+    - attr:tracetest.response.body | json_path '$.items[*].spec.id' contains var:GRPC_TEST_ID # check if the test is listed
+  - selector: span[name="GET /api/tests" tracetest.span.type="http"]
+    assertions:
+    - attr:tracetest.selected_spans.count = 1
+  - selector: span[name = "query SELECT"]
+    assertions:
+    - attr:tracetest.selected_spans.count = 2

--- a/testing/server-tracetesting/features/kafka_test/03_run_kafka_test.yml
+++ b/testing/server-tracetesting/features/kafka_test/03_run_kafka_test.yml
@@ -1,0 +1,40 @@
+type: Test
+spec:
+  id: oCzH6DQVRp
+  name: Run gRPC Test
+  description: Test step of 'gRPC Test Feature - Test Suite'
+  trigger:
+    type: http
+    httpRequest:
+      url: ${var:TARGET_URL}/api/tests/${var:GRPC_TEST_ID}/run
+      method: POST
+      headers:
+      - key: Content-Type
+        value: application/json
+      body: '{}'
+  specs:
+  - selector: span[name = "Tracetest trigger"]
+    assertions:
+    - attr:tracetest.selected_spans.count = 1
+    - attr:tracetest.response.status = 200
+  - selector: span[name = "POST /api/tests/{testId}/run" tracetest.span.type = "http"]
+    assertions:
+    - attr:tracetest.selected_spans.count = 1
+  - selector: span[name = "Trigger test"]
+    assertions:
+    - attr:tracetest.selected_spans.count = 1
+    - attr:tracetest.run.trigger.test_id = "${var:GRPC_TEST_ID}"
+    - attr:tracetest.run.trigger.type = "grpc"
+    - attr:tracetest.run.trigger.grpc.response_status_code = 0
+    - attr:tracetest.run.trigger.grpc.response_status = "OK"
+  - selector: span[name = "Fetch trace"]
+    assertions:
+    - attr:tracetest.selected_spans.count > 0
+    - attr:tracetest.run.trace_poller.test_id = "${var:GRPC_TEST_ID}"
+  - selector: span[name = "Fetch trace"]:last
+    assertions:
+    - attr:tracetest.run.trace_poller.succesful = "true"
+  - selector: span[name = "Execute assertions"]
+    assertions:
+    - attr:tracetest.selected_spans.count = 1
+    - attr:tracetest.run.assertion_runner.all_assertions_passed = "true"

--- a/testing/server-tracetesting/features/kafka_test/03_run_kafka_test.yml
+++ b/testing/server-tracetesting/features/kafka_test/03_run_kafka_test.yml
@@ -1,40 +1,44 @@
 type: Test
 spec:
-  id: oCzH6DQVRp
-  name: Run gRPC Test
-  description: Test step of 'gRPC Test Feature - Test Suite'
+  id: as8d7da8s6
+  name: Run Kafka Test
+  description: Test step of 'Kafka Test Feature - Test Suite'
   trigger:
     type: http
     httpRequest:
-      url: ${var:TARGET_URL}/api/tests/${var:GRPC_TEST_ID}/run
+      url: ${var:TARGET_URL}/api/tests/${var:KAFKA_TEST_ID}/run
       method: POST
       headers:
       - key: Content-Type
         value: application/json
       body: '{}'
   specs:
-  - selector: span[name = "Tracetest trigger"]
+  - name: Tracetest API started to run the test correctly
+    selector: span[name = "Tracetest trigger"]
     assertions:
     - attr:tracetest.selected_spans.count = 1
     - attr:tracetest.response.status = 200
-  - selector: span[name = "POST /api/tests/{testId}/run" tracetest.span.type = "http"]
+  - name: Tracetest API endpoint 'POST /api/tests/{testId}/run' was called once
+    selector: span[name = "POST /api/tests/{testId}/run" tracetest.span.type = "http"]
     assertions:
     - attr:tracetest.selected_spans.count = 1
-  - selector: span[name = "Trigger test"]
+  - name: The test trigger was executed correctly
+    selector: span[name = "Trigger test"]
     assertions:
     - attr:tracetest.selected_spans.count = 1
-    - attr:tracetest.run.trigger.test_id = "${var:GRPC_TEST_ID}"
-    - attr:tracetest.run.trigger.type = "grpc"
-    - attr:tracetest.run.trigger.grpc.response_status_code = 0
-    - attr:tracetest.run.trigger.grpc.response_status = "OK"
-  - selector: span[name = "Fetch trace"]
+    - attr:tracetest.run.trigger.test_id = "${var:KAFKA_TEST_ID}"
+    - attr:tracetest.run.trigger.type = "kafka"
+  - name: The trace poller was started
+    selector: span[name = "Fetch trace"]
     assertions:
     - attr:tracetest.selected_spans.count > 0
-    - attr:tracetest.run.trace_poller.test_id = "${var:GRPC_TEST_ID}"
-  - selector: span[name = "Fetch trace"]:last
+    - attr:tracetest.run.trace_poller.test_id = "${var:KAFKA_TEST_ID}"
+  - name: The trace poller finished with success
+    selector: span[name = "Fetch trace"]:last
     assertions:
     - attr:tracetest.run.trace_poller.succesful = "true"
-  - selector: span[name = "Execute assertions"]
+  - name: All assertions were validated and passed
+    selector: span[name = "Execute assertions"]
     assertions:
     - attr:tracetest.selected_spans.count = 1
     - attr:tracetest.run.assertion_runner.all_assertions_passed = "true"

--- a/testing/server-tracetesting/features/kafka_test/04_delete_kafka_test.yml
+++ b/testing/server-tracetesting/features/kafka_test/04_delete_kafka_test.yml
@@ -1,0 +1,26 @@
+---
+type: Test
+spec:
+  id: ojzNeDw4gh
+  name: Delete gRPC Test
+  description: Test step of 'gRPC Test Feature - Test Suite'
+  trigger:
+    type: http
+    httpRequest:
+      url: ${var:TARGET_URL}/api/tests/${var:GRPC_TEST_ID}
+      method: DELETE
+      headers:
+        - key: Content-Type
+          value: application/json
+  specs:
+  - selector: span[name = "Tracetest trigger"]
+    assertions:
+    - attr:tracetest.selected_spans.count = 1
+    - attr:tracetest.response.status = 204
+  - selector: span[name="DELETE /api/tests/{id}" tracetest.span.type="http"]
+    assertions:
+    - attr:tracetest.selected_spans.count = 1
+  - selector: span[name = "exec DELETE"]
+    assertions:
+    # must delete test and runs. That's why we need 2 deletes
+    - attr:tracetest.selected_spans.count = 4

--- a/testing/server-tracetesting/features/kafka_test/04_delete_kafka_test.yml
+++ b/testing/server-tracetesting/features/kafka_test/04_delete_kafka_test.yml
@@ -1,26 +1,29 @@
 ---
 type: Test
 spec:
-  id: ojzNeDw4gh
-  name: Delete gRPC Test
-  description: Test step of 'gRPC Test Feature - Test Suite'
+  id: asd978dfg
+  name: Delete Kafka Test
+  description: Test step of 'Kafka Test Feature - Test Suite'
   trigger:
     type: http
     httpRequest:
-      url: ${var:TARGET_URL}/api/tests/${var:GRPC_TEST_ID}
+      url: ${var:TARGET_URL}/api/tests/${var:KAFKA_TEST_ID}
       method: DELETE
       headers:
         - key: Content-Type
           value: application/json
   specs:
-  - selector: span[name = "Tracetest trigger"]
+  - name: Tracetest API deleted the test last test created
+    selector: span[name = "Tracetest trigger"]
     assertions:
     - attr:tracetest.selected_spans.count = 1
     - attr:tracetest.response.status = 204
-  - selector: span[name="DELETE /api/tests/{id}" tracetest.span.type="http"]
+  - name: Tracetest API endpoint 'DELETE /api/tests/{id}' was called once
+    selector: span[name="DELETE /api/tests/{id}" tracetest.span.type="http"]
     assertions:
     - attr:tracetest.selected_spans.count = 1
-  - selector: span[name = "exec DELETE"]
+  - name: All test entities were deleted
+    selector: span[name = "exec DELETE"]
     assertions:
     # must delete test and runs. That's why we need 2 deletes
     - attr:tracetest.selected_spans.count = 4

--- a/testing/server-tracetesting/features/kafka_test/_test_suite.yml
+++ b/testing/server-tracetesting/features/kafka_test/_test_suite.yml
@@ -1,0 +1,14 @@
+type: TestSuite
+spec:
+  id: kajwb6asd
+  name: Kafka Test Feature
+  description: Sequence of tests to validate if our Kafka Test feature is working as expected
+  steps:
+    # create a Kafka Test
+    - ./01_create_kafka_test.yml
+    # check if this test is listed on API
+    - ./02_list_kafka_test.yml
+    # run test
+    - ./03_run_kafka_test.yml
+    # delete test
+    - ./04_delete_kafka_test.yml


### PR DESCRIPTION
This PR adds Kafka trigger tests for our internal dogfooding tests.

## Changes

- Update dogfooding script to add Kafka trigger tests

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [x] added a test
