### PR TITLE
chore: update tests to use a new pg version

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -32,7 +32,7 @@ services:
       TRACETEST_DATASTOREPIPELINES_TESTCONNECTION_ENABLED: ${TRACETEST_DATASTOREPIPELINES_TESTCONNECTION_ENABLED}
 
   postgres:
-    image: postgres:14
+    image: postgres:15.2
     environment:
       POSTGRES_PASSWORD: postgres
       POSTGRES_USER: postgres

--- a/server/testsuite/testsuite_repository.go
+++ b/server/testsuite/testsuite_repository.go
@@ -273,7 +273,7 @@ func (r *Repository) Get(ctx context.Context, id id.ID) (TestSuite, error) {
 
 func (r *Repository) get(ctx context.Context, id id.ID, augmented bool) (TestSuite, error) {
 	query, params := sqlutil.TenantWithPrefix(ctx, querySelect()+" WHERE t.id = $1", "t.", id)
-	stmt, err := r.db.Prepare(query + "ORDER BY t.version DESC LIMIT 1")
+	stmt, err := r.db.Prepare(query + " ORDER BY t.version DESC LIMIT 1")
 	if err != nil {
 		return TestSuite{}, fmt.Errorf("prepare: %w", err)
 	}

--- a/testing/cli-e2etest/environment/jaeger/server-setup/docker-compose-no-api.yaml
+++ b/testing/cli-e2etest/environment/jaeger/server-setup/docker-compose-no-api.yaml
@@ -28,7 +28,7 @@ services:
       TRACETEST_DEV: ${TRACETEST_DEV}
 
   postgres:
-    image: postgres:14
+    image: postgres:15.2
     environment:
       POSTGRES_PASSWORD: postgres
       POSTGRES_USER: postgres

--- a/testing/load/infra/docker-compose.yaml
+++ b/testing/load/infra/docker-compose.yaml
@@ -30,7 +30,7 @@ services:
       TRACETEST_DEV: ${TRACETEST_DEV}
 
   postgres:
-    image: postgres:14
+    image: postgres:15.2
     restart: unless-stopped
     environment:
       POSTGRES_PASSWORD: postgres


### PR DESCRIPTION
This PR updates our Dog food and CLI e2e tests to run with Postgres 15.2, to validate if there are more queries with malformation.

## Changes

- Updated dogfood tests to use Postgres 15.2
- Updated CLI e2e tests to use Postgres 15.2

## Fixes

- Order by Concatenation bug on TestSuite queries

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
