### PR TITLE
chore(frontend): remove unneeded flag

### DIFF
--- a/web/src/components/CustomizationWrapper/CustomizationWrapper.tsx
+++ b/web/src/components/CustomizationWrapper/CustomizationWrapper.tsx
@@ -6,7 +6,6 @@ interface IProps {
 }
 
 const flagValues = {
-  [Flag.IsAnalyticsPageEnabled]: true,
   [Flag.IsAgentDataStoreEnabled]: false,
   [Flag.IsLocalModeEnabled]: false,
 };

--- a/web/src/pages/Settings/Content.tsx
+++ b/web/src/pages/Settings/Content.tsx
@@ -7,7 +7,7 @@ import Linter from 'components/Settings/Linter';
 import Polling from 'components/Settings/Polling';
 import TestRunner from 'components/Settings/TestRunner';
 import BetaBadge from 'components/BetaBadge/BetaBadge';
-import {Flag, useCustomization, withCustomization} from 'providers/Customization';
+import {useCustomization, withCustomization} from 'providers/Customization';
 import * as S from './Settings.styled';
 
 const TabsKeys = {
@@ -40,11 +40,9 @@ const Content = () => {
           <Tabs.TabPane key={TabsKeys.DataStore} tab="Configure Data Store">
             <DataStore />
           </Tabs.TabPane>
-          {getFlag(Flag.IsAnalyticsPageEnabled) && (
-            <Tabs.TabPane key={TabsKeys.Analytics} tab="Analytics">
-              <Analytics />
-            </Tabs.TabPane>
-          )}
+          <Tabs.TabPane key={TabsKeys.Analytics} tab="Analytics">
+            <Analytics />
+          </Tabs.TabPane>
           <Tabs.TabPane key={TabsKeys.Polling} tab="Trace Polling">
             <Polling />
           </Tabs.TabPane>

--- a/web/src/providers/Customization/Customization.provider.tsx
+++ b/web/src/providers/Customization/Customization.provider.tsx
@@ -7,7 +7,6 @@ export enum Operation {
 }
 
 export enum Flag {
-  IsAnalyticsPageEnabled = 'isAnalyticsPageEnabled',
   IsAgentDataStoreEnabled = 'isAgentDataStoreEnabled',
   IsLocalModeEnabled = 'isLocalModeEnabled',
 }


### PR DESCRIPTION
This PR removes the unneeded `IsAnalyticsPageEnabled` flag.

## Changes

- remove `IsAnalyticsPageEnabled` flag

## Fixes

-

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test