### PR TITLE
fix: Default Sort By

### DIFF
--- a/web/src/constants/Test.constants.ts
+++ b/web/src/constants/Test.constants.ts
@@ -25,14 +25,14 @@ export enum SortDirection {
 
 export const sortOptions = [
   {
-    label: 'Recently Created',
-    value: 'created',
-    params: {sortDirection: SortDirection.Desc, sortBy: SortBy.Created},
-  },
-  {
     label: 'Last Run',
     value: 'last_run',
     params: {sortDirection: SortDirection.Desc, sortBy: SortBy.LastRun},
+  },
+  {
+    label: 'Recently Created',
+    value: 'created',
+    params: {sortDirection: SortDirection.Desc, sortBy: SortBy.Created},
   },
   {
     label: 'Name, A to Z',


### PR DESCRIPTION
This PR switches the default sort by to use `Last Run` as default

## Changes

- Updates sort options order 

## Fixes

- https://github.com/kubeshop/tracetest-cloud-frontend/issues/137

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
