### PR TITLE
fix(CLI): Fixing CLI version command

### DIFF
--- a/cli/cmd/config.go
+++ b/cli/cmd/config.go
@@ -152,11 +152,7 @@ func teardownCommand(cmd *cobra.Command, args []string) {
 }
 
 func setupVersion() {
-	versionText, isVersionMatch = config.GetVersion(
-		context.Background(),
-		cliConfig,
-		config.GetAPIClient(cliConfig),
-	)
+	versionText, isVersionMatch = config.GetVersion(context.Background(), cliConfig)
 }
 
 func validateVersionMismatch() {

--- a/cli/config/version.go
+++ b/cli/config/version.go
@@ -9,20 +9,29 @@ import (
 
 const defaultVersionExtension = "json"
 
-func GetVersion(ctx context.Context, cfg Config, client *openapi.APIClient) (string, bool) {
+func GetVersion(ctx context.Context, cfg Config) (string, bool) {
 	result := fmt.Sprintf(`CLI: %s`, Version)
+
+	if cfg.UIEndpoint != "" {
+		scheme, endpoint, path, _ := ParseServerURL(cfg.UIEndpoint)
+		cfg.Scheme = scheme
+		cfg.Endpoint = endpoint
+		cfg.ServerPath = path
+	}
+	client := GetAPIClient(cfg)
 
 	if cfg.IsEmpty() {
 		return result + `
 Server: Not Configured`, false
 	}
 
-	version, err := getServerVersion(ctx, client)
+	meta, err := getVersionMetadata(ctx, client)
 	if err != nil {
 		return result + fmt.Sprintf(`
 Server: Failed to get the server version - %s`, err.Error()), false
 	}
 
+	version := meta.GetVersion()
 	isVersionMatch := version == Version
 	if isVersionMatch {
 		version += `
@@ -31,17 +40,6 @@ Server: Failed to get the server version - %s`, err.Error()), false
 
 	return result + fmt.Sprintf(`
 Server: %s`, version), isVersionMatch
-}
-
-func getServerVersion(ctx context.Context, client *openapi.APIClient) (string, error) {
-	resp, _, err := client.ApiApi.
-		GetVersion(ctx, defaultVersionExtension).
-		Execute()
-	if err != nil {
-		return "", err
-	}
-
-	return resp.GetVersion(), nil
 }
 
 func getVersionMetadata(ctx context.Context, client *openapi.APIClient) (*openapi.Version, error) {


### PR DESCRIPTION
This PR fixes the version command to point it to the cloud FE version file

## Changes

- Updates endpoint for the version function

## Fixes

- https://github.com/kubeshop/tracetest-cloud/issues/141

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
