### PR TITLE
fix: Adding ingestor docs link

### DIFF
--- a/web/src/components/Settings/DataStorePlugin/forms/Agent/Ingestor.tsx
+++ b/web/src/components/Settings/DataStorePlugin/forms/Agent/Ingestor.tsx
@@ -1,6 +1,7 @@
 import {Form, Switch} from 'antd';
 import DocsBanner from 'components/DocsBanner/DocsBanner';
 import {TCollectorDataStores, TDraftDataStore} from 'types/DataStore.types';
+import {INGESTOR_ENDPOINT_URL} from 'constants/Common.constants';
 import * as S from './Agent.styled';
 
 const Ingestor = () => {
@@ -29,7 +30,7 @@ const Ingestor = () => {
       </S.SwitchContainer>
       <DocsBanner>
         Need more information about setting up the agent ingestion endpoint?{' '}
-        <a target="_blank" href="">
+        <a target="_blank" href={INGESTOR_ENDPOINT_URL}>
           Go to our docs
         </a>
       </DocsBanner>

--- a/web/src/constants/Common.constants.ts
+++ b/web/src/constants/Common.constants.ts
@@ -11,7 +11,7 @@ export const OCTOLIINT_ISSUE_URL = 'https://github.com/kubeshop/tracetest/issues
 export const CLI_RUNNING_TESTS_URL = 'https://docs.tracetest.io/cli/running-tests';
 export const CLI_RUNNING_TEST_SUITES_URL = 'https://docs.tracetest.io/cli/running-test-suites';
 
-export const INGESTOR_ENDPOINT_URL = 'https://docs.tracetest.io/configuration/ingestor-endpoint';
+export const INGESTOR_ENDPOINT_URL = 'https://docs.tracetest.io/configuration/opentelemetry-collector-configuration-file-reference';
 
 export const TRACE_SEMANTIC_CONVENTIONS_URL =
   'https://github.com/open-telemetry/opentelemetry-specification/tree/main/specification/trace/semantic_conventions';


### PR DESCRIPTION
This PR adds a fix to the ingestor docs URL so it has something to open while we work on the actual explanation

## Changes

- Adds ingestor endpoint

## Fixes

- https://github.com/kubeshop/tracetest-cloud-frontend/issues/133

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Loom video

https://www.loom.com/share/13afc4ce5b1a4892bf82fcdb06173d5f
