### PR TITLE
fix(cli): check for docker-compose on installer

### DIFF
--- a/cli/installer/docker_compose.go
+++ b/cli/installer/docker_compose.go
@@ -18,6 +18,8 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+var localSystemDockerComposeCommand = "docker compose"
+
 var dockerCompose = installer{
 	name: "docker-compose",
 	preChecks: []preChecker{
@@ -70,7 +72,8 @@ func dockerComposeInstaller(config configuration, ui cliUI.UI) {
 	dockerComposeFName := filepath.Join(dir, dockerComposeFilename)
 
 	dockerCmd := fmt.Sprintf(
-		"docker compose -f %s up -d",
+		"%s -f %s up -d",
+		localSystemDockerComposeCommand,
 		dockerComposeFName,
 	)
 
@@ -364,7 +367,14 @@ func dockerReadyChecker(ui cliUI.UI) {
 }
 
 func dockerComposeChecker(ui cliUI.UI) {
+	if commandSuccess("docker-compose") {
+		localSystemDockerComposeCommand = "docker-compose"
+		ui.Println(ui.Green("✔ docker-compose already installed"))
+		return
+	}
+
 	if commandSuccess("docker compose") {
+		localSystemDockerComposeCommand = "docker compose"
 		ui.Println(ui.Green("✔ docker compose already installed"))
 		return
 	}


### PR DESCRIPTION
This PR makes the installer check for both `docker compose` and `docker-compose` (dash vs space) when doing system checks. On install success, it shows the correct command in the message, depending on the system check

![Screenshot 2023-10-09 at 18 02 06](https://github.com/kubeshop/tracetest/assets/314548/4f02fa69-4662-40a5-a9d4-d6b7e7dd37ca)

## Changes

- check for `docker-compose` on installer

## Fixes

- https://github.com/kubeshop/tracetest/issues/3229

## Checklist

- [ ] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Loom video

Add your loom video here if your work can be visualized
