### PR TITLE
feat(cli): Token Support

### DIFF
--- a/cli/cmd/start_cmd.go
+++ b/cli/cmd/start_cmd.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"context"
+	"os"
 
 	agentConfig "github.com/kubeshop/tracetest/agent/config"
 	"github.com/kubeshop/tracetest/cli/config"
@@ -10,8 +11,9 @@ import (
 )
 
 var (
-	start      = starter.NewStarter(configurator, resources)
-	saveParams = &saveParameters{}
+	start        = starter.NewStarter(configurator, resources)
+	defaultToken = os.Getenv("TRACETEST_TOKEN")
+	saveParams   = &saveParameters{}
 )
 
 var startCmd = &cobra.Command{
@@ -28,6 +30,7 @@ var startCmd = &cobra.Command{
 			EnvironmentID:  saveParams.environmentID,
 			Endpoint:       saveParams.endpoint,
 			AgentApiKey:    saveParams.agentApiKey,
+			TokenApiKey:    saveParams.tokenApiKey,
 		}
 
 		cfg, err := agentConfig.LoadConfig()
@@ -49,6 +52,7 @@ func init() {
 	startCmd.Flags().StringVarP(&saveParams.organizationID, "organization", "", "", "organization id")
 	startCmd.Flags().StringVarP(&saveParams.environmentID, "environment", "", "", "environment id")
 	startCmd.Flags().StringVarP(&saveParams.agentApiKey, "api-key", "", "", "agent api key")
+	startCmd.Flags().StringVarP(&saveParams.tokenApiKey, "token", "", defaultToken, "token api key")
 	startCmd.Flags().StringVarP(&saveParams.endpoint, "endpoint", "e", config.DefaultCloudEndpoint, "set the value for the endpoint, so the CLI won't ask for this value")
 	rootCmd.AddCommand(startCmd)
 }
@@ -58,4 +62,5 @@ type saveParameters struct {
 	environmentID  string
 	endpoint       string
 	agentApiKey    string
+	tokenApiKey    string
 }

--- a/cli/cmd/start_cmd.go
+++ b/cli/cmd/start_cmd.go
@@ -12,7 +12,7 @@ import (
 
 var (
 	start        = starter.NewStarter(configurator, resources)
-	defaultToken = os.Getenv("TRACETEST_TOKEN")
+	defaultToken = os.Getenv("TRACETEST_CLI_API_KEY")
 	saveParams   = &saveParameters{}
 )
 

--- a/cli/cmd/start_cmd.go
+++ b/cli/cmd/start_cmd.go
@@ -12,7 +12,7 @@ import (
 
 var (
 	start        = starter.NewStarter(configurator, resources)
-	defaultToken = os.Getenv("TRACETEST_CLI_API_KEY")
+	defaultToken = os.Getenv("TRACETEST_TOKEN")
 	saveParams   = &saveParameters{}
 )
 
@@ -30,7 +30,7 @@ var startCmd = &cobra.Command{
 			EnvironmentID:  saveParams.environmentID,
 			Endpoint:       saveParams.endpoint,
 			AgentApiKey:    saveParams.agentApiKey,
-			CLIApiKey:      saveParams.cliApiKey,
+			Token:          saveParams.token,
 		}
 
 		cfg, err := agentConfig.LoadConfig()
@@ -52,7 +52,7 @@ func init() {
 	startCmd.Flags().StringVarP(&saveParams.organizationID, "organization", "", "", "organization id")
 	startCmd.Flags().StringVarP(&saveParams.environmentID, "environment", "", "", "environment id")
 	startCmd.Flags().StringVarP(&saveParams.agentApiKey, "api-key", "", "", "agent api key")
-	startCmd.Flags().StringVarP(&saveParams.cliApiKey, "cli-api-key", "", defaultToken, "CLI api key")
+	startCmd.Flags().StringVarP(&saveParams.token, "token", "", defaultToken, "token api key")
 	startCmd.Flags().StringVarP(&saveParams.endpoint, "endpoint", "e", config.DefaultCloudEndpoint, "set the value for the endpoint, so the CLI won't ask for this value")
 	rootCmd.AddCommand(startCmd)
 }
@@ -62,5 +62,5 @@ type saveParameters struct {
 	environmentID  string
 	endpoint       string
 	agentApiKey    string
-	cliApiKey      string
+	token          string
 }

--- a/cli/cmd/start_cmd.go
+++ b/cli/cmd/start_cmd.go
@@ -30,7 +30,7 @@ var startCmd = &cobra.Command{
 			EnvironmentID:  saveParams.environmentID,
 			Endpoint:       saveParams.endpoint,
 			AgentApiKey:    saveParams.agentApiKey,
-			TokenApiKey:    saveParams.tokenApiKey,
+			CLIApiKey:      saveParams.cliApiKey,
 		}
 
 		cfg, err := agentConfig.LoadConfig()
@@ -52,7 +52,7 @@ func init() {
 	startCmd.Flags().StringVarP(&saveParams.organizationID, "organization", "", "", "organization id")
 	startCmd.Flags().StringVarP(&saveParams.environmentID, "environment", "", "", "environment id")
 	startCmd.Flags().StringVarP(&saveParams.agentApiKey, "api-key", "", "", "agent api key")
-	startCmd.Flags().StringVarP(&saveParams.tokenApiKey, "token", "", defaultToken, "token api key")
+	startCmd.Flags().StringVarP(&saveParams.cliApiKey, "cli-api-key", "", defaultToken, "CLI api key")
 	startCmd.Flags().StringVarP(&saveParams.endpoint, "endpoint", "e", config.DefaultCloudEndpoint, "set the value for the endpoint, so the CLI won't ask for this value")
 	rootCmd.AddCommand(startCmd)
 }
@@ -62,5 +62,5 @@ type saveParameters struct {
 	environmentID  string
 	endpoint       string
 	agentApiKey    string
-	tokenApiKey    string
+	cliApiKey      string
 }

--- a/cli/config/config.go
+++ b/cli/config/config.go
@@ -27,7 +27,7 @@ type ConfigFlags struct {
 	EnvironmentID  string
 	CI             bool
 	AgentApiKey    string
-	TokenApiKey    string
+	CLIApiKey      string
 }
 
 type Config struct {

--- a/cli/config/config.go
+++ b/cli/config/config.go
@@ -27,7 +27,7 @@ type ConfigFlags struct {
 	EnvironmentID  string
 	CI             bool
 	AgentApiKey    string
-	CLIApiKey      string
+	Token          string
 }
 
 type Config struct {

--- a/cli/config/config.go
+++ b/cli/config/config.go
@@ -27,6 +27,7 @@ type ConfigFlags struct {
 	EnvironmentID  string
 	CI             bool
 	AgentApiKey    string
+	TokenApiKey    string
 }
 
 type Config struct {

--- a/cli/config/configurator.go
+++ b/cli/config/configurator.go
@@ -107,14 +107,14 @@ func (c Configurator) Start(ctx context.Context, prev Config, flags ConfigFlags)
 		cfg.Token = prev.Token
 	}
 
-	if flags.CLIApiKey != "" {
-		jwt, err := oauth.ExchangeToken(oauthEndpoint, flags.CLIApiKey)
+	if flags.Token != "" {
+		jwt, err := oauth.ExchangeToken(oauthEndpoint, flags.Token)
 		if err != nil {
 			return err
 		}
 
 		cfg.Jwt = jwt
-		cfg.Token = flags.CLIApiKey
+		cfg.Token = flags.Token
 
 		claims, err := GetTokenClaims(jwt)
 		if err != nil {

--- a/cli/config/configurator.go
+++ b/cli/config/configurator.go
@@ -107,14 +107,14 @@ func (c Configurator) Start(ctx context.Context, prev Config, flags ConfigFlags)
 		cfg.Token = prev.Token
 	}
 
-	if flags.TokenApiKey != "" {
-		jwt, err := oauth.ExchangeToken(oauthEndpoint, flags.TokenApiKey)
+	if flags.CLIApiKey != "" {
+		jwt, err := oauth.ExchangeToken(oauthEndpoint, flags.CLIApiKey)
 		if err != nil {
 			return err
 		}
 
 		cfg.Jwt = jwt
-		cfg.Token = flags.TokenApiKey
+		cfg.Token = flags.CLIApiKey
 
 		claims, err := GetTokenClaims(jwt)
 		if err != nil {

--- a/cli/pkg/starter/starter.go
+++ b/cli/pkg/starter/starter.go
@@ -30,7 +30,7 @@ func (s *Starter) Run(ctx context.Context, cfg config.Config, flags config.Confi
 	s.ui.Println(`Tracetest start launches a lightweight agent. It enables you to run tests and collect traces with Tracetest.
 Once started, Tracetest Agent exposes OTLP ports 4317 and 4318 to ingest traces via gRCP and HTTP.`)
 
-	if flags.CLIApiKey == "" || flags.AgentApiKey != "" {
+	if flags.Token == "" || flags.AgentApiKey != "" {
 		s.configurator = s.configurator.WithOnFinish(s.onStartAgent)
 	}
 

--- a/cli/pkg/starter/starter.go
+++ b/cli/pkg/starter/starter.go
@@ -30,7 +30,7 @@ func (s *Starter) Run(ctx context.Context, cfg config.Config, flags config.Confi
 	s.ui.Println(`Tracetest start launches a lightweight agent. It enables you to run tests and collect traces with Tracetest.
 Once started, Tracetest Agent exposes OTLP ports 4317 and 4318 to ingest traces via gRCP and HTTP.`)
 
-	if flags.TokenApiKey == "" || flags.AgentApiKey != "" {
+	if flags.CLIApiKey == "" || flags.AgentApiKey != "" {
 		s.configurator = s.configurator.WithOnFinish(s.onStartAgent)
 	}
 


### PR DESCRIPTION
This PR adds token support for the `tracetest start` command

## Changes

- Adds new env variable to support the TOKEN
- Adds config to replace jwt and token from the given flags

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Loom video
https://www.loom.com/share/a1405279a47a429cae4fe0bb8df25233
