### PR TITLE
fix(frontend): add variable set selector

### DIFF
--- a/web/src/components/CreateTest/CreateTest.styled.ts
+++ b/web/src/components/CreateTest/CreateTest.styled.ts
@@ -33,7 +33,7 @@ export const HeaderRight = styled.div`
 
 export const Body = styled.div`
   display: flex;
-  height: calc(100vh - 166px);
+  height: calc(100vh - 172px);
   width: 100%;
 `;
 

--- a/web/src/components/Fields/SkipTraceCollection/SkipTraceCollection.tsx
+++ b/web/src/components/Fields/SkipTraceCollection/SkipTraceCollection.tsx
@@ -5,11 +5,11 @@ import * as S from '../SSL/SSL.styled';
 const SkipTraceCollection = () => {
   return (
     <S.SSLVerificationContainer>
-      <label htmlFor="skipTraceCollection">Skip Trace Collection</label>
+      <label htmlFor="skipTraceCollection">Skip Trace collection</label>
       <Form.Item name="skipTraceCollection" valuePropName="checked" style={{marginBottom: 0}}>
         <Switch id="skipTraceCollection" />
       </Form.Item>
-      <TooltipQuestion title="Skips Trace Collection for all runs. You can still create and run tests." />
+      <TooltipQuestion title="Skip Trace collection for all runs. You can still create and run tests." />
     </S.SSLVerificationContainer>
   );
 };

--- a/web/src/components/ImportModal/ImportModal.styled.ts
+++ b/web/src/components/ImportModal/ImportModal.styled.ts
@@ -1,5 +1,5 @@
 import styled from 'styled-components';
-import {Modal as AntModal} from 'antd';
+import {Modal as AntModal, Typography} from 'antd';
 
 export const Modal = styled(AntModal)`
   min-width: 625px;
@@ -14,4 +14,10 @@ export const Modal = styled(AntModal)`
 
 export const Container = styled.div`
   min-height: 361px;
