### PR TITLE
chore(cli): UX Improvements

### DIFF
--- a/agent/workers/poller.go
+++ b/agent/workers/poller.go
@@ -50,7 +50,6 @@ func NewPollerWorker(client *client.Client, opts ...PollerOption) *PollerWorker 
 }
 
 func (w *PollerWorker) Poll(ctx context.Context, request *proto.PollingRequest) error {
-	fmt.Println("Poll handled by agent")
 	datastoreConfig, err := convertProtoToDataStore(request.Datastore)
 	if err != nil {
 		return err

--- a/agent/workers/trigger.go
+++ b/agent/workers/trigger.go
@@ -51,7 +51,6 @@ func NewTriggerWorker(client *client.Client, opts ...TriggerOption) *TriggerWork
 }
 
 func (w *TriggerWorker) Trigger(ctx context.Context, triggerRequest *proto.TriggerRequest) error {
-	fmt.Println("Trigger handled by agent")
 	triggerConfig := convertProtoToTrigger(triggerRequest.Trigger)
 	triggerer, err := w.registry.Get(triggerConfig.Type)
 	if err != nil {

--- a/cli/cmd/start_cmd.go
+++ b/cli/cmd/start_cmd.go
@@ -19,7 +19,7 @@ var startCmd = &cobra.Command{
 	Use:     "start",
 	Short:   "Start Tracetest",
 	Long:    "Start using Tracetest",
-	PreRun:  setupCommand(SkipVersionMismatchCheck()),
+	PreRun:  setupCommand(SkipConfigValidation()),
 	Run: WithResultHandler((func(_ *cobra.Command, _ []string) (string, error) {
 		ctx := context.Background()
 

--- a/cli/config/configurator.go
+++ b/cli/config/configurator.go
@@ -113,6 +113,12 @@ func (c Configurator) Start(ctx context.Context, prev Config, flags ConfigFlags)
 		return nil
 	}
 
+	confirmed := c.ui.Enter("Lets get to it! Press enter to launch a browser and authenticate:")
+	if !confirmed {
+		c.ui.Finish()
+		return nil
+	}
+
 	oauthServer := oauth.NewOAuthServer(fmt.Sprintf("%s%s", cfg.URL(), cfg.Path()), cfg.UIEndpoint)
 	err = oauthServer.WithOnSuccess(c.onOAuthSuccess(ctx, cfg)).
 		WithOnFailure(c.onOAuthFailure).

--- a/cli/config/selector.go
+++ b/cli/config/selector.go
@@ -26,7 +26,8 @@ func (c Configurator) organizationSelector(ctx context.Context, cfg Config) (str
 	}
 
 	if len(elements) == 1 {
-		c.ui.Println(fmt.Sprintf("Defaulting to only available Organization: %s", elements[0].Name))
+		c.ui.Println(fmt.Sprintf(`
+Defaulting to only available Organization: %s`, elements[0].Name))
 		return elements[0].ID, nil
 	}
 
@@ -43,7 +44,8 @@ func (c Configurator) organizationSelector(ctx context.Context, cfg Config) (str
 		}
 	}
 
-	option := c.ui.Select("What Organization do you want to use?", options, 0)
+	option := c.ui.Select(`
+What Organization do you want to use?`, options, 0)
 	option.Fn(c.ui)
 
 	return orgID, nil

--- a/cli/ui/ui.go
+++ b/cli/ui/ui.go
@@ -32,6 +32,7 @@ type UI interface {
 	Red(string) string
 
 	Confirm(prompt string, defaultValue bool) bool
+	Enter(msg string) bool
 	Select(prompt string, options []Option, defaultIndex int) (selected Option)
 	TextInput(msg, defaultValue string) string
 }
@@ -110,6 +111,25 @@ func (ui ptermUI) Confirm(msg string, defaultValue bool) bool {
 		ConfirmStyle: &pterm.ThemeDefault.SuccessMessageStyle,
 		RejectText:   "No",
 		RejectStyle:  &pterm.ThemeDefault.ErrorMessageStyle,
+		SuffixStyle:  &pterm.ThemeDefault.SecondaryStyle,
+	}).
+		Show()
+	if err != nil {
+		ui.Panic(err)
+	}
+
+	return confirm
+}
+
+func (ui ptermUI) Enter(msg string) bool {
+	confirm, err := (&pterm.InteractiveConfirmPrinter{
+		DefaultText:  msg,
+		DefaultValue: true,
+		TextStyle:    &pterm.ThemeDefault.DefaultText,
+		ConfirmText:  "Enter",
+		RejectText:   "Cancel",
+		RejectStyle:  &pterm.ThemeDefault.ErrorMessageStyle,
+		ConfirmStyle: &pterm.ThemeDefault.SuccessMessageStyle,
 		SuffixStyle:  &pterm.ThemeDefault.SecondaryStyle,
 	}).
 		Show()


### PR DESCRIPTION
This PR updates a couple of things regarding the `tracetest start` command to show better messaging and remove some of the things we don't need

## Changes

- Adds start message to inform the user what we are trying to accomplish
- Removes log messages from agent workers
- Fixes stop agent logic (again 🥴 )

## Fixes

- [Change tracetest start CLI to add initial instructions and prompt for launching authentication#192](https://github.com/kubeshop/tracetest-cloud/issues/192)
- https://github.com/kubeshop/tracetest-cloud/issues/136

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Loom video
https://www.loom.com/share/8bb1e837317c4641ac2795ae47e0ff9c

