### PR TITLE
fix: convert zipCode as string for HTTP tests on OTel Demo

### DIFF
--- a/web/src/constants/Demo.constants.ts
+++ b/web/src/constants/Demo.constants.ts
@@ -187,7 +187,7 @@ export function getOtelDemo(demoSettings: Demo) {
             state: 'CA',
             country: 'United States',
             city: 'Mountain View',
-            zipCode: 94043,
+            zipCode: '94043',
           },
           userCurrency: 'USD',
           creditCard: {


### PR DESCRIPTION
This PR converts zipCode as a string for HTTP tests on OTel Demo. Without this, the OTel Demo can throw an HTTP 500 error.

## Changes

- Updated OTel Demo template on UI

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
