### PR TITLE
fix(cli): add kafka demo services to installer

### DIFF
--- a/cli/installer/docker_compose.go
+++ b/cli/installer/docker_compose.go
@@ -106,7 +106,7 @@ func getDockerComposeFileContents(ui cliUI.UI, config configuration) []byte {
 	include := []string{"tracetest", "postgres"}
 
 	if config.Bool("demo.enable.pokeshop") {
-		include = append(include, "cache", "queue", "demo-api", "demo-worker", "demo-rpc", "otel-collector")
+		include = append(include, "cache", "queue", "stream", "demo-api", "demo-worker", "demo-rpc", "demo-streaming-worker", "otel-collector")
 	}
 
 	// filter and update project


### PR DESCRIPTION
This PR fixes the kafka demo when using the installer with docker.

## Changes

- add missing kafka services to installer

## Fixes

- fixes #3110 

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Screenshot

<img width="1624" alt="Screenshot 2023-08-30 at 13 52 28" src="https://github.com/kubeshop/tracetest/assets/3879892/9af20d7e-242c-4535-a041-4fdaad3d0fe6">