+`;
+
+export const Title = styled(Typography.Title)`
+  && {
+    margin-bottom: 0px;
+  }
 `;

--- a/web/src/components/ImportModal/ImportModal.tsx
+++ b/web/src/components/ImportModal/ImportModal.tsx
@@ -6,9 +6,9 @@ import ImportService from 'services/Import.service';
 import {useDashboard} from 'providers/Dashboard/Dashboard.provider';
 import {ImportTypeToPlugin} from 'constants/Plugins.constants';
 import {useCreateTest} from 'providers/CreateTest/CreateTest.provider';
+import {ImportSelector} from 'components/Inputs';
+import ImportFactory from 'components/TestPlugins/ImportFactory';
 import * as S from './ImportModal.styled';
-import {ImportSelector} from '../Inputs';
-import ImportFactory from '../TestPlugins/ImportFactory';
 import Tip from './Tip';
 
 interface IProps {
@@ -55,7 +55,7 @@ const ImportModal = ({isOpen, onClose}: IProps) => {
         </>
       }
       onCancel={onClose}
-      title="Import to Tracetest"
+      title={<S.Title level={2}>Import a test</S.Title>}
       visible={isOpen}
       centered
     >

--- a/web/src/components/ImportModal/Tip.tsx
+++ b/web/src/components/ImportModal/Tip.tsx
@@ -1,15 +1,13 @@
 import {BulbOutlined} from '@ant-design/icons';
 import {Typography} from 'antd';
 
-const Tip = () => {
-  return (
-    <>
-      <Typography.Title level={3} type="secondary">
-        <BulbOutlined /> What are supported formats?
-      </Typography.Title>
-      <Typography.Text type="secondary">We support cURL & Postman. OpenAPI is coming soon!</Typography.Text>
-    </>
-  );
-};
+const Tip = () => (
+  <>
+    <Typography.Title level={3} type="secondary">
+      <BulbOutlined /> What are the supported formats?
+    </Typography.Title>
+    <Typography.Text type="secondary">We support cURL & Postman. OpenAPI is coming soon!</Typography.Text>
+  </>
+);
 
 export default Tip;

--- a/web/src/components/RunDetailLayout/HeaderLeft.tsx
+++ b/web/src/components/RunDetailLayout/HeaderLeft.tsx
@@ -5,7 +5,7 @@ import {useTestRun} from 'providers/TestRun/TestRun.provider';
 import {useMemo} from 'react';
 import Date from 'utils/Date';
 import {isRunStateFinished} from 'models/TestRun.model';
-import { TDraftTest } from 'types/Test.types';
+import {TDraftTest} from 'types/Test.types';
 import TestService from 'services/Test.service';
 import HeaderForm from './HeaderForm';
 import Info from './Info';
@@ -53,12 +53,8 @@ const HeaderLeft = ({name, triggerType, origin}: IProps) => {
         <S.BackIcon />
       </a>
       <S.InfoContainer>
-        <S.Row>
-          <HeaderForm
-            name={name}
-            onSubmit={handleOnEdit}
-            isDisabled={isLoading || !stateIsFinished}
-          />
+        <S.Row $height={24}>
+          <HeaderForm name={name} onSubmit={handleOnEdit} isDisabled={isLoading || !stateIsFinished} />
           <Info
             date={createdAt ?? ''}
             executionTime={executionTime ?? 0}

--- a/web/src/components/RunDetailLayout/RunDetailLayout.styled.ts
+++ b/web/src/components/RunDetailLayout/RunDetailLayout.styled.ts
@@ -85,8 +85,9 @@ export const InfoContainer = styled.div`
   flex: 1;
 `;
 
-export const Row = styled.div`
+export const Row = styled.div<{$height?: number}>`
   display: flex;
+  height: ${({$height}) => `${$height}px` || 'auto'};
 `;
 
 export const Section = styled.div<{$justifyContent: string}>`

--- a/web/src/components/TestPlugins/Imports/Curl/Curl.tsx
+++ b/web/src/components/TestPlugins/Imports/Curl/Curl.tsx
@@ -9,7 +9,7 @@ export const FORM_ID = 'create-test';
 const Curl = () => {
   return (
     <Form.Item
-      label="Paste cUrl command, raw text, or url to definition file"
+      label="Paste cURL command"
       name="command"
       rules={[
         {required: true, message: 'Please enter a command'},
@@ -21,7 +21,7 @@ const Curl = () => {
 
             return Promise.resolve();
           },
-          message: 'Invalid CURL command',
+          message: 'Invalid cURL command',
         },
       ]}
     >

--- a/web/src/components/TestPlugins/Imports/Postman/fields/CollectionFileField.tsx
+++ b/web/src/components/TestPlugins/Imports/Postman/fields/CollectionFileField.tsx
@@ -12,7 +12,7 @@ export const CollectionFileField = ({form}: IProps): React.ReactElement => (
   <Form.Item
     rules={[{required: true, message: 'No file selected yet'}]}
     name="collectionFile"
-    label="Upload Postman Collection"
+    label="Upload Postman collection"
   >
     <FileUpload data-cy="collectionFile" accept=".json" onChange={useUploadCollectionCallback(form)} />
   </Form.Item>

--- a/web/src/components/TestPlugins/Imports/Postman/fields/SelectTestFromCollection.tsx
+++ b/web/src/components/TestPlugins/Imports/Postman/fields/SelectTestFromCollection.tsx
@@ -16,7 +16,7 @@ export const SelectTestFromCollection = ({form}: IProps) => {
     <Form.Item
       rules={[{required: true, message: 'No test selected yet'}]}
       name="collectionTest"
-      label="Select test from Postman Collection"
+      label="Select test from Postman collection"
     >
       <Select<string>
         data-cy="collectionTest-select"

--- a/web/src/pages/CreateTest/HeaderLeft.tsx
+++ b/web/src/pages/CreateTest/HeaderLeft.tsx
@@ -17,12 +17,12 @@ const HeaderLeft = ({triggerType, origin}: IProps) => {
         <S.BackIcon />
       </a>
       <S.InfoContainer>
-        <Form.Item name="name" noStyle>
-          <Overlay />
-        </Form.Item>
-        <S.Row>
-          <S.Text>{triggerType.toUpperCase()}</S.Text>
+        <S.Row $height={24}>
+          <Form.Item name="name" noStyle>
+            <Overlay />
+          </Form.Item>
         </S.Row>
+        <S.Text>{triggerType.toUpperCase()}</S.Text>
       </S.InfoContainer>
     </S.Section>
   );

--- a/web/src/pages/CreateTest/HeaderRight.tsx
+++ b/web/src/pages/CreateTest/HeaderRight.tsx
@@ -10,7 +10,7 @@ interface IProps {
 const HeaderRight = ({demos}: IProps) => (
   <S.Section $justifyContent="flex-end">
     <VariableSetSelector />
-    {demos.length && <DemoSelector demos={demos} />}
+    {!!demos.length && <DemoSelector demos={demos} />}
   </S.Section>
 );
 

--- a/web/src/pages/CreateTest/HeaderRight.tsx
+++ b/web/src/pages/CreateTest/HeaderRight.tsx
@@ -1,19 +1,17 @@
-import * as S from 'components/RunDetailLayout/RunDetailLayout.styled';
 import DemoSelector from 'components/DemoSelector';
+import * as S from 'components/RunDetailLayout/RunDetailLayout.styled';
+import VariableSetSelector from 'components/VariableSetSelector';
 import {TDraftTest} from 'types/Test.types';
 
 interface IProps {
   demos: TDraftTest[];
 }
 
-const HeaderRight = ({demos}: IProps) => {
-  return demos.length ? (
-    <S.Section $justifyContent="end">
-      <DemoSelector demos={demos} />
-    </S.Section>
-  ) : (
-    <S.Section $justifyContent="" />
-  );
-};
+const HeaderRight = ({demos}: IProps) => (
+  <S.Section $justifyContent="flex-end">
+    <VariableSetSelector />
+    {demos.length && <DemoSelector demos={demos} />}
+  </S.Section>
+);
 
 export default HeaderRight;


### PR DESCRIPTION
This PR introduces minor fixes for the test creation flow epic.

## Changes

- add variable set selector
- fix header height to match the run detail layout
- improve copy

## Fixes

-

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Screenshot

<img width="1624" alt="Screenshot 2023-11-20 at 16 20 54" src="https://github.com/kubeshop/tracetest/assets/3879892/fdb007c5-2555-4375-a7ba-b8cd64d47861">