### PR TITLE
feat(server): add resolved trigger to test run object

### DIFF
--- a/api/tests.yaml
+++ b/api/tests.yaml
@@ -197,6 +197,8 @@ components:
           format: date-time
         variableSet:
           $ref: "./variableSets.yaml#/components/schemas/VariableSet"
+        resolvedTrigger:
+          $ref: "./triggers.yaml#/components/schemas/Trigger"
         triggerResult:
           $ref: "./triggers.yaml#/components/schemas/TriggerResult"
         trace:

--- a/cli/openapi/model_test_run.go
+++ b/cli/openapi/model_test_run.go
@@ -39,6 +39,7 @@ type TestRun struct {
 	ObtainedTraceAt           *time.Time            `json:"obtainedTraceAt,omitempty"`
 	CompletedAt               *time.Time            `json:"completedAt,omitempty"`
 	VariableSet               *VariableSet          `json:"variableSet,omitempty"`
+	ResolvedTrigger           *Trigger              `json:"resolvedTrigger,omitempty"`
 	TriggerResult             *TriggerResult        `json:"triggerResult,omitempty"`
 	Trace                     *Trace                `json:"trace,omitempty"`
 	Result                    *AssertionResults     `json:"result,omitempty"`
@@ -515,6 +516,38 @@ func (o *TestRun) SetVariableSet(v VariableSet) {
 	o.VariableSet = &v
 }
 
+// GetResolvedTrigger returns the ResolvedTrigger field value if set, zero value otherwise.
+func (o *TestRun) GetResolvedTrigger() Trigger {
+	if o == nil || isNil(o.ResolvedTrigger) {
+		var ret Trigger
+		return ret
+	}
+	return *o.ResolvedTrigger
+}
+
+// GetResolvedTriggerOk returns a tuple with the ResolvedTrigger field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *TestRun) GetResolvedTriggerOk() (*Trigger, bool) {
+	if o == nil || isNil(o.ResolvedTrigger) {
+		return nil, false
+	}
+	return o.ResolvedTrigger, true
+}
+
+// HasResolvedTrigger returns a boolean if a field has been set.
+func (o *TestRun) HasResolvedTrigger() bool {
+	if o != nil && !isNil(o.ResolvedTrigger) {
+		return true
+	}
+
+	return false
+}
+
+// SetResolvedTrigger gets a reference to the given Trigger and assigns it to the ResolvedTrigger field.
+func (o *TestRun) SetResolvedTrigger(v Trigger) {
+	o.ResolvedTrigger = &v
+}
+
 // GetTriggerResult returns the TriggerResult field value if set, zero value otherwise.
 func (o *TestRun) GetTriggerResult() TriggerResult {
 	if o == nil || isNil(o.TriggerResult) {
@@ -848,6 +881,9 @@ func (o TestRun) ToMap() (map[string]interface{}, error) {
 	}
 	if !isNil(o.VariableSet) {
 		toSerialize["variableSet"] = o.VariableSet
+	}
+	if !isNil(o.ResolvedTrigger) {
+		toSerialize["resolvedTrigger"] = o.ResolvedTrigger
 	}
 	if !isNil(o.TriggerResult) {
 		toSerialize["triggerResult"] = o.TriggerResult

--- a/server/executor/runner.go
+++ b/server/executor/runner.go
@@ -146,6 +146,9 @@ func (r persistentRunner) ProcessItem(ctx context.Context, job Job) {
 		r.handleError(job.Run, err)
 	}
 
+	run.ResolvedTrigger = resolvedTest.Trigger
+	r.handleDBError(run, r.updater.Update(ctx, run))
+
 	err = r.eventEmitter.Emit(ctx, events.TriggerResolveSuccess(job.Run.TestID, job.Run.ID))
 	if err != nil {
 		r.handleError(job.Run, err)

--- a/server/executor/workers/trigger_preparation_worker.go
+++ b/server/executor/workers/trigger_preparation_worker.go
@@ -1,0 +1,24 @@
+package workers
+
+import (
+	"context"
+
+	"github.com/kubeshop/tracetest/server/executor"
+	triggerer "github.com/kubeshop/tracetest/server/executor/trigger"
+	"github.com/kubeshop/tracetest/server/model"
+	"github.com/kubeshop/tracetest/server/test"
+)
+
+type EventEmitter interface {
+	Emit(ctx context.Context, event model.TestRunEvent) error
+}
+
+type TriggerPreparationWorker struct {
+	runRepository test.RunRepository
+	eventEmiter   EventEmitter
+	triggers      *triggerer.Registry
+}
+
+func (w *TriggerPreparationWorker) ProcessItem(ctx context.Context, job executor.Job) {
+
+}

--- a/server/http/mappings/tests.go
+++ b/server/http/mappings/tests.go
@@ -281,6 +281,7 @@ func (m OpenAPI) Run(in *test.Run) openapi.TestRun {
 		ServiceTriggerCompletedAt: in.ServiceTriggerCompletedAt,
 		ObtainedTraceAt:           in.ObtainedTraceAt,
 		CompletedAt:               in.CompletedAt,
+		ResolvedTrigger:           m.Trigger(in.ResolvedTrigger),
 		TriggerResult:             m.TriggerResult(in.TriggerResult),
 		TestVersion:               int32(in.TestVersion),
 		Trace:                     m.Trace(in.Trace),

--- a/server/migrations/32_add_resolved_trigger_to_test_run.down.sql
+++ b/server/migrations/32_add_resolved_trigger_to_test_run.down.sql
@@ -1,0 +1,3 @@
+ALTER TABLE
+  test_runs
+DROP COLUMN resolved_trigger;

--- a/server/migrations/32_add_resolved_trigger_to_test_run.up.sql
+++ b/server/migrations/32_add_resolved_trigger_to_test_run.up.sql
@@ -1,0 +1,4 @@
+ALTER TABLE
+  test_runs
+ADD
+  COLUMN resolved_trigger jsonb;

--- a/server/openapi/model_test_run.go
+++ b/server/openapi/model_test_run.go
@@ -47,6 +47,8 @@ type TestRun struct {
 
 	VariableSet VariableSet `json:"variableSet,omitempty"`
 
+	ResolvedTrigger Trigger `json:"resolvedTrigger,omitempty"`
+
 	TriggerResult TriggerResult `json:"triggerResult,omitempty"`
 
 	Trace Trace `json:"trace,omitempty"`
@@ -69,6 +71,9 @@ type TestRun struct {
 // AssertTestRunRequired checks if the required fields are not zero-ed
 func AssertTestRunRequired(obj TestRun) error {
 	if err := AssertVariableSetRequired(obj.VariableSet); err != nil {
+		return err
+	}
+	if err := AssertTriggerRequired(obj.ResolvedTrigger); err != nil {
 		return err
 	}
 	if err := AssertTriggerResultRequired(obj.TriggerResult); err != nil {

--- a/server/test/test_entities.go
+++ b/server/test/test_entities.go
@@ -113,13 +113,14 @@ type (
 		SpanID  trace.SpanID
 
 		// result info
-		TriggerResult trigger.TriggerResult
-		Results       *RunResults
-		Trace         *traces.Trace
-		Outputs       maps.Ordered[string, RunOutput]
-		LastError     error
-		Pass          int
-		Fail          int
+		ResolvedTrigger trigger.Trigger
+		TriggerResult   trigger.TriggerResult
+		Results         *RunResults
+		Trace           *traces.Trace
+		Outputs         maps.Ordered[string, RunOutput]
+		LastError       error
+		Pass            int
+		Fail            int
 
 		Metadata RunMetadata
 

--- a/web/src/models/TestRun.model.ts
+++ b/web/src/models/TestRun.model.ts
@@ -27,6 +27,7 @@ type TestRun = Model<
     triggerTime: number;
     lastErrorState?: string;
     trigger?: TTriggerSchemas['Trigger'];
+    resolvedTrigger?: TTriggerSchemas['Trigger'];
     triggerResult?: TriggerResult;
     outputs?: TestRunOutput[];
     variableSet?: VariableSet;

--- a/web/src/types/Generated.types.ts
+++ b/web/src/types/Generated.types.ts
@@ -1846,6 +1846,7 @@ export interface external {
           /** Format: date-time */
           completedAt?: string;
           variableSet?: external["variableSets.yaml"]["components"]["schemas"]["VariableSet"];
+          resolvedTrigger?: external["triggers.yaml"]["components"]["schemas"]["Trigger"];
           triggerResult?: external["triggers.yaml"]["components"]["schemas"]["TriggerResult"];
           trace?: external["trace.yaml"]["components"]["schemas"]["Trace"];
           result?: external["tests.yaml"]["components"]["schemas"]["AssertionResults"];


### PR DESCRIPTION
This PR adds the field `resolved_trigger` to the test run and exposes it thought the API

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
