### PR TITLE
fix(agent): trace propagation via agent

### DIFF
--- a/agent/workers/trigger/instrument.go
+++ b/agent/workers/trigger/instrument.go
@@ -39,8 +39,11 @@ func (t *instrumentedTriggerer) Trigger(ctx context.Context, triggerConfig trigg
 		return Response{}, fmt.Errorf("could not create tracestate: %w", err)
 	}
 
+	var tf trace.TraceFlags
 	spanContextConfig := trace.SpanContextConfig{
 		TraceState: tracestate,
+		Remote:     true,
+		TraceFlags: tf.WithSampled(true),
 	}
 
 	if opts != nil {


### PR DESCRIPTION
This PR fixes the propagation error that we had in the agent when running grpc and kafka triggers

## Checklist

- [ ] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Loom video

Add your loom video here if your work can be visualized
