### PR TITLE
fix(backend): Adding Composed Primary Keys

### DIFF
--- a/server/migrations/34_add_composite_pkey.down.sql
+++ b/server/migrations/34_add_composite_pkey.down.sql
@@ -27,6 +27,8 @@ ALTER TABLE
   test_runs DROP CONSTRAINT test_runs_pkey CASCADE,
 ADD
   CONSTRAINT test_runs_pkey PRIMARY KEY (id, test_id),
+ADD
+  CONSTRAINT fk_test_runs_tests FOREIGN KEY (test_id, test_version) REFERENCES tests(id, version),
 ALTER COLUMN
   tenant_id DROP DEFAULT,
 ALTER COLUMN
@@ -71,6 +73,8 @@ ALTER TABLE
   test_suite_runs DROP CONSTRAINT transaction_run_pkey CASCADE,
 ADD
   CONSTRAINT transaction_run_pkey PRIMARY KEY (id, test_suite_id),
+ADD
+  CONSTRAINT transaction_run_transactions_fk FOREIGN KEY (test_suite_id, test_suite_version) REFERENCES test_suites(id, version),
 ALTER COLUMN
   tenant_id DROP DEFAULT,
 ALTER COLUMN

--- a/server/migrations/34_add_composite_pkey.down.sql
+++ b/server/migrations/34_add_composite_pkey.down.sql
@@ -1,0 +1,113 @@
+BEGIN;
+
+-- Tests
+ALTER TABLE
+  tests DROP CONSTRAINT tests_pkey CASCADE,
+ADD
+  CONSTRAINT tests_pkey PRIMARY KEY (id, version),
+ALTER COLUMN
+  tenant_id DROP DEFAULT,
+ALTER COLUMN
+  tenant_id DROP NOT NULL;
+
+UPDATE
+  tests
+SET
+  tenant_id = null
+WHERE
+  tenant_id = '';
+
+ALTER TABLE
+  tests
+ALTER COLUMN
+  tenant_id TYPE uuid using tenant_id :: uuid;
+
+-- # Test Runs
+ALTER TABLE
+  test_runs DROP CONSTRAINT test_runs_pkey CASCADE,
+ADD
+  CONSTRAINT test_runs_pkey PRIMARY KEY (id, test_id),
+ALTER COLUMN
+  tenant_id DROP DEFAULT,
+ALTER COLUMN
+  tenant_id DROP NOT NULL;
+
+UPDATE
+  test_runs
+SET
+  tenant_id = null
+WHERE
+  tenant_id = '';
+
+ALTER TABLE
+  test_runs
+ALTER COLUMN
+  tenant_id TYPE uuid using tenant_id :: uuid;
+
+-- Test Suites
+ALTER TABLE
+  test_suites DROP CONSTRAINT transaction_pkey CASCADE,
+ADD
+  CONSTRAINT transaction_pkey PRIMARY KEY (id, version),
+ALTER COLUMN
+  tenant_id DROP DEFAULT,
+ALTER COLUMN
+  tenant_id DROP NOT NULL;
+
+UPDATE
+  test_suites
+SET
+  tenant_id = null
+WHERE
+  tenant_id = '';
+
+ALTER TABLE
+  test_suites
+ALTER COLUMN
+  tenant_id TYPE uuid using tenant_id :: uuid;
+
+-- Test Suite Runs
+ALTER TABLE
+  test_suite_runs DROP CONSTRAINT transaction_run_pkey CASCADE,
+ADD
+  CONSTRAINT transaction_run_pkey PRIMARY KEY (id, test_suite_id),
+ALTER COLUMN
+  tenant_id DROP DEFAULT,
+ALTER COLUMN
+  tenant_id DROP NOT NULL;
+
+UPDATE
+  test_suite_runs
+SET
+  tenant_id = null
+WHERE
+  tenant_id = '';
+
+ALTER TABLE
+  test_suite_runs
+ALTER COLUMN
+  tenant_id TYPE uuid using tenant_id :: uuid;
+
+-- Variable Sets
+ALTER TABLE
+  variable_sets DROP CONSTRAINT environments_pkey CASCADE,
+ADD
+  CONSTRAINT environments_pkey PRIMARY KEY (id),
+ALTER COLUMN
+  tenant_id DROP DEFAULT,
+ALTER COLUMN
+  tenant_id DROP NOT NULL;
+
+UPDATE
+  variable_sets
+SET
+  tenant_id = null
+WHERE
+  tenant_id = '';
+
+ALTER TABLE
+  variable_sets
+ALTER COLUMN
+  tenant_id TYPE uuid using tenant_id :: uuid;
+
+COMMIT;

