### PR TITLE
fix: adding github action parallel runs to cli e2e tests

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -352,7 +352,7 @@ jobs:
           docker load --input dist/image.tar
       - name: Run tests
         run: |
-          curl -sfL https://raw.githubusercontent.com/Songmu/gotesplit/main/install.sh | sh -s
+          go get github.com/Songmu/gotesplit/cmd/gotesplit
 
           find ./dist -name 'tracetest' -exec cp {} ./dist \;
           chmod +x ./dist/tracetest

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -350,11 +350,10 @@ jobs:
       - name: Import image
         run: |
           docker load --input dist/image.tar
-      - name: Install gotesplit to run tests parallelly
-        run: |
-          curl -sfL https://raw.githubusercontent.com/Songmu/gotesplit/main/install.sh | sh -s
       - name: Run tests
         run: |
+          curl -sfL https://raw.githubusercontent.com/Songmu/gotesplit/main/install.sh | sh -s
+
           find ./dist -name 'tracetest' -exec cp {} ./dist \;
           chmod +x ./dist/tracetest
 
@@ -362,10 +361,8 @@ jobs:
 
           export TRACETEST_CLI=$PWD/dist/tracetest
           export TEST_ENVIRONMENT=jaeger
-          export ENABLE_CLI_DEBUG=false
-          export TAG=$(TAG)
 
-          bin/gotesplit -total ${{ matrix.total_splits }} -index ${{ matrix.index }} ./... -- -v -timeout 300s -p 1
+          ./bin/gotesplit -total ${{ matrix.total_splits }} -index ${{ matrix.index }} ./... -- -v -timeout 300s -p 1
 
   # TODO: this would be a great idea but it doesn't work on GHA with docker
   # it can probablly be implemented with k8s in a separated job

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -362,8 +362,7 @@ jobs:
           export TRACETEST_CLI=$PWD/dist/tracetest
           export TEST_ENVIRONMENT=jaeger
 
-          ls .
-          bin/gotesplit -total ${{ matrix.total_splits }} -index ${{ matrix.index }} ./... -- -v -timeout 300s -p 1
+          ../../bin/gotesplit -total ${{ matrix.total_splits }} -index ${{ matrix.index }} ./... -- -v -timeout 300s -p 1
 
   # TODO: this would be a great idea but it doesn't work on GHA with docker
   # it can probablly be implemented with k8s in a separated job

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -357,10 +357,10 @@ jobs:
           find ./dist -name 'tracetest' -exec cp {} ./dist \;
           chmod +x ./dist/tracetest
 
-          cd ./testing/cli-e2etest
-
           export TRACETEST_CLI=$PWD/dist/tracetest
           export TEST_ENVIRONMENT=jaeger
+
+          cd ./testing/cli-e2etest
 
           ../../bin/gotesplit -total ${{ matrix.total_splits }} -index ${{ matrix.index }} ./... -- -v -timeout 300s -p 1
 

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -350,11 +350,10 @@ jobs:
       - name: Import image
         run: |
           docker load --input dist/image.tar
-      - name: Install gotesplit
-        run: |
-          go get github.com/Songmu/gotesplit/cmd/gotesplit
       - name: Run tests
         run: |
+          curl -sfL https://raw.githubusercontent.com/Songmu/gotesplit/main/install.sh | sh -s
+
           find ./dist -name 'tracetest' -exec cp {} ./dist \;
           chmod +x ./dist/tracetest
 
@@ -363,7 +362,8 @@ jobs:
           export TRACETEST_CLI=$PWD/dist/tracetest
           export TEST_ENVIRONMENT=jaeger
 
