### PR TITLE
fix(agent): set prefix in viper config

### DIFF
--- a/agent/config/config.go
+++ b/agent/config/config.go
@@ -26,6 +26,7 @@ func LoadConfig() (Config, error) {
 	vp := viper.NewWithOptions(
 		viper.EnvKeyReplacer(strings.NewReplacer(".", "_")),
 	)
+	vp.SetEnvPrefix("tracetest")
 
 	tracetestFolder := getTracetestFolder()
 


### PR DESCRIPTION
Our env variables are not parsed corrected because the `TRACETEST_` prefix is not set in our viper instance in the agent codebase.

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Loom video

Add your loom video here if your work can be visualized
