### PR TITLE
fix: use histogram to keep track of request counts

### DIFF
--- a/.goreleaser.demo.yaml
+++ b/.goreleaser.demo.yaml
@@ -25,8 +25,8 @@ builds:
     binary: tracetest-server
     main: ./server/main.go
     ldflags:
-    - -X github.com/kubeshop/tracetest/server/app.Version={{ .Env.VERSION }}
-    - -X github.com/kubeshop/tracetest/server/app.Env={{ .Env.TRACETEST_ENV }}
+    - -X github.com/kubeshop/tracetest/server/version.Version={{ .Env.VERSION }}
+    - -X github.com/kubeshop/tracetest/server/version.Env={{ .Env.TRACETEST_ENV }}
     - -X github.com/kubeshop/tracetest/server/analytics.SecretKey={{ .Env.ANALYTICS_BE_KEY }}
     - -X github.com/kubeshop/tracetest/server/analytics.FrontendKey={{ .Env.ANALYTICS_FE_KEY }}
     env:

--- a/.goreleaser.dev.yaml
+++ b/.goreleaser.dev.yaml
@@ -28,8 +28,8 @@ builds:
     binary: tracetest-server
     main: ./server/main.go
     ldflags:
-    - -X github.com/kubeshop/tracetest/server/app.Version={{ .Env.VERSION }}
-    - -X github.com/kubeshop/tracetest/server/app.Env={{ .Env.TRACETEST_ENV }}
+    - -X github.com/kubeshop/tracetest/server/version.Version={{ .Env.VERSION }}
+    - -X github.com/kubeshop/tracetest/server/version.Env={{ .Env.TRACETEST_ENV }}
     - -X github.com/kubeshop/tracetest/server/analytics.SecretKey={{ .Env.ANALYTICS_BE_KEY }}
     - -X github.com/kubeshop/tracetest/server/analytics.FrontendKey={{ .Env.ANALYTICS_FE_KEY }}
     env:

--- a/.goreleaser.rc.yaml
+++ b/.goreleaser.rc.yaml
@@ -27,8 +27,8 @@ builds:
     binary: tracetest-server
     main: ./server/main.go
     ldflags:
-    - -X github.com/kubeshop/tracetest/server/app.Version={{ .Env.VERSION }}
-    - -X github.com/kubeshop/tracetest/server/app.Env={{ .Env.TRACETEST_ENV }}
+    - -X github.com/kubeshop/tracetest/server/version.Version={{ .Env.VERSION }}
+    - -X github.com/kubeshop/tracetest/server/version.Env={{ .Env.TRACETEST_ENV }}
     - -X github.com/kubeshop/tracetest/server/analytics.SecretKey={{ .Env.ANALYTICS_BE_KEY }}
     - -X github.com/kubeshop/tracetest/server/analytics.FrontendKey={{ .Env.ANALYTICS_FE_KEY }}
     env:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -29,8 +29,8 @@ builds:
     binary: tracetest-server
     main: ./server/main.go
     ldflags:
-    - -X github.com/kubeshop/tracetest/server/app.Version={{ .Env.VERSION }}
-    - -X github.com/kubeshop/tracetest/server/app.Env={{ .Env.TRACETEST_ENV }}
+    - -X github.com/kubeshop/tracetest/server/version.Version={{ .Env.VERSION }}
+    - -X github.com/kubeshop/tracetest/server/version.Env={{ .Env.TRACETEST_ENV }}
     - -X github.com/kubeshop/tracetest/server/analytics.SecretKey={{ .Env.ANALYTICS_BE_KEY }}
     - -X github.com/kubeshop/tracetest/server/analytics.FrontendKey={{ .Env.ANALYTICS_FE_KEY }}
     env:

--- a/server/Makefile
+++ b/server/Makefile
@@ -1,8 +1,8 @@
 VERSION ?= "dev"
 TRACETEST_ENV ?= "dev"
 GO_LDFLAGS := $(shell echo \
-		-X "'github.com/kubeshop/tracetest/server/app.Version=$(VERSION)'" \
-		-X "'github.com/kubeshop/tracetest/server/app.Env=$(TRACETEST_ENV)'" \
+		-X "'github.com/kubeshop/tracetest/server/version.Version=$(VERSION)'" \
+		-X "'github.com/kubeshop/tracetest/server/version.Env=$(TRACETEST_ENV)'" \
 		-X "'github.com/kubeshop/tracetest/server/analytics.SecretKey=$(ANALYTICS_BE_KEY)'" \
 		-X "'github.com/kubeshop/tracetest/server/analytics.FrontendKey=$(ANALYTICS_FE_KEY)'" \
 	| sed 's/ / /g')

