### PR TITLE
docs(hotfix): fix flaky links

### DIFF
--- a/docs/src/components/CoreGettingStartedGuide/index.tsx
+++ b/docs/src/components/CoreGettingStartedGuide/index.tsx
@@ -9,7 +9,7 @@ import Heading from '@theme/Heading';
 const CoreGettingStartedGuides = [
   {
     name: '👇 Install Tracetest Core',
-    url: './installation',
+    url: '/core/getting-started/installation',
     description: (
       <Translate >
         Set up Tracetest Core and start trace-based testing your distributed system.
@@ -19,7 +19,7 @@ const CoreGettingStartedGuides = [
   },
   {
     name: '🙌 Open Tracetest Core',
-    url: './open',
+    url: '/core/getting-started/open',
     description: (
       <Translate>
         After installing it, open Tracetest Core start to creating trace-based tests.

--- a/docs/src/components/GettingStartedGuide/index.tsx
+++ b/docs/src/components/GettingStartedGuide/index.tsx
@@ -8,7 +8,7 @@ import Heading from '@theme/Heading';
 const GettingStartedGuides = [
   {
     name: 'Tracetest 🚀',
-    url: './installation',
+    url: '/getting-started/installation',
     description: (
       <Translate >
         Set up Tracetest and start trace-based testing your distributed system.
@@ -18,7 +18,7 @@ const GettingStartedGuides = [
   },
   {
     name: 'Tracetest Core 🪨 ',
-    url: '../core/getting-started/installation',
+    url: '/core/getting-started/installation',
     description: (
       <Translate>
         Use the open-source Tracetest Core in your own infrastructure.

--- a/docs/src/components/WelcomeGuide/index.tsx
+++ b/docs/src/components/WelcomeGuide/index.tsx
@@ -29,7 +29,7 @@ const WelcomeGuides = [
   },
   {
     name: '⚙️ Configure trace data stores',
-    url: '../configuration/overview#supported-trace-data-stores',
+    url: '/configuration/overview#supported-trace-data-stores',
     description: (
       <Translate>
         Connect your existing trace data store or send traces to Tracetest directly!
@@ -39,7 +39,7 @@ const WelcomeGuides = [
   },
   {
     name: '🙄 New to Trace-based Testing?',
-    url: '../concepts/what-is-trace-based-testing',
+    url: '/concepts/what-is-trace-based-testing',
     description: (
       <Translate>
         Read about the concepts of trace-based testing to learn more!


### PR DESCRIPTION
This PR fixes flaky links in the cards on docs landing pages.

## Changes

-

## Fixes

-

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Loom video

Add your loom video here if your work can be visualized
