### PR TITLE
fix(cli): improving relative file detection for protobuf

### DIFF
--- a/cli/pkg/fileutil/path.go
+++ b/cli/pkg/fileutil/path.go
@@ -29,6 +29,11 @@ func LooksLikeFilePath(path string) bool {
 		strings.HasPrefix(path, "/")
 }
 
+func LooksLikeRelativeFilePath(path string) bool {
+	return strings.HasPrefix(path, "./") ||
+		strings.HasPrefix(path, "../")
+}
+
 func IsFilePath(path string) bool {
 	// for the current working dir, check if the file exists
 	// by finding its absolute path and executing a stat command

--- a/cli/pkg/fileutil/path.go
+++ b/cli/pkg/fileutil/path.go
@@ -27,7 +27,6 @@ func LooksLikeFilePath(path string) bool {
 	return strings.HasPrefix(path, "./") ||
 		strings.HasPrefix(path, "../") ||
 		strings.HasPrefix(path, "/")
-
 }
 
 func IsFilePath(path string) bool {
@@ -47,4 +46,10 @@ func IsFilePath(path string) bool {
 	// if the string is empty the absolute path will the entire dir
 	// otherwise the user also could send a directory by mistake
 	return info != nil && !info.IsDir()
+}
+
+func IsFilePathToRelativeDir(path, dir string) bool {
+	fullPath := filepath.Join(dir, path)
+
+	return IsFilePath(fullPath)
 }

--- a/cli/preprocessor/test.go
+++ b/cli/preprocessor/test.go
@@ -48,7 +48,7 @@ func (t test) consolidateGRPCFile(input fileutil.File, test openapi.TestResource
 	}
 
 	definedPBFile := test.Spec.Trigger.Grpc.GetProtobufFile()
-	if !fileutil.LooksLikeFilePath(definedPBFile) {
+	if !fileutil.IsFilePathToRelativeDir(definedPBFile, input.AbsDir()) {
 		t.logger.Debug("protobuf file is not a file path", zap.String("protobufFile", definedPBFile))
 		return test, nil
 	}

--- a/cli/preprocessor/test.go
+++ b/cli/preprocessor/test.go
@@ -48,7 +48,7 @@ func (t test) consolidateGRPCFile(input fileutil.File, test openapi.TestResource
 	}
 
 	definedPBFile := test.Spec.Trigger.Grpc.GetProtobufFile()
-	if !fileutil.IsFilePathToRelativeDir(definedPBFile, input.AbsDir()) {
+	if !t.isValidGrpcFilePath(definedPBFile, input.AbsDir()) {
 		t.logger.Debug("protobuf file is not a file path", zap.String("protobufFile", definedPBFile))
 		return test, nil
 	}
@@ -65,4 +65,14 @@ func (t test) consolidateGRPCFile(input fileutil.File, test openapi.TestResource
 	test.Spec.Trigger.Grpc.SetProtobufFile(string(pbFile.Contents()))
 
 	return test, nil
+}
+
+func (t test) isValidGrpcFilePath(grpcFilePath, testFile string) bool {
+	if fileutil.LooksLikeRelativeFilePath(grpcFilePath) {
+		// if looks like a relative file path, test is it exists
+		return fileutil.IsFilePathToRelativeDir(grpcFilePath, testFile)
+	}
+
+	// it could be an absolute file path, test it
+	return fileutil.IsFilePath(grpcFilePath)
 }

--- a/cli/preprocessor/test.go
+++ b/cli/preprocessor/test.go
@@ -69,7 +69,7 @@ func (t test) consolidateGRPCFile(input fileutil.File, test openapi.TestResource
 
 func (t test) isValidGrpcFilePath(grpcFilePath, testFile string) bool {
 	if fileutil.LooksLikeRelativeFilePath(grpcFilePath) {
-		// if looks like a relative file path, test is it exists
+		// if looks like a relative file path, test if it exists
 		return fileutil.IsFilePathToRelativeDir(grpcFilePath, testFile)
 	}
 

--- a/testing/cli-e2etest/testscenarios/test/apply_test_test.go
+++ b/testing/cli-e2etest/testscenarios/test/apply_test_test.go
@@ -97,7 +97,7 @@ func TestApplyTest(t *testing.T) {
 		require := require.New(t)
 		assert := assert.New(t)
 
-		proto, err := os.ReadFile("./resources/api.proto")
+		proto, err := os.ReadFile("./resources/api-with-comment.proto")
 		require.NoError(err)
 
 		// setup isolated e2e environment

--- a/testing/cli-e2etest/testscenarios/test/apply_test_test.go
+++ b/testing/cli-e2etest/testscenarios/test/apply_test_test.go
@@ -123,7 +123,7 @@ func TestApplyTest(t *testing.T) {
 
 		listTest := helpers.UnmarshalYAML[types.TestResource](t, result.StdOut)
 		assert.Equal("Test", listTest.Type)
-		assert.Equal("create-pokemon", listTest.Spec.ID)
+		assert.Equal("create-pokemon-embedded", listTest.Spec.ID)
 		assert.Equal("grpc", listTest.Spec.Trigger.Type)
 		assert.Equal(string(proto), listTest.Spec.Trigger.GRPCRequest.ProtobufFile)
 	})

--- a/testing/cli-e2etest/testscenarios/test/resources/api-with-comment.proto
+++ b/testing/cli-e2etest/testscenarios/test/resources/api-with-comment.proto
@@ -1,0 +1,38 @@
+// This is a comment
+syntax = "proto3";
+
+option java_multiple_files = true;
+option java_outer_classname = "PokeshopProto";
+option objc_class_prefix = "PKS";
+
+package pokeshop;
+
+service Pokeshop {
+  rpc getPokemonList (GetPokemonRequest) returns (GetPokemonListResponse) {}
+  rpc createPokemon (Pokemon) returns (Pokemon) {}
+  rpc importPokemon (ImportPokemonRequest) returns (ImportPokemonRequest) {}
+}
+
+message ImportPokemonRequest {
+  int32 id = 1;
+  optional bool isFixed = 2;
+}
+
+message GetPokemonRequest {
+  optional int32 skip = 1;
+  optional int32 take = 2;
+  optional bool isFixed = 3;
+}
+
+message GetPokemonListResponse {
+  repeated Pokemon items = 1;
+  int32 totalCount = 2;
+}
+
+message Pokemon {
+  optional int32 id = 1;
+  string name = 2;
+  string type = 3;
+  bool isFeatured = 4;
+  optional string imageUrl = 5;
+}

--- a/testing/cli-e2etest/testscenarios/test/resources/grpc-trigger-embedded-protobuf-with-comment.yaml
+++ b/testing/cli-e2etest/testscenarios/test/resources/grpc-trigger-embedded-protobuf-with-comment.yaml
@@ -1,6 +1,6 @@
 type: Test
 spec:
-  id: create-pokemon
+  id: create-pokemon-embedded
   name: "Create Pokemon"
   description: Create a single pokemon on Pokeshop
   trigger:

--- a/testing/cli-e2etest/testscenarios/test/resources/grpc-trigger-embedded-protobuf-with-comment.yaml
+++ b/testing/cli-e2etest/testscenarios/test/resources/grpc-trigger-embedded-protobuf-with-comment.yaml
@@ -45,7 +45,6 @@ spec:
           bool isFeatured = 4;
           optional string imageUrl = 5;
         }
-
       address: demo-rpc:8082
       method: pokeshop.Pokeshop.createPokemon
       request: |-

--- a/testing/cli-e2etest/testscenarios/test/resources/grpc-trigger-embedded-protobuf-with-comment.yaml
+++ b/testing/cli-e2etest/testscenarios/test/resources/grpc-trigger-embedded-protobuf-with-comment.yaml
@@ -1,0 +1,61 @@
+type: Test
+spec:
+  id: create-pokemon
+  name: "Create Pokemon"
+  description: Create a single pokemon on Pokeshop
+  trigger:
+    type: grpc
+    grpc:
+      protobufFile: |
+        // This is a comment
+        syntax = "proto3";
+
+        option java_multiple_files = true;
+        option java_outer_classname = "PokeshopProto";
+        option objc_class_prefix = "PKS";
+
+        package pokeshop;
+
+        service Pokeshop {
+          rpc getPokemonList (GetPokemonRequest) returns (GetPokemonListResponse) {}
+          rpc createPokemon (Pokemon) returns (Pokemon) {}
+          rpc importPokemon (ImportPokemonRequest) returns (ImportPokemonRequest) {}
+        }
+
+        message ImportPokemonRequest {
+          int32 id = 1;
+          optional bool isFixed = 2;
+        }
+
+        message GetPokemonRequest {
+          optional int32 skip = 1;
+          optional int32 take = 2;
+          optional bool isFixed = 3;
+        }
+
+        message GetPokemonListResponse {
+          repeated Pokemon items = 1;
+          int32 totalCount = 2;
+        }
+
+        message Pokemon {
+          optional int32 id = 1;
+          string name = 2;
+          string type = 3;
+          bool isFeatured = 4;
+          optional string imageUrl = 5;
+        }
+
+      address: demo-rpc:8082
+      method: pokeshop.Pokeshop.createPokemon
+      request: |-
+        {
+          "name": "Pikachu",
+          "type": "eletric",
+          "isFeatured": true
+        }
+  specs:
+    - name: It calls Pokeshop correctly
+      selector: span[tracetest.span.type="rpc" name="pokeshop.Pokeshop/createPokemon" rpc.system="grpc" rpc.method="createPokemon" rpc.service="pokeshop.Pokeshop"]
+      assertions:
+        - attr:rpc.grpc.status_code  =  0


### PR DESCRIPTION
This PR fixes https://github.com/kubeshop/tracetest/issues/3090 by improving the relative file detection on gRPC test triggers.

## Changes

- Improve relative file detection on gRPC test triggers

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [x] added a test