--- a/server/migrations/34_add_composite_pkey.up.sql
+++ b/server/migrations/34_add_composite_pkey.up.sql
@@ -39,6 +39,8 @@ ALTER TABLE
   test_runs DROP CONSTRAINT test_runs_pkey CASCADE,
 ADD
   CONSTRAINT test_runs_pkey PRIMARY KEY (id, test_id, tenant_id),
+ADD
+  CONSTRAINT fk_test_runs_tests FOREIGN KEY (test_id, test_version, tenant_id) REFERENCES tests(id, version, tenant_id),
 ALTER COLUMN
   tenant_id
 SET
@@ -83,6 +85,8 @@ ALTER TABLE
   test_suite_runs DROP CONSTRAINT transaction_run_pkey CASCADE,
 ADD
   CONSTRAINT transaction_run_pkey PRIMARY KEY (id, test_suite_id, tenant_id),
+ADD
+  CONSTRAINT transaction_run_transactions_fk FOREIGN KEY (test_suite_id, test_suite_version, tenant_id) REFERENCES test_suites(id, version, tenant_id),
 ALTER COLUMN
   tenant_id
 SET

--- a/server/migrations/34_add_composite_pkey.up.sql
+++ b/server/migrations/34_add_composite_pkey.up.sql
@@ -1,0 +1,113 @@
+BEGIN;
+
+--  Tests
+ALTER TABLE
+  tests
+ALTER COLUMN
+  tenant_id TYPE varchar;
+
+UPDATE
+  tests
+SET
+  tenant_id = ''
+WHERE
+  tenant_id is null;
+
+ALTER TABLE
+  tests DROP CONSTRAINT tests_pkey CASCADE,
+ADD
+  CONSTRAINT tests_pkey PRIMARY KEY (id, version, tenant_id),
+ALTER COLUMN
+  tenant_id
+SET
+  DEFAULT '';
+
+--  Test Runs
+ALTER TABLE
+  test_runs
+ALTER COLUMN
+  tenant_id TYPE varchar;
+
+UPDATE
+  test_runs
+SET
+  tenant_id = ''
+WHERE
+  tenant_id is null;
+
+ALTER TABLE
+  test_runs DROP CONSTRAINT test_runs_pkey CASCADE,
+ADD
+  CONSTRAINT test_runs_pkey PRIMARY KEY (id, test_id, tenant_id),
+ALTER COLUMN
+  tenant_id
+SET
+  DEFAULT '';
+
+--  Test Suites
+ALTER TABLE
+  test_suites
+ALTER COLUMN
+  tenant_id TYPE varchar;
+
+UPDATE
+  test_suites
+SET
+  tenant_id = ''
+WHERE
+  tenant_id is null;
+
+ALTER TABLE
+  test_suites DROP CONSTRAINT transaction_pkey CASCADE,
+ADD
+  CONSTRAINT transaction_pkey PRIMARY KEY (id, version, tenant_id),
+ALTER COLUMN
+  tenant_id
+SET
+  DEFAULT '';
+
+--  Test Suite Runs
+ALTER TABLE
+  test_suite_runs
+ALTER COLUMN
+  tenant_id TYPE varchar;
+
+UPDATE
+  test_suite_runs
+SET
+  tenant_id = ''
+WHERE
+  tenant_id is null;
+
+ALTER TABLE
+  test_suite_runs DROP CONSTRAINT transaction_run_pkey CASCADE,
+ADD
+  CONSTRAINT transaction_run_pkey PRIMARY KEY (id, test_suite_id, tenant_id),
+ALTER COLUMN
+  tenant_id
+SET
+  DEFAULT '';
+
+--  Variable Sets
+ALTER TABLE
+  variable_sets
+ALTER COLUMN
+  tenant_id TYPE varchar;
+
+UPDATE
+  variable_sets
+SET
+  tenant_id = ''
+WHERE
+  tenant_id is null;
+
+ALTER TABLE
+  variable_sets DROP CONSTRAINT environments_pkey CASCADE,
+ADD
+  CONSTRAINT environments_pkey PRIMARY KEY (id, tenant_id),
+ALTER COLUMN
+  tenant_id
+SET
+  DEFAULT '';
+
+COMMIT;

