### PR TITLE
feat(frontend): add trigger type modal

### DIFF
--- a/web/src/components/Router/Router.tsx
+++ b/web/src/components/Router/Router.tsx
@@ -22,6 +22,7 @@ const Router = () => (
     </Route>
 
     <Route element={<Layout />}>
+      <Route path="/test/create/:triggerType" element={<div />} />
       <Route path="/test/:testId" element={<Test />} />
       <Route path="/test/:testId/run/:runId" element={<RunDetail />} />
       <Route path="/test/:testId/run/:runId/:mode" element={<RunDetail />} />

--- a/web/src/components/TriggerTypeModal/TriggerTypeCard.tsx
+++ b/web/src/components/TriggerTypeModal/TriggerTypeCard.tsx
@@ -1,0 +1,37 @@
+import {GITHUB_ISSUES_URL} from 'constants/Common.constants';
+import {IPlugin} from 'types/Plugins.types';
+import * as S from './TriggerTypeModal.styled';
+
+interface IProps {
+  onClick(plugin: IPlugin): void;
+  plugin: IPlugin;
+}
+
+const TriggerTypeCard = ({plugin: {name, title, description, isActive}, plugin, onClick}: IProps) => (
+  <S.CardContainer
+    data-cy={`${name.toLowerCase()}-plugin`}
+    onClick={() => isActive && onClick(plugin)}
+    $isActive={isActive}
+  >
+    <S.Circle $isActive={isActive}>
+      <S.Check className="check" />
+    </S.Circle>
+
+    <S.CardContent>
+      <div>
+        <S.CardTitle $isActive={isActive}>{title} </S.CardTitle>
+        {!isActive && (
+          <S.CardTitle $isActive>
+            &nbsp;-{' '}
+            <a href={GITHUB_ISSUES_URL} target="_blank">
+              Coming soon!
+            </a>
+          </S.CardTitle>
+        )}
+      </div>
+      <S.CardDescription $isActive={isActive}>{description}</S.CardDescription>
+    </S.CardContent>
+  </S.CardContainer>
+);
+
+export default TriggerTypeCard;

--- a/web/src/components/TriggerTypeModal/TriggerTypeModal.styled.ts
+++ b/web/src/components/TriggerTypeModal/TriggerTypeModal.styled.ts
@@ -1,0 +1,87 @@
+import styled from 'styled-components';
+import {Modal as AntModal, Typography} from 'antd';
+
+export const CardContainer = styled.div<{$isActive: boolean}>`
+  align-items: center;
+  background: ${({theme}) => theme.color.white};
+  border: 1px solid ${({theme}) => theme.color.borderLight};
+  border-radius: 4px;
+  cursor: ${({$isActive}) => ($isActive ? 'pointer' : 'default')};
+  display: flex;
+  gap: 12px;
+  padding: 4px;
+  padding-left: 16px;
+  width: 48%;
+
+  &:hover {
+    background: ${({theme}) => theme.color.background};
+    border: 1px solid ${({theme}) => theme.color.primary};
+
+    .check {
+      opacity: 1;
+    }
+  }
+`;
+
+export const CardContent = styled.div`
+  display: flex;
+  flex-direction: column;
+`;
+
+export const CardDescription = styled(Typography.Text)<{$isActive: boolean}>`
+  font-size: ${({theme}) => theme.size.xs};
+  opacity: ${({$isActive}) => ($isActive ? 1 : 0.5)};
+`;
+
+export const CardList = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
+  margin-bottom: 48px;
+`;
+
+export const CardTitle = styled(Typography.Text).attrs({
+  strong: true,
+})<{$isActive: boolean}>`
+  display: inline-block;
+  font-size: ${({theme}) => theme.size.sm};
+  opacity: ${({$isActive}) => ($isActive ? 1 : 0.5)};
+
+  a {
+    opacity: 1;
+  }
+`;
+
+export const Check = styled.div`
+  background: ${({theme}) => theme.color.primary};
+  border-radius: 50%;
+  display: inline-block;
+  height: 8px;
+  opacity: 0;
+  width: 8px;
+`;
+
+export const Circle = styled.div<{$isActive: boolean}>`
+  align-items: center;
+  border-radius: 50%;
+  border: ${({theme}) => `1px solid ${theme.color.primary}`};
+  display: flex;
+  justify-content: center;
+  max-height: 16px;
+  max-width: 16px;
+  min-height: 16px;
+  min-width: 16px;
+  opacity: ${({$isActive}) => ($isActive ? 1 : 0.5)};
+`;
+
+export const Modal = styled(AntModal)`
+  .ant-modal-body {
+    background: ${({theme}) => theme.color.background};
+  }
+`;
+
+export const Title = styled(Typography.Title)<{$marginBottom?: number}>`
+  && {
+    margin-bottom: ${({$marginBottom}) => $marginBottom || 0}px;
+  }
+`;

--- a/web/src/components/TriggerTypeModal/TriggerTypeModal.tsx
+++ b/web/src/components/TriggerTypeModal/TriggerTypeModal.tsx
@@ -1,0 +1,45 @@
+import {TriggerTypeToPlugin} from 'constants/Plugins.constants';
+import {useDashboard} from 'providers/Dashboard/Dashboard.provider';
+import CreateTestAnalyticsService from 'services/Analytics/CreateTestAnalytics.service';
+import TriggerTypeCard from './TriggerTypeCard';
+import * as S from './TriggerTypeModal.styled';
+
+const pluginList = Object.values(TriggerTypeToPlugin);
+
+interface IProps {
+  isOpen: boolean;
+  onClose(): void;
+}
+
+const TriggerTypeModal = ({isOpen, onClose}: IProps) => {
+  const {navigate} = useDashboard();
+
+  return (
+    <S.Modal
+      onCancel={onClose}
+      footer={null}
+      title={<S.Title level={2}>Create a new test</S.Title>}
+      visible={isOpen}
+      width={625}
+    >
+      <S.Title level={3} $marginBottom={16}>
+        What kind of trigger do you want to use to initiate this Tracetest?
+      </S.Title>
+
+      <S.CardList>
+        {pluginList.map(plugin => (
+          <TriggerTypeCard
+            key={plugin.name}
+            onClick={selectedPlugin => {
+              CreateTestAnalyticsService.onPluginSelected(selectedPlugin.name);
+              navigate(`test/create/${selectedPlugin.type}`);
+            }}
+            plugin={plugin}
+          />
+        ))}
+      </S.CardList>
+    </S.Modal>
+  );
+};
+
+export default TriggerTypeModal;

--- a/web/src/components/TriggerTypeModal/index.ts
+++ b/web/src/components/TriggerTypeModal/index.ts
@@ -1,0 +1,2 @@
+// eslint-disable-next-line no-restricted-exports
+export {default} from './TriggerTypeModal';

--- a/web/src/pages/Home/TestsList.tsx
+++ b/web/src/pages/Home/TestsList.tsx
@@ -1,8 +1,8 @@
 import AllowButton, {Operation} from 'components/AllowButton';
 import CreateButton from 'components/CreateButton';
-import CreateTestModal from 'components/CreateTestModal/CreateTestModal';
 import Pagination from 'components/Pagination';
 import TestCard from 'components/ResourceCard/TestCard';
+import TriggerTypeModal from 'components/TriggerTypeModal';
 import {SortBy, SortDirection, sortOptions} from 'constants/Test.constants';
 import usePagination from 'hooks/usePagination';
 import useTestCrud from 'providers/Test/hooks/useTestCrud';
@@ -98,7 +98,7 @@ const Tests = () => {
         </Pagination>
       </S.Wrapper>
 
-      <CreateTestModal isOpen={isCreateTestOpen} onClose={() => setIsCreateTestOpen(false)} />
+      <TriggerTypeModal isOpen={isCreateTestOpen} onClose={() => setIsCreateTestOpen(false)} />
     </>
   );
 };


### PR DESCRIPTION
This PR adds the Trigger type selection modal that should be part of the new Test creation flow.

## Changes

- Trigger type modal

## Fixes

- fixes https://github.com/kubeshop/tracetest-cloud/issues/253

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Screenshot

<img width="1624" alt="Screenshot 2023-10-31 at 19 03 02" src="https://github.com/kubeshop/tracetest/assets/3879892/a09aebc0-1ca8-429b-82e5-e4fb6e6b726c">