### PR TITLE
fix(server): panic on concurrent read write

### DIFF
--- a/server/traces/caching.go
+++ b/server/traces/caching.go
@@ -26,10 +26,16 @@ func resetCache() {
 }
 
 func (c spanCache) Get(key string) (*Span, bool) {
+	cacheMutex.Lock()
+	defer cacheMutex.Unlock()
+
 	value, ok := c[key]
 	return value, ok
 }
 
 func (c spanCache) Set(key string, value *Span) {
+	cacheMutex.Lock()
+	defer cacheMutex.Unlock()
+
 	c[key] = value
 }


### PR DESCRIPTION
This PR adds mutex locks to prevent a concurrent map read/write on spans cache.
I hit this issue a few times but it's hard to reproduce

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
