### PR TITLE
fix(frontend): fix method to parse url

### DIFF
--- a/web/src/utils/Common.ts
+++ b/web/src/utils/Common.ts
@@ -80,19 +80,10 @@ export const getIsValidUrl = (url: string): boolean => {
   }
 };
 
-const regex =
-  '(?:\\S+(?::\\S*)?@)?(?:(?:(?:[1-9]\\d?|1\\d\\d|2[01]\\d|22[0-3])(?:\\.(?:1?\\d{1,2}|2[0-4]\\d|25[0-5])){2}(?:\\.(?:[0-9]\\d?|1\\d\\d|2[0-4]\\d|25[0-4]))|(?:(?:[a-z\\u00a1-\\uffff0-9]+-?)*[a-z\\u00a1-\\uffff0-9]+)(?:\\.(?:[a-z\\u00a1-\\uffff0-9]+-?)*[a-z\\u00a1-\\uffff0-9]+)*(?:\\.(?:[a-z\\u00a1-\\uffff]{2,})))|localhost)(?::\\d{2,5})?(?:(/|\\?|#)[^\\s]*)?$';
-
 export const getParsedURL = (rawUrl: string): URL => {
-  const urlRegex = new RegExp(regex, 'i');
-
-  const [matchedUrl = ''] = rawUrl.match(urlRegex) || [];
-
-  if (!matchedUrl) throw new Error('Invalid URL');
-
-  if (!!matchedUrl && !matchedUrl.startsWith('http')) {
-    return new URL(`http://${matchedUrl}`);
+  if (!!rawUrl && !rawUrl.startsWith('http')) {
+    return new URL(`http://${rawUrl}`);
   }
 
-  return new URL(matchedUrl);
+  return new URL(rawUrl);
 };


### PR DESCRIPTION
This PR fixes a FE bug with the `Url Docker Suggestion` component. It was causing the web app to stop responding when using some specific URLs in your test definition.

## Changes

- remove url regex validation

## Fixes

- fixes #2968

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
