### PR TITLE
fix(frontend): fix scroll behavior in test specs list

### DIFF
--- a/web/src/components/RunDetailTest/RunDetailTest.styled.ts
+++ b/web/src/components/RunDetailTest/RunDetailTest.styled.ts
@@ -16,10 +16,11 @@ export const SectionLeft = styled(Section)`
   z-index: 1;
 `;
 
-export const SectionRight = styled(Section)<{$shouldScroll: boolean}>`
+export const SectionRight = styled(Section)`
   background-color: ${({theme}) => theme.color.white};
   box-shadow: 0 20px 24px rgba(153, 155, 168, 0.18);
-  overflow-y: ${({$shouldScroll}) => ($shouldScroll ? 'scroll' : 'hidden')};
+  overflow: hidden;
+  position: relative;
   z-index: 2;
 `;
 
@@ -32,6 +33,7 @@ export const SwitchContainer = styled.div`
 
 export const TabsContainer = styled.div`
   height: 100%;
+  overflow-y: auto;
   padding: 24px;
   position: relative;
 

--- a/web/src/components/RunDetailTest/TestPanel.tsx
+++ b/web/src/components/RunDetailTest/TestPanel.tsx
@@ -123,7 +123,7 @@ const TestPanel = ({run, testId, runEvents}: IProps) => {
           />
         </S.SectionLeft>
 
-        <S.SectionRight $shouldScroll={!selectedTestSpec}>
+        <S.SectionRight>
           {isTestSpecFormOpen && (
             <TestSpecForm
               onSubmit={values => {
@@ -202,19 +202,19 @@ const TestPanel = ({run, testId, runEvents}: IProps) => {
                   <TestOutputs outputs={outputs} />
                 </Tabs.TabPane>
               </Tabs>
-
-              <TestSpecDetail
-                isOpen={Boolean(selectedTestSpec)}
-                onClose={handleClose}
-                onDelete={handleDelete}
-                onEdit={handleEdit}
-                onRevert={handleRevert}
-                onSelectSpan={handleSelectSpan}
-                selectedSpan={selectedSpan?.id}
-                testSpec={selectedTestSpec}
-              />
             </S.TabsContainer>
           )}
+
+          <TestSpecDetail
+            isOpen={Boolean(selectedTestSpec)}
+            onClose={handleClose}
+            onDelete={handleDelete}
+            onEdit={handleEdit}
+            onRevert={handleRevert}
+            onSelectSpan={handleSelectSpan}
+            selectedSpan={selectedSpan?.id}
+            testSpec={selectedTestSpec}
+          />
         </S.SectionRight>
       </S.Container>
     </FillPanel>


### PR DESCRIPTION
This PR fixes a broken behavior in the test specs list when trying to open a spec detail.

## Changes

- fix scroll and styles

## Fixes

-

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Screenshot

### Bug

![Screenshot 2023-10-30 at 11 27 56](https://github.com/kubeshop/tracetest/assets/3879892/a4a6f087-cd25-4391-b4e3-d14a112f3fe4)

### Fix

![2023-10-30 11 28 47](https://github.com/kubeshop/tracetest/assets/3879892/8341e1bd-a3d4-45d2-ab16-5c49ee86534a)