### PR TITLE
chore(agent): make docker image multiarch

### DIFF
--- a/.github/workflows/release-version.yml
+++ b/.github/workflows/release-version.yml
@@ -102,20 +102,6 @@ jobs:
           ANALYTICS_BE_KEY: ${{ secrets.ANALYTICS_BE_KEY }}
           TRACETEST_DEFAULT_CLOUD_ENDPOINT: ${{ secrets.TRACETEST_DEFAULT_CLOUD_ENDPOINT }}
 
-      # release agent
-      - name: Build and push agent
-        uses: docker/build-push-action@v5
-        with:
-          push: true
-          tags: kubeshop/tracetest-agent:latest,kubeshop/tracetest-agent:${{ env.VERSION }}
-          file: agent/Dockerfile
-          build-args: |
-            TRACETEST_VERSION=${{ env.VERSION }}
-        env:
-          VERSION: ${{ github.ref_name }}
-
-
-
   helm_chart_version_bump:
       name: "Trigger Helm chart appVersion update"
       needs: "release"

--- a/.goreleaser.demo.yaml
+++ b/.goreleaser.demo.yaml
@@ -65,3 +65,17 @@ dockers:
   - "--platform=linux/amd64"
   goos: linux
   goarch: amd64
+
+- image_templates:
+  - 'kubeshop/tracetest-agent:{{ .Env.VERSION }}-amd64'
+  dockerfile: "Dockerfile.agent"
+  build_flag_templates:
+  - "--pull"
+  - "--label=org.opencontainers.image.created={{.Date}}"
+  - "--label=org.opencontainers.image.name={{.ProjectName}}"
+  - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+  - "--label=org.opencontainers.image.version={{.Version}}"
+  - "--label=org.opencontainers.image.source={{.GitURL}}"
+  - "--platform=linux/amd64"
+  goos: linux
+  goarch: amd64

--- a/.goreleaser.dev.yaml
+++ b/.goreleaser.dev.yaml
@@ -69,3 +69,18 @@ dockers:
   - "--platform=linux/amd64"
   goos: linux
   goarch: amd64
+
+- skip_push: true
+  image_templates:
+  - 'kubeshop/tracetest-agent:{{ .Env.VERSION }}-amd64'
+  dockerfile: "Dockerfile.agent"
+  build_flag_templates:
+  - "--pull"
+  - "--label=org.opencontainers.image.created={{.Date}}"
+  - "--label=org.opencontainers.image.name={{.ProjectName}}"
+  - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+  - "--label=org.opencontainers.image.version={{.Version}}"
+  - "--label=org.opencontainers.image.source={{.GitURL}}"
+  - "--platform=linux/amd64"
+  goos: linux
+  goarch: amd64

--- a/.goreleaser.dev.yaml
+++ b/.goreleaser.dev.yaml
@@ -72,7 +72,7 @@ dockers:
 
 - skip_push: true
   image_templates:
-  - 'kubeshop/tracetest-agent:{{ .Env.VERSION }}-amd64'
+  - 'kubeshop/tracetest-agent:{{ .Env.VERSION }}'
   dockerfile: "Dockerfile.agent"
   build_flag_templates:
   - "--pull"

--- a/.goreleaser.rc.yaml
+++ b/.goreleaser.rc.yaml
@@ -102,11 +102,48 @@ dockers:
   goarch: arm64
   use: buildx
 
+# agent
+- image_templates:
+  - 'kubeshop/tracetest-agent:{{ .Env.VERSION }}-amd64'
+  dockerfile: "Dockerfile.agent"
+  build_flag_templates:
+  - "--pull"
+  - "--label=org.opencontainers.image.created={{.Date}}"
+  - "--label=org.opencontainers.image.name={{.ProjectName}}"
+  - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+  - "--label=org.opencontainers.image.version={{.Version}}"
+  - "--label=org.opencontainers.image.source={{.GitURL}}"
+  - "--platform=linux/amd64"
+  goos: linux
+  goarch: amd64
+  use: buildx
+
+- image_templates:
+  - 'kubeshop/tracetest-agent:{{ .Env.VERSION }}-arm64'
+  dockerfile: "Dockerfile.agent"
+  build_flag_templates:
+  - "--pull"
+  - "--label=org.opencontainers.image.created={{.Date}}"
+  - "--label=org.opencontainers.image.name={{.ProjectName}}"
+  - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+  - "--label=org.opencontainers.image.version={{.Version}}"
+  - "--label=org.opencontainers.image.source={{.GitURL}}"
+  - "--platform=linux/arm64/v8"
+  goos: linux
+  goarch: arm64
+  use: buildx
+
 docker_manifests:
 - name_template: 'kubeshop/tracetest:{{ .Env.VERSION }}'
   image_templates:
   - 'kubeshop/tracetest:{{ .Env.VERSION }}-amd64'
   - 'kubeshop/tracetest:{{ .Env.VERSION }}-arm64'
