### PR TITLE
fix(cli): update docker compose library call

### DIFF
--- a/cli/installer/docker_compose.go
+++ b/cli/installer/docker_compose.go
@@ -1,6 +1,7 @@
 package installer
 
 import (
+	"context"
 	_ "embed"
 	"fmt"
 	"io"
@@ -324,12 +325,14 @@ func getCompleteProject(ui cliUI.UI, config configuration) *types.Project {
 		ui.Panic(err)
 	}
 
-	project, err := loader.Load(types.ConfigDetails{
+	project, err := loader.LoadWithContext(context.Background(), types.ConfigDetails{
 		WorkingDir:  workingDir,
 		ConfigFiles: configFiles,
 		Environment: map[string]string{
 			"TRACETEST_DEV": "",
 		},
+	}, func(o *loader.Options) {
+		o.SetProjectName("tracetest", true)
 	})
 	if err != nil {
 		ui.Exit(fmt.Errorf("cannot parse docker-compose file: %w", err).Error())

--- a/cli/installer/docker_compose.go
+++ b/cli/installer/docker_compose.go
@@ -326,7 +326,7 @@ func getCompleteProject(ui cliUI.UI, config configuration) *types.Project {
 	}
 
 	project, err := loader.LoadWithContext(context.Background(), types.ConfigDetails{
-		WorkingDir:  workingDir,
+		WorkingDir:  fmt.Sprintf("%s/tracetest", workingDir),
 		ConfigFiles: configFiles,
 		Environment: map[string]string{
 			"TRACETEST_DEV": "",


### PR DESCRIPTION
This PR fixes the docker compose installer. The issue was a libray update that changed the project name to be required, and since we're not using an actual file, the project name cannot be inferred, causing an error.

The fix is to manually set a project name.