### PR TITLE
feat(agent): in-memory datastore to support otlp datastores

### DIFF
--- a/agent/initialization/start.go
+++ b/agent/initialization/start.go
@@ -9,6 +9,7 @@ import (
 	"github.com/kubeshop/tracetest/agent/config"
 	"github.com/kubeshop/tracetest/agent/proto"
 	"github.com/kubeshop/tracetest/agent/workers"
+	"github.com/kubeshop/tracetest/agent/workers/poller"
 	"go.opentelemetry.io/otel/trace"
 )
 
@@ -22,7 +23,9 @@ func NewClient(ctx context.Context, config config.Config, traceCache collector.T
 	}
 
 	triggerWorker := workers.NewTriggerWorker(client, workers.WithTraceCache(traceCache))
-	pollingWorker := workers.NewPollerWorker(client)
+	pollingWorker := workers.NewPollerWorker(client, workers.WithInMemoryDatastore(
+		poller.NewInMemoryDatastore(traceCache),
+	))
 	dataStoreTestConnectionWorker := workers.NewTestConnectionWorker(client)
 
 	client.OnDataStoreTestConnectionRequest(dataStoreTestConnectionWorker.Test)

--- a/agent/workers/poller/inmemory_datastore.go
+++ b/agent/workers/poller/inmemory_datastore.go
@@ -1,0 +1,60 @@
+package poller
+
+import (
+	"context"
+
+	"github.com/kubeshop/tracetest/agent/collector"
+	"github.com/kubeshop/tracetest/agent/workers/datastores/connection"
+	"github.com/kubeshop/tracetest/server/pkg/id"
+	"github.com/kubeshop/tracetest/server/tracedb"
+	"github.com/kubeshop/tracetest/server/traces"
+	"go.opentelemetry.io/otel/trace"
+)
+
+func NewInMemoryDatastore(cache collector.TraceCache) tracedb.TraceDB {
+	return &inmemoryDatastore{cache}
+}
+
+type inmemoryDatastore struct {
+	cache collector.TraceCache
+}
+
+// Close implements tracedb.TraceDB.
+func (d *inmemoryDatastore) Close() error {
+	return nil
+}
+
+// Connect implements tracedb.TraceDB.
+func (d *inmemoryDatastore) Connect(ctx context.Context) error {
+	return nil
+}
+
+// GetEndpoints implements tracedb.TraceDB.
+func (d *inmemoryDatastore) GetEndpoints() string {
+	return ""
+}
+
+// GetTraceByID implements tracedb.TraceDB.
+func (d *inmemoryDatastore) GetTraceByID(ctx context.Context, traceID string) (traces.Trace, error) {
+	spans, found := d.cache.Get(traceID)
+	if !found || len(spans) == 0 {
+		return traces.Trace{}, connection.ErrTraceNotFound
+	}
+
+	return traces.FromSpanList(spans), nil
+}
+
+// GetTraceID implements tracedb.TraceDB.
+func (d *inmemoryDatastore) GetTraceID() trace.TraceID {
+	return id.NewRandGenerator().TraceID()
+}
+
+// Ready implements tracedb.TraceDB.
+func (d *inmemoryDatastore) Ready() bool {
+	return true
+}
+
+// ShouldRetry implements tracedb.TraceDB.
+func (d *inmemoryDatastore) ShouldRetry() bool {
+	return true
+}

--- a/agent/workers/poller_test.go
+++ b/agent/workers/poller_test.go
@@ -151,7 +151,7 @@ func TestPollerWorkerWithInmemoryDatastore(t *testing.T) {
 
 	time.Sleep(1 * time.Second)
 
-	// expect traces to be sent to endpoint
+	// expect traces to not be sent to endpoint
 	pollingResponse := controlPlane.GetLastPollingResponse()
 	require.NotNil(t, pollingResponse, "agent did not send polling response back to server")
 


### PR DESCRIPTION
This PR makes the agent use an in-memory datastore that is populated by the collector when receiving traces in the OTLP endpoint.

## Checklist

- [ ] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [x] added a test