+
+# agent
+- name_template: 'kubeshop/tracetest-agent:{{ .Env.VERSION }}'
+  image_templates:
+  - 'kubeshop/tracetest-agent:{{ .Env.VERSION }}-amd64'
+  - 'kubeshop/tracetest-agent:{{ .Env.VERSION }}-arm64'
 
 archives:
 - name_template: >-

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -112,6 +112,37 @@ dockers:
   goarch: arm64
   use: buildx
 
+# agent
+- image_templates:
+  - 'kubeshop/tracetest-agent:{{ .Env.VERSION }}-amd64'
+  dockerfile: "Dockerfile.agent"
+  build_flag_templates:
+  - "--pull"
+  - "--label=org.opencontainers.image.created={{.Date}}"
+  - "--label=org.opencontainers.image.name={{.ProjectName}}"
+  - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+  - "--label=org.opencontainers.image.version={{.Version}}"
+  - "--label=org.opencontainers.image.source={{.GitURL}}"
+  - "--platform=linux/amd64"
+  goos: linux
+  goarch: amd64
+  use: buildx
+
+- image_templates:
+  - 'kubeshop/tracetest-agent:{{ .Env.VERSION }}-arm64'
+  dockerfile: "Dockerfile.agent"
+  build_flag_templates:
+  - "--pull"
+  - "--label=org.opencontainers.image.created={{.Date}}"
+  - "--label=org.opencontainers.image.name={{.ProjectName}}"
+  - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+  - "--label=org.opencontainers.image.version={{.Version}}"
+  - "--label=org.opencontainers.image.source={{.GitURL}}"
+  - "--platform=linux/arm64/v8"
+  goos: linux
+  goarch: arm64
+  use: buildx
+
 docker_manifests:
 - name_template: 'kubeshop/tracetest:{{ .Env.VERSION }}'
   image_templates:
@@ -121,6 +152,16 @@ docker_manifests:
   image_templates:
   - 'kubeshop/tracetest:{{ .Env.VERSION }}-amd64'
   - 'kubeshop/tracetest:{{ .Env.VERSION }}-arm64'
+
+# agent
+- name_template: 'kubeshop/tracetest-agent:{{ .Env.VERSION }}'
+  image_templates:
+  - 'kubeshop/tracetest-agent:{{ .Env.VERSION }}-amd64'
+  - 'kubeshop/tracetest-agent:{{ .Env.VERSION }}-arm64'
+- name_template: '{{ if not .IsNightly }}kubeshop/tracetest-agent:latest{{ end }}'
+  image_templates:
+  - 'kubeshop/tracetest-agent:{{ .Env.VERSION }}-amd64'
+  - 'kubeshop/tracetest-agent:{{ .Env.VERSION }}-arm64'
 
 archives:
 - name_template: >-

--- a/Dockerfile.agent
+++ b/Dockerfile.agent
@@ -1,0 +1,11 @@
+FROM alpine
+
+ENV PATH="$PATH:/app"
+ENV TRACETEST_API_KEY ""
+
+WORKDIR /app
+
+COPY ./tracetest /app/tracetest
+
+ENTRYPOINT [ "tracetest", "start", "--api-key", "$TRACETEST_API_KEY" ]
+

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION?="dev"
+VERSION?=dev
 TAG?=$(VERSION)
 GORELEASER_VERSION=1.21.2-pro
 
@@ -34,7 +34,7 @@ web/build: web/node_modules $(WEB_SRC_FILES)
 dist/tracetest-docker-$(TAG).tar dist/tracetest-agent-docker-$(TAG).tar: $(CLI_SRC_FILES) $(SERVER_SRC_FILES) $(WEB_SRC_FILES)
 	goreleaser release --clean --skip-announce --snapshot -f .goreleaser.dev.yaml
 	docker save --output dist/tracetest-docker-$(TAG).tar "kubeshop/tracetest:$(TAG)"
