### PR TITLE
feat(agent): inject env variables in agent configuration

### DIFF
--- a/agent/cmd/start.go
+++ b/agent/cmd/start.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"log"
 	"os"
 
 	"github.com/kubeshop/tracetest/agent/config"
@@ -24,6 +25,8 @@ var StartCmd = cobra.Command{
 			fmt.Fprintln(os.Stderr, err)
 			ExitCLI(1)
 		}
+
+		log.Printf("starting agent [%s] connecting to %s", cfg.Name, cfg.ServerURL)
 
 		initialization.Start(cfg)
 	},

--- a/agent/config/config.go
+++ b/agent/config/config.go
@@ -31,7 +31,7 @@ func LoadConfig() (Config, error) {
 	vp.AutomaticEnv()
 
 	vp.SetDefault("DEV_MODE", false)
-	vp.SetDefault("AGENT_NAME", "")
+	vp.SetDefault("AGENT_NAME", getHostname())
 	vp.SetDefault("API_KEY", "")
 	vp.SetDefault("SERVER_URL", "https://cloud.tracetest.io")
 
@@ -42,6 +42,10 @@ func LoadConfig() (Config, error) {
 	err := vp.Unmarshal(&config)
 	if err != nil {
 		return Config{}, fmt.Errorf("could not load config: %w", err)
+	}
+
+	if config.Name == "" {
+		return Config{}, fmt.Errorf("invalid host name, use the environment variable TRACETEST_AGENT_NAME to name your agent")
 	}
 
 	return config, nil
@@ -55,4 +59,15 @@ func getTracetestFolder() string {
 	}
 
 	return path.Join(homeFolder, ".tracetest")
+}
+
+func getHostname() string {
+	hostname, err := os.Hostname()
+	if err != nil {
+		// Don't fail yet because user still can name the agent using the TRACETEST_AGENT_NAME
+		// env variable.
+		return ""
+	}
+
+	return hostname
 }

--- a/agent/config/config.go
+++ b/agent/config/config.go
@@ -10,7 +10,6 @@ import (
 )
 
 type Config struct {
-	DevMode   bool   `mapstructure:"dev_mode"`
 	APIKey    string `mapstructure:"api_key"`
 	Name      string `mapstructure:"agent_name"`
 	ServerURL string `mapstructure:"server_url"`

--- a/agent/config/config.go
+++ b/agent/config/config.go
@@ -12,7 +12,7 @@ import (
 type Config struct {
 	DevMode   bool   `mapstructure:"dev_mode"`
 	APIKey    string `mapstructure:"api_key"`
-	Name      string `mapstructure:"name"`
+	Name      string `mapstructure:"agent_name"`
 	ServerURL string `mapstructure:"server_url"`
 }
 
@@ -21,11 +21,7 @@ func LoadConfig() (Config, error) {
 		viper.EnvKeyReplacer(strings.NewReplacer(".", "_")),
 	)
 
-	homeFolder, err := os.UserHomeDir()
-	if err != nil {
-		return Config{}, fmt.Errorf("could not get user home folder")
-	}
-	tracetestFolder := path.Join(homeFolder, ".tracetest")
+	tracetestFolder := getTracetestFolder()
 
 	vp.SetEnvPrefix("tracetest")
 	vp.AddConfigPath(tracetestFolder)
@@ -35,16 +31,28 @@ func LoadConfig() (Config, error) {
 	vp.AutomaticEnv()
 
 	vp.SetDefault("DEV_MODE", false)
+	vp.SetDefault("AGENT_NAME", "")
+	vp.SetDefault("API_KEY", "")
 	vp.SetDefault("SERVER_URL", "https://cloud.tracetest.io")
 
 	config := Config{}
 
 	vp.ReadInConfig()
 
-	err = vp.Unmarshal(&config)
+	err := vp.Unmarshal(&config)
 	if err != nil {
 		return Config{}, fmt.Errorf("could not load config: %w", err)
 	}
 
 	return config, nil
+}
+
+func getTracetestFolder() string {
+	homeFolder, err := os.UserHomeDir()
+	if err != nil {
+		// as a fallback, just return the current folder
+		return "."
+	}
+
+	return path.Join(homeFolder, ".tracetest")
 }

--- a/agent/config/config.go
+++ b/agent/config/config.go
@@ -2,26 +2,46 @@ package config
 
 import (
 	"fmt"
+	"os"
+	"path"
 	"strings"
 
 	"github.com/spf13/viper"
 )
 
 type Config struct {
-	ServerURL string `json:"serverURL"`
-	DevMode   bool   `json:"devMode"`
-	APIKey    string `json:"apiKey"`
-	AgentName string `json:"name"`
+	DevMode   bool   `mapstructure:"dev_mode"`
+	APIKey    string `mapstructure:"api_key"`
+	Name      string `mapstructure:"name"`
+	ServerURL string `mapstructure:"server_url"`
 }
 
 func LoadConfig() (Config, error) {
-	viper.SetEnvPrefix("tracetest")
-	viper.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
-	viper.AutomaticEnv()
+	vp := viper.NewWithOptions(
+		viper.EnvKeyReplacer(strings.NewReplacer(".", "_")),
+	)
+
+	homeFolder, err := os.UserHomeDir()
+	if err != nil {
+		return Config{}, fmt.Errorf("could not get user home folder")
+	}
+	tracetestFolder := path.Join(homeFolder, ".tracetest")
+
+	vp.SetEnvPrefix("tracetest")
+	vp.AddConfigPath(tracetestFolder)
+	vp.AddConfigPath("tracetest-agent.yaml")
+	vp.SetConfigName("agent")
+	vp.SetConfigType("env")
+	vp.AutomaticEnv()
+
+	vp.SetDefault("DEV_MODE", false)
+	vp.SetDefault("SERVER_URL", "https://cloud.tracetest.io")
 
 	config := Config{}
 
-	err := viper.Unmarshal(&config)
+	vp.ReadInConfig()
+
+	err = vp.Unmarshal(&config)
 	if err != nil {
 		return Config{}, fmt.Errorf("could not load config: %w", err)
 	}

--- a/agent/config/config_test.go
+++ b/agent/config/config_test.go
@@ -14,8 +14,10 @@ func TestConfigDefaults(t *testing.T) {
 
 	require.NoError(t, err)
 
+	hostname, _ := os.Hostname()
+
 	assert.Equal(t, "", cfg.APIKey)
-	assert.Equal(t, "", cfg.Name)
+	assert.Equal(t, hostname, cfg.Name)
 	assert.Equal(t, "https://cloud.tracetest.io", cfg.ServerURL)
 }
 

--- a/agent/config/config_test.go
+++ b/agent/config/config_test.go
@@ -1,0 +1,44 @@
+package config_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/kubeshop/tracetest/agent/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConfigDefaults(t *testing.T) {
+	cfg, err := config.LoadConfig()
+
+	require.NoError(t, err)
+
+	assert.Equal(t, "", cfg.APIKey)
+	assert.Equal(t, "", cfg.Name)
+	assert.Equal(t, false, cfg.DevMode)
+	assert.Equal(t, "https://cloud.tracetest.io", cfg.ServerURL)
+}
+
+func TestConfigWithEnvs(t *testing.T) {
+	t.Cleanup(func() {
+		os.Unsetenv("TRACETEST_AGENT_NAME")
+		os.Unsetenv("TRACETEST_API_KEY")
+		os.Unsetenv("TRACETEST_DEV_MODE")
+		os.Unsetenv("TRACETEST_SERVER_URL")
+	})
+
+	os.Setenv("TRACETEST_AGENT_NAME", "my-agent-name")
+	os.Setenv("TRACETEST_API_KEY", "my-agent-api-key")
+	os.Setenv("TRACETEST_DEV_MODE", "true")
+	os.Setenv("TRACETEST_SERVER_URL", "https://custom.server.com")
+
+	cfg, err := config.LoadConfig()
+
+	require.NoError(t, err)
+
+	assert.Equal(t, "my-agent-api-key", cfg.APIKey)
+	assert.Equal(t, "my-agent-name", cfg.Name)
+	assert.Equal(t, true, cfg.DevMode)
+	assert.Equal(t, "https://custom.server.com", cfg.ServerURL)
+}

--- a/agent/config/config_test.go
+++ b/agent/config/config_test.go
@@ -16,7 +16,6 @@ func TestConfigDefaults(t *testing.T) {
 
 	assert.Equal(t, "", cfg.APIKey)
 	assert.Equal(t, "", cfg.Name)
-	assert.Equal(t, false, cfg.DevMode)
 	assert.Equal(t, "https://cloud.tracetest.io", cfg.ServerURL)
 }
 
@@ -39,6 +38,5 @@ func TestConfigWithEnvs(t *testing.T) {
 
 	assert.Equal(t, "my-agent-api-key", cfg.APIKey)
 	assert.Equal(t, "my-agent-name", cfg.Name)
-	assert.Equal(t, true, cfg.DevMode)
 	assert.Equal(t, "https://custom.server.com", cfg.ServerURL)
 }

--- a/agent/initialization/start.go
+++ b/agent/initialization/start.go
@@ -15,10 +15,9 @@ import (
 func Start(config config.Config) {
 	fmt.Println("Starting agent")
 	ctx := context.Background()
-
 	client, err := client.Connect(ctx, config.ServerURL,
 		client.WithAPIKey(config.APIKey),
-		client.WithAgentName(config.AgentName),
+		client.WithAgentName(config.Name),
 	)
 	if err != nil {
 		log.Fatal(err)


### PR DESCRIPTION
This PR allows the agent be configured by env variables instead of a file
## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

https://www.loom.com/share/995251a49b784f9c9da9587c95788134