### PR TITLE
fix: http metric middleware improvements

### DIFF
--- a/server/http/middleware/metrics.go
+++ b/server/http/middleware/metrics.go
@@ -23,6 +23,9 @@ func (m *httpMetricMiddleware) ServeHTTP(w http.ResponseWriter, r *http.Request)
 
 	route := mux.CurrentRoute(r)
 	pathTemplate, _ := route.GetPathTemplate()
+	if pathTemplate == "" {
+		pathTemplate = "/"
+	}
 
 	metricAttributes := []attribute.KeyValue{
 		attribute.String(semconv.AttributeHTTPRoute, pathTemplate),

--- a/server/http/middleware/metrics.go
+++ b/server/http/middleware/metrics.go
@@ -37,7 +37,9 @@ func (m *httpMetricMiddleware) ServeHTTP(w http.ResponseWriter, r *http.Request)
 		metricAttributes = append(metricAttributes, attribute.String("tracetest.tenant_id", tenantID))
 	}
 
-	m.requestDurationHistogram.Record(r.Context(), duration.Milliseconds(), metric.WithAttributes(metricAttributes...))
+	m.requestDurationHistogram.Record(r.Context(), duration.Milliseconds(), metric.WithAttributeSet(
+		attribute.NewSet(metricAttributes...),
+	))
 }
 
 var _ http.Handler = &httpMetricMiddleware{}


### PR DESCRIPTION
This PR achieves two things:

1. Make sure `GET /` endpoint calls are collected with the correct `http.route`. Today it's considered empty
2. Use `attributes.Set` for recording the metric attributes (it's recommended by OpenTelemetry due to performance)

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Loom video

Add your loom video here if your work can be visualized
