### PR TITLE
fix: skip server version validation

### DIFF
--- a/cli/cmd/start_cmd.go
+++ b/cli/cmd/start_cmd.go
@@ -18,7 +18,7 @@ var startCmd = &cobra.Command{
 	Use:     "start",
 	Short:   "Start Tracetest",
 	Long:    "Start using Tracetest",
-	PreRun:  setupCommand(),
+	PreRun:  setupCommand(SkipVersionMismatchCheck()),
 	Run: WithResultHandler((func(_ *cobra.Command, _ []string) (string, error) {
 		ctx := context.Background()
 


### PR DESCRIPTION
This PR makes the `tracetest start` command skip the server version validation.

##Why?
We gonna need to run `tracetest start --api-key <key>` and it will fail every time we update the cloud server, forcing all users to upgrade their agents

## Checklist

- [ ] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
