### PR TITLE
fix(server): Fixing nil Trace

### DIFF
--- a/server/executor/tracepollerworker/evaluator_worker.go
+++ b/server/executor/tracepollerworker/evaluator_worker.go
@@ -142,6 +142,11 @@ func (w *tracePollerEvaluatorWorker) ProcessItem(ctx context.Context, job execut
 	log.Printf("[TracePoller] Test %s Run %d: Done polling. (%s)", job.Test.ID, job.Run.ID, reason)
 
 	log.Printf("[TracePoller] Test %s Run %d: Start Sorting", job.Test.ID, job.Run.ID)
+	if job.Run.Trace == nil {
+		newTrace := traces.NewTrace(job.Run.TraceID.String(), []traces.Span{})
+		job.Run.Trace = &newTrace
+	}
+
 	sorted := job.Run.Trace.Sort()
 	job.Run.Trace = &sorted
 	log.Printf("[TracePoller] Test %s Run %d: Sorting complete", job.Test.ID, job.Run.ID)


### PR DESCRIPTION
This PR adds a check to validate if a trace is `nil` before starting to manipulate it as part of the evaluation process

## Changes

- Adds trace nil validation check

## Fixes

- https://github.com/kubeshop/tracetest-cloud/issues/140

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
