### PR TITLE
fix: add "server closed" as connection error

### DIFF
--- a/agent/client/client.go
+++ b/agent/client/client.go
@@ -193,7 +193,21 @@ func (c *Client) handleDisconnectionError(inputErr error) (bool, error) {
 }
 
 func isConnectionError(err error) bool {
-	return err != nil && strings.Contains(err.Error(), "connection refused")
+	if err == nil {
+		return false
+	}
+
+	possibleErrors := []string{
+		"connection refused",
+		"server closed",
+	}
+	for _, possibleErr := range possibleErrors {
+		if strings.Contains(err.Error(), possibleErr) {
+			return true
+		}
+	}
+
+	return false
 }
 
 func isEndOfFileError(err error) bool {


### PR DESCRIPTION
This PR adds the "server closed" error as a connection error for the agent to reconnect to the server.


## Checklist

- [ ] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Loom video

Add your loom video here if your work can be visualized
