### PR TITLE
fix: fix run id and suite run id to use `integer` instead of `string` in openapi spec

### DIFF
--- a/api/definition.yaml
+++ b/api/definition.yaml
@@ -18,7 +18,7 @@ components:
           type: string
           description: resource ID
         runId:
-          type: string
+          type: integer
           description: run ID
         type:
           type: string

--- a/api/expressions.yaml
+++ b/api/expressions.yaml
@@ -15,7 +15,7 @@ components:
         testId:
           type: string
         runId:
-          type: string
+          type: integer
         spanId:
           type: string
         selector:

--- a/api/tests.yaml
+++ b/api/tests.yaml
@@ -230,7 +230,7 @@ components:
         testSuiteId:
           type: string
         testSuiteRunId:
-          type: string
+          type: integer
 
     RunInformation:
       type: object

--- a/api/tests.yaml
+++ b/api/tests.yaml
@@ -143,7 +143,7 @@ components:
       type: object
       properties:
         id:
-          type: integer
+          type: string
           readOnly: true
         traceId:
           type: string

--- a/api/tests.yaml
+++ b/api/tests.yaml
@@ -143,7 +143,7 @@ components:
       type: object
       properties:
         id:
-          type: string
+          type: integer
           readOnly: true
         traceId:
           type: string

--- a/api/testsuites.yaml
+++ b/api/testsuites.yaml
@@ -57,7 +57,7 @@ components:
       type: object
       properties:
         id:
-          type: string
+          type: number
           readOnly: true
         version:
           type: integer

--- a/api/testsuites.yaml
+++ b/api/testsuites.yaml
@@ -57,7 +57,7 @@ components:
       type: object
       properties:
         id:
-          type: number
+          type: integer
           readOnly: true
         version:
           type: integer

--- a/cli/formatters/test_run.go
+++ b/cli/formatters/test_run.go
@@ -293,8 +293,8 @@ func (f testRun) getColoredText(passed bool, text string) string {
 	return pterm.FgRed.Sprintf(text)
 }
 
