### PR TITLE
feat: date generator functions

### DIFF
--- a/docs/docs/cli/creating-tests.mdx
+++ b/docs/docs/cli/creating-tests.mdx
@@ -184,7 +184,7 @@ Available functions:
 | `dateTime(format?)`   | Get the current datetime and formats it. Default is RFC3339 but you can specify other formats |
 
 :::tip
-[Continue reading about date and datetime formats, here.](https://www.w3.org/TR/NOTE-datetime)
+[Continue reading about date and datetime formats here.](https://www.w3.org/TR/NOTE-datetime)
 :::
 
 :::tip

--- a/docs/docs/cli/creating-tests.mdx
+++ b/docs/docs/cli/creating-tests.mdx
@@ -180,7 +180,7 @@ Available functions:
 | `creditCardCvv()`     | Generates a random credit card cvv (3 digits).                                                |
 | `creditCardExpDate()` | Generates a random credit card expiration date (mm/yy).                                       |
 | `randomInt(min, max)` | Generates a random integer contained in the closed interval defined by [`min`, `max`].        |
-| `date(format?)`       | Get the current date and formats it. Default is `YYYY-MM-DD` but you can specify other formats|
+| `date(format?)`       | Get the current date and formats it. Default is `YYYY-MM-DD` but you can specify other formats.|
 | `dateTime(format?)`   | Get the current datetime and formats it. Default is RFC3339 but you can specify other formats |
 
 :::tip

--- a/docs/docs/cli/creating-tests.mdx
+++ b/docs/docs/cli/creating-tests.mdx
@@ -181,7 +181,7 @@ Available functions:
 | `creditCardExpDate()` | Generates a random credit card expiration date (mm/yy).                                       |
 | `randomInt(min, max)` | Generates a random integer contained in the closed interval defined by [`min`, `max`].        |
 | `date(format?)`       | Get the current date and formats it. Default is `YYYY-MM-DD` but you can specify other formats.|
-| `dateTime(format?)`   | Get the current datetime and formats it. Default is RFC3339 but you can specify other formats |
+| `dateTime(format?)`   | Get the current datetime and formats it. Default is RFC3339 but you can specify other formats.|
 
 :::tip
 [Continue reading about date and datetime formats here.](https://www.w3.org/TR/NOTE-datetime)

--- a/docs/docs/cli/creating-tests.mdx
+++ b/docs/docs/cli/creating-tests.mdx
@@ -188,7 +188,7 @@ Available functions:
 :::
 
 :::tip
-[Continue reading about Test Specs, here.](/cli/creating-test-specifications)
+[Continue reading about Test Specs here.](/cli/creating-test-specifications)
 :::
 
 :::tip

--- a/docs/docs/cli/creating-tests.mdx
+++ b/docs/docs/cli/creating-tests.mdx
@@ -169,17 +169,23 @@ Generator functions can be invoked as part of expressions. Therefore, you only n
 Available functions:
 
 | Function              | Description |
-| :-------------------- | ------------------------------------------------------------------------------------- |
-| `uuid()`              | Generates a random v4 uuid.                                                            |
-| `firstName()`         | Generates a random English first name.                                                 |
-| `lastName()`          | Generates a random English last name.                                                  |
-| `fullName()`          | Generates a random English first and last name.                                        |
-| `email()`             | Generates a random email address.                                                      |
-| `phone()`             | Generates a random phone number.                                                       |
-| `creditCard()`        | Generates a random credit card number (from 12 to 19 digits).                          |
-| `creditCardCvv()`     | Generates a random credit card cvv (3 digits).                                         |
-| `creditCardExpDate()` | Generates a random credit card expiration date (mm/yy).                                |
-| `randomInt(min, max)` | Generates a random integer contained in the closed interval defined by [`min`, `max`]. |
+| :-------------------- | --------------------------------------------------------------------------------------------- |
+| `uuid()`              | Generates a random v4 uuid.                                                                   |
+| `firstName()`         | Generates a random English first name.                                                        |
+| `lastName()`          | Generates a random English last name.                                                         |
+| `fullName()`          | Generates a random English first and last name.                                               |
+| `email()`             | Generates a random email address.                                                             |
+| `phone()`             | Generates a random phone number.                                                              |
+| `creditCard()`        | Generates a random credit card number (from 12 to 19 digits).                                 |
+| `creditCardCvv()`     | Generates a random credit card cvv (3 digits).                                                |
+| `creditCardExpDate()` | Generates a random credit card expiration date (mm/yy).                                       |
+| `randomInt(min, max)` | Generates a random integer contained in the closed interval defined by [`min`, `max`].        |
+| `date(format?)`       | Get the current date and formats it. Default is `YYYY-MM-DD` but you can specify other formats|
+| `dateTime(format?)`   | Get the current datetime and formats it. Default is RFC3339 but you can specify other formats |
+
+:::tip
+[Continue reading about date and datetime formats, here.](https://www.w3.org/TR/NOTE-datetime)
+:::
 
 :::tip
 [Continue reading about Test Specs, here.](/cli/creating-test-specifications)

--- a/go.mod
+++ b/go.mod
@@ -171,6 +171,7 @@ require (
 	github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 // indirect
 	github.com/xeipuuv/gojsonschema v1.2.0 // indirect
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect
+	gitlab.com/metakeule/fmtdate v1.2.2 // indirect
 	go.opentelemetry.io/collector v0.80.0 // indirect
 	go.opentelemetry.io/collector/config/configauth v0.80.0 // indirect
 	go.opentelemetry.io/collector/config/confignet v0.80.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1848,6 +1848,8 @@ github.com/yvasiyarov/go-metrics v0.0.0-20140926110328-57bccd1ccd43/go.mod h1:aX
 github.com/yvasiyarov/gorelic v0.0.0-20141212073537-a9bba5b9ab50/go.mod h1:NUSPSUX/bi6SeDMUh6brw0nXpxHnc96TguQh0+r/ssA=
 github.com/yvasiyarov/newrelic_platform_go v0.0.0-20140908184405-b21fdbd4370f/go.mod h1:GlGEuHIJweS1mbCqG+7vt2nvWLzLLnRHbXz5JKd/Qbg=
 github.com/zenazn/goji v0.9.0/go.mod h1:7S9M489iMyHBNxwZnk9/EHS098H4/F6TATF2mIxtB1Q=
+gitlab.com/metakeule/fmtdate v1.2.2 h1:ce0Qnwo6PAONi6xwPr4YxdxAFIKqNfoMbHG4c49vIjk=
+gitlab.com/metakeule/fmtdate v1.2.2/go.mod h1:uZUf21xepWGLp6PgJGBbHeBVWO+/gsKi3Gdh0Fu4lGg=
 gitlab.com/nyarla/go-crypt v0.0.0-20160106005555-d9a5dc2b789b/go.mod h1:T3BPAOm2cqquPa0MKWeNkmOM5RQsRhkrwMWonFMN7fE=
 go.etcd.io/bbolt v1.3.2/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
 go.etcd.io/bbolt v1.3.3/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=

--- a/server/expression/executor_test.go
+++ b/server/expression/executor_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/kubeshop/tracetest/server/expression"
 	"github.com/kubeshop/tracetest/server/traces"
@@ -243,6 +244,26 @@ func TestFunctionExecution(t *testing.T) {
 			Name:       "should_generate_a_random_int_and_fail_comparison",
 			Query:      `randomInt(10,20) < 10`,
 			ShouldPass: false,
+		},
+		{
+			Name:       "should_generate_date_string",
+			Query:      fmt.Sprintf(`date() = "%s"`, time.Now().Format(time.DateOnly)),
+			ShouldPass: true,
+		},
+		{
+			Name:       "should_generate_date_string",
+			Query:      fmt.Sprintf(`date("DD/MM/YYYY") = "%s"`, time.Now().Format("02/01/2006")),
+			ShouldPass: true,
+		},
+		{
+			Name:       "should_generate_date_string",
+			Query:      fmt.Sprintf(`dateTime() = "%s"`, time.Now().Format(time.RFC3339)),
+			ShouldPass: true,
+		},
+		{
+			Name:       "should_generate_date_string",
+			Query:      fmt.Sprintf(`dateTime("DD/MM/YYYY hh:mm") = "%s"`, time.Now().Format("02/01/2006 15:04")),
+			ShouldPass: true,
 		},
 	}
 

--- a/server/expression/functions/function.go
+++ b/server/expression/functions/function.go
@@ -74,6 +74,8 @@ func DefaultRegistry() Registry {
 	registry.Add("fullName", generateFullName)
 	registry.Add("email", generateEmail)
 	registry.Add("phone", generatePhoneNumber)
+	registry.Add("date", generateDate, OptionalParam(types.TypeString))
+	registry.Add("dateTime", generateDateTime, OptionalParam(types.TypeString))
 	registry.Add("creditCard", generateCreditCard)
 	registry.Add("creditCardCvv", generateCreditCardCVV)
 	registry.Add("creditCardExpDate", generateCreditCardExpiration)

--- a/server/expression/functions/function.go
+++ b/server/expression/functions/function.go
@@ -9,20 +9,55 @@ import (
 type Invoker func(args ...types.TypedValue) string
 
 type Function struct {
-	name     string
-	invoker  Invoker
-	argTypes []types.Type
+	name       string
+	invoker    Invoker
+	parameters []Parameter
+}
+
+func (f Function) NumRequiredParams() int {
+	count := 0
+	for _, param := range f.parameters {
+		if !param.optional {
+			count++
+		}
+	}
+
+	return count
+}
+
+func (f Function) Validate() error {
+	foundOptionalParameterIndex := -1
+	for i, param := range f.parameters {
+		if param.optional {
+			foundOptionalParameterIndex = i
+		}
+
+		if foundOptionalParameterIndex > -1 && !param.optional {
+			// there's a required parameter after a optional parameter
+			// this is invalid in most programming languages and makes it
+			// extremely hard to resolve the function, so fail it.
+			return fmt.Errorf("argument at index %d is required, but it's after optional argument at index %d", i, foundOptionalParameterIndex)
+		}
+	}
+
+	return nil
+}
+
+type Parameter struct {
+	pType    types.Type
+	optional bool
 }
 
 func (f Function) Invoke(args ...types.TypedValue) (types.TypedValue, error) {
-	if len(args) != len(f.argTypes) {
-		return types.TypedValue{}, fmt.Errorf("invalid number of arguments. Expected %d, got %d", len(f.argTypes), len(args))
+	numberRequiredParams := f.NumRequiredParams()
+	if len(args) < numberRequiredParams {
+		return types.TypedValue{}, fmt.Errorf("missing required parameters. Expected at least %d params, got %d", numberRequiredParams, len(args))
 	}
 
 	for i, arg := range args {
-		expectedArgType := f.argTypes[i]
-		if arg.Type != expectedArgType {
-			return types.TypedValue{}, fmt.Errorf("invalid argument type on index %d: expected %s, got %s", i, arg.Type.String(), expectedArgType.String())
+		param := f.parameters[i]
+		if arg.Type != param.pType {
+			return types.TypedValue{}, fmt.Errorf("invalid argument type on index %d: expected %s, got %s", i, arg.Type.String(), param.pType.String())
 		}
 	}
 
@@ -31,19 +66,26 @@ func (f Function) Invoke(args ...types.TypedValue) (types.TypedValue, error) {
 }
 
 func DefaultRegistry() Registry {
-	emptyArgsConfig := []types.Type{}
 	registry := newRegistry()
 
-	registry.Add("uuid", generateUUID, emptyArgsConfig)
-	registry.Add("firstName", generateFirstName, emptyArgsConfig)
-	registry.Add("lastName", generateLastName, emptyArgsConfig)
-	registry.Add("fullName", generateFullName, emptyArgsConfig)
-	registry.Add("email", generateEmail, emptyArgsConfig)
-	registry.Add("phone", generatePhoneNumber, emptyArgsConfig)
-	registry.Add("creditCard", generateCreditCard, emptyArgsConfig)
-	registry.Add("creditCardCvv", generateCreditCardCVV, emptyArgsConfig)
-	registry.Add("creditCardExpDate", generateCreditCardExpiration, emptyArgsConfig)
-	registry.Add("randomInt", generateRandomInt, []types.Type{types.TypeNumber, types.TypeNumber})
+	registry.Add("uuid", generateUUID)
+	registry.Add("firstName", generateFirstName)
+	registry.Add("lastName", generateLastName)
+	registry.Add("fullName", generateFullName)
+	registry.Add("email", generateEmail)
+	registry.Add("phone", generatePhoneNumber)
+	registry.Add("creditCard", generateCreditCard)
+	registry.Add("creditCardCvv", generateCreditCardCVV)
+	registry.Add("creditCardExpDate", generateCreditCardExpiration)
+	registry.Add("randomInt", generateRandomInt, Param(types.TypeNumber), Param(types.TypeNumber))
 
 	return registry
+}
+
+func Param(pType types.Type) Parameter {
+	return Parameter{pType: pType, optional: false}
+}
+
+func OptionalParam(pType types.Type) Parameter {
+	return Parameter{pType: pType, optional: true}
 }

--- a/server/expression/functions/function_registry_test.go
+++ b/server/expression/functions/function_registry_test.go
@@ -10,6 +10,20 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestFunctionValidation(t *testing.T) {
+	registry := functions.DefaultRegistry()
+
+	emptyStringFn := func(args ...types.TypedValue) string { return "" }
+
+	assert.Panics(t, func() {
+		registry.Add("faulty", emptyStringFn,
+			functions.Param(types.TypeString),
+			functions.OptionalParam(types.TypeString),
+			functions.Param(types.TypeNumber),
+		)
+	})
+}
+
 func TestFunctionWithoutArgs(t *testing.T) {
 	registry := functions.DefaultRegistry()
 
@@ -55,7 +69,7 @@ func TestFunctionWithWrongArgNumber(t *testing.T) {
 
 	_, err = function.Invoke()
 	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "invalid number of arguments")
+	assert.Contains(t, err.Error(), "missing required parameters")
 }
 
 func TestFunctionWithWrongArgType(t *testing.T) {

--- a/server/expression/functions/functions.go
+++ b/server/expression/functions/functions.go
@@ -3,9 +3,11 @@ package functions
 import (
 	"fmt"
 	"strconv"
+	"time"
 
 	"github.com/brianvoe/gofakeit/v6"
 	"github.com/kubeshop/tracetest/server/expression/types"
+	"gitlab.com/metakeule/fmtdate"
 )
 
 func generateUUID(args ...types.TypedValue) string {
@@ -49,4 +51,21 @@ func generateRandomInt(args ...types.TypedValue) string {
 	min, _ := strconv.Atoi(args[0].Value)
 	max, _ := strconv.Atoi(args[1].Value)
 	return fmt.Sprintf("%d", gofakeit.Number(min, max))
+}
+
+func generateDate(args ...types.TypedValue) string {
+	format := time.DateOnly
+	if len(args) > 0 {
+		format = args[0].Value
+	}
+
+	return fmtdate.Format(format, time.Now())
+}
+
+func generateDateTime(args ...types.TypedValue) string {
+	format := time.RFC3339
+	if len(args) > 0 {
+		format = args[0].Value
+	}
+	return fmtdate.Format(format, time.Now())
 }


### PR DESCRIPTION
This PR adds support for two new generator functions: `date()` and `dateTime()`.

## Motivation
This was asked by a user in our [discord channel](https://discordapp.com/channels/884464549347074049/963470167327772703/1169196012120834130)

## About the functions
```go
// returns the date in the time.DateOnly format (YYYY-MM-DD)
// if format is provided, it will be formatted based on it.
date(format optional<string>)

// returns the date and time in the time.RFC3339 format (2006-01-02T15:04:05Z07:00)
// if format is provided, it will be formatted based on it.
dateTime(format optional<string>)
```

## Examples

```
date() : 2023-11-01
date("MM-DD-YYYY") : 11-01-2023
date("DD/MM/YYYY") : 01/11/2023
dateTime() : 2023-11-01T12:38:12Z03:00
dateTime("hh:mm:ss") : 12:38:12
```

## Checklist

- [x] tested locally
- [x] added new dependencies
- [x] updated the docs
- [x] added a test

## Loom video

Add your loom video here if your work can be visualized
