### PR TITLE
feat: cache hit metrics

### DIFF
--- a/server/app/app.go
+++ b/server/app/app.go
@@ -228,7 +228,7 @@ func (app *App) Start(opts ...appOption) error {
 	variableSetRepo := variableset.NewRepository(db)
 	linterRepo := analyzer.NewRepository(db)
 	testRepo := test.NewRepository(db)
-	runRepo := test.NewRunRepository(db, test.NewCache(instanceID))
+	runRepo := test.NewRunRepository(db, test.NewCache(instanceID, test.WithMetricMeter(meter)))
 	testRunnerRepo := testrunner.NewRepository(db)
 	tracesRepo := traces.NewTraceRepository(db)
 

--- a/server/telemetry/metrics.go
+++ b/server/telemetry/metrics.go
@@ -43,7 +43,7 @@ func newMeterProvider(ctx context.Context, cfg exporterConfig) (metric.MeterProv
 		return nil, fmt.Errorf("could not get collector exporter: %w", err)
 	}
 
-	interval := 60 * time.Second
+	interval := 10 * time.Second
 	if exporterConfig.MetricsReaderInterval != 0 {
 		interval = exporterConfig.MetricsReaderInterval
 	}


### PR DESCRIPTION
This PR adds metrics on the test run cache, it keeps track of two things:

* Number of cache requests (and register hits/misses)
* Histogram of cache latency

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Loom video

https://www.loom.com/share/4adc268b91a045409dbe216bb0c3a006
