### PR TITLE
fix(cli): Check if Agent API flag exists first

### DIFF
--- a/cli/config/configurator.go
+++ b/cli/config/configurator.go
@@ -99,16 +99,16 @@ func (c Configurator) Start(ctx context.Context, prev Config, flags ConfigFlags)
 		return Save(cfg)
 	}
 
-	if prev.Jwt != "" {
-		cfg.Jwt = prev.Jwt
-		cfg.Token = prev.Token
-
+	if flags.AgentApiKey != "" {
+		cfg.AgentApiKey = flags.AgentApiKey
 		c.ShowOrganizationSelector(ctx, cfg, flags)
 		return nil
 	}
 
-	if flags.AgentApiKey != "" {
-		cfg.AgentApiKey = flags.AgentApiKey
+	if prev.Jwt != "" {
+		cfg.Jwt = prev.Jwt
+		cfg.Token = prev.Token
+
 		c.ShowOrganizationSelector(ctx, cfg, flags)
 		return nil
 	}

--- a/web/src/pages/Home/CreateButton.tsx
+++ b/web/src/pages/Home/CreateButton.tsx
@@ -4,11 +4,12 @@ import * as S from '../TestSuites/TestSuites.styled';
 interface IProps {
   onCreate(): void;
   title?: string;
+  dataCy?: string;
 }
 
-const CreateButton = ({onCreate, title}: IProps) => (
+const CreateButton = ({onCreate, title, dataCy}: IProps) => (
   <S.ActionContainer>
-    <S.CreateTestButton operation={Operation.Edit} type="primary" data-cy="create-button" onClick={onCreate}>
+    <S.CreateTestButton operation={Operation.Edit} type="primary" data-cy={dataCy} onClick={onCreate}>
       {title || 'Create'}
     </S.CreateTestButton>
   </S.ActionContainer>

--- a/web/src/pages/Home/TestsList.tsx
+++ b/web/src/pages/Home/TestsList.tsx
@@ -67,7 +67,7 @@ const Tests = () => {
             onSortBy={(sortBy, sortDirection) => setParameters({sortBy, sortDirection})}
             isEmpty={pagination.list?.length === 0}
           />
-          <CreateButton onCreate={() => setIsCreateTestOpen(true)} />
+          <CreateButton onCreate={() => setIsCreateTestOpen(true)} dataCy="create-button" />
         </S.ActionsContainer>
 
         <Pagination<Test>

--- a/web/src/pages/TestSuites/TestSuitesList.tsx
+++ b/web/src/pages/TestSuites/TestSuitesList.tsx
@@ -66,7 +66,7 @@ const Resources = () => {
             onSortBy={(sortBy, sortDirection) => setParameters({sortBy, sortDirection})}
             isEmpty={pagination.list?.length === 0}
           />
-          <CreateButton onCreate={() => setIsCreateTestSuiteOpen(true)} />
+          <CreateButton onCreate={() => setIsCreateTestSuiteOpen(true)} dataCy="create-button" />
         </S.ActionsContainer>
 
         <Pagination<TestSuite>


### PR DESCRIPTION
This PR fixes an issue when switching between named and local mode where the agent API key wasn't used as the primary auth method.

## Changes

- Moves the agent API key check before the jwt

## Fixes

- https://github.com/kubeshop/tracetest-cloud/issues/148

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
