### PR TITLE
feat(cli): adding `tracetest start` command

### DIFF
--- a/agent/cmd/start.go
+++ b/agent/cmd/start.go
@@ -20,6 +20,7 @@ var StartCmd = cobra.Command{
 	Short: "Start the local agent",
 	Long:  "Start the local agent",
 	Run: func(cmd *cobra.Command, args []string) {
+		ctx := cmd.Context()
 		cfg, err := config.LoadConfig()
 		if err != nil {
 			fmt.Fprintln(os.Stderr, err)
@@ -28,7 +29,7 @@ var StartCmd = cobra.Command{
 
 		log.Printf("starting agent [%s] connecting to %s", cfg.Name, cfg.ServerURL)
 
-		initialization.Start(cfg)
+		initialization.Start(ctx, cfg)
 	},
 }
 

--- a/agent/cmd/start.go
+++ b/agent/cmd/start.go
@@ -29,7 +29,11 @@ var StartCmd = cobra.Command{
 
 		log.Printf("starting agent [%s] connecting to %s", cfg.Name, cfg.ServerURL)
 
-		initialization.Start(ctx, cfg)
+		err = initialization.Start(ctx, cfg)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			ExitCLI(1)
+		}
 	},
 }
 

--- a/agent/initialization/start.go
+++ b/agent/initialization/start.go
@@ -3,7 +3,6 @@ package initialization
 import (
 	"context"
 	"fmt"
-	"log"
 
 	"github.com/kubeshop/tracetest/agent/client"
 	"github.com/kubeshop/tracetest/agent/config"
@@ -12,15 +11,14 @@ import (
 )
 
 // Start the agent with given configuration
-func Start(config config.Config) {
+func Start(ctx context.Context, config config.Config) error {
 	fmt.Println("Starting agent")
-	ctx := context.Background()
 	client, err := client.Connect(ctx, config.ServerURL,
 		client.WithAPIKey(config.APIKey),
 		client.WithAgentName(config.Name),
 	)
 	if err != nil {
-		log.Fatal(err)
+		return err
 	}
 
 	triggerWorker := workers.NewTriggerWorker(client)
@@ -35,8 +33,9 @@ func Start(config config.Config) {
 
 	err = client.Start(ctx)
 	if err != nil {
-		log.Fatal(err)
+		return err
 	}
 
 	client.WaitUntilDisconnected()
+	return nil
 }

--- a/agent/initialization/start.go
+++ b/agent/initialization/start.go
@@ -36,6 +36,7 @@ func Start(ctx context.Context, config config.Config) error {
 		return err
 	}
 
+	fmt.Println("Agent started! Do not close the terminal.")
 	client.WaitUntilDisconnected()
 	return nil
 }

--- a/agent/workers/trigger.go
+++ b/agent/workers/trigger.go
@@ -30,7 +30,7 @@ func NewTriggerWorker(client *client.Client) *TriggerWorker {
 }
 
 func (w *TriggerWorker) Trigger(ctx context.Context, triggerRequest *proto.TriggerRequest) error {
-	fmt.Println("@@@@ TriggerWorker.Trigger")
+	fmt.Println("Trigger handled by agent")
 	triggerConfig := convertProtoToTrigger(triggerRequest.Trigger)
 	triggerer, err := w.registry.Get(triggerConfig.Type)
 	if err != nil {

--- a/agent/workers/trigger.go
+++ b/agent/workers/trigger.go
@@ -30,6 +30,7 @@ func NewTriggerWorker(client *client.Client) *TriggerWorker {
 }
 
 func (w *TriggerWorker) Trigger(ctx context.Context, triggerRequest *proto.TriggerRequest) error {
+	fmt.Println("@@@@ TriggerWorker.Trigger")
 	triggerConfig := convertProtoToTrigger(triggerRequest.Trigger)
 	triggerer, err := w.registry.Get(triggerConfig.Type)
 	if err != nil {

--- a/cli/cmd/resource_select_cmd.go
+++ b/cli/cmd/resource_select_cmd.go
@@ -16,11 +16,8 @@ type selectableFn func(ctx context.Context, cfg config.Config)
 var (
 	selectParams  = &resourceIDParameters{}
 	selectCmd     *cobra.Command
-	selectable    = strings.Join([]string{"environment", "organization"}, "|")
+	selectable    = strings.Join([]string{"organization"}, "|")
 	selectableMap = map[string]selectableFn{
-		"env": func(ctx context.Context, cfg config.Config) {
-			configurator.ShowEnvironmentSelector(ctx, cfg)
-		},
 		"organization": func(ctx context.Context, cfg config.Config) {
 			configurator.ShowOrganizationSelector(ctx, cfg)
 		}}

--- a/cli/cmd/start_cmd.go
+++ b/cli/cmd/start_cmd.go
@@ -1,0 +1,31 @@
+package cmd
+
+import (
+	"context"
+
+	"github.com/kubeshop/tracetest/cli/pkg/starter"
+	"github.com/spf13/cobra"
+)
+
+var (
+	start = starter.NewStarter(configurator, resources)
+)
+
+var startCmd = &cobra.Command{
+	GroupID: cmdGroupCloud.ID,
+	Use:     "start",
+	Short:   "Start Tracetest",
+	Long:    "Start Tracetest",
+	PreRun:  setupCommand(),
+	Run: WithResultHandler((func(_ *cobra.Command, _ []string) (string, error) {
+		ctx := context.Background()
+
+		err := start.Run(ctx, cliConfig)
+		return "", err
+	})),
+	PostRun: teardownCommand,
+}
+
+func init() {
+	rootCmd.AddCommand(startCmd)
+}

--- a/cli/config/selector.go
+++ b/cli/config/selector.go
@@ -25,6 +25,12 @@ func (c Configurator) organizationSelector(ctx context.Context, cfg Config) (Con
 		return cfg, err
 	}
 
+	if len(elements) == 1 {
+		cfg.OrganizationID = elements[0].ID
+		c.ui.Println(fmt.Sprintf("Defaulting to only available Organization: %s", elements[0].Name))
+		return cfg, nil
+	}
+
 	options := make([]cliUI.Option, len(elements))
 	for i, org := range elements {
 		options[i] = cliUI.Option{
@@ -39,6 +45,7 @@ func (c Configurator) organizationSelector(ctx context.Context, cfg Config) (Con
 
 	option := c.ui.Select("What Organization do you want to use?", options, 0)
 	option.Fn(c.ui)
+
 	return cfg, nil
 }
 
@@ -54,6 +61,12 @@ func (c Configurator) environmentSelector(ctx context.Context, cfg Config) (Conf
 	elements, err := getElements(ctx, resource, cfg)
 	if err != nil {
 		return cfg, err
+	}
+
+	if len(elements) == 1 {
+		cfg.EnvironmentID = elements[0].ID
+		c.ui.Println(fmt.Sprintf("Defaulting to only available Environment: %s", elements[0].Name))
+		return cfg, nil
 	}
 
 	options := make([]cliUI.Option, len(elements))
@@ -78,7 +91,7 @@ type entryList struct {
 }
 
 func getElements(ctx context.Context, resource resourcemanager.Client, cfg Config) ([]entry, error) {
-	resource = resource.WithHttpClient(setupHttpClient(cfg))
+	resource = resource.WithHttpClient(SetupHttpClient(cfg))
 
 	var list entryList
 	resultFormat, err := resourcemanager.Formats.GetWithFallback("json", "json")

--- a/cli/pkg/starter/starter.go
+++ b/cli/pkg/starter/starter.go
@@ -1,0 +1,97 @@
+package starter
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/kubeshop/tracetest/cli/config"
+	"github.com/kubeshop/tracetest/cli/pkg/resourcemanager"
+	"github.com/kubeshop/tracetest/cli/ui"
+
+	agentConfig "github.com/kubeshop/tracetest/agent/config"
+	"github.com/kubeshop/tracetest/agent/initialization"
+)
+
+type Starter struct {
+	configurator config.Configurator
+	resources    *resourcemanager.Registry
+	ui           ui.UI
+}
+
+func NewStarter(configurator config.Configurator, resources *resourcemanager.Registry) *Starter {
+	ui := ui.DefaultUI
+	return &Starter{configurator, resources, ui}
+}
+
+func (s *Starter) Run(ctx context.Context, cfg config.Config) error {
+	flags := config.ConfigFlags{
+		Endpoint: "http://localhost:8090/",
+	}
+	s.ui.Banner(config.Version)
+
+	return s.configurator.WithOnFinish(s.onStartAgent).Start(ctx, cfg, flags)
+}
+
+func (s *Starter) onStartAgent(ctx context.Context, cfg config.Config) {
+	env, err := s.getEnvironment(ctx, cfg)
+	if err != nil {
+		s.ui.Error(err.Error())
+	}
+
+	s.ui.Println(fmt.Sprintf("Connecting Agent to environment %s...", env.Name))
+	err = startAgent(ctx, env.AgentApiKey, "localhost:8091")
+	if err != nil {
+		s.ui.Error(err.Error())
+	}
+
+	s.ui.Finish()
+}
+
+type environment struct {
+	ID             string `json:"id"`
+	Name           string `json:"name"`
+	AgentApiKey    string `json:"agentApiKey"`
+	OrganizationID string `json:"organizationID"`
+}
+
+func (s *Starter) getEnvironment(ctx context.Context, cfg config.Config) (environment, error) {
+	resource, err := s.resources.Get("env")
+	if err != nil {
+		return environment{}, err
+	}
+
+	resource = resource.
+		WithHttpClient(config.SetupHttpClient(cfg)).
+		WithOptions(resourcemanager.WithPrefixGetter(func() string {
+			return fmt.Sprintf("/organizations/%s/", cfg.OrganizationID)
+		}))
+
+	resultFormat, err := resourcemanager.Formats.GetWithFallback("json", "json")
+	if err != nil {
+		return environment{}, err
+	}
+
+	raw, err := resource.Get(ctx, cfg.EnvironmentID, resultFormat)
+	if err != nil {
+		return environment{}, err
+	}
+
+	var env environment
+	err = json.Unmarshal([]byte(raw), &env)
+	if err != nil {
+		return environment{}, err
+	}
+
+	return env, nil
+}
+
+func startAgent(ctx context.Context, apiKey, controlPanelUrl string) error {
+	cfg := agentConfig.Config{
+		Name:      "local",
+		APIKey:    apiKey,
+		ServerURL: controlPanelUrl,
+	}
+
+	return initialization.Start(ctx, cfg)
+}

--- a/cli/pkg/starter/starter.go
+++ b/cli/pkg/starter/starter.go
@@ -5,12 +5,12 @@ import (
 	"encoding/json"
 	"fmt"
 
+	agentConfig "github.com/kubeshop/tracetest/agent/config"
+	"github.com/kubeshop/tracetest/agent/initialization"
+
 	"github.com/kubeshop/tracetest/cli/config"
 	"github.com/kubeshop/tracetest/cli/pkg/resourcemanager"
 	"github.com/kubeshop/tracetest/cli/ui"
-
-	agentConfig "github.com/kubeshop/tracetest/agent/config"
-	"github.com/kubeshop/tracetest/agent/initialization"
 )
 
 type Starter struct {
@@ -40,12 +40,10 @@ func (s *Starter) onStartAgent(ctx context.Context, cfg config.Config) {
 	}
 
 	s.ui.Println(fmt.Sprintf("Connecting Agent to environment %s...", env.Name))
-	err = startAgent(ctx, env.AgentApiKey, "localhost:8091")
+	err = startAgent(ctx, "localhost:8091", env.AgentApiKey)
 	if err != nil {
 		s.ui.Error(err.Error())
 	}
-
-	s.ui.Finish()
 }
 
 type environment struct {
@@ -86,11 +84,11 @@ func (s *Starter) getEnvironment(ctx context.Context, cfg config.Config) (enviro
 	return env, nil
 }
 
-func startAgent(ctx context.Context, apiKey, controlPanelUrl string) error {
+func startAgent(ctx context.Context, endpoint, agentApiKey string) error {
 	cfg := agentConfig.Config{
+		ServerURL: endpoint,
+		APIKey:    agentApiKey,
 		Name:      "local",
-		APIKey:    apiKey,
-		ServerURL: controlPanelUrl,
 	}
 
 	return initialization.Start(ctx, cfg)

--- a/go.work.sum
+++ b/go.work.sum
@@ -1,3 +1,4 @@
+
 atomicgo.dev/assert v0.0.2/go.mod h1:ut4NcI3QDdJtlmAxQULOmA13Gz6e2DWbSAS8RUOmNYQ=
 cloud.google.com/go v0.100.2/go.mod h1:4Xra9TjzAeYHrl5+oeLlzbM2k3mjVhZh4UqTZ//w99A=
 cloud.google.com/go v0.105.0/go.mod h1:PrLgOJNe5nfE9UMxKxgXj4mD3voiP+YQ6gdt6KMFOKM=


### PR DESCRIPTION
This PR adds the start command

## Changes

- Adds the sequence of configure
- Oauth
- Select org/env
- Start agent

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test


https://www.loom.com/share/5d0d2dd361294f89a1e9a63b10d1177b