### PR TITLE
feat(server): support event properties header

### DIFF
--- a/server/analytics/analytics.go
+++ b/server/analytics/analytics.go
@@ -1,6 +1,7 @@
 package analytics
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 )
@@ -66,4 +67,22 @@ func SendEvent(name, category, clientID string, data *map[string]string) error {
 	}
 
 	return err
+}
+
+func InjectProperties(data map[string]string, properties string) map[string]string {
+	if properties == "" {
+		return data
+	}
+
+	var p map[string]string
+	err := json.Unmarshal([]byte(properties), &p)
+	if err != nil {
+		return data
+	}
+
+	for k, v := range p {
+		data[k] = v
+	}
+
+	return data
 }

--- a/server/app/app.go
+++ b/server/app/app.go
@@ -368,11 +368,15 @@ func analyticsMW(next http.Handler) http.Handler {
 		routeName := mux.CurrentRoute(r).GetName()
 		machineID := r.Header.Get("x-client-id")
 		source := r.Header.Get("x-source")
+		eventProperties := r.Header.Get("x-event-properties")
+
+		eventData := map[string]string{
+			"source": source,
+		}
+		eventData = analytics.InjectProperties(eventData, eventProperties)
 
 		if routeName != "" {
-			analytics.SendEvent(toWords(routeName), "test", machineID, &map[string]string{
-				"source": source,
-			})
+			analytics.SendEvent(toWords(routeName), "test", machineID, &eventData)
 		}
 
 		next.ServeHTTP(w, r)

--- a/server/executor/assertion_runner.go
+++ b/server/executor/assertion_runner.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/kubeshop/tracetest/server/analytics"
 	"github.com/kubeshop/tracetest/server/expression"
+	"github.com/kubeshop/tracetest/server/http/middleware"
 	"github.com/kubeshop/tracetest/server/model/events"
 	"github.com/kubeshop/tracetest/server/pkg/maps"
 	"github.com/kubeshop/tracetest/server/pkg/pipeline"
@@ -80,6 +81,7 @@ func (e *defaultAssertionRunner) runAssertionsAndUpdateResult(ctx context.Contex
 		run = run.AssertionFailed(err)
 		analytics.SendEvent("test_run_finished", "error", "", &map[string]string{
 			"finalState": string(run.State),
+			"tenant_id":  middleware.TenantIDFromContext(ctx),
 		})
 
 		return test.Run{}, e.updater.Update(ctx, run)
@@ -139,6 +141,7 @@ func (e *defaultAssertionRunner) executeAssertions(ctx context.Context, req Job)
 
 	analytics.SendEvent("test_run_finished", "successful", "", &map[string]string{
 		"finalState": string(run.State),
+		"tenant_id":  middleware.TenantIDFromContext(ctx),
 	})
 
 	return run, nil

--- a/server/executor/linter_runner.go
+++ b/server/executor/linter_runner.go
@@ -6,6 +6,7 @@ import (
 	"log"
 
 	"github.com/kubeshop/tracetest/server/analytics"
+	"github.com/kubeshop/tracetest/server/http/middleware"
 	"github.com/kubeshop/tracetest/server/linter"
 	"github.com/kubeshop/tracetest/server/linter/analyzer"
 	"github.com/kubeshop/tracetest/server/model/events"
@@ -131,6 +132,7 @@ func (e *defaultLinterRunner) onError(ctx context.Context, job Job, run test.Run
 
 	analytics.SendEvent("test_run_finished", "error", "", &map[string]string{
 		"finalState": string(run.State),
+		"tenant_id":  middleware.TenantIDFromContext(ctx),
 	})
 
 	run = run.LinterError(err)

--- a/server/executor/trace_poller.go
+++ b/server/executor/trace_poller.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/kubeshop/tracetest/server/analytics"
 	"github.com/kubeshop/tracetest/server/executor/pollingprofile"
+	"github.com/kubeshop/tracetest/server/http/middleware"
 	"github.com/kubeshop/tracetest/server/model/events"
 	"github.com/kubeshop/tracetest/server/pkg/pipeline"
 	"github.com/kubeshop/tracetest/server/subscription"
@@ -204,6 +205,7 @@ func (tp tracePoller) handleTraceDBError(ctx context.Context, job Job, err error
 	run = run.TraceFailed(err)
 	analytics.SendEvent("test_run_finished", "error", "", &map[string]string{
 		"finalState": string(run.State),
+		"tenant_id":  middleware.TenantIDFromContext(ctx),
 	})
 
 	tp.handleDBError(tp.updater.Update(ctx, run))

--- a/server/executor/tracepollerworker/evaluator_worker.go
+++ b/server/executor/tracepollerworker/evaluator_worker.go
@@ -9,6 +9,7 @@ import (
 	"github.com/kubeshop/tracetest/server/analytics"
 	"github.com/kubeshop/tracetest/server/datastore"
 	"github.com/kubeshop/tracetest/server/executor"
+	"github.com/kubeshop/tracetest/server/http/middleware"
 	"github.com/kubeshop/tracetest/server/model/events"
 	"github.com/kubeshop/tracetest/server/pkg/pipeline"
 	"github.com/kubeshop/tracetest/server/resourcemanager"
@@ -98,6 +99,7 @@ func (w *tracePollerEvaluatorWorker) ProcessItem(ctx context.Context, job execut
 		run := job.Run.TraceFailed(err)
 		analytics.SendEvent("test_run_finished", "error", "", &map[string]string{
 			"finalState": string(run.State),
+			"tenant_id":  middleware.TenantIDFromContext(ctx),
 		})
 
 		handleDBError(w.state.updater.Update(ctx, run))


### PR DESCRIPTION
This PR adds support for the `x-event-properties` header in order to enhance the analytics middleware. It also adds the `tenant_id` (from context) in the `test_run_finished` event.

## Changes

- support for `x-event-properties` header
- add `tenant_id` in `test_run_finished` event

## Fixes

-

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