--- a/server/test/test_repository.go
+++ b/server/test/test_repository.go
@@ -380,10 +380,7 @@ func (r *repository) insertTest(ctx context.Context, test Test) (Test, error) {
 		return Test{}, fmt.Errorf("encoding error: %w", err)
 	}
 
-	tenantID := sqlutil.TenantID(ctx)
-
-	_, err = stmt.ExecContext(
-		ctx,
+	params := sqlutil.TenantInsert(ctx,
 		test.ID,
 		test.Version,
 		test.Name,
@@ -392,8 +389,9 @@ func (r *repository) insertTest(ctx context.Context, test Test) (Test, error) {
 		specsJson,
 		outputsJson,
 		test.CreatedAt,
-		tenantID,
 	)
+
+	_, err = stmt.ExecContext(ctx, params...)
 	if err != nil {
 		return Test{}, fmt.Errorf("sql exec: %w", err)
 	}

--- a/server/test/test_repository.go
+++ b/server/test/test_repository.go
@@ -74,14 +74,14 @@ const (
 		t.specs,
 		t.outputs,
 		t.created_at,
-		(SELECT COUNT(*) FROM test_runs tr WHERE tr.test_id = t.id) as total_runs,
+		(SELECT COUNT(*) FROM test_runs tr WHERE tr.test_id = t.id AND tr.tenant_id = t.tenant_id) as total_runs,
 		last_test_run.created_at as last_test_run_time,
 		last_test_run.pass as last_test_run_pass,
 		last_test_run.fail as last_test_run_fail
 	FROM tests t
 	LEFT OUTER JOIN (
-		SELECT MAX(id) as id, test_id FROM test_runs GROUP BY test_id
-	) as ltr ON ltr.test_id = t.id
+		SELECT MAX(id) as id, test_id, tenant_id FROM test_runs GROUP BY test_id, tenant_id
+	) as ltr ON ltr.test_id = t.id AND ltr.tenant_id = t.tenant_id
 	LEFT OUTER JOIN
 		test_runs last_test_run
 	ON last_test_run.test_id = ltr.test_id AND last_test_run.id = ltr.id
@@ -89,8 +89,8 @@ const (
 
 	testMaxVersionQuery = `
 	INNER JOIN (
-		SELECT id as idx, max(version) as latest_version FROM tests GROUP BY idx
-		) as latest_tests ON latest_tests.idx = t.id AND t.version = latest_tests.latest_version
+		SELECT id as idx, tenant_id, max(version) as latest_version FROM tests GROUP BY idx, tenant_id
+		) as latest_tests ON latest_tests.idx = t.id AND t.version = latest_tests.latest_version AND t.tenant_id = latest_tests.tenant_id
 	`
 )
 

--- a/server/testsuite/testsuite_repository.go
+++ b/server/testsuite/testsuite_repository.go
@@ -353,17 +353,15 @@ func (r *Repository) insertIntoTestSuites(ctx context.Context, suite TestSuite) 
 	}
 	defer stmt.Close()
 
-	tenantID := sqlutil.TenantID(ctx)
-
-	_, err = stmt.ExecContext(
-		ctx,
+	params := sqlutil.TenantInsert(ctx,
 		suite.ID,
 		suite.GetVersion(),
 		suite.Name,
 		suite.Description,
 		suite.GetCreatedAt(),
-		tenantID,
 	)
+
+	_, err = stmt.ExecContext(ctx, params...)
 	if err != nil {
 		return TestSuite{}, fmt.Errorf("sql exec: %w", err)
 	}

--- a/server/testsuite/testsuite_repository.go
+++ b/server/testsuite/testsuite_repository.go
@@ -162,8 +162,8 @@ const getTestSuiteSQL = `
 		%s
 	FROM test_suites t
 	LEFT OUTER JOIN (
-		SELECT MAX(id) as id, test_suite_id FROM test_suite_runs GROUP BY test_suite_id
-	) as ltr ON ltr.test_suite_id = t.id
+		SELECT MAX(id) as id, tenant_id, test_suite_id FROM test_suite_runs GROUP BY test_suite_id, tenant_id
+	) as ltr ON ltr.test_suite_id = t.id AND ltr.tenant_id = t.tenant_id
 	LEFT OUTER JOIN
 		test_suite_runs last_test_suite_run
 	ON last_test_suite_run.test_suite_id = ltr.test_suite_id AND last_test_suite_run.id = ltr.id
@@ -171,8 +171,8 @@ const getTestSuiteSQL = `
 
 const testSuiteMaxVersionQuery = `
 	INNER JOIN (
-		SELECT id as idx, max(version) as latest_version FROM test_suites GROUP BY idx
-	) as latest_test_suites ON latest_test_suites.idx = t.id
+		SELECT id as idx, tenant_id, max(version) as latest_version FROM test_suites GROUP BY idx, tenant_id
+	) as latest_test_suites ON latest_test_suites.idx = t.id AND latest_test_suites.tenant_id = t.tenant_id
 
 	WHERE t.version = latest_test_suites.latest_version `
 
@@ -241,7 +241,7 @@ func querySelect() string {
 				HAVING ts.test_suite_id = t.id AND ts.test_suite_version = t.version
 			) as step_ids_query
 		) as step_ids,
-		(SELECT COUNT(*) FROM test_suite_runs tr WHERE tr.test_suite_id = t.id) as total_runs,
+		(SELECT COUNT(*) FROM test_suite_runs tr WHERE tr.test_suite_id = t.id AND tr.tenant_id = t.tenant_id) as total_runs,
 		last_test_suite_run.created_at as last_test_suite_run_time,
 		last_test_suite_run.pass as last_test_run_pass,
 		last_test_suite_run.fail as last_test_run_fail

--- a/server/testsuite/testsuite_run_repository.go
+++ b/server/testsuite/testsuite_run_repository.go
@@ -124,12 +124,7 @@ func (td *RunRepository) CreateRun(ctx context.Context, tr TestSuiteRun) (TestSu
 		return TestSuiteRun{}, fmt.Errorf("sql exec: %w", err)
 	}
 
-	tenantID := sqlutil.TenantID(ctx)
-
-	var runID int
-	err = tx.QueryRowContext(
-		ctx,
-		replaceTestSuiteRunSequenceName(createTestSuiteRunQuery, tr.TestSuiteID),
+	params := sqlutil.TenantInsert(ctx,
 		tr.TestSuiteID,
 		tr.TestSuiteVersion,
 		tr.CreatedAt,
@@ -137,7 +132,13 @@ func (td *RunRepository) CreateRun(ctx context.Context, tr TestSuiteRun) (TestSu
 		tr.CurrentTest,
 		jsonMetadata,
 		jsonVariableSet,
-		tenantID,
+	)
+
+	var runID int
+	err = tx.QueryRowContext(
+		ctx,
+		replaceTestSuiteRunSequenceName(createTestSuiteRunQuery, tr.TestSuiteID),
+		params...,
 	).Scan(&runID)
 	if err != nil {
 		tx.Rollback()

--- a/server/variableset/variableset_repository.go
+++ b/server/variableset/variableset_repository.go
@@ -259,17 +259,15 @@ func (r *Repository) insertIntoEnvironments(ctx context.Context, variableSet Var
 		return VariableSet{}, fmt.Errorf("encoding error: %w", err)
 	}
 
-	tenantID := sqlutil.TenantID(ctx)
-
-	_, err = stmt.ExecContext(
-		ctx,
+	params := sqlutil.TenantInsert(ctx,
 		variableSet.ID,
 		variableSet.Name,
 		variableSet.Description,
 		variableSet.CreatedAt,
 		jsonValues,
-		tenantID,
 	)
+
+	_, err = stmt.ExecContext(ctx, params...)
 
 	if err != nil {
 		return VariableSet{}, fmt.Errorf("sql exec: %w", err)


### PR DESCRIPTION
This PR fixes the problem when trying to use the same ID for tests, test suites, and variable sets from a different tenant ID perspective

## Changes

- Adds migrations to use composed primary keys for the missing tables
- Fixes queries around listing and getting tests/test suites by adding tenant id

## Fixes

- https://github.com/kubeshop/tracetest-cloud/issues/259

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Loom video

https://www.loom.com/share/bd1cbd2dc57e46cfb50c710a8ac00119