-func (f testRun) GetRunLink(testID, runID string) string {
-	return fmt.Sprintf("%s/test/%s/run/%s/test", f.baseURLFn(), testID, runID)
+func (f testRun) GetRunLink(testID string, runID int32) string {
+	return fmt.Sprintf("%s/test/%s/run/%d/test", f.baseURLFn(), testID, runID)
 }
 
 func (f testRun) getDeepLink(baseLink string, index int, spanID string) string {

--- a/cli/formatters/test_run_test.go
+++ b/cli/formatters/test_run_test.go
@@ -19,7 +19,7 @@ func TestJSON(t *testing.T) {
 			Name: openapi.PtrString("Testcase 1"),
 		},
 		Run: openapi.TestRun{
-			Id:    openapi.PtrString("1"),
+			Id:    openapi.PtrInt32(1),
 			State: openapi.PtrString("FINISHED"),
 			Result: &openapi.AssertionResults{
 				AllPassed: openapi.PtrBool(true),
@@ -43,7 +43,7 @@ func TestSuccessfulTestRunOutput(t *testing.T) {
 			Name: openapi.PtrString("Testcase 1"),
 		},
 		Run: openapi.TestRun{
-			Id:      openapi.PtrString("1"),
+			Id:      openapi.PtrInt32(1),
 			State:   openapi.PtrString("FINISHED"),
 			TraceId: openapi.PtrString("cb5e80748cc06f8a63f6b96c056defec"),
 			Result: &openapi.AssertionResults{
@@ -72,7 +72,7 @@ func TestSuccessfulTestRunOutputWithResult(t *testing.T) {
 			},
 		},
 		Run: openapi.TestRun{
-			Id:      openapi.PtrString("1"),
+			Id:      openapi.PtrInt32(1),
 			TraceId: openapi.PtrString("cb5e80748cc06f8a63f6b96c056defec"),
 			State:   openapi.PtrString("FINISHED"),
 			Result: &openapi.AssertionResults{
@@ -128,7 +128,7 @@ func TestFailingTestOutput(t *testing.T) {
 			},
 		},
 		Run: openapi.TestRun{
-			Id:      openapi.PtrString("1"),
+			Id:      openapi.PtrInt32(1),
 			TraceId: openapi.PtrString("cb5e80748cc06f8a63f6b96c056defec"),
 			Result: &openapi.AssertionResults{
 				AllPassed: openapi.PtrBool(false),
@@ -220,7 +220,7 @@ func TestFailingTestOutputWithPadding(t *testing.T) {
 			},
 		},
 		Run: openapi.TestRun{
-			Id:      openapi.PtrString("1"),
+			Id:      openapi.PtrInt32(1),
 			TraceId: openapi.PtrString("cb5e80748cc06f8a63f6b96c056defec"),
 			Result: &openapi.AssertionResults{
 				AllPassed: openapi.PtrBool(false),

--- a/cli/formatters/testsuite.go
+++ b/cli/formatters/testsuite.go
@@ -128,6 +128,6 @@ func (f testSuiteRun) getColoredText(passed bool, text string) string {
 	return pterm.FgRed.Sprintf(text)
 }
 
-func (f testSuiteRun) getRunLink(tsID, runID string) string {
+func (f testSuiteRun) getRunLink(tsID string, runID int32) string {
 	return fmt.Sprintf("%s/testsuite/%s/run/%s", f.baseURLFn(), tsID, runID)
 }

--- a/cli/formatters/testsuite.go
+++ b/cli/formatters/testsuite.go
@@ -129,5 +129,5 @@ func (f testSuiteRun) getColoredText(passed bool, text string) string {
 }
 
 func (f testSuiteRun) getRunLink(tsID string, runID int32) string {
-	return fmt.Sprintf("%s/testsuite/%s/run/%s", f.baseURLFn(), tsID, runID)
+	return fmt.Sprintf("%s/testsuite/%s/run/%d", f.baseURLFn(), tsID, runID)
 }

--- a/cli/openapi/model_resolve_context.go
+++ b/cli/openapi/model_resolve_context.go
@@ -20,7 +20,7 @@ var _ MappedNullable = &ResolveContext{}
 // ResolveContext struct for ResolveContext
 type ResolveContext struct {
 	TestId        *string `json:"testId,omitempty"`
-	RunId         *string `json:"runId,omitempty"`
+	RunId         *int32  `json:"runId,omitempty"`
 	SpanId        *string `json:"spanId,omitempty"`
 	Selector      *string `json:"selector,omitempty"`
 	VariableSetId *string `json:"variableSetId,omitempty"`
@@ -76,9 +76,9 @@ func (o *ResolveContext) SetTestId(v string) {
 }
 
 // GetRunId returns the RunId field value if set, zero value otherwise.
-func (o *ResolveContext) GetRunId() string {
+func (o *ResolveContext) GetRunId() int32 {
 	if o == nil || isNil(o.RunId) {
-		var ret string
+		var ret int32
 		return ret
 	}
 	return *o.RunId
@@ -86,7 +86,7 @@ func (o *ResolveContext) GetRunId() string {
 
 // GetRunIdOk returns a tuple with the RunId field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *ResolveContext) GetRunIdOk() (*string, bool) {
+func (o *ResolveContext) GetRunIdOk() (*int32, bool) {
 	if o == nil || isNil(o.RunId) {
 		return nil, false
 	}
@@ -102,8 +102,8 @@ func (o *ResolveContext) HasRunId() bool {
 	return false
 }
 
-// SetRunId gets a reference to the given string and assigns it to the RunId field.
-func (o *ResolveContext) SetRunId(v string) {
+// SetRunId gets a reference to the given int32 and assigns it to the RunId field.
+func (o *ResolveContext) SetRunId(v int32) {
 	o.RunId = &v
 }
 

--- a/cli/openapi/model_test_run.go
+++ b/cli/openapi/model_test_run.go
@@ -20,7 +20,7 @@ var _ MappedNullable = &TestRun{}
 
 // TestRun struct for TestRun
 type TestRun struct {
-	Id      *string `json:"id,omitempty"`
+	Id      *int32  `json:"id,omitempty"`
 	TraceId *string `json:"traceId,omitempty"`
 	SpanId  *string `json:"spanId,omitempty"`
 	// Test version used when running this test run
@@ -69,9 +69,9 @@ func NewTestRunWithDefaults() *TestRun {
 }
 
 // GetId returns the Id field value if set, zero value otherwise.
-func (o *TestRun) GetId() string {
+func (o *TestRun) GetId() int32 {
 	if o == nil || isNil(o.Id) {
-		var ret string
+		var ret int32
 		return ret
 	}
 	return *o.Id
@@ -79,7 +79,7 @@ func (o *TestRun) GetId() string {
 
 // GetIdOk returns a tuple with the Id field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *TestRun) GetIdOk() (*string, bool) {
+func (o *TestRun) GetIdOk() (*int32, bool) {
 	if o == nil || isNil(o.Id) {
 		return nil, false
 	}
@@ -95,8 +95,8 @@ func (o *TestRun) HasId() bool {
 	return false
 }
 
-// SetId gets a reference to the given string and assigns it to the Id field.
-func (o *TestRun) SetId(v string) {
+// SetId gets a reference to the given int32 and assigns it to the Id field.
+func (o *TestRun) SetId(v int32) {
 	o.Id = &v
 }
 

--- a/cli/openapi/model_test_run.go
+++ b/cli/openapi/model_test_run.go
@@ -48,7 +48,7 @@ type TestRun struct {
 	RequiredGatesResult       *RequiredGatesResult  `json:"requiredGatesResult,omitempty"`
 	Metadata                  *map[string]string    `json:"metadata,omitempty"`
 	TestSuiteId               *string               `json:"testSuiteId,omitempty"`
-	TestSuiteRunId            *string               `json:"testSuiteRunId,omitempty"`
+	TestSuiteRunId            *int32                `json:"testSuiteRunId,omitempty"`
 }
 
 // NewTestRun instantiates a new TestRun object
@@ -805,9 +805,9 @@ func (o *TestRun) SetTestSuiteId(v string) {
 }
 
 // GetTestSuiteRunId returns the TestSuiteRunId field value if set, zero value otherwise.
-func (o *TestRun) GetTestSuiteRunId() string {
+func (o *TestRun) GetTestSuiteRunId() int32 {
 	if o == nil || isNil(o.TestSuiteRunId) {
-		var ret string
+		var ret int32
 		return ret
 	}
 	return *o.TestSuiteRunId
@@ -815,7 +815,7 @@ func (o *TestRun) GetTestSuiteRunId() string {
 
 // GetTestSuiteRunIdOk returns a tuple with the TestSuiteRunId field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *TestRun) GetTestSuiteRunIdOk() (*string, bool) {
+func (o *TestRun) GetTestSuiteRunIdOk() (*int32, bool) {
 	if o == nil || isNil(o.TestSuiteRunId) {
 		return nil, false
 	}
@@ -831,8 +831,8 @@ func (o *TestRun) HasTestSuiteRunId() bool {
 	return false
 }
 
-// SetTestSuiteRunId gets a reference to the given string and assigns it to the TestSuiteRunId field.
-func (o *TestRun) SetTestSuiteRunId(v string) {
+// SetTestSuiteRunId gets a reference to the given int32 and assigns it to the TestSuiteRunId field.
+func (o *TestRun) SetTestSuiteRunId(v int32) {
 	o.TestSuiteRunId = &v
 }
 

--- a/cli/openapi/model_test_suite_run.go
+++ b/cli/openapi/model_test_suite_run.go
@@ -20,7 +20,7 @@ var _ MappedNullable = &TestSuiteRun{}
 
 // TestSuiteRun struct for TestSuiteRun
 type TestSuiteRun struct {
-	Id                          *string            `json:"id,omitempty"`
+	Id                          *int32             `json:"id,omitempty"`
 	Version                     *int32             `json:"version,omitempty"`
 	CreatedAt                   *time.Time         `json:"createdAt,omitempty"`
 	CompletedAt                 *time.Time         `json:"completedAt,omitempty"`
@@ -51,9 +51,9 @@ func NewTestSuiteRunWithDefaults() *TestSuiteRun {
 }
 
 // GetId returns the Id field value if set, zero value otherwise.
-func (o *TestSuiteRun) GetId() string {
+func (o *TestSuiteRun) GetId() int32 {
 	if o == nil || isNil(o.Id) {
-		var ret string
+		var ret int32
 		return ret
 	}
 	return *o.Id
@@ -61,7 +61,7 @@ func (o *TestSuiteRun) GetId() string {
 
 // GetIdOk returns a tuple with the Id field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *TestSuiteRun) GetIdOk() (*string, bool) {
+func (o *TestSuiteRun) GetIdOk() (*int32, bool) {
 	if o == nil || isNil(o.Id) {
 		return nil, false
 	}
@@ -77,8 +77,8 @@ func (o *TestSuiteRun) HasId() bool {
 	return false
 }
 
-// SetId gets a reference to the given string and assigns it to the Id field.
-func (o *TestSuiteRun) SetId(v string) {
+// SetId gets a reference to the given int32 and assigns it to the Id field.
+func (o *TestSuiteRun) SetId(v int32) {
 	o.Id = &v
 }
 

--- a/cli/runner/test_runner.go
+++ b/cli/runner/test_runner.go
@@ -3,7 +3,6 @@ package runner
 import (
 	"context"
 	"fmt"
-	"strconv"
 
 	"github.com/kubeshop/tracetest/cli/formatters"
 	"github.com/kubeshop/tracetest/cli/openapi"
@@ -97,13 +96,9 @@ func (r testRunner) StartRun(ctx context.Context, resource any, runInfo openapi.
 func (r testRunner) UpdateResult(ctx context.Context, result RunResult) (RunResult, error) {
 	test := result.Resource.(openapi.TestResource)
 	run := result.Run.(openapi.TestRun)
-	runID, err := strconv.Atoi(run.GetId())
-	if err != nil {
-		return RunResult{}, fmt.Errorf("invalid test run id format: %w", err)
-	}
 
 	updated, _, err := r.openapiClient.ApiApi.
-		GetTestRun(ctx, test.Spec.GetId(), int32(runID)).
+		GetTestRun(ctx, test.Spec.GetId(), run.GetId()).
 		Execute()
 
 	if err != nil {
@@ -123,16 +118,12 @@ func (r testRunner) UpdateResult(ctx context.Context, result RunResult) (RunResu
 func (r testRunner) JUnitResult(ctx context.Context, result RunResult) (string, error) {
 	test := result.Resource.(openapi.TestResource)
 	run := result.Run.(openapi.TestRun)
-	runID, err := strconv.Atoi(run.GetId())
-	if err != nil {
-		return "", fmt.Errorf("invalid run id format: %w", err)
-	}
 
 	junit, _, err := r.openapiClient.ApiApi.
 		GetRunResultJUnit(
 			ctx,
 			test.Spec.GetId(),
-			int32(runID),
+			int32(run.GetId()),
 		).
 		Execute()
 	if err != nil {

--- a/cli/runner/testsuite_runner.go
+++ b/cli/runner/testsuite_runner.go
@@ -3,7 +3,6 @@ package runner
 import (
 	"context"
 	"fmt"
-	"strconv"
 
 	"github.com/kubeshop/tracetest/cli/formatters"
 	"github.com/kubeshop/tracetest/cli/openapi"
@@ -97,13 +96,9 @@ func (r testSuiteRunner) StartRun(ctx context.Context, resource any, runInfo ope
 func (r testSuiteRunner) UpdateResult(ctx context.Context, result RunResult) (RunResult, error) {
 	testSuite := result.Resource.(openapi.TestSuiteResource)
 	run := result.Run.(openapi.TestSuiteRun)
-	runID, err := strconv.Atoi(run.GetId())
-	if err != nil {
-		return RunResult{}, fmt.Errorf("invalid test suite run id format: %w", err)
-	}
 
 	updated, _, err := r.openapiClient.ApiApi.
-		GetTestSuiteRun(ctx, testSuite.Spec.GetId(), int32(runID)).
+		GetTestSuiteRun(ctx, testSuite.Spec.GetId(), *run.Id).
 		Execute()
 
 	if err != nil {

--- a/server/http/controller.go
+++ b/server/http/controller.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
-	"strconv"
 
 	"github.com/kubeshop/tracetest/server/assertions/selectors"
 	"github.com/kubeshop/tracetest/server/datastore"
@@ -448,14 +447,8 @@ func (c *controller) buildDataStores(ctx context.Context, info openapi.ResolveRe
 		}}, ds...)
 	}
 
-	if context.RunId != "" && context.TestId != "" {
-		runId, err := strconv.Atoi(context.RunId)
-
-		if err != nil {
-			return [][]expression.DataStore{}, err
-		}
-
-		run, err := c.testRunRepository.GetRun(ctx, id.ID(context.TestId), runId)
+	if context.TestId != "" && context.RunId > 0 {
+		run, err := c.testRunRepository.GetRun(ctx, id.ID(context.TestId), int(context.RunId))
 		if err != nil {
 			return [][]expression.DataStore{}, err
 		}

--- a/server/http/mappings/tests.go
+++ b/server/http/mappings/tests.go
@@ -40,7 +40,7 @@ func (m OpenAPI) TestSuiteRun(in testsuite.TestSuiteRun) openapi.TestSuiteRun {
 	}
 
 	return openapi.TestSuiteRun{
-		Id:                          strconv.Itoa(in.ID),
+		Id:                          int32(in.ID),
 		Version:                     int32(in.TestSuiteVersion),
 		CreatedAt:                   in.CreatedAt,
 		CompletedAt:                 in.CompletedAt,
@@ -268,6 +268,8 @@ func (m OpenAPI) Run(in *test.Run) openapi.TestRun {
 		return openapi.TestRun{}
 	}
 
+	testSuiteID, _ := strconv.Atoi(in.TestSuiteID)
+
 	return openapi.TestRun{
 		Id:                        int32(in.ID),
 		TraceId:                   in.TraceID.String(),
@@ -290,7 +292,7 @@ func (m OpenAPI) Run(in *test.Run) openapi.TestRun {
 		Metadata:                  in.Metadata,
 		VariableSet:               m.VariableSet(in.VariableSet),
 		TestSuiteId:               in.TestSuiteID,
-		TestSuiteRunId:            in.TestSuiteRunID,
+		TestSuiteRunId:            int32(testSuiteID),
 		Linter:                    m.LinterResult(in.Linter),
 		RequiredGatesResult:       m.RequiredGatesResult(in.RequiredGatesResult),
 	}

--- a/server/http/mappings/tests.go
+++ b/server/http/mappings/tests.go
@@ -269,7 +269,7 @@ func (m OpenAPI) Run(in *test.Run) openapi.TestRun {
 	}
 
 	return openapi.TestRun{
-		Id:                        strconv.Itoa(in.ID),
+		Id:                        int32(in.ID),
 		TraceId:                   in.TraceID.String(),
 		SpanId:                    in.SpanID.String(),
 		State:                     string(in.State),
@@ -391,7 +391,6 @@ func (m Model) Definition(in []openapi.TestSpec) test.Specs {
 func (m Model) Run(in openapi.TestRun) (*test.Run, error) {
 	tid, _ := trace.TraceIDFromHex(in.TraceId)
 	sid, _ := trace.SpanIDFromHex(in.SpanId)
-	id, _ := strconv.Atoi(in.Id)
 	result, err := m.Result(in.Result)
 
 	if err != nil {
@@ -399,7 +398,7 @@ func (m Model) Run(in openapi.TestRun) (*test.Run, error) {
 	}
 
 	return &test.Run{
-		ID:                        id,
+		ID:                        int(in.Id),
 		TraceID:                   tid,
 		SpanID:                    sid,
 		State:                     test.RunState(in.State),

--- a/server/openapi/model_resolve_context.go
+++ b/server/openapi/model_resolve_context.go
@@ -12,7 +12,7 @@ package openapi
 type ResolveContext struct {
 	TestId string `json:"testId,omitempty"`
 
-	RunId string `json:"runId,omitempty"`
+	RunId int32 `json:"runId,omitempty"`
 
 	SpanId string `json:"spanId,omitempty"`
 

--- a/server/openapi/model_test_run.go
+++ b/server/openapi/model_test_run.go
@@ -65,7 +65,7 @@ type TestRun struct {
 
 	TestSuiteId string `json:"testSuiteId,omitempty"`
 
-	TestSuiteRunId string `json:"testSuiteRunId,omitempty"`
+	TestSuiteRunId int32 `json:"testSuiteRunId,omitempty"`
 }
 
 // AssertTestRunRequired checks if the required fields are not zero-ed

--- a/server/openapi/model_test_run.go
+++ b/server/openapi/model_test_run.go
@@ -14,7 +14,7 @@ import (
 )
 
 type TestRun struct {
-	Id string `json:"id,omitempty"`
+	Id int32 `json:"id,omitempty"`
 
 	TraceId string `json:"traceId,omitempty"`
 

--- a/server/openapi/model_test_suite_run.go
+++ b/server/openapi/model_test_suite_run.go
@@ -14,7 +14,7 @@ import (
 )
 
 type TestSuiteRun struct {
-	Id string `json:"id,omitempty"`
+	Id int32 `json:"id,omitempty"`
 
 	Version int32 `json:"version,omitempty"`
 

--- a/web/src/components/Editor/Expression/Expression.tsx
+++ b/web/src/components/Editor/Expression/Expression.tsx
@@ -30,7 +30,7 @@ const Expression = ({
   onSelectAutocompleteOption = noop,
   context = {},
 }: IEditorProps) => {
-  const {testId = '', runId = ''} = context;
+  const {testId = '', runId = 0} = context;
   const [isHovering, setIsHovering] = useState(false);
   const {selectedVariableSet} = useVariableSet();
   const editorTheme = useEditorTheme();

--- a/web/src/components/Editor/Expression/hooks/useAutoComplete.ts
+++ b/web/src/components/Editor/Expression/hooks/useAutoComplete.ts
@@ -10,7 +10,7 @@ import {SupportedEditors} from 'constants/Editor.constants';
 
 interface IProps {
   testId: string;
-  runId: string;
+  runId: number;
   onSelect?(option: Completion): void;
   autocompleteCustomValues: string[];
 }

--- a/web/src/components/Editor/Selector/hooks/useAutoComplete.ts
+++ b/web/src/components/Editor/Selector/hooks/useAutoComplete.ts
@@ -16,7 +16,7 @@ import {escapeString} from 'utils/Common';
 
 interface IProps {
   testId: string;
-  runId: string;
+  runId: number;
 }
 
 const useAutoComplete = ({testId, runId}: IProps) => {

--- a/web/src/components/Editor/Selector/hooks/useLint.ts
+++ b/web/src/components/Editor/Selector/hooks/useLint.ts
@@ -7,7 +7,7 @@ import AssertionSelectors from 'selectors/Assertion.selectors';
 
 interface IProps {
   testId: string;
-  runId: string;
+  runId: number;
 }
 
 const useLint = ({runId, testId}: IProps): LintSource => {

--- a/web/src/components/FileViewerModal/FileViewerModal.provider.tsx
+++ b/web/src/components/FileViewerModal/FileViewerModal.provider.tsx
@@ -6,7 +6,7 @@ import useDefinitionFile from 'hooks/useDefinitionFile';
 import useJUnitResult from 'hooks/useJUnitResult';
 
 interface IContext {
-  onJUnit(testId: string, runId: string): void;
+  onJUnit(testId: string, runId: number): void;
   onDefinition(resourceType: ResourceType, resourceId: string, version?: number): void;
 }
 
@@ -48,7 +48,7 @@ const FileViewerModalProvider = ({children}: IProps) => {
   });
 
   const onJUnit = useCallback(
-    async (testId: string, runId: string) => {
+    async (testId: string, runId: number) => {
       loadJUnit(testId, runId);
       setIsFileViewerOpen(true);
       setProps(propsMap.junit);

--- a/web/src/components/PaginatedList/PaginatedList.tsx
+++ b/web/src/components/PaginatedList/PaginatedList.tsx
@@ -19,7 +19,7 @@ interface IProps<T, P> {
 }
 
 interface IId {
-  id: string;
+  id: string | number;
 }
 
 const PaginatedList = <T extends IId, P>({dataCy, itemComponent: ItemComponent, params, query}: IProps<T, P>) => {

--- a/web/src/components/RunActionsMenu/RunActionsMenu.tsx
+++ b/web/src/components/RunActionsMenu/RunActionsMenu.tsx
@@ -9,11 +9,11 @@ import {ResourceType} from 'types/Resource.type';
 import * as S from './RunActionsMenu.styled';
 
 interface IProps {
-  resultId: string;
+  resultId: number;
   testId: string;
   isRunView?: boolean;
   testSuiteId?: string;
-  testSuiteRunId: string;
+  testSuiteRunId: number;
 }
 
 const RunActionsMenu = ({resultId, testId, testSuiteId, testSuiteRunId, isRunView = false}: IProps) => {

--- a/web/src/components/RunDetailLayout/RunDetailLayout.tsx
+++ b/web/src/components/RunDetailLayout/RunDetailLayout.tsx
@@ -28,7 +28,7 @@ const renderTabBar: TabsProps['renderTabBar'] = (props, DefaultTabBar) => (
   </S.ContainerHeader>
 );
 
-const renderTab = (title: string, testId: string, runId: string, mode: string) => (
+const renderTab = (title: string, testId: string, runId: number, mode: string) => (
   <S.TabLink $isActive={mode === title.toLowerCase()} to={`/test/${testId}/run/${runId}/${title.toLowerCase()}`}>
     {title}
   </S.TabLink>

--- a/web/src/components/RunDetailTrace/Search.tsx
+++ b/web/src/components/RunDetailTrace/Search.tsx
@@ -17,7 +17,7 @@ import * as S from './RunDetailTrace.styled';
 const {useLazyGetSelectedSpansQuery} = TracetestAPI.instance;
 
 interface IProps {
-  runId: string;
+  runId: number;
   testId: string;
 }
 

--- a/web/src/components/RunDetailTriggerResponse/RunDetailTriggerResponseFactory.tsx
+++ b/web/src/components/RunDetailTriggerResponse/RunDetailTriggerResponseFactory.tsx
@@ -5,7 +5,7 @@ import RunDetailTriggerData from './RunDetailTriggerData';
 import RunDetailTriggerResponse from './RunDetailTriggerResponse';
 
 export interface IPropsComponent {
-  runId: string;
+  runId: number;
   state: TTestRunState;
   testId: string;
   triggerResult?: TriggerResult;

--- a/web/src/components/TestOutputForm/SelectorInput.tsx
+++ b/web/src/components/TestOutputForm/SelectorInput.tsx
@@ -7,7 +7,7 @@ import TestOutput from 'models/TestOutput.model';
 
 interface IProps {
   form: FormInstance<TestOutput>;
-  runId: string;
+  runId: number;
   spanIdList: string[];
   testId: string;
 }

--- a/web/src/components/TestOutputForm/TestOutputForm.tsx
+++ b/web/src/components/TestOutputForm/TestOutputForm.tsx
@@ -23,7 +23,7 @@ interface IProps {
   onValidate(_: any, output: TestOutput): void;
   isValid: boolean;
   output?: TestOutput;
-  runId: string;
+  runId: number;
   testId: string;
 }
 

--- a/web/src/components/TestSpecDetail/Assertion.tsx
+++ b/web/src/components/TestSpecDetail/Assertion.tsx
@@ -10,7 +10,7 @@ import * as S from './TestSpecDetail.styled';
 interface IProps {
   check: ICheckResult;
   testId: string;
-  runId: string;
+  runId: number;
   selector: string;
 }
 

--- a/web/src/components/TestSpecForm/AssertionCheck.tsx
+++ b/web/src/components/TestSpecForm/AssertionCheck.tsx
@@ -24,7 +24,7 @@ interface IProps {
   field: Pick<FormListFieldData, never>;
   name: number;
   attributeList: TSpanFlatAttribute[];
-  runId: string;
+  runId: number;
   testId: string;
   spanIdList: string[];
 }

--- a/web/src/components/TestSpecForm/AssertionCheckList.tsx
+++ b/web/src/components/TestSpecForm/AssertionCheckList.tsx
@@ -14,7 +14,7 @@ interface IProps {
   fields: FormListFieldData[];
   form: FormInstance<IValues>;
   remove(name: number): void;
-  runId: string;
+  runId: number;
   testId: string;
   spanIdList: string[];
 }

--- a/web/src/components/TestSpecForm/SelectorInput.tsx
+++ b/web/src/components/TestSpecForm/SelectorInput.tsx
@@ -8,7 +8,7 @@ import {IValues} from './TestSpecForm';
 interface IProps {
   form: FormInstance<IValues>;
   testId: string;
-  runId: string;
+  runId: number;
   onValidSelector(isValid: boolean): void;
 }
 

--- a/web/src/components/TestSpecForm/TestSpecForm.tsx
+++ b/web/src/components/TestSpecForm/TestSpecForm.tsx
@@ -34,7 +34,7 @@ interface IProps {
   onSubmit(values: IValues): void;
   isValid: boolean;
   onIsValid(isValid: boolean): void;
-  runId: string;
+  runId: number;
   testId: string;
 }
 

--- a/web/src/components/TestSpecForm/hooks/useQuerySelector.ts
+++ b/web/src/components/TestSpecForm/hooks/useQuerySelector.ts
@@ -15,13 +15,13 @@ import {IValues} from '../TestSpecForm';
 
 interface IDebounceProps {
   q: string;
-  rId: string;
+  rId: number;
   tId: string;
 }
 
 interface IProps {
   form: FormInstance<IValues>;
-  runId: string;
+  runId: number;
   testId: string;
   onValidSelector(isValid: boolean): void;
 }

--- a/web/src/components/TestSuiteRunActionsMenu/TestSuiteRunActionsMenu.tsx
+++ b/web/src/components/TestSuiteRunActionsMenu/TestSuiteRunActionsMenu.tsx
@@ -7,7 +7,7 @@ import {ResourceType} from 'types/Resource.type';
 import * as S from './TestSuiteRunActionsMenu.styled';
 
 interface IProps {
-  runId: string;
+  runId: number;
   testSuiteId: string;
   isRunView?: boolean;
 }

--- a/web/src/components/TestSuiteRunLayout/TestSuiteRunLayout.tsx
+++ b/web/src/components/TestSuiteRunLayout/TestSuiteRunLayout.tsx
@@ -7,10 +7,10 @@ interface IProps {
 }
 
 const TestSuiteRunLayout = ({children}: IProps) => {
-  const {testSuiteId = '', runId = ''} = useParams();
+  const {testSuiteId = '', runId = 0} = useParams();
 
   return (
-    <TestSuiteRunProvider testSuiteId={testSuiteId} runId={runId}>
+    <TestSuiteRunProvider testSuiteId={testSuiteId} runId={Number(runId)}>
       <TestSuiteHeader />
       {children}
     </TestSuiteRunProvider>

--- a/web/src/components/Visualization/components/DAG/BaseSpanNode/BaseSpanNode.tsx
+++ b/web/src/components/Visualization/components/DAG/BaseSpanNode/BaseSpanNode.tsx
@@ -15,42 +15,44 @@ interface IProps {
   span: Span;
 }
 
-const BaseSpanNode = ({className, footer, id, isMatched, isSelected, span}: IProps) => (
-  <S.Container className={className} data-cy={`trace-node-${span.type}`} $matched={isMatched} $selected={isSelected}>
-    <Handle id={id} position={Position.Top} style={{top: 0, visibility: 'hidden'}} type="target" />
+const BaseSpanNode = ({className, footer, id, isMatched, isSelected, span}: IProps) => {
+  return (
+    <S.Container className={className} data-cy={`trace-node-${span.type}`} $matched={isMatched} $selected={isSelected}>
+      <Handle id={id} position={Position.Top} style={{ top: 0, visibility: 'hidden' }} type="target" />
 
-    <S.TopLine $type={span.type} />
+      <S.TopLine $type={span.type} />
 
-    <S.Header>
-      <S.BadgeContainer>
-        <S.BadgeType count={SemanticGroupNamesToText[span.type]} $hasMargin $type={span.type} />
-      </S.BadgeContainer>
-      <S.HeaderText>{span.name}</S.HeaderText>
-    </S.Header>
+      <S.Header>
+        <S.BadgeContainer>
+          <S.BadgeType count={SemanticGroupNamesToText[span.type]} $hasMargin $type={span.type} />
+        </S.BadgeContainer>
+        <S.HeaderText>{span.name}</S.HeaderText>
+      </S.Header>
 
-    <S.Body>
-      <S.Item>
-        <SettingOutlined />
-        <S.ItemText>
-          {span.service} {SpanKindToText[span.kind]}
-        </S.ItemText>
-      </S.Item>
-      {Boolean(span.system) && (
+      <S.Body>
         <S.Item>
-          <ToolOutlined />
-          <S.ItemText>{span.system}</S.ItemText>
+          <SettingOutlined />
+          <S.ItemText>
+            {span.service} {SpanKindToText[span.kind]}
+          </S.ItemText>
         </S.Item>
-      )}
-      <S.Item>
-        <ClockCircleOutlined />
-        <S.ItemText>{span.duration}</S.ItemText>
-      </S.Item>
-    </S.Body>
+        {Boolean(span.system) && (
+          <S.Item>
+            <ToolOutlined />
+            <S.ItemText>{span.system}</S.ItemText>
+          </S.Item>
+        )}
+        <S.Item>
+          <ClockCircleOutlined />
+          <S.ItemText>{span.duration}</S.ItemText>
+        </S.Item>
+      </S.Body>
 
-    <S.Footer>{footer}</S.Footer>
+      <S.Footer>{footer}</S.Footer>
 
-    <Handle id={id} position={Position.Bottom} style={{bottom: 0, visibility: 'hidden'}} type="source" />
-  </S.Container>
-);
+      <Handle id={id} position={Position.Bottom} style={{ bottom: 0, visibility: 'hidden' }} type="source" />
+    </S.Container>
+  );
+};
 
 export default BaseSpanNode;

--- a/web/src/gateways/TestRun.gateway.ts
+++ b/web/src/gateways/TestRun.gateway.ts
@@ -6,13 +6,13 @@ const TestRunGateway = () => ({
   get(testId: string, take = 25, skip = 0) {
     return TracetestAPI.instance.endpoints.getRunList.initiate({testId, take, skip});
   },
-  getById(testId: string, runId: string) {
+  getById(testId: string, runId: number) {
     return TracetestAPI.instance.endpoints.getRunById.initiate({testId, runId});
   },
-  reRun(testId: string, runId: string) {
+  reRun(testId: string, runId: number) {
     return TracetestAPI.instance.endpoints.reRun.initiate({testId, runId});
   },
-  dryRun(testId: string, runId: string, testDefinition: Partial<TRawTestSpecs>) {
+  dryRun(testId: string, runId: number, testDefinition: Partial<TRawTestSpecs>) {
     return TracetestAPI.instance.endpoints.dryRun.initiate({testId, runId, testDefinition});
   },
   runTest(testId: string, variableSetId = '') {

--- a/web/src/hooks/useDeleteResourceRun.tsx
+++ b/web/src/hooks/useDeleteResourceRun.tsx
@@ -21,7 +21,7 @@ const useDeleteResourceRun = ({id, isRunView = false, type}: IProps) => {
   const {onOpen} = useConfirmationModal();
 
   const onConfirmDelete = useCallback(
-    (runId: string) => {
+    (runId: number) => {
       if (type === ResourceType.Test) {
         TestAnalyticsService.onDeleteTestRun();
         deleteTestRunById({testId: id, runId});
@@ -35,7 +35,7 @@ const useDeleteResourceRun = ({id, isRunView = false, type}: IProps) => {
   );
 
   return useCallback(
-    (runId: string) => {
+    (runId: number) => {
       onOpen({
         title: `Are you sure you want to delete the Run?`,
         onConfirm: () => onConfirmDelete(runId),

--- a/web/src/hooks/useJUnitResult.ts
+++ b/web/src/hooks/useJUnitResult.ts
@@ -8,7 +8,7 @@ const useJUnitResult = () => {
   const [jUnit, setJUnit] = useState<string>('');
 
   const loadJUnit = useCallback(
-    async (testId: string, runId: string) => {
+    async (testId: string, runId: number) => {
       const data = await getJUnit({runId, testId}).unwrap();
 
       setJUnit(data);

--- a/web/src/models/TestRun.model.ts
+++ b/web/src/models/TestRun.model.ts
@@ -34,6 +34,7 @@ type TestRun = Model<
     state: TTestRunState;
     linter: LinterResult;
     requiredGatesResult: RequiredGatesResult;
+    testSuiteRunId: number;
   }
 >;
 
@@ -91,7 +92,7 @@ export function isRunStateAnalyzingError(state: TTestRunState) {
 }
 
 const TestRun = ({
-  id = '',
+  id = 0,
   traceId = '',
   spanId = '',
   state = 'CREATED',
@@ -111,7 +112,7 @@ const TestRun = ({
   outputs = [],
   variableSet = {},
   testSuiteId = '',
-  testSuiteRunId = '',
+  testSuiteRunId = 0,
   linter = {},
   requiredGatesResult = {required: [], failed: [], passed: true},
 }: TRawTestRun): TestRun => {
@@ -139,7 +140,7 @@ const TestRun = ({
     outputs: outputs?.map(rawOutput => TestRunOutput(rawOutput)),
     variableSet: VariableSet.fromRun(variableSet),
     testSuiteId,
-    testSuiteRunId,
+    testSuiteRunId: testSuiteRunId ? Number(testSuiteRunId) : 0,
     linter: LinterResult(linter),
     requiredGatesResult: RequiredGatesResult(requiredGatesResult),
   };

--- a/web/src/models/TestSuiteRun.model.ts
+++ b/web/src/models/TestSuiteRun.model.ts
@@ -13,7 +13,7 @@ type TestSuiteRun = Model<
 >;
 
 const TestSuiteRun = ({
-  id = '',
+  id = 0,
   createdAt = '',
   completedAt = '',
   state = 'CREATED',

--- a/web/src/models/__mocks__/TestRun.mock.ts
+++ b/web/src/models/__mocks__/TestRun.mock.ts
@@ -8,7 +8,7 @@ import TraceMock from './Trace.mock';
 const TestRunMock: IMockFactory<TestRun, TRawTestRun> = () => ({
   raw(data = {}) {
     return {
-      id: faker.datatype.uuid(),
+      id: faker.datatype.number(),
       traceId: faker.datatype.uuid(),
       spanId: faker.datatype.uuid(),
       createdAt: faker.date.past().toISOString(),

--- a/web/src/pages/RunDetail/RunDetail.tsx
+++ b/web/src/pages/RunDetail/RunDetail.tsx
@@ -10,15 +10,15 @@ import TestRunProvider from 'providers/TestRun';
 import Content from './Content';
 
 const RunDetail = () => {
-  const {testId = '', runId = ''} = useParams();
+  const {testId = '', runId = 0} = useParams();
 
   return (
     <GuidedTourProvider>
-      <TestRunProvider testId={testId} runId={runId}>
-        <TestSpecsProvider testId={testId} runId={runId}>
+      <TestRunProvider testId={testId} runId={Number(runId)}>
+        <TestSpecsProvider testId={testId} runId={Number(runId)}>
           <TestSpecFormProvider testId={testId}>
             <SpanProvider>
-              <TestOutputProvider testId={testId} runId={runId}>
+              <TestOutputProvider testId={testId} runId={Number(runId)}>
                 <Content />
               </TestOutputProvider>
             </SpanProvider>

--- a/web/src/providers/Span/Span.provider.tsx
+++ b/web/src/providers/Span/Span.provider.tsx
@@ -22,7 +22,7 @@ interface IContext {
   onSelectSpan(spanId: string): void;
   onSetMatchedSpans(spanIdList: string[]): void;
   onSetFocusedSpan(spanId: string): void;
-  onTriggerSelector(query: string, testId: string, runId: string): void;
+  onTriggerSelector(query: string, testId: string, runId: number): void;
   onClearMatchedSpans(): void;
   onClearSelectedSpan(): void;
 }
@@ -82,7 +82,7 @@ const SpanProvider = ({children}: IProps) => {
   );
 
   const onTriggerSelector = useCallback(
-    async (query: string, testId: string, runId: string) => {
+    async (query: string, testId: string, runId: number) => {
       const {spanIds = []} = await triggerSelector({
         query,
         testId,

--- a/web/src/providers/TestOutput/TestOutput.provider.tsx
+++ b/web/src/providers/TestOutput/TestOutput.provider.tsx
@@ -64,7 +64,7 @@ export const Context = createContext<IContext>({
 
 interface IProps {
   children: React.ReactNode;
-  runId: string;
+  runId: number;
   testId: string;
 }
 

--- a/web/src/providers/TestRun/TestRun.provider.tsx
+++ b/web/src/providers/TestRun/TestRun.provider.tsx
@@ -26,7 +26,7 @@ export const Context = createContext<IContext>({
 
 interface IProps {
   testId: string;
-  runId?: string;
+  runId?: number;
   children: React.ReactNode;
 }
 
@@ -34,7 +34,7 @@ export const useTestRun = () => useContext(Context);
 
 const POLLING_INTERVAL = 5000;
 
-const TestRunProvider = ({children, testId, runId = ''}: IProps) => {
+const TestRunProvider = ({children, testId, runId = 0}: IProps) => {
   const [pollingInterval, setPollingInterval] = useState<number | undefined>(POLLING_INTERVAL);
   const {data: run, isError} = useGetRunByIdQuery({testId, runId}, {skip: !runId, pollingInterval});
   const {data: runEvents = []} = useGetRunEventsQuery({testId, runId}, {skip: !runId});

--- a/web/src/providers/TestSpecs/TestSpecs.provider.tsx
+++ b/web/src/providers/TestSpecs/TestSpecs.provider.tsx
@@ -50,7 +50,7 @@ export const Context = createContext<IContext>({
 
 interface IProps {
   testId: string;
-  runId: string;
+  runId: number;
   children: React.ReactNode;
 }
 

--- a/web/src/providers/TestSpecs/hooks/useTestSpecsCrud.ts
+++ b/web/src/providers/TestSpecs/hooks/useTestSpecsCrud.ts
@@ -26,7 +26,7 @@ import {
 import {ISuggestion} from 'types/TestSpecs.types';
 
 interface IProps {
-  runId: string;
+  runId: number;
   testId: string;
   test: Test;
   isDraftMode: boolean;

--- a/web/src/providers/TestSuite/TestSuite.provider.tsx
+++ b/web/src/providers/TestSuite/TestSuite.provider.tsx
@@ -19,7 +19,7 @@ interface IContext {
   isEditLoading: boolean;
   onDelete(id: string, name: string): void;
   onEdit(draft: TDraftTestSuite): void;
-  onRun(runId?: string): void;
+  onRun(runId?: number): void;
   testSuite: TestSuite;
   latestTestSuite: TestSuite;
 }
@@ -65,7 +65,7 @@ const TestSuiteProvider = ({children, testSuiteId, version = 0}: IProps) => {
   const {navigate} = useDashboard();
 
   const onRun = useCallback(
-    (runId?: string) => {
+    (runId?: number) => {
       if (isLatestVersion) runTestSuite(testSuite!, runId);
       else {
         setAction('run');

--- a/web/src/providers/TestSuite/hooks/useTestSuiteCrud.ts
+++ b/web/src/providers/TestSuite/hooks/useTestSuiteCrud.ts
@@ -27,7 +27,7 @@ const useTestSuiteCrud = () => {
   const {onOpen} = useMissingVariablesModal();
 
   const runTestSuite = useCallback(
-    async (suite: TestSuite, runId?: string, variableSetId = selectedVariableSet?.id) => {
+    async (suite: TestSuite, runId?: number, variableSetId = selectedVariableSet?.id) => {
       const {fullSteps: testList} = await getTestSuite({
         testSuiteId: suite.id,
         version: suite.version,

--- a/web/src/providers/TestSuiteRun/TestSuite.provider.tsx
+++ b/web/src/providers/TestSuiteRun/TestSuite.provider.tsx
@@ -15,7 +15,7 @@ export const Context = createContext<IContext>({
 
 interface IProps {
   testSuiteId: string;
-  runId: string;
+  runId: number;
   children: React.ReactNode;
 }
 

--- a/web/src/redux/actions/Router.actions.ts
+++ b/web/src/redux/actions/Router.actions.ts
@@ -39,10 +39,10 @@ const RouterActions = () => ({
   ),
   updateSelectedSpan: createAsyncThunk<void, IQuery>(
     'router/updateSelectedSpan',
-    async ({params: {testId = '', runId = ''}, search}, {getState, dispatch}) => {
+    async ({params: {testId = '', runId = '0'}, search}, {getState, dispatch}) => {
       const {[RouterSearchFields.SelectedSpan]: spanId = ''} = search;
       const state = getState() as RootState;
-      const span = SpanSelectors.selectSpanById(state, String(spanId), testId, runId);
+      const span = SpanSelectors.selectSpanById(state, String(spanId), testId, Number(runId));
 
       if (span) dispatch(setSelectedSpan({span}));
     }

--- a/web/src/redux/actions/TestSpecs.actions.ts
+++ b/web/src/redux/actions/TestSpecs.actions.ts
@@ -20,7 +20,7 @@ export type TChange = {
 };
 
 const TestSpecsActions = () => ({
-  publish: createAsyncThunk<TestRun, {test: Test; testId: string; runId: string}>(
+  publish: createAsyncThunk<TestRun, {test: Test; testId: string; runId: number}>(
     'testDefinition/publish',
     async ({test, testId, runId}, {dispatch, getState}) => {
       const specs = TestSpecsSelectors.selectSpecs(getState() as RootState).filter(def => !def.isDeleted);
@@ -30,7 +30,7 @@ const TestSpecsActions = () => ({
       return dispatch(TestRunGateway.reRun(testId, runId)).unwrap();
     }
   ),
-  dryRun: createAsyncThunk<AssertionResults, {definitionList: TTestSpecEntry[]; testId: string; runId: string}>(
+  dryRun: createAsyncThunk<AssertionResults, {definitionList: TTestSpecEntry[]; testId: string; runId: number}>(
     'testDefinition/dryRun',
     ({definitionList, testId, runId}, {dispatch}) => {
       const specs = definitionList.map(def => TestDefinitionService.toRaw(def));

--- a/web/src/redux/actions/__tests_/TestSpecs.actions.test.ts
+++ b/web/src/redux/actions/__tests_/TestSpecs.actions.test.ts
@@ -27,7 +27,7 @@ describe('TestDefinitionActions', () => {
         TestSpecsActions.publish({
           test: TestMock.model(),
           testId: 'testId',
-          runId: 'runId',
+          runId: 1,
         })
       );
 
@@ -52,7 +52,7 @@ describe('TestDefinitionActions', () => {
       await store.dispatch(
         TestSpecsActions.dryRun({
           testId: 'testId',
-          runId: 'runId',
+          runId: 1,
           definitionList: [],
         })
       );

--- a/web/src/redux/apis/Tracetest/endpoints/Expression.endpoint.ts
+++ b/web/src/redux/apis/Tracetest/endpoints/Expression.endpoint.ts
@@ -5,7 +5,7 @@ import { TTestApiEndpointBuilder } from '../Tracetest.api';
 
 export const expressionEndpoints = (builder: TTestApiEndpointBuilder) => ({
   parseExpression: builder.mutation<string[], TResolveRequestInfo>({
-    query: ({expression, context: {spanId = '', runId = '', variableSetId = '', testId = '', selector = ''} = {}}) => ({
+    query: ({expression, context: {spanId = '', runId = 0, variableSetId = '', testId = '', selector = ''} = {}}) => ({
       url: '/expressions/resolve',
       method: HTTP_METHOD.POST,
       body: {

--- a/web/src/redux/apis/Tracetest/endpoints/TestRun.endpoint.ts
+++ b/web/src/redux/apis/Tracetest/endpoints/TestRun.endpoint.ts
@@ -42,7 +42,7 @@ export const testRunEndpoints = (builder: TTestApiEndpointBuilder) => ({
       items: rawTestResultList.map(rawTestResult => TestRun(rawTestResult)),
     }),
   }),
-  getRunById: builder.query<TestRun, {runId: string; testId: string}>({
+  getRunById: builder.query<TestRun, {runId: number; testId: string}>({
     query: ({testId, runId}) => `/tests/${testId}/run/${runId}`,
     providesTags: result => (result ? [{type: TracetestApiTags.TEST_RUN, id: result?.id}] : []),
     transformResponse: (rawTestResult: TRawTestRun) => TestRun(rawTestResult),
@@ -58,7 +58,7 @@ export const testRunEndpoints = (builder: TTestApiEndpointBuilder) => ({
       });
     },
   }),
-  reRun: builder.mutation<TestRun, {testId: string; runId: string}>({
+  reRun: builder.mutation<TestRun, {testId: string; runId: number}>({
     query: ({testId, runId}) => ({
       url: `/tests/${testId}/run/${runId}/rerun`,
       method: HTTP_METHOD.POST,
@@ -70,7 +70,7 @@ export const testRunEndpoints = (builder: TTestApiEndpointBuilder) => ({
     ],
     transformResponse: (rawTestRun: TRawTestRun) => TestRun(rawTestRun),
   }),
-  dryRun: builder.mutation<AssertionResults, {testId: string; runId: string; testDefinition: Partial<TRawTestSpecs>}>({
+  dryRun: builder.mutation<AssertionResults, {testId: string; runId: number; testDefinition: Partial<TRawTestSpecs>}>({
     query: ({testId, runId, testDefinition}) => ({
       url: `/tests/${testId}/run/${runId}/dry-run`,
       method: HTTP_METHOD.PUT,
@@ -78,7 +78,7 @@ export const testRunEndpoints = (builder: TTestApiEndpointBuilder) => ({
     }),
     transformResponse: (rawTestResults: TRawAssertionResults) => AssertionResults(rawTestResults),
   }),
-  deleteRunById: builder.mutation<Test, {testId: string; runId: string}>({
+  deleteRunById: builder.mutation<Test, {testId: string; runId: number}>({
     query: ({testId, runId}) => ({url: `/tests/${testId}/run/${runId}`, method: 'DELETE'}),
     invalidatesTags: (result, error, {testId}) => [
       {type: TracetestApiTags.TEST_RUN},
@@ -86,25 +86,25 @@ export const testRunEndpoints = (builder: TTestApiEndpointBuilder) => ({
       {type: TracetestApiTags.RESOURCE, id: 'LIST'},
     ],
   }),
-  stopRun: builder.mutation<null, {runId: string; testId: string}>({
+  stopRun: builder.mutation<null, {runId: number; testId: string}>({
     query: ({runId, testId}) => ({
       url: `/tests/${testId}/run/${runId}/stop`,
       method: HTTP_METHOD.POST,
     }),
   }),
-  getJUnitByRunId: builder.query<string, {testId: string; runId: string}>({
+  getJUnitByRunId: builder.query<string, {testId: string; runId: number}>({
     query: ({testId, runId}) => ({url: `/tests/${testId}/run/${runId}/junit.xml`, responseHandler: 'text'}),
     providesTags: (result, error, {testId, runId}) => [
       {type: TracetestApiTags.TEST_RUN, id: `${testId}-${runId}-junit`},
     ],
   }),
-  getSelectedSpans: builder.query<SelectedSpans, {testId: string; runId: string; query: string}>({
+  getSelectedSpans: builder.query<SelectedSpans, {testId: string; runId: number; query: string}>({
     query: ({testId, runId, query}) => `/tests/${testId}/run/${runId}/select?query=${encodeURIComponent(query)}`,
     providesTags: (result, error, {query}) => (result ? [{type: TracetestApiTags.SPAN, id: `${query}-LIST`}] : []),
     transformResponse: (rawSpanList: TRawSelectedSpans) => SelectedSpans(rawSpanList),
   }),
 
-  getRunEvents: builder.query<TestRunEvent[], {runId: string; testId: string}>({
+  getRunEvents: builder.query<TestRunEvent[], {runId: number; testId: string}>({
     query: ({runId, testId}) => `/tests/${testId}/run/${runId}/events`,
     providesTags: [{type: TracetestApiTags.TEST_RUN, id: 'EVENTS'}],
     transformResponse: (rawTestRunEvent: TRawTestRunEvent[]) => rawTestRunEvent.map(event => TestRunEvent(event)),

--- a/web/src/redux/apis/Tracetest/endpoints/TestSuiteRun.endpoint.ts
+++ b/web/src/redux/apis/Tracetest/endpoints/TestSuiteRun.endpoint.ts
@@ -41,7 +41,7 @@ export const testSuiteRunEndpoints = (builder: TTestApiEndpointBuilder) => ({
     }),
   }),
 
-  getTestSuiteRunById: builder.query<TestSuiteRun, {testSuiteId: string; runId: string}>({
+  getTestSuiteRunById: builder.query<TestSuiteRun, {testSuiteId: string; runId: number}>({
     query: ({testSuiteId, runId}) => `/testsuites/${testSuiteId}/run/${runId}`,
     providesTags: result => [{type: TracetestApiTags.TESTSUITE_RUN, id: result?.id}],
     transformResponse: (raw: TRawTestSuiteRunResourceRun) => TestSuiteRun(raw),
@@ -59,7 +59,7 @@ export const testSuiteRunEndpoints = (builder: TTestApiEndpointBuilder) => ({
     },
   }),
 
-  deleteTestSuiteRunById: builder.mutation<TestSuiteRun, {testSuiteId: string; runId: string}>({
+  deleteTestSuiteRunById: builder.mutation<TestSuiteRun, {testSuiteId: string; runId: number}>({
     query: ({testSuiteId, runId}) => ({
       url: `/testsuites/${testSuiteId}/run/${runId}`,
       method: HTTP_METHOD.DELETE,

--- a/web/src/selectors/Assertion.selectors.ts
+++ b/web/src/selectors/Assertion.selectors.ts
@@ -8,7 +8,7 @@ import {TSpanSelector} from '../types/Assertion.types';
 import SpanSelectors from './Span.selectors';
 
 const stateSelector = (state: RootState) => state;
-const paramsSelector = (state: RootState, testId: string, runId: string, spanIdList: string[] = []) => ({
+const paramsSelector = (state: RootState, testId: string, runId: number, spanIdList: string[] = []) => ({
   spanIdList,
   testId,
   runId,
@@ -17,12 +17,12 @@ const paramsSelector = (state: RootState, testId: string, runId: string, spanIdL
 const currentSelectorListSelector = (
   state: RootState,
   testId: string,
-  runId: string,
+  runId: number,
   spanIdList?: string[],
   currentSelectorList: TSpanSelector[] = []
 ) => currentSelectorList.map(({key}) => key);
 
-const attributeKeySelector = (state: RootState, testId: string, runId: string, spanIdList: string[], key: string) =>
+const attributeKeySelector = (state: RootState, testId: string, runId: number, spanIdList: string[], key: string) =>
   key;
 
 const selectMatchedSpanList = createSelector(stateSelector, paramsSelector, (state, {spanIdList, testId, runId}) => {

--- a/web/src/selectors/Span.selectors.ts
+++ b/web/src/selectors/Span.selectors.ts
@@ -4,7 +4,7 @@ import TracetestAPI from 'redux/apis/Tracetest/Tracetest.api';
 
 const spansStateSelector = (state: RootState) => state.spans;
 const stateSelector = (state: RootState) => state;
-const paramsSelector = (state: RootState, spanId: string, testId: string, runId: string) => ({spanId, testId, runId});
+const paramsSelector = (state: RootState, spanId: string, testId: string, runId: number) => ({spanId, testId, runId});
 
 const selectMatchedSpans = createSelector(
   spansStateSelector,

--- a/web/src/selectors/TestRun.selectors.ts
+++ b/web/src/selectors/TestRun.selectors.ts
@@ -6,9 +6,9 @@ import TracetestAPI from 'redux/apis/Tracetest';
 import TestRunService from 'services/TestRun.service';
 import {RootState} from '../redux/store';
 
-const selectParams = (state: RootState, params: {testId: string; runId: string; spanId: string}) => params;
+const selectParams = (state: RootState, params: {testId: string; runId: number; spanId: string}) => params;
 
-const selectTestRun = (state: RootState, params: {testId: string; runId: string; spanId: string}) => {
+const selectTestRun = (state: RootState, params: {testId: string; runId: number; spanId: string}) => {
   const {data} = TracetestAPI.instance.endpoints.getRunById.select({testId: params.testId, runId: params.runId})(state);
   return data ?? TestRun({});
 };

--- a/web/src/types/Generated.types.ts
+++ b/web/src/types/Generated.types.ts
@@ -1414,7 +1414,7 @@ export interface external {
         };
         ResolveContext: {
           testId?: string;
-          runId?: string;
+          runId?: number;
           spanId?: string;
           selector?: string;
           variableSetId?: string;
@@ -1860,7 +1860,7 @@ export interface external {
           requiredGatesResult?: external["testRunner.yaml"]["components"]["schemas"]["RequiredGatesResult"];
           metadata?: { [key: string]: string };
           testSuiteId?: string;
-          testSuiteRunId?: string;
+          testSuiteRunId?: number;
         };
         RunInformation: {
           metadata?: { [key: string]: string } | null;
@@ -1955,7 +1955,7 @@ export interface external {
           summary?: external["tests.yaml"]["components"]["schemas"]["TestSummary"];
         };
         TestSuiteRun: {
-          id?: string;
+          id?: number;
           version?: number;
           /** Format: date-time */
           createdAt?: string;

--- a/web/src/types/Generated.types.ts
+++ b/web/src/types/Generated.types.ts
@@ -1808,7 +1808,7 @@ export interface external {
           assertions?: string[];
         };
         TestRun: {
-          id?: string;
+          id?: number;
           traceId?: string;
           spanId?: string;
           /** @description Test version used when running this test run */


### PR DESCRIPTION
This PR changes the type of `TestRun` and `TestSuiteRun` id from `string` to `integer`. This was a discrepancy between our specs and our actual api and it was causing issues in some calls in our go client.


## Checklist

- [ ] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