-	docker save --output dist/tracetest-agent-docker-$(TAG).tar "kubeshop/tracetest-agent-:$(TAG)"
+	docker save --output dist/tracetest-agent-docker-$(TAG).tar "kubeshop/tracetest-agent:$(TAG)"
 
 help: Makefile ## show list of commands
 	@echo "Choose a command run:"

--- a/Makefile
+++ b/Makefile
@@ -31,9 +31,10 @@ WEB_SRC_FILES := $(shell find web -type f -not -path "*node_modules*" -not -path
 web/build: web/node_modules $(WEB_SRC_FILES)
 	cd web; npm run build
 
-dist/docker-image-$(TAG).tar: $(CLI_SRC_FILES) $(SERVER_SRC_FILES) $(WEB_SRC_FILES)
+dist/tracetest-docker-$(TAG).tar dist/tracetest-agent-docker-$(TAG).tar: $(CLI_SRC_FILES) $(SERVER_SRC_FILES) $(WEB_SRC_FILES)
 	goreleaser release --clean --skip-announce --snapshot -f .goreleaser.dev.yaml
-	docker save --output dist/docker-image-$(TAG).tar "kubeshop/tracetest:$(TAG)"
+	docker save --output dist/tracetest-docker-$(TAG).tar "kubeshop/tracetest:$(TAG)"
+	docker save --output dist/tracetest-agent-docker-$(TAG).tar "kubeshop/tracetest-agent-:$(TAG)"
 
 help: Makefile ## show list of commands
 	@echo "Choose a command run:"
@@ -51,7 +52,7 @@ run: build-docker ## build and run tracetest using docker compose
 	docker compose up
 build-go: dist/tracetest dist/tracetest-server ## build all go code
 build-web: web/build ## build web
-build-docker: goreleaser-version web/build .goreleaser.dev.yaml dist/docker-image-$(TAG).tar ## build and tag docker image as defined in .goreleaser.dev.yaml
+build-docker: goreleaser-version web/build .goreleaser.dev.yaml dist/tracetest-docker-$(TAG).tar dist/tracetest-agent-docker-$(TAG).tar ## build and tag docker image as defined in .goreleaser.dev.yaml
 
 .PHONY: generate generate-server generate-cli generate-web
 generate: generate-server generate-cli generate-web ## generate code entities from openapi definitions for all parts of the code

--- a/cli/go.mod
+++ b/cli/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/davecgh/go-spew v1.1.1
 	github.com/denisbrodbeck/machineid v1.0.1
 	github.com/goccy/go-yaml v1.11.0
-	github.com/golang-jwt/jwt/v4 v4.5.0
+	github.com/golang-jwt/jwt v3.2.1+incompatible
 	github.com/goware/urlx v0.3.2
 	github.com/kubeshop/tracetest/agent v0.0.0-20230907210810-84198fc9f4ef
 	github.com/kubeshop/tracetest/server v0.0.0-20231010015728-ab7381aa0030
@@ -63,6 +63,7 @@ require (
 	github.com/go-logr/logr v1.2.4 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
+	github.com/golang-jwt/jwt/v4 v4.5.0 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/golang/protobuf v1.5.3 // indirect
 	github.com/golang/snappy v0.0.4 // indirect

--- a/cli/go.sum
+++ b/cli/go.sum
@@ -732,6 +732,7 @@ github.com/gogo/protobuf v1.3.0/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXP
 github.com/gogo/protobuf v1.3.1/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXPKa29o=
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
+github.com/golang-jwt/jwt v3.2.1+incompatible h1:73Z+4BJcrTC+KczS6WvTPvRGOp1WmfEP4Q1lOd9Z/+c=
 github.com/golang-jwt/jwt v3.2.1+incompatible/go.mod h1:8pz2t5EyA70fFQQSrl6XZXzqecmYZeUEB8OUGHkxJ+I=
 github.com/golang-jwt/jwt/v4 v4.0.0/go.mod h1:/xlHOz8bRuivTWchD4jCa+NbatV+wEUSzwAxVc6locg=
 github.com/golang-jwt/jwt/v4 v4.5.0 h1:7cYmW1XlMY7h7ii7UhUyChSgS5wUJEnm9uZVTGqOWzg=


### PR DESCRIPTION
This PR makes the agent docker image mutliarch. For simplicity, it uses the same approach as the main tracetest image. Meaning the building happens through goreleaser. Because of how goreleaser works, it was not practical to keep the agent image "inheriting" from the main tracetest image, instead the easiest way was to have a dockerfile that simply imports the already built cli binary and set an entrypoint.

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
