### PR TITLE
chore(cli): Adding otlp server error handling

### DIFF
--- a/agent/initialization/start.go
+++ b/agent/initialization/start.go
@@ -2,6 +2,7 @@ package initialization
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/kubeshop/tracetest/agent/client"
@@ -12,6 +13,8 @@ import (
 	"github.com/kubeshop/tracetest/agent/workers/poller"
 	"go.opentelemetry.io/otel/trace"
 )
+
+var ErrOtlpServerStart = errors.New("OTLP server start error")
 
 func NewClient(ctx context.Context, config config.Config, traceCache collector.TraceCache) (*client.Client, error) {
 	client, err := client.Connect(ctx, config.ServerURL,
@@ -72,7 +75,7 @@ func StartCollector(ctx context.Context, config config.Config, traceCache collec
 
 	_, err := collector.Start(ctx, collectorConfig, noopTracer, collector.WithTraceCache(traceCache), collector.WithStartRemoteServer(false))
 	if err != nil {
-		return err
+		return ErrOtlpServerStart
 	}
 
 	return nil

--- a/cli/pkg/starter/starter.go
+++ b/cli/pkg/starter/starter.go
@@ -3,6 +3,7 @@ package starter
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 
 	"github.com/golang-jwt/jwt/v4"
@@ -110,6 +111,14 @@ func (s *Starter) StartAgent(ctx context.Context, endpoint, agentApiKey, uiEndpo
 
 	s.ui.Info(fmt.Sprintf("Starting Agent with name %s...", cfg.Name))
 	session, err := initialization.Start(ctx, cfg)
+
+	if err != nil && errors.Is(err, initialization.ErrOtlpServerStart) {
+		s.ui.Error("Tracetest Agent binds to the OpenTelemetry ports 4317 and 4318 which are used to receive trace information from your system. The agent tried to bind to these ports, but failed.")
+		s.ui.Error("Please stop the process currently listening on these ports and enter to try again.")
+
+		return nil
+	}
+
 	if err != nil {
 		return err
 	}

--- a/cli/pkg/starter/starter.go
+++ b/cli/pkg/starter/starter.go
@@ -115,7 +115,7 @@ func (s *Starter) StartAgent(ctx context.Context, endpoint, agentApiKey, uiEndpo
 		session, err = initialization.Start(ctx, cfg)
 		if err != nil && errors.Is(err, initialization.ErrOtlpServerStart) {
 			s.ui.Error("Tracetest Agent binds to the OpenTelemetry ports 4317 and 4318 which are used to receive trace information from your system. The agent tried to bind to these ports, but failed.")
-			shouldRetry := s.ui.Enter("Please stop the process currently listening on these ports and enter to try again.")
+			shouldRetry := s.ui.Enter("Please stop the process currently listening on these ports and press enter to try again.")
 
 			if !shouldRetry {
 				s.ui.Finish()


### PR DESCRIPTION
This PR updates the error message when the ports for the OTLP server are not available to be more descriptive instead of just the default error

## Changes

- Updates error message
- Adds custom error

## Fixes

- https://github.com/kubeshop/tracetest-cloud/issues/116

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Loom video
https://www.loom.com/share/4660f8bbbb0441e492cba69b73aa7e05
