### PR TITLE
fix: json mapping for gRPC metadata headers

### DIFF
--- a/server/test/trigger/grpc.go
+++ b/server/test/trigger/grpc.go
@@ -5,8 +5,8 @@ import "google.golang.org/grpc/metadata"
 const TriggerTypeGRPC TriggerType = "grpc"
 
 type GRPCHeader struct {
-	Key   string `expr_enabled:"true"`
-	Value string `expr_enabled:"true"`
+	Key   string `expr_enabled:"true" json:"key"`
+	Value string `expr_enabled:"true" json:"value"`
 }
 
 type GRPCRequest struct {


### PR DESCRIPTION
This PR fixes the gRPC mapping for metadata headers

## Fixes
- #3258 

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
