### PR TITLE
Update git clone

### DIFF
--- a/docs/docs/getting-started/open.mdx
+++ b/docs/docs/getting-started/open.mdx
@@ -22,7 +22,7 @@ Once you've installed Tracetest, as explained in the [installation guide](./inst
 To create tests quickly, start the official sample called Pokeshop API.
 
 ```bash title=Terminal
-git clone https://github.com/kubeshop/tracetest.git
+git clone --depth 1 https://github.com/kubeshop/tracetest.git
 cd tracetest/examples/tracetest-agent/pokeshop/
 docker-compose up
 ```


### PR DESCRIPTION
The repository is quite large and downloading the whole git history wouldn't be helpful apart from increasing the download time. This fix helps increase the speed of the clone. 