### PR TITLE
feat(agent): keep track of spans that were generated by tests

### DIFF
--- a/agent/collector/cache.go
+++ b/agent/collector/cache.go
@@ -1,0 +1,43 @@
+package collector
+
+import (
+	"sync"
+
+	gocache "github.com/Code-Hex/go-generics-cache"
+	v1 "go.opentelemetry.io/proto/otlp/trace/v1"
+)
+
+type TraceCache interface {
+	Get(string) ([]*v1.Span, bool)
+	Set(string, []*v1.Span)
+}
+
+type traceCache struct {
+	mutex         sync.Mutex
+	internalCache *gocache.Cache[string, []*v1.Span]
+}
+
+// Get implements TraceCache.
+func (c *traceCache) Get(traceID string) ([]*v1.Span, bool) {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+
+	return c.internalCache.Get(traceID)
+}
+
+// Set implements TraceCache.
+func (c *traceCache) Set(traceID string, spans []*v1.Span) {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+
+	existingTraces, _ := c.internalCache.Get(traceID)
+	spans = append(existingTraces, spans...)
+
+	c.internalCache.Set(traceID, spans)
+}
+
+func NewTraceCache() TraceCache {
+	return &traceCache{
+		internalCache: gocache.New[string, []*v1.Span](),
+	}
+}

