### PR TITLE
feat(agent): configure retry strategy

### DIFF
--- a/agent/initialization/start.go
+++ b/agent/initialization/start.go
@@ -17,7 +17,7 @@ import (
 var ErrOtlpServerStart = errors.New("OTLP server start error")
 
 func NewClient(ctx context.Context, config config.Config, traceCache collector.TraceCache) (*client.Client, error) {
-	client, err := client.Connect(ctx, config.ServerURL,
+	c, err := client.Connect(ctx, config.ServerURL,
 		client.WithAPIKey(config.APIKey),
 		client.WithAgentName(config.Name),
 	)
@@ -25,44 +25,44 @@ func NewClient(ctx context.Context, config config.Config, traceCache collector.T
 		return nil, err
 	}
 
-	triggerWorker := workers.NewTriggerWorker(client, workers.WithTraceCache(traceCache))
-	pollingWorker := workers.NewPollerWorker(client, workers.WithInMemoryDatastore(
+	triggerWorker := workers.NewTriggerWorker(c, workers.WithTraceCache(traceCache))
+	pollingWorker := workers.NewPollerWorker(c, workers.WithInMemoryDatastore(
 		poller.NewInMemoryDatastore(traceCache),
 	))
-	dataStoreTestConnectionWorker := workers.NewTestConnectionWorker(client)
+	dataStoreTestConnectionWorker := workers.NewTestConnectionWorker(c)
 
-	client.OnDataStoreTestConnectionRequest(dataStoreTestConnectionWorker.Test)
-	client.OnTriggerRequest(triggerWorker.Trigger)
-	client.OnPollingRequest(pollingWorker.Poll)
-	client.OnConnectionClosed(func(ctx context.Context, sr *proto.ShutdownRequest) error {
+	c.OnDataStoreTestConnectionRequest(dataStoreTestConnectionWorker.Test)
+	c.OnTriggerRequest(triggerWorker.Trigger)
+	c.OnPollingRequest(pollingWorker.Poll)
+	c.OnConnectionClosed(func(ctx context.Context, sr *proto.ShutdownRequest) error {
 		fmt.Printf("Server terminated the connection with the agent. Reason: %s\n", sr.Reason)
-		return client.Close()
+		return c.Close()
 	})
 
-	return client, nil
+	return c, nil
 }
 
 // Start the agent with given configuration
-func Start(ctx context.Context, config config.Config) (*Session, error) {
+func Start(ctx context.Context, cfg config.Config) (*Session, error) {
 	traceCache := collector.NewTraceCache()
-	client, err := NewClient(ctx, config, traceCache)
+	c, err := NewClient(ctx, cfg, traceCache)
 	if err != nil {
 		return nil, err
 	}
 
-	err = client.Start(ctx)
+	err = c.Start(ctx)
 	if err != nil {
 		return nil, err
 	}
 
-	err = StartCollector(ctx, config, traceCache)
+	err = StartCollector(ctx, cfg, traceCache)
 	if err != nil {
 		return nil, err
 	}
 
 	return &Session{
-		client: client,
-		Token:  client.SessionConfiguration().AgentIdentification.Token,
+		client: c,
+		Token:  c.SessionConfiguration().AgentIdentification.Token,
 	}, nil
 }
 

--- a/agent/initialization/start.go
+++ b/agent/initialization/start.go
@@ -45,12 +45,12 @@ func NewClient(ctx context.Context, config config.Config, traceCache collector.T
 // Start the agent with given configuration
 func Start(ctx context.Context, cfg config.Config) (*Session, error) {
 	traceCache := collector.NewTraceCache()
-	c, err := NewClient(ctx, cfg, traceCache)
+	controlPlaneClient, err := NewClient(ctx, cfg, traceCache)
 	if err != nil {
 		return nil, err
 	}
 
-	err = c.Start(ctx)
+	err = controlPlaneClient.Start(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -61,8 +61,8 @@ func Start(ctx context.Context, cfg config.Config) (*Session, error) {
 	}
 
 	return &Session{
-		client: c,
-		Token:  c.SessionConfiguration().AgentIdentification.Token,
+		client: controlPlaneClient,
+		Token:  controlPlaneClient.SessionConfiguration().AgentIdentification.Token,
 	}, nil
 }
 


### PR DESCRIPTION
This PR configures the gRPC client retry strategy to allow better handling of connection issues. In the case of connection interruption between the server and the agent for whatever reason (server restarted, networking issues, etc), the client will retry the operation using an exponential backoff strategy. With the currently configured values, this is the retry timeline:

```
Attempt 1 at 0.1 seconds, Backoff Time: 0.1 seconds
Attempt 2 at 0.3 seconds, Backoff Time: 0.2 seconds
Attempt 3 at 0.7 seconds, Backoff Time: 0.4 seconds
Attempt 4 at 1.5 seconds, Backoff Time: 0.8 seconds
Attempt 5 at 3.1 seconds, Backoff Time: 1.6 seconds
Attempt 6 at 6.3 seconds, Backoff Time: 3.2 seconds
Attempt 7 at 11.3 seconds, Backoff Time: 5.0 seconds
Attempt 8 at 16.3 seconds, Backoff Time: 5.0 seconds
Attempt 9 at 21.3 seconds, Backoff Time: 5.0 seconds
Attempt 10 at 26.3 seconds, Backoff Time: 5.0 seconds
Attempt 11 at 31.3 seconds, Backoff Time: 5.0 seconds
Attempt 12 at 36.3 seconds, Backoff Time: 5.0 seconds
Attempt 13 at 41.3 seconds, Backoff Time: 5.0 seconds
Attempt 14 at 46.3 seconds, Backoff Time: 5.0 seconds
Attempt 15 at 51.3 seconds, Backoff Time: 5.0 seconds
Attempt 16 at 56.3 seconds, Backoff Time: 5.0 seconds
Attempt 17 at 61.3 seconds, Backoff Time: 5.0 seconds
Attempt 18 at 66.3 seconds, Backoff Time: 5.0 seconds
Attempt 19 at 71.3 seconds, Backoff Time: 5.0 seconds
Attempt 20 at 76.3 seconds, Backoff Time: 5.0 seconds
Attempt 21 at 81.3 seconds, Backoff Time: 5.0 seconds
Attempt 22 at 86.3 seconds, Backoff Time: 5.0 seconds
Attempt 23 at 91.3 seconds, Backoff Time: 5.0 seconds
Attempt 24 at 96.3 seconds, Backoff Time: 5.0 seconds
Attempt 25 at 101.3 seconds, Backoff Time: 5.0 seconds
Attempt 26 at 106.3 seconds, Backoff Time: 5.0 seconds
Attempt 27 at 111.3 seconds, Backoff Time: 5.0 seconds
Attempt 28 at 116.3 seconds, Backoff Time: 5.0 seconds
Attempt 29 at 121.3 seconds, Backoff Time: 5.0 seconds
```

If  the operation was not succesful after the last attempt, it will fail, causing the agent to exit with an erro message.

This behaviour is specially useful on docker/k8s environments, since it kills the container and makes the orchestrator restart it, allowing the process to be restarted until a succesful connection is established
