### PR TITLE
fix(frontend): fix resource type in automate command

### DIFF
--- a/web/src/services/CliCommand.service.ts
+++ b/web/src/services/CliCommand.service.ts
@@ -63,7 +63,7 @@ const CliCommandService = () => ({
     let command = Object.entries(options).reduce(
       (acc, [option, enabled]) =>
         this.applyOptions[option as CliCommandOption]({command: acc, enabled, id, variableSetId, fileName}),
-      `run ${resourceType}`
+      `run ${resourceType.slice(0, -1)}`
     );
 
     command = this.applyRequiredGates(command, requiredGates);


### PR DESCRIPTION
This PR fixes the resource type in the automate command service.

## Changes

- fix resource type in automate command (from `tests` to `test`, from `testsuites` to `testsuite`)

## Fixes

-

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
