### PR TITLE
fix: Settings styles

### DIFF
--- a/web/src/components/Settings/DataStore/DataStore.styled.ts
+++ b/web/src/components/Settings/DataStore/DataStore.styled.ts
@@ -12,7 +12,6 @@ export const Title = styled(Typography.Title)`
 export const Wrapper = styled.div`
   display: flex;
   flex-direction: column;
-  margin-bottom: 24px;
   background: ${({theme}) => theme.color.white};
 `;
 

--- a/web/src/components/Settings/DataStoreForm/DataStoreForm.styled.ts
+++ b/web/src/components/Settings/DataStoreForm/DataStoreForm.styled.ts
@@ -2,12 +2,12 @@ import styled, {css} from 'styled-components';
 import {Tabs, Typography} from 'antd';
 import {CheckCircleOutlined} from '@ant-design/icons';
 
-const defaultHeight = 'calc(100vh - 106px - 48px);';
+const defaultHeight = '100vh - 106px - 60px - 40px';
 
 export const FormContainer = styled.div`
   display: grid;
   grid-template-columns: auto 1fr;
-  height: ${defaultHeight};
+  height: calc(${defaultHeight} - 48px);
   overflow: hidden;
 `;
 
@@ -16,7 +16,7 @@ export const FactoryContainer = styled.div`
   flex-direction: column;
   padding: 22px 0;
   justify-content: space-between;
-  height: ${defaultHeight};
+  height: calc(${defaultHeight} - 25px);
   overflow-y: scroll;
 
   .ant-form-item {
@@ -32,7 +32,7 @@ export const TopContainer = styled.div`
 `;
 
 export const DataStoreListContainer = styled(Tabs)`
-  height: calc(100vh - 25px - 106px - 48px);
+  height: calc(${defaultHeight} - 50px);
 
   && {
     .ant-tabs-content-holder {


### PR DESCRIPTION
This PR fixes the settings styles to not be pushed down based on the different banners that can appear on screen

## Changes

- Updates default height and spacing

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Screenshots

![Screenshot 2023-10-05 at 10 18 47](https://github.com/kubeshop/tracetest/assets/11051031/a5fd8500-fb39-47ec-82ca-f377e4cce030)