-          gotesplit -total ${{ matrix.total_splits }} -index ${{ matrix.index }} ./... -- -v -timeout 300s -p 1
+          ls .
+          bin/gotesplit -total ${{ matrix.total_splits }} -index ${{ matrix.index }} ./... -- -v -timeout 300s -p 1
 
   # TODO: this would be a great idea but it doesn't work on GHA with docker
   # it can probablly be implemented with k8s in a separated job

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -337,9 +337,9 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
-    matrix:
-      parallelism: [4]
-      index: [0,1,2,3]
+      matrix:
+        total_splits: [4]
+        index: [0,1,2,3]
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -350,7 +350,7 @@ jobs:
       - name: Import image
         run: |
           docker load --input dist/image.tar
-      - name: Run tests parallelly
+      - name: Install gotesplit to run tests parallelly
         run: |
           curl -sfL https://raw.githubusercontent.com/Songmu/gotesplit/main/install.sh | sh -s
       - name: Run tests
@@ -365,7 +365,7 @@ jobs:
           export ENABLE_CLI_DEBUG=false
           export TAG=$(TAG)
 
-          bin/gotesplit -total ${{ matrix.parallelism }} -index ${{ matrix.index }} ./... -- -v -timeout 300s -p 1
+          bin/gotesplit -total ${{ matrix.total_splits }} -index ${{ matrix.index }} ./... -- -v -timeout 300s -p 1
 
   # TODO: this would be a great idea but it doesn't work on GHA with docker
   # it can probablly be implemented with k8s in a separated job

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -108,7 +108,6 @@ jobs:
       - name: Run unit tests
         run: cd agent; make test -B
 
-
   unit-test-web:
     name: WebUI unit tests
     runs-on: ubuntu-latest
@@ -336,6 +335,11 @@ jobs:
     name: CLI e2e tests
     needs: [build-docker]
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+    matrix:
+      parallelism: [4]
+      index: [0,1,2,3]
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -346,16 +350,22 @@ jobs:
       - name: Import image
         run: |
           docker load --input dist/image.tar
+      - name: Run tests parallelly
+        run: |
+          curl -sfL https://raw.githubusercontent.com/Songmu/gotesplit/main/install.sh | sh -s
       - name: Run tests
         run: |
           find ./dist -name 'tracetest' -exec cp {} ./dist \;
           chmod +x ./dist/tracetest
 
+          cd ./testing/cli-e2etest
+
           export TRACETEST_CLI=$PWD/dist/tracetest
           export TEST_ENVIRONMENT=jaeger
+          export ENABLE_CLI_DEBUG=false
+          export TAG=$(TAG)
 
-          cd ./testing/cli-e2etest
-          make test
+          bin/gotesplit -total ${{ matrix.parallelism }} -index ${{ matrix.index }} ./... -- -v -timeout 300s -p 1
 
   # TODO: this would be a great idea but it doesn't work on GHA with docker
   # it can probablly be implemented with k8s in a separated job

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -350,10 +350,11 @@ jobs:
       - name: Import image
         run: |
           docker load --input dist/image.tar
-      - name: Run tests
+      - name: Install gotesplit
         run: |
           go get github.com/Songmu/gotesplit/cmd/gotesplit
-
+      - name: Run tests
+        run: |
           find ./dist -name 'tracetest' -exec cp {} ./dist \;
           chmod +x ./dist/tracetest
 
@@ -362,7 +363,7 @@ jobs:
           export TRACETEST_CLI=$PWD/dist/tracetest
           export TEST_ENVIRONMENT=jaeger
 
-          ./bin/gotesplit -total ${{ matrix.total_splits }} -index ${{ matrix.index }} ./... -- -v -timeout 300s -p 1
+          gotesplit -total ${{ matrix.total_splits }} -index ${{ matrix.index }} ./... -- -v -timeout 300s -p 1
 
   # TODO: this would be a great idea but it doesn't work on GHA with docker
   # it can probablly be implemented with k8s in a separated job

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -338,8 +338,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        total_splits: [4]
-        index: [0,1,2,3]
+        total_splits: [8]
+        index: [0,1,2,3,4,5,6,7]
     steps:
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
This PR aims to split the CLI e2e into 8 containers to speed up the CI pipeline.

## Changes

- Updated test pipeline

## Checklist

- [ ] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
