### PR TITLE
fix: fixing cloud defaults

### DIFF
--- a/agent/config/config.go
+++ b/agent/config/config.go
@@ -38,7 +38,7 @@ func LoadConfig() (Config, error) {
 
 	vp.SetDefault("AGENT_NAME", getHostname())
 	vp.SetDefault("API_KEY", "")
-	vp.SetDefault("SERVER_URL", "https://cloud.tracetest.io")
+	vp.SetDefault("SERVER_URL", "https://app.tracetest.io")
 	vp.SetDefault("OTLP_SERVER.GRPC_PORT", 4317)
 	vp.SetDefault("OTLP_SERVER.HTTP_PORT", 4318)
 

--- a/agent/config/config_test.go
+++ b/agent/config/config_test.go
@@ -18,7 +18,7 @@ func TestConfigDefaults(t *testing.T) {
 
 	assert.Equal(t, "", cfg.APIKey)
 	assert.Equal(t, hostname, cfg.Name)
-	assert.Equal(t, "https://cloud.tracetest.io", cfg.ServerURL)
+	assert.Equal(t, "https://app.tracetest.io", cfg.ServerURL)
 	assert.Equal(t, 4317, cfg.OTLPServer.GRPCPort)
 	assert.Equal(t, 4318, cfg.OTLPServer.HTTPPort)
 }


### PR DESCRIPTION
This PR fixes the cloud default endpoints to point to the new prod url

## Changes

- cloud to app endpoints