--- a/server/app/app.go
+++ b/server/app/app.go
@@ -41,14 +41,12 @@ import (
 	"github.com/kubeshop/tracetest/server/tracedb"
 	"github.com/kubeshop/tracetest/server/traces"
 	"github.com/kubeshop/tracetest/server/variableset"
+	"github.com/kubeshop/tracetest/server/version"
 	"go.opentelemetry.io/otel/metric"
 	"go.opentelemetry.io/otel/trace"
 )
 
 var (
-	Version = "dev"
-	Env     = "dev"
-
 	pgChannelName = "tracetest_queue"
 )
 
@@ -71,7 +69,7 @@ func New(config *config.AppConfig) (*App, error) {
 }
 
 func (app *App) Version() string {
-	return fmt.Sprintf("tracetest-server %s (%s)", Version, Env)
+	return fmt.Sprintf("tracetest-server %s (%s)", version.Version, version.Env)
 }
 
 func (app *App) Stop() {
@@ -135,7 +133,7 @@ func (app *App) subscribeToConfigChanges(sm *subscription.Manager) {
 }
 
 func (app *App) initAnalytics(configFromDB config.Config) error {
-	return analytics.Init(configFromDB.IsAnalyticsEnabled(), app.serverID, Version, Env, app.cfg.AnalyticsServerKey(), app.cfg.AnalyticsFrontendKey())
+	return analytics.Init(configFromDB.IsAnalyticsEnabled(), app.serverID, version.Version, version.Env, app.cfg.AnalyticsServerKey(), app.cfg.AnalyticsFrontendKey())
 }
 
 var instanceID = id.GenerateID().String()
@@ -407,8 +405,8 @@ func registerSPAHandler(router *mux.Router, cfg httpServerConfig, analyticsEnabl
 				cfg,
 				analyticsEnabled,
 				serverID,
-				Version,
-				Env,
+				version.Version,
+				version.Env,
 				isTracetestDev,
 			),
 		)
@@ -642,7 +640,7 @@ func httpRouter(
 
 		tracedbFactory,
 		mappers,
-		Version,
+		version.Version,
 	)
 	apiApiController := openapi.NewApiApiController(controller)
 	customController := httpServer.NewCustomController(controller, apiApiController, openapi.DefaultErrorHandler, tracer)

--- a/server/telemetry/resource.go
+++ b/server/telemetry/resource.go
@@ -5,6 +5,7 @@ import (
 	"os"
 
 	"github.com/kubeshop/tracetest/server/config"
+	"github.com/kubeshop/tracetest/server/version"
 	"go.opentelemetry.io/otel/sdk/resource"
 	semconv "go.opentelemetry.io/otel/semconv/v1.21.0"
 )
@@ -26,6 +27,7 @@ func getResource(cfg *config.TelemetryExporterOption) (*resource.Resource, error
 			semconv.SchemaURL,
 			semconv.ServiceNameKey.String(serviceName),
 			semconv.HostName(hostname),
+			semconv.ServiceVersion(version.Version),
 		),
 	)
 

--- a/server/telemetry/tracer.go
+++ b/server/telemetry/tracer.go
@@ -9,9 +9,7 @@ import (
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc"
 	"go.opentelemetry.io/otel/propagation"
-	"go.opentelemetry.io/otel/sdk/resource"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
-	semconv "go.opentelemetry.io/otel/semconv/v1.21.0"
 	"go.opentelemetry.io/otel/trace"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
@@ -58,14 +56,7 @@ func NewTracerProvider(ctx context.Context, exporterConfig *config.TelemetryExpo
 		return sdktrace.NewTracerProvider(), nil
 	}
 
-	r, err := resource.Merge(
-		resource.Default(),
-		resource.NewWithAttributes(
-			semconv.SchemaURL,
-			semconv.ServiceNameKey.String(exporterConfig.ServiceName),
-		),
-	)
-
+	r, err := getResource(exporterConfig)
 	if err != nil {
 		return nil, fmt.Errorf("could not get provider resource: %w", err)
 	}

--- a/server/version/version.go
+++ b/server/version/version.go
@@ -1,0 +1,6 @@
+package version
+
+var (
+	Version = "dev"
+	Env     = "dev"
+)


### PR DESCRIPTION
This PR fixes all counter metrics. It uses a histogram instead of the `metric.Counter` which is accumulative over time

## Changes

-

## Fixes

-

## Checklist

- [ ] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Loom video

Add your loom video here if your work can be visualized
