### PR TITLE
fix(server): allow analytics cfg override

### DIFF
--- a/server/analytics/analytics.go
+++ b/server/analytics/analytics.go
@@ -16,7 +16,7 @@ type noopTracker struct{}
 func (t noopTracker) Track(event string, props map[string]string) error { return nil }
 func (t noopTracker) Ready() bool                                       { return true }
 
-func Init(enabled bool, serverID, appVersion, env string) error {
+func Init(enabled bool, serverID, appVersion, env, secretKey, frontendKey string) error {
 	// ga not enabled, use dumb settings
 	if !enabled {
 		defaultClient = noopTracker{}
@@ -29,7 +29,7 @@ func Init(enabled bool, serverID, appVersion, env string) error {
 		return fmt.Errorf("could not get hostname: %w", err)
 	}
 
-	defaultClient = newSegmentTracker(hostname, serverID, appVersion, env)
+	defaultClient = newSegmentTracker(hostname, serverID, appVersion, env, secretKey, frontendKey)
 
 	return nil
 }

--- a/server/analytics/analytics_test.go
+++ b/server/analytics/analytics_test.go
@@ -8,19 +8,19 @@ import (
 )
 
 func TestReadyness(t *testing.T) {
-	analytics.Init(false, "serverID", "1.0", "env")
+	analytics.Init(false, "serverID", "1.0", "env", "123", "123")
 	assert.True(t, analytics.Ready())
 
-	analytics.Init(true, "serverID", "1.0", "env")
+	analytics.Init(true, "serverID", "1.0", "env", "123", "123")
 	assert.True(t, analytics.Ready())
 
-	analytics.Init(true, "serverID", "", "env")
+	analytics.Init(true, "serverID", "", "env", "", "")
 	assert.False(t, analytics.Ready())
 
-	analytics.Init(true, "", "1.0", "env")
+	analytics.Init(true, "", "1.0", "env", "", "")
 	assert.False(t, analytics.Ready())
 
-	analytics.Init(true, "serverID", "1.0", "")
+	analytics.Init(true, "serverID", "1.0", "", "", "")
 	assert.False(t, analytics.Ready())
 
 }

--- a/server/analytics/segment.go
+++ b/server/analytics/segment.go
@@ -9,7 +9,15 @@ var (
 	FrontendKey = ""
 )
 
-func newSegmentTracker(hostname, serverID, appVersion, env string) Tracker {
+func newSegmentTracker(hostname, serverID, appVersion, env, secretKey, frontendKey string) Tracker {
+	if secretKey != "" {
+		SecretKey = secretKey
+	}
+
+	if frontendKey != "" {
+		FrontendKey = frontendKey
+	}
+
 	client, _ := segment.NewWithConfig(SecretKey, segment.Config{
 		BatchSize: 1,
 	})

--- a/server/app/app.go
+++ b/server/app/app.go
@@ -134,7 +134,7 @@ func (app *App) subscribeToConfigChanges(sm *subscription.Manager) {
 }
 
 func (app *App) initAnalytics(configFromDB config.Config) error {
-	return analytics.Init(configFromDB.IsAnalyticsEnabled(), app.serverID, Version, Env)
+	return analytics.Init(configFromDB.IsAnalyticsEnabled(), app.serverID, Version, Env, app.cfg.AnalyticsServerKey(), app.cfg.AnalyticsFrontendKey())
 }
 
 var instanceID = id.GenerateID().String()

--- a/server/config/server.go
+++ b/server/config/server.go
@@ -91,6 +91,16 @@ var serverOptions = options{
 		defaultValue: "true",
 		description:  "enable otlp server",
 	},
+	{
+		key:          "analytics.serverKey",
+		defaultValue: "",
+		description:  "analytics server key",
+	},
+	{
+		key:          "analytics.frontendKey",
+		defaultValue: "",
+		description:  "analytics frontend key",
+	},
 }
 
 func init() {
@@ -180,4 +190,18 @@ func (c *AppConfig) OtlpServerEnabled() bool {
 	defer c.mu.Unlock()
 
 	return c.vp.GetString("otlpServer.enabled") == "true"
+}
+
+func (c *AppConfig) AnalyticsServerKey() string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	return c.vp.GetString("analytics.serverKey")
+}
+
+func (c *AppConfig) AnalyticsFrontendKey() string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	return c.vp.GetString("analytics.frontendKey")
 }


### PR DESCRIPTION
This PR updates the server config to allow analytics keys to override the ones provided during compilation.

## Changes

- Adds new analytics environment flags
- Overrides feature flags from the app config

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
