### PR TITLE
feature(cli): Adding CLI cloud login and auth logic

### DIFF
--- a/cli/cmd/config.go
+++ b/cli/cmd/config.go
@@ -10,6 +10,7 @@ import (
 	"github.com/kubeshop/tracetest/cli/config"
 	"github.com/kubeshop/tracetest/cli/formatters"
 	"github.com/kubeshop/tracetest/cli/openapi"
+	"github.com/kubeshop/tracetest/cli/pkg/oauth"
 	"github.com/kubeshop/tracetest/cli/utils"
 	"github.com/spf13/cobra"
 	"go.uber.org/zap"
@@ -22,6 +23,7 @@ var (
 	openapiClient  = &openapi.APIClient{}
 	versionText    string
 	isVersionMatch bool
+	oauthServer    = oauth.NewOAuthServer(&cliConfig)
 )
 
 type setupConfig struct {

--- a/cli/cmd/configure_cmd.go
+++ b/cli/cmd/configure_cmd.go
@@ -5,6 +5,7 @@ import (
 	"net/url"
 
 	"github.com/kubeshop/tracetest/cli/actions"
+	"github.com/kubeshop/tracetest/cli/config"
 	"github.com/spf13/cobra"
 )
 
@@ -20,7 +21,7 @@ var configureCmd = &cobra.Command{
 		ctx := context.Background()
 		action := actions.NewConfigureAction(cliConfig)
 
-		actionConfig := actions.ConfigureConfig{
+		actionConfig := config.ConfigureConfig{
 			Global: configParams.Global,
 		}
 

--- a/cli/cmd/login_cmd.go
+++ b/cli/cmd/login_cmd.go
@@ -1,0 +1,46 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/kubeshop/tracetest/cli/config"
+	"github.com/spf13/cobra"
+)
+
+var loginCmd = &cobra.Command{
+	GroupID: cmdGroupCloud.ID,
+	Use:     "login",
+	Short:   "Tracetst Cloud Login",
+	Long:    "Initializes the Tracetst Cloud Login process",
+	PreRun:  setupCommand(),
+	Run: WithResultHandler(func(_ *cobra.Command, _ []string) (string, error) {
+		ctx := context.Background()
+		onSuccess := func(token string, jwt string) {
+			fmt.Printf("✔ Successful Authenticated with token: %s and jwt: %s\n", token, jwt)
+			cliConfig.Token = token
+			cliConfig.Jwt = jwt
+			serverPath := ""
+			cliConfig.ServerPath = &serverPath
+			config.Save(ctx, cliConfig, config.ConfigureConfig{})
+			ExitCLI(0)
+		}
+
+		onFailure := func(err error) {
+			OnError(err)
+		}
+
+		// create server
+		oauthServer = oauthServer.
+			WithOnSuccess(onSuccess).
+			WithOnFailure(onFailure)
+
+		oauthServer.GetAuthCookie()
+		return "", nil
+	}),
+	PostRun: teardownCommand,
+}
+
+func init() {
+	rootCmd.AddCommand(loginCmd)
+}

--- a/cli/cmd/middleware.go
+++ b/cli/cmd/middleware.go
@@ -16,15 +16,7 @@ func WithResultHandler(runFn RunFn) CobraRunFn {
 		res, err := runFn(cmd, args)
 
 		if err != nil {
-			fmt.Fprintf(os.Stderr, `
-Version
-%s
-
-An error ocurred when executing the command
-
-%s
-`, versionText, err.Error())
-			ExitCLI(1)
+			OnError(err)
 			return
 		}
 
@@ -32,6 +24,18 @@ An error ocurred when executing the command
 			fmt.Println(res)
 		}
 	}
+}
+
+func OnError(err error) {
+	fmt.Fprintf(os.Stderr, `
+Version
+%s
+
+An error ocurred when executing the command
+
+%s
+`, versionText, err.Error())
+	ExitCLI(1)
 }
 
 func WithParamsHandler(validators ...Validator) MiddlewareWrapper {

--- a/cli/cmd/resources.go
+++ b/cli/cmd/resources.go
@@ -271,6 +271,9 @@ func setupResources() {
 	extraHeaders := http.Header{}
 	extraHeaders.Set("x-client-id", analytics.ClientID())
 	extraHeaders.Set("x-source", "cli")
+	extraHeaders.Set("x-organization-id", cliConfig.OrganizationID)
+	extraHeaders.Set("x-environment-id", cliConfig.EnvironmentID)
+	extraHeaders.Set("Authorization", fmt.Sprintf("Bearer %s", cliConfig.Jwt))
 
 	// To avoid a ciruclar reference initialization when setting up the registry and its resources,
 	// we create the resources with a pointer to an unconfigured HTTPClient.

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -70,6 +70,11 @@ var (
 		ID:    "misc",
 		Title: "Misc",
 	}
+
+	cmdGroupCloud = &cobra.Group{
+		ID:    "cloud",
+		Title: "Cloud",
+	}
 )
 
 func init() {
@@ -84,6 +89,7 @@ func init() {
 		cmdGroupResources,
 		cmdGroupTests,
 		cmdGroupMisc,
+		cmdGroupCloud,
 	)
 
 	rootCmd.SetCompletionCommandGroupID(cmdGroupConfig.ID)

--- a/cli/config/config.go
+++ b/cli/config/config.go
@@ -97,6 +97,7 @@ func loadConfig(configFile string) (Config, error) {
 		return Config{}, fmt.Errorf("could not unmarshal config: %w", err)
 	}
 
+	config.FrontendEndpoint = FrontendEndpoint
 	return config, nil
 }
 

--- a/cli/config/config.go
+++ b/cli/config/config.go
@@ -1,24 +1,42 @@
 package config
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"os"
+	"path"
 	"path/filepath"
 	"strings"
 
 	"github.com/spf13/viper"
+	"gopkg.in/yaml.v2"
 )
 
 var (
-	Version = "dev"
-	Env     = "dev"
+	Version          = "dev"
+	Env              = "dev"
+	FrontendEndpoint = "http://localhost:3001"
 )
 
+type ConfigureConfig struct {
+	Global    bool
+	SetValues ConfigureConfigSetValues
+}
+
+type ConfigureConfigSetValues struct {
+	Endpoint string
+}
+
 type Config struct {
-	Scheme     string  `yaml:"scheme"`
-	Endpoint   string  `yaml:"endpoint"`
-	ServerPath *string `yaml:"serverPath,omitempty"`
+	Scheme           string  `yaml:"scheme"`
+	Endpoint         string  `yaml:"endpoint"`
+	ServerPath       *string `yaml:"serverPath,omitempty"`
+	FrontendEndpoint string  `yaml:"-"`
+	OrganizationID   string  `yaml:"organizationID,omitempty"`
+	EnvironmentID    string  `yaml:"environmentID,omitempty"`
+	Token            string  `yaml:"token,omitempty"`
+	Jwt              string  `yaml:"jwt,omitempty"`
 }
 
 func (c Config) URL() string {
@@ -26,7 +44,12 @@ func (c Config) URL() string {
 		return ""
 	}
 
-	return fmt.Sprintf("%s://%s", c.Scheme, strings.TrimSuffix(c.Endpoint, "/"))
+	pathPrefix := "/api"
+	if c.ServerPath != nil {
+		pathPrefix = *c.ServerPath
+	}
+
+	return fmt.Sprintf("%s://%s%s", c.Scheme, strings.TrimSuffix(c.Endpoint, "/"), pathPrefix)
 }
 
 func (c Config) IsEmpty() bool {
@@ -45,6 +68,8 @@ func LoadConfig(configFile string) (Config, error) {
 	if !config.IsEmpty() {
 		return config, nil
 	}
+
+	config.FrontendEndpoint = FrontendEndpoint
 
 	homePath, err := os.UserHomeDir()
 	if err != nil {
@@ -93,4 +118,39 @@ func ParseServerURL(serverURL string) (scheme, endpoint string, err error) {
 	endpoint = strings.TrimSuffix(urlParts[1], "/")
 
 	return scheme, endpoint, nil
+}
+
+func Save(ctx context.Context, config Config, args ConfigureConfig) error {
+	configPath, err := GetConfigurationPath(args)
+	if err != nil {
+		return fmt.Errorf("could not get configuration path: %w", err)
+	}
+
+	configYml, err := yaml.Marshal(config)
+	if err != nil {
+		return fmt.Errorf("could not marshal configuration into yml: %w", err)
+	}
+
+	if _, err := os.Stat(configPath); os.IsNotExist(err) {
+		os.MkdirAll(filepath.Dir(configPath), 0700) // Ensure folder exists
+	}
+	err = os.WriteFile(configPath, configYml, 0755)
+	if err != nil {
+		return fmt.Errorf("could not write file: %w", err)
+	}
+
+	return nil
+}
+
+func GetConfigurationPath(args ConfigureConfig) (string, error) {
+	configPath := "./config.yml"
+	if args.Global {
+		homePath, err := os.UserHomeDir()
+		if err != nil {
+			return "", fmt.Errorf("could not get user home dir: %w", err)
+		}
+		configPath = path.Join(homePath, ".tracetest/config.yml")
+	}
+
+	return configPath, nil
 }

--- a/cli/pkg/oauth/oauth.go
+++ b/cli/pkg/oauth/oauth.go
@@ -1,0 +1,157 @@
+package oauth
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"os/exec"
+	"runtime"
+
+	"github.com/kubeshop/tracetest/cli/config"
+)
+
+type OnAuthSuccess func(token string, jwt string)
+type OnAuthFailure func(err error)
+
+type OAuthServer struct {
+	config    *config.Config
+	onSuccess OnAuthSuccess
+	onFailure OnAuthFailure
+	port      int
+}
+
+type Option func(*OAuthServer)
+
+func NewOAuthServer(config *config.Config) *OAuthServer {
+	return &OAuthServer{
+		config: config,
+	}
+}
+
+func (s *OAuthServer) WithOnSuccess(onSuccess OnAuthSuccess) *OAuthServer {
+	s.onSuccess = onSuccess
+	return s
+}
+
+func (s *OAuthServer) WithOnFailure(onFailure OnAuthFailure) *OAuthServer {
+	s.onFailure = onFailure
+	return s
+}
+
+func (s *OAuthServer) GetAuthCookie() error {
+	url, err := s.getUrl()
+	if err != nil {
+		return fmt.Errorf("failed to start oauth server: %w", err)
+	}
+
+	loginUrl := fmt.Sprintf("%s/oauth?callback=%s", s.config.FrontendEndpoint, url)
+
+	err = openBrowser(loginUrl)
+	if err != nil {
+		return fmt.Errorf("failed to open the oauth url: %s", loginUrl)
+	}
+
+	return s.start()
+}
+
+type JWTResponse struct {
+	Jwt string `json:"jwt"`
+}
+
+func (s *OAuthServer) ExchangeToken(token string) (string, error) {
+	req, err := http.NewRequest("GET", fmt.Sprintf("%s/tokens/%s/exchange", s.config.URL(), token), nil)
+	if err != nil {
+		return "", fmt.Errorf("failed to create request: %w", err)
+	}
+
+	res, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("failed to exchange token: %w", err)
+	}
+
+	if res.StatusCode != http.StatusCreated {
+		return "", fmt.Errorf("failed to exchange token: %s", res.Status)
+	}
+
+	defer res.Body.Close()
+	body, err := io.ReadAll(res.Body)
+	if err != nil {
+		return "", fmt.Errorf("failed to read response body: %w", err)
+	}
+
+	var jwtResponse JWTResponse
+	err = json.Unmarshal(body, &jwtResponse)
+	if err != nil {
+		return "", fmt.Errorf("failed to unmarshal response body: %w", err)
+	}
+
+	return jwtResponse.Jwt, nil
+}
+
+func (s *OAuthServer) getUrl() (string, error) {
+	port, err := getFreePort()
+	if err != nil {
+		return "", fmt.Errorf("failed to get free port: %w", err)
+	}
+
+	s.port = port
+	return fmt.Sprintf("http://localhost:%d", port), nil
+}
+
+func (s *OAuthServer) start() error {
+	http.HandleFunc("/", s.callback)
+	return http.ListenAndServe(fmt.Sprintf(":%d", s.port), nil)
+}
+
+func (s *OAuthServer) callback(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	w.Header().Set("Access-Control-Allow-Origin", s.config.FrontendEndpoint)
+
+	w.WriteHeader(http.StatusOK)
+	w.Write([]byte(`{"success": true}`))
+
+	go s.handleResult(r)
+}
+
+func (s *OAuthServer) handleResult(r *http.Request) {
+	tokenId := r.URL.Query().Get("tokenId")
+	if tokenId == "" {
+		s.onFailure(fmt.Errorf("tokenId not found"))
+		return
+	}
+
+	jwt, err := s.ExchangeToken(tokenId)
+	if err != nil {
+		s.onFailure(err)
+		return
+	}
+
+	s.onSuccess(tokenId, jwt)
+}
+
+func getFreePort() (port int, err error) {
+	var a *net.TCPAddr
+	if a, err = net.ResolveTCPAddr("tcp", "localhost:0"); err == nil {
+		var l *net.TCPListener
+		if l, err = net.ListenTCP("tcp", a); err == nil {
+			defer l.Close()
+			return l.Addr().(*net.TCPAddr).Port, nil
+		}
+	}
+	return
+}
+
+func openBrowser(u string) error {
+	switch runtime.GOOS {
+	case "linux":
+		return exec.Command("xdg-open", u).Start()
+	case "windows":
+		return exec.Command("rundll32", "url.dll,FileProtocolHandler", u).Start()
+	case "darwin":
+		return exec.Command("open", u).Start()
+	default:
+		return fmt.Errorf("unsupported platform")
+	}
+}

--- a/cli/pkg/resourcemanager/client.go
+++ b/cli/pkg/resourcemanager/client.go
@@ -47,7 +47,7 @@ func NewHTTPClient(baseURL string, extraHeaders http.Header) *HTTPClient {
 }
 
 func (c HTTPClient) url(resourceName string, extra ...string) *url.URL {
-	urlStr := c.baseURL + path.Join("/api", resourceName, strings.Join(extra, "/"))
+	urlStr := c.baseURL + path.Join("/", resourceName, strings.Join(extra, "/"))
 	url, _ := url.Parse(urlStr)
 	return url
 }

--- a/cli/utils/api.go
+++ b/cli/utils/api.go
@@ -1,6 +1,7 @@
 package utils
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/kubeshop/tracetest/cli/analytics"
@@ -20,6 +21,10 @@ func GetAPIClient(cliConfig config.Config) *openapi.APIClient {
 	config := openapi.NewConfiguration()
 	config.AddDefaultHeader("x-client-id", analytics.ClientID())
 	config.AddDefaultHeader("x-source", "cli")
+	config.AddDefaultHeader("x-organization-id", cliConfig.OrganizationID)
+	config.AddDefaultHeader("x-environment-id", cliConfig.EnvironmentID)
+	config.AddDefaultHeader("Authorization", fmt.Sprintf("Bearer %s", cliConfig.Jwt))
+
 	config.Scheme = cliConfig.Scheme
 	config.Host = strings.TrimSuffix(cliConfig.Endpoint, "/")
 	if cliConfig.ServerPath != nil {


### PR DESCRIPTION
This PR adds the base logic to support CLI cloud login and authentication

## Changes

- Adds `tracetest login` command
- Implements oauth logic for resources and the API

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