--- a/agent/collector/collector_test.go
+++ b/agent/collector/collector_test.go
@@ -22,7 +22,7 @@ func TestCollector(t *testing.T) {
 
 	noopTracer := trace.NewNoopTracerProvider().Tracer("noop_tracer")
 
-	err = collector.Start(
+	c, err := collector.Start(
 		context.Background(),
 		collector.Config{
 			HTTPPort:        4318,
@@ -33,6 +33,8 @@ func TestCollector(t *testing.T) {
 		noopTracer,
 	)
 	require.NoError(t, err)
+
+	defer c.Stop()
 
 	tracer, err := mocks.NewTracer(context.Background(), "localhost:4317")
 	require.NoError(t, err)
@@ -62,7 +64,7 @@ func TestCollectorWatchingSpansFromTest(t *testing.T) {
 	cache := collector.NewTraceCache()
 	noopTracer := trace.NewNoopTracerProvider().Tracer("noop_tracer")
 
-	err = collector.Start(
+	c, err := collector.Start(
 		context.Background(),
 		collector.Config{
 			HTTPPort:        4318,
@@ -74,6 +76,8 @@ func TestCollectorWatchingSpansFromTest(t *testing.T) {
 		collector.WithTraceCache(cache),
 	)
 	require.NoError(t, err)
+
+	defer c.Stop()
 
 	tracer, err := mocks.NewTracer(context.Background(), "localhost:4317")
 	require.NoError(t, err)

--- a/agent/collector/collector_test.go
+++ b/agent/collector/collector_test.go
@@ -3,14 +3,17 @@ package collector_test
 import (
 	"context"
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/kubeshop/tracetest/agent/collector"
 	"github.com/kubeshop/tracetest/agent/collector/mocks"
+	"github.com/kubeshop/tracetest/server/pkg/id"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/otel/trace"
+	v1 "go.opentelemetry.io/proto/otlp/trace/v1"
 )
 
 func TestCollector(t *testing.T) {
@@ -50,4 +53,73 @@ func TestCollector(t *testing.T) {
 	// Now after waiting the timeout, it should contain all spans
 	time.Sleep(4 * time.Second)
 	assert.Len(t, targetServer.ReceivedSpans(), 10)
+}
+
+func TestCollectorWatchingSpansFromTest(t *testing.T) {
+	targetServer, err := mocks.NewOTLPIngestionServer()
+	require.NoError(t, err)
+
+	cache := collector.NewTraceCache()
+	noopTracer := trace.NewNoopTracerProvider().Tracer("noop_tracer")
+
+	err = collector.Start(
+		context.Background(),
+		collector.Config{
+			HTTPPort:        4318,
+			GRPCPort:        4317,
+			BatchTimeout:    2 * time.Second,
+			RemoteServerURL: targetServer.Addr(),
+		},
+		noopTracer,
+		collector.WithTraceCache(cache),
+	)
+	require.NoError(t, err)
+
+	tracer, err := mocks.NewTracer(context.Background(), "localhost:4317")
+	require.NoError(t, err)
+
+	watchedTraceID := id.NewRandGenerator().TraceID()
+	spanContext := trace.NewSpanContext(trace.SpanContextConfig{
+		TraceID: watchedTraceID,
+	})
+
+	ctx := trace.ContextWithSpanContext(context.Background(), spanContext)
+
+	cache.Set(watchedTraceID.String(), []*v1.Span{})
+
+	// 10 spans will be watched and stored in the cache
+	func(ctx context.Context) {
+		for i := 0; i < 10; i++ {
+			spanCtx, span := tracer.Start(ctx, fmt.Sprintf("watched span %d", i))
+			ctx = spanCtx
+
+			defer span.End()
+		}
+	}(ctx)
+
+	// 10 spans will not be watched neither stored in the cache
+	func(ctx context.Context) {
+		for i := 0; i < 10; i++ {
+			spanCtx, span := tracer.Start(ctx, fmt.Sprintf("span %d", i))
+			ctx = spanCtx
+
+			defer span.End()
+		}
+	}(context.Background())
+
+	time.Sleep(500 * time.Millisecond)
+	// Should not have any spans yet, because batch timeout is 2 seconds
+	assert.Len(t, targetServer.ReceivedSpans(), 0)
+
+	// Now after waiting the timeout, it should contain all spans
+	time.Sleep(4 * time.Second)
+	assert.Len(t, targetServer.ReceivedSpans(), 20)
+
+	cachedSpans, ok := cache.Get(watchedTraceID.String())
+	assert.True(t, ok)
+	assert.Len(t, cachedSpans, 10)
+	for _, span := range cachedSpans {
+		isWatched := strings.Contains(span.Name, "watched")
+		assert.True(t, isWatched)
+	}
 }

--- a/agent/collector/ingester.go
+++ b/agent/collector/ingester.go
@@ -65,9 +65,11 @@ func (i *forwardIngester) Ingest(ctx context.Context, request *pb.ExportTraceSer
 	i.buffer.spans = append(i.buffer.spans, request.ResourceSpans...)
 	i.buffer.mutex.Unlock()
 
-	// In case of OTLP datastore, those spans will be polled from this cache instead
-	// of a real datastore
-	i.cacheTestSpans(request.ResourceSpans)
+	if i.traceCache != nil {
+		// In case of OTLP datastore, those spans will be polled from this cache instead
+		// of a real datastore
+		i.cacheTestSpans(request.ResourceSpans)
+	}
 
 	return &pb.ExportTraceServiceResponse{
 		PartialSuccess: &pb.ExportTracePartialSuccess{

--- a/agent/collector/ingester.go
+++ b/agent/collector/ingester.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/kubeshop/tracetest/server/otlp"
+	"go.opencensus.io/trace"
 	pb "go.opentelemetry.io/proto/otlp/collector/trace/v1"
 	v1 "go.opentelemetry.io/proto/otlp/trace/v1"
 	"google.golang.org/grpc"
@@ -24,6 +25,7 @@ func newForwardIngester(ctx context.Context, batchTimeout time.Duration, remoteI
 		RemoteIngester: remoteIngesterConfig,
 		buffer:         &buffer{},
 		done:           make(chan bool),
+		traceCache:     remoteIngesterConfig.traceCache,
 	}
 
 	err := ingester.connectToRemoteServer(ctx)
@@ -44,11 +46,13 @@ type forwardIngester struct {
 	client         pb.TraceServiceClient
 	buffer         *buffer
 	done           chan bool
+	traceCache     TraceCache
 }
 
 type remoteIngesterConfig struct {
-	URL   string
-	Token string
+	URL        string
+	Token      string
+	traceCache TraceCache
 }
 
 type buffer struct {
@@ -60,6 +64,10 @@ func (i *forwardIngester) Ingest(ctx context.Context, request *pb.ExportTraceSer
 	i.buffer.mutex.Lock()
 	i.buffer.spans = append(i.buffer.spans, request.ResourceSpans...)
 	i.buffer.mutex.Unlock()
+
+	// In case of OTLP datastore, those spans will be polled from this cache instead
+	// of a real datastore
+	i.cacheTestSpans(request.ResourceSpans)
 
 	return &pb.ExportTraceServiceResponse{
 		PartialSuccess: &pb.ExportTracePartialSuccess{
@@ -122,6 +130,27 @@ func (i *forwardIngester) forwardSpans(ctx context.Context, spans []*v1.Resource
 	}
 
 	return nil
+}
+
+func (i *forwardIngester) cacheTestSpans(resourceSpans []*v1.ResourceSpans) {
+	spans := make(map[string][]*v1.Span)
+	for _, resourceSpan := range resourceSpans {
+		for _, scopedSpan := range resourceSpan.ScopeSpans {
+			for _, span := range scopedSpan.Spans {
+				traceID := trace.TraceID(span.TraceId).String()
+				spans[traceID] = append(spans[traceID], span)
+			}
+		}
+	}
+
+	for traceID, spans := range spans {
+		if _, ok := i.traceCache.Get(traceID); !ok {
+			// traceID is not part of a test
+			continue
+		}
+
+		i.traceCache.Set(traceID, spans)
+	}
 }
 
 func (i *forwardIngester) Stop() {

--- a/agent/initialization/start.go
+++ b/agent/initialization/start.go
@@ -4,17 +4,15 @@ import (
 	"context"
 	"fmt"
 
-	gocache "github.com/Code-Hex/go-generics-cache"
 	"github.com/kubeshop/tracetest/agent/client"
 	"github.com/kubeshop/tracetest/agent/collector"
 	"github.com/kubeshop/tracetest/agent/config"
 	"github.com/kubeshop/tracetest/agent/proto"
 	"github.com/kubeshop/tracetest/agent/workers"
-	"github.com/kubeshop/tracetest/server/traces"
 	"go.opentelemetry.io/otel/trace"
 )
 
-func NewClient(ctx context.Context, config config.Config) (*client.Client, error) {
+func NewClient(ctx context.Context, config config.Config, traceCache collector.TraceCache) (*client.Client, error) {
 	client, err := client.Connect(ctx, config.ServerURL,
 		client.WithAPIKey(config.APIKey),
 		client.WithAgentName(config.Name),
@@ -23,9 +21,7 @@ func NewClient(ctx context.Context, config config.Config) (*client.Client, error
 		return nil, err
 	}
 
-	tracesCache := gocache.New[string, []traces.Span]()
-
-	triggerWorker := workers.NewTriggerWorker(client, workers.WithTraceCache(tracesCache))
+	triggerWorker := workers.NewTriggerWorker(client, workers.WithTraceCache(traceCache))
 	pollingWorker := workers.NewPollerWorker(client)
 	dataStoreTestConnectionWorker := workers.NewTestConnectionWorker(client)
 
@@ -42,7 +38,8 @@ func NewClient(ctx context.Context, config config.Config) (*client.Client, error
 
 // Start the agent with given configuration
 func Start(ctx context.Context, config config.Config) error {
-	client, err := NewClient(ctx, config)
+	traceCache := collector.NewTraceCache()
+	client, err := NewClient(ctx, config, traceCache)
 	if err != nil {
 		return err
 	}
@@ -52,7 +49,7 @@ func Start(ctx context.Context, config config.Config) error {
 		return err
 	}
 
-	err = startCollector(ctx, config)
+	err = startCollector(ctx, config, traceCache)
 	if err != nil {
 		return err
 	}
@@ -61,14 +58,14 @@ func Start(ctx context.Context, config config.Config) error {
 	return nil
 }
 
-func startCollector(ctx context.Context, config config.Config) error {
+func startCollector(ctx context.Context, config config.Config, traceCache collector.TraceCache) error {
 	noopTracer := trace.NewNoopTracerProvider().Tracer("noop")
 	collectorConfig := collector.Config{
 		HTTPPort: config.OTLPServer.HTTPPort,
 		GRPCPort: config.OTLPServer.GRPCPort,
 	}
 
-	err := collector.Start(ctx, collectorConfig, noopTracer)
+	err := collector.Start(ctx, collectorConfig, noopTracer, collector.WithTraceCache(traceCache))
 	if err != nil {
 		return err
 	}

--- a/agent/initialization/start.go
+++ b/agent/initialization/start.go
@@ -65,7 +65,7 @@ func startCollector(ctx context.Context, config config.Config, traceCache collec
 		GRPCPort: config.OTLPServer.GRPCPort,
 	}
 
-	err := collector.Start(ctx, collectorConfig, noopTracer, collector.WithTraceCache(traceCache))
+	_, err := collector.Start(ctx, collectorConfig, noopTracer, collector.WithTraceCache(traceCache))
 	if err != nil {
 		return err
 	}

--- a/agent/initialization/start.go
+++ b/agent/initialization/start.go
@@ -4,10 +4,12 @@ import (
 	"context"
 	"fmt"
 
+	gocache "github.com/Code-Hex/go-generics-cache"
 	"github.com/kubeshop/tracetest/agent/client"
 	"github.com/kubeshop/tracetest/agent/config"
 	"github.com/kubeshop/tracetest/agent/proto"
 	"github.com/kubeshop/tracetest/agent/workers"
+	"github.com/kubeshop/tracetest/server/traces"
 )
 
 func NewClient(ctx context.Context, config config.Config) (*client.Client, error) {
@@ -19,7 +21,9 @@ func NewClient(ctx context.Context, config config.Config) (*client.Client, error
 		return nil, err
 	}
 
-	triggerWorker := workers.NewTriggerWorker(client)
+	tracesCache := gocache.New[string, []traces.Span]()
+
+	triggerWorker := workers.NewTriggerWorker(client, workers.WithTraceCache(tracesCache))
 	pollingWorker := workers.NewPollerWorker(client)
 	dataStoreTestConnectionWorker := workers.NewTestConnectionWorker(client)
 

--- a/agent/workers/trigger.go
+++ b/agent/workers/trigger.go
@@ -4,25 +4,25 @@ import (
 	"context"
 	"fmt"
 
-	gocache "github.com/Code-Hex/go-generics-cache"
 	"github.com/kubeshop/tracetest/agent/client"
+	"github.com/kubeshop/tracetest/agent/collector"
 	"github.com/kubeshop/tracetest/agent/proto"
 	agentTrigger "github.com/kubeshop/tracetest/agent/workers/trigger"
 	"github.com/kubeshop/tracetest/server/pkg/id"
 	"github.com/kubeshop/tracetest/server/test/trigger"
-	"github.com/kubeshop/tracetest/server/traces"
 	"go.opentelemetry.io/otel/trace"
+	v1 "go.opentelemetry.io/proto/otlp/trace/v1"
 )
 
 type TriggerWorker struct {
 	client     *client.Client
 	registry   *agentTrigger.Registry
-	traceCache *gocache.Cache[string, []traces.Span]
+	traceCache collector.TraceCache
 }
 
 type TriggerOption func(*TriggerWorker)
 
-func WithTraceCache(cache *gocache.Cache[string, []traces.Span]) TriggerOption {
+func WithTraceCache(cache collector.TraceCache) TriggerOption {
 	return func(tw *TriggerWorker) {
 		tw.traceCache = cache
 	}
@@ -64,7 +64,7 @@ func (w *TriggerWorker) Trigger(ctx context.Context, triggerRequest *proto.Trigg
 
 	// Set traceID to cache so the collector starts watching for incoming traces
 	// with same id
-	w.traceCache.Set(triggerRequest.TraceID, []traces.Span{})
+	w.traceCache.Set(triggerRequest.TraceID, []*v1.Span{})
 
 	response, err := triggerer.Trigger(ctx, triggerConfig, &agentTrigger.Options{
 		TraceID: traceID,

--- a/agent/workers/trigger.go
+++ b/agent/workers/trigger.go
@@ -62,9 +62,11 @@ func (w *TriggerWorker) Trigger(ctx context.Context, triggerRequest *proto.Trigg
 		return fmt.Errorf("invalid traceID was received in TriggerRequest: %w", err)
 	}
 
-	// Set traceID to cache so the collector starts watching for incoming traces
-	// with same id
-	w.traceCache.Set(triggerRequest.TraceID, []*v1.Span{})
+	if w.traceCache != nil {
+		// Set traceID to cache so the collector starts watching for incoming traces
+		// with same id
+		w.traceCache.Set(triggerRequest.TraceID, []*v1.Span{})
+	}
 
 	response, err := triggerer.Trigger(ctx, triggerConfig, &agentTrigger.Options{
 		TraceID: traceID,

--- a/agent/workers/trigger_test.go
+++ b/agent/workers/trigger_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/kubeshop/tracetest/agent/client"
 	"github.com/kubeshop/tracetest/agent/client/mocks"
+	"github.com/kubeshop/tracetest/agent/collector"
 	"github.com/kubeshop/tracetest/agent/proto"
 	"github.com/kubeshop/tracetest/agent/workers"
 	"github.com/stretchr/testify/assert"
@@ -16,12 +17,13 @@ import (
 )
 
 func TestTrigger(t *testing.T) {
+	cache := collector.NewTraceCache()
 	controlPlane := mocks.NewGrpcServer()
 
 	client, err := client.Connect(context.Background(), controlPlane.Addr())
 	require.NoError(t, err)
 
-	triggerWorker := workers.NewTriggerWorker(client)
+	triggerWorker := workers.NewTriggerWorker(client, workers.WithTraceCache(cache))
 
 	client.OnTriggerRequest(func(ctx context.Context, tr *proto.TriggerRequest) error {
 		err := triggerWorker.Trigger(ctx, tr)
@@ -32,11 +34,12 @@ func TestTrigger(t *testing.T) {
 	client.Start(context.Background())
 
 	targetServer := createHelloWorldApi()
+	traceID := "42a2c381da1a5b3a32bc4988bf2431b0"
 
 	triggerRequest := &proto.TriggerRequest{
 		TestID:  "my test",
 		RunID:   1,
-		TraceID: "42a2c381da1a5b3a32bc4988bf2431b0",
+		TraceID: traceID,
 		Trigger: &proto.Trigger{
 			Type: "http",
 			Http: &proto.HttpRequest{
@@ -59,6 +62,9 @@ func TestTrigger(t *testing.T) {
 	assert.Equal(t, "http", response.TriggerResult.Type)
 	assert.Equal(t, int32(http.StatusOK), response.TriggerResult.Http.StatusCode)
 	assert.JSONEq(t, `{"hello": "world"}`, response.TriggerResult.Http.Body)
+
+	_, traceIdIsWatched := cache.Get(traceID)
+	assert.True(t, traceIdIsWatched)
 }
 
 func createHelloWorldApi() *httptest.Server {

--- a/cli/pkg/starter/starter.go
+++ b/cli/pkg/starter/starter.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 
 	"github.com/golang-jwt/jwt/v4"
+	"github.com/kubeshop/tracetest/agent/collector"
 	agentConfig "github.com/kubeshop/tracetest/agent/config"
 	"github.com/kubeshop/tracetest/agent/initialization"
 
@@ -93,7 +94,8 @@ func (s *Starter) StartAgent(ctx context.Context, endpoint, name, agentApiKey, u
 	}
 
 	s.ui.Info(fmt.Sprintf("Starting Agent with name %s...", name))
-	client, err := initialization.NewClient(ctx, cfg)
+	cache := collector.NewTraceCache()
+	client, err := initialization.NewClient(ctx, cfg, cache)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This PR makes the agent's internal collector keep track of spans that are generated by tests triggered by the agent.

## Checklist

- [ ] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
