### PR TITLE
fix(cli): fix oauth flow

### DIFF
--- a/cli/config/config.go
+++ b/cli/config/config.go
@@ -126,7 +126,8 @@ func ParseServerURL(serverURL string) (scheme, endpoint string, serverPath *stri
 		return "", "", nil, fmt.Errorf("could not parse server URL: %w", err)
 	}
 
-	var path *string
+	defaultPath := "/"
+	path := &defaultPath
 	if url.Path != "" {
 		path = &url.Path
 	}

--- a/cli/config/config.go
+++ b/cli/config/config.go
@@ -17,6 +17,8 @@ var (
 	Version                 = "dev"
 	Env                     = "dev"
 	DefaultCloudAPIEndpoint = "http://localhost:8090"
+	DefaultCloudDomain      = "tracetest.io"
+	DefaultCloudPath        = "/"
 )
 
 type ConfigFlags struct {
@@ -126,8 +128,7 @@ func ParseServerURL(serverURL string) (scheme, endpoint string, serverPath *stri
 		return "", "", nil, fmt.Errorf("could not parse server URL: %w", err)
 	}
 
-	defaultPath := "/"
-	path := &defaultPath
+	var path *string
 	if url.Path != "" {
 		path = &url.Path
 	}

--- a/cli/config/configurator.go
+++ b/cli/config/configurator.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"strings"
 
 	"github.com/kubeshop/tracetest/cli/analytics"
 	"github.com/kubeshop/tracetest/cli/pkg/oauth"
@@ -58,6 +59,10 @@ func (c Configurator) Start(ctx context.Context, prev Config, flags ConfigFlags)
 	scheme, endpoint, path, err := ParseServerURL(serverURL)
 	if err != nil {
 		return err
+	}
+
+	if strings.Contains(serverURL, DefaultCloudDomain) {
+		path = &DefaultCloudPath
 	}
 
 	cfg := Config{

--- a/cli/pkg/oauth/oauth.go
+++ b/cli/pkg/oauth/oauth.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net"
 	"net/http"
+	"strings"
 	"sync"
 
 	"github.com/kubeshop/tracetest/cli/ui"
@@ -115,7 +116,7 @@ func (s *OAuthServer) start() error {
 
 func (s *OAuthServer) callback(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
-	w.Header().Set("Access-Control-Allow-Origin", s.frontendEndpoint)
+	w.Header().Set("Access-Control-Allow-Origin", strings.TrimSuffix(s.frontendEndpoint, "/"))
 
 	w.WriteHeader(http.StatusOK)
 	w.Write([]byte(`{"success": true}`))


### PR DESCRIPTION
This PR fixes the cli oauth flow by adding a `default path` and fixing the `Access-Control-Allow-Origin` header.

## Changes

- add `default path` and 
- fix `Access-Control-Allow-Origin` header

## Fixes

- 

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
