### PR TITLE
feat(agent): add support for port 443

### DIFF
--- a/agent/client/connector.go
+++ b/agent/client/connector.go
@@ -2,10 +2,13 @@ package client
 
 import (
 	"context"
+	"crypto/tls"
 	"fmt"
+	"net"
 	"time"
 
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/insecure"
 )
 
@@ -27,11 +30,38 @@ func connect(ctx context.Context, endpoint string) (*grpc.ClientConn, error) {
 	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
 	defer cancel()
 
-	// TODO: don't use insecure transportation
-	conn, err := grpc.DialContext(ctx, endpoint, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	transportCredentials, err := getTransportCredentialsForEndpoint(endpoint)
+	if err != nil {
+		return nil, fmt.Errorf("could not get transport credentials: %w", err)
+	}
+
+	conn, err := grpc.DialContext(
+		ctx, endpoint,
+		grpc.WithTransportCredentials(transportCredentials),
+	)
 	if err != nil {
 		return nil, fmt.Errorf("could not connect to server: %w", err)
 	}
 
 	return conn, nil
+}
+
+func getTransportCredentialsForEndpoint(endpoint string) (credentials.TransportCredentials, error) {
+	_, port, err := net.SplitHostPort(endpoint)
+	if err != nil {
+		return nil, fmt.Errorf("cannot parse endpoint: %w", err)
+	}
+
+	switch port {
+	case "443":
+		tlsConfig := &tls.Config{
+			InsecureSkipVerify: true,
+		}
+		transportCredentials := credentials.NewTLS(tlsConfig)
+		return transportCredentials, nil
+
+	default:
+		return insecure.NewCredentials(), nil
+	}
+
 }


### PR DESCRIPTION
This PR updates the agent TLS settings so it can correctly work with port 443. Since this port uses actual TLS, the client needs to be correctly setup.

The TLS settings for port 443 and 8091 are mutually exclusive, so this PR makes sure the agent can work with both ports

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Loom video

Add your loom video here if your work can be visualized
