### PR TITLE
chore: add verbose mode for Tracetest agent

### DIFF
--- a/agent/collector/collector.go
+++ b/agent/collector/collector.go
@@ -8,6 +8,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/kubeshop/tracetest/agent/event"
 	"github.com/kubeshop/tracetest/server/otlp"
 	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/zap"
@@ -38,6 +39,12 @@ func WithStartRemoteServer(startRemoteServer bool) CollectorOption {
 func WithLogger(logger *zap.Logger) CollectorOption {
 	return func(ric *remoteIngesterConfig) {
 		ric.logger = logger
+	}
+}
+
+func WithObserver(observer event.Observer) CollectorOption {
+	return func(ric *remoteIngesterConfig) {
+		ric.observer = observer
 	}
 }
 

--- a/agent/config/flags.go
+++ b/agent/config/flags.go
@@ -15,4 +15,5 @@ type Flags struct {
 	AgentApiKey    string
 	Token          string
 	Mode           Mode
+	LogLevel       string
 }

--- a/agent/event/observer.go
+++ b/agent/event/observer.go
@@ -1,0 +1,106 @@
+package event
+
+import (
+	"github.com/kubeshop/tracetest/agent/proto"
+	v1 "go.opentelemetry.io/proto/otlp/trace/v1"
+)
+
+type Observer interface {
+	StartTriggerExecution(*proto.TriggerRequest)
+	EndTriggerExecution(*proto.TriggerRequest, error)
+
+	StartTracePoll(*proto.PollingRequest)
+	EndTracePoll(*proto.PollingRequest, error)
+
+	StartSpanReceive([]*v1.Span)
+	EndSpanReceive([]*v1.Span, error)
+
+	StartDataStoreConnection(*proto.DataStoreConnectionTestRequest)
+	EndDataStoreConnection(*proto.DataStoreConnectionTestRequest, error)
+
+	Error(error)
+}
+
+type wrapperObserver struct {
+	wrappedObserver Observer
+}
+
+func WrapObserver(observer Observer) Observer {
+	return &wrapperObserver{
+		wrappedObserver: observer,
+	}
+}
+
+var _ Observer = &wrapperObserver{}
+
+func (o *wrapperObserver) StartDataStoreConnection(request *proto.DataStoreConnectionTestRequest) {
+	if o.wrappedObserver == nil {
+		return
+	}
+
+	o.wrappedObserver.StartDataStoreConnection(request)
+}
+
+func (o *wrapperObserver) EndDataStoreConnection(request *proto.DataStoreConnectionTestRequest, err error) {
+	if o.wrappedObserver == nil {
+		return
+	}
+
+	o.wrappedObserver.EndDataStoreConnection(request, err)
+}
+
+func (o *wrapperObserver) StartSpanReceive(spans []*v1.Span) {
+	if o.wrappedObserver == nil {
+		return
+	}
+
+	o.wrappedObserver.StartSpanReceive(spans)
+}
+
+func (o *wrapperObserver) EndSpanReceive(spans []*v1.Span, err error) {
+	if o.wrappedObserver == nil {
+		return
+	}
+
+	o.wrappedObserver.EndSpanReceive(spans, err)
+}
+
+func (o *wrapperObserver) Error(err error) {
+	if o.wrappedObserver == nil {
+		return
+	}
+
+	o.wrappedObserver.Error(err)
+}
+
+func (o *wrapperObserver) StartTracePoll(request *proto.PollingRequest) {
+	if o.wrappedObserver == nil {
+		return
+	}
+
+	o.wrappedObserver.StartTracePoll(request)
+}
+
+func (o *wrapperObserver) EndTracePoll(request *proto.PollingRequest, err error) {
+	if o.wrappedObserver == nil {
+		return
+	}
+
+	o.wrappedObserver.EndTracePoll(request, err)
+}
+
+func (o *wrapperObserver) StartTriggerExecution(request *proto.TriggerRequest) {
+	if o.wrappedObserver == nil {
+		return
+	}
+
+	o.wrappedObserver.StartTriggerExecution(request)
+}
+
+func (o *wrapperObserver) EndTriggerExecution(request *proto.TriggerRequest, err error) {
+	if o.wrappedObserver == nil {
+		return
+	}
+
+	o.wrappedObserver.EndTriggerExecution(request, err)
+}

--- a/agent/runner/runstrategy_desktop.go
+++ b/agent/runner/runstrategy_desktop.go
@@ -11,8 +11,8 @@ import (
 	consoleUI "github.com/kubeshop/tracetest/agent/ui"
 )
 
-func RunDesktopStrategy(ctx context.Context, cfg agentConfig.Config, ui consoleUI.ConsoleUI, uiEndpoint string) error {
-	ui.Infof("Starting Agent with name %s...", cfg.Name)
+func (s *Runner) RunDesktopStrategy(ctx context.Context, cfg agentConfig.Config, uiEndpoint string) error {
+	s.ui.Infof("Starting Agent with name %s...", cfg.Name)
 
 	isStarted := false
 	session := &Session{}
@@ -20,13 +20,13 @@ func RunDesktopStrategy(ctx context.Context, cfg agentConfig.Config, ui consoleU
 	var err error
 
 	for !isStarted {
-		session, err = StartSession(ctx, cfg)
+		session, err = StartSession(ctx, cfg, nil, s.logger)
 		if err != nil && errors.Is(err, ErrOtlpServerStart) {
-			ui.Error("Tracetest Agent binds to the OpenTelemetry ports 4317 and 4318 which are used to receive trace information from your system. The agent tried to bind to these ports, but failed.")
-			shouldRetry := ui.Enter("Please stop the process currently listening on these ports and press enter to try again.")
+			s.ui.Error("Tracetest Agent binds to the OpenTelemetry ports 4317 and 4318 which are used to receive trace information from your system. The agent tried to bind to these ports, but failed.")
+			shouldRetry := s.ui.Enter("Please stop the process currently listening on these ports and press enter to try again.")
 
 			if !shouldRetry {
-				ui.Finish()
+				s.ui.Finish()
 				return err
 			}
 
@@ -51,20 +51,20 @@ You can`
 	options := []consoleUI.Option{{
 		Text: "Open Tracetest in a browser to this environment",
 		Fn: func(_ consoleUI.ConsoleUI) {
-			ui.OpenBrowser(fmt.Sprintf("%sorganizations/%s/environments/%s/dashboard", uiEndpoint, claims["organization_id"], claims["environment_id"]))
+			s.ui.OpenBrowser(fmt.Sprintf("%sorganizations/%s/environments/%s/dashboard", uiEndpoint, claims["organization_id"], claims["environment_id"]))
 		},
 	}, {
 		Text: "Stop this agent",
 		Fn: func(_ consoleUI.ConsoleUI) {
 			isOpen = false
 			session.Close()
-			ui.Finish()
+			s.ui.Finish()
 		},
 	}}
 
 	for isOpen {
-		selected := ui.Select(message, options, 0)
-		selected.Fn(ui)
+		selected := s.ui.Select(message, options, 0)
+		selected.Fn(s.ui)
 	}
 	return nil
 }

--- a/agent/runner/runstrategy_verbose.go
+++ b/agent/runner/runstrategy_verbose.go
@@ -1,0 +1,118 @@
+package runner
+
+import (
+	"context"
+	"errors"
+	"os"
+	"os/signal"
+	"syscall"
+
+	agentConfig "github.com/kubeshop/tracetest/agent/config"
+	"github.com/kubeshop/tracetest/agent/event"
+	"github.com/kubeshop/tracetest/agent/proto"
+	consoleUI "github.com/kubeshop/tracetest/agent/ui"
+	v1 "go.opentelemetry.io/proto/otlp/trace/v1"
+)
+
+func (s *Runner) RunVerboseStrategy(ctx context.Context, cfg agentConfig.Config) error {
+	s.ui.Infof("%s Starting Agent with name %s...", consoleUI.Emoji_Truck, cfg.Name)
+
+	session, err := StartSession(ctx, cfg, &verboseObserver{ui: s.ui}, s.logger)
+
+	if err != nil && errors.Is(err, ErrOtlpServerStart) {
+		s.ui.Errorf("%s Tracetest Agent binds to the OpenTelemetry ports 4317 and 4318 which are used to receive trace information from your system. The agent tried to bind to these ports, but failed.", consoleUI.Emoji_RedCircle)
+
+		s.ui.Finish()
+		return err
+	}
+
+	s.ui.Infof("%s Agent is started!", consoleUI.Emoji_Truck)
+	s.ui.Println("")
+
+	signalChannel := make(chan os.Signal, 1)
+	signal.Notify(signalChannel, os.Interrupt, syscall.SIGTERM, syscall.SIGQUIT)
+
+	sig := <-signalChannel
+	s.ui.Infof("%s Received stop signal %s. Stopping agent...", consoleUI.Emoji_YellowCircle, sig)
+
+	session.Close()
+	s.ui.Finish()
+
+	return nil
+}
+
+type verboseObserver struct {
+	ui consoleUI.ConsoleUI
+}
+
+var _ event.Observer = &verboseObserver{}
+
+func (o *verboseObserver) EndDataStoreConnection(request *proto.DataStoreConnectionTestRequest, err error) {
+	if err != nil {
+		o.ui.Warningf("%s Testing connection to DataStore %s failed!", consoleUI.Emoji_YellowCircle, request.Datastore.Type)
+		o.ui.Warningf("Error: %s", err.Error())
+		o.ui.Println("")
+		return
+	}
+
+	o.ui.Infof("%s Testing connection to DataStore %s succeed", consoleUI.Emoji_WhiteCheckMark, request.Datastore.Type)
+	o.ui.Println("")
+}
+
+func (o *verboseObserver) EndSpanReceive(spans []*v1.Span, err error) {
+	if err != nil {
+		o.ui.Warningf("%s Trace spans reception failed!", consoleUI.Emoji_YellowCircle)
+		o.ui.Warningf("Error: %s", err.Error())
+		o.ui.Println("")
+		return
+	}
+
+	o.ui.Infof("%s Trace spans received with success. %d spans received", consoleUI.Emoji_WhiteCheckMark, len(spans))
+	o.ui.Println("")
+}
+
+func (o *verboseObserver) EndTracePoll(request *proto.PollingRequest, err error) {
+	if err != nil {
+		o.ui.Warningf("%s Test run %d, test %s trace spans fetch failed!", consoleUI.Emoji_YellowCircle, request.RunID, request.TestID)
+		o.ui.Warningf("Error: %s", err.Error())
+		o.ui.Println("")
+		return
+	}
+
+	o.ui.Infof("%s Test run %d, test %s trace spans fetch with success", consoleUI.Emoji_WhiteCheckMark, request.RunID, request.TestID)
+	o.ui.Println("")
+}
+
+func (o *verboseObserver) EndTriggerExecution(request *proto.TriggerRequest, err error) {
+	if err != nil {
+		o.ui.Warningf("%s Test run %d, test %s trigger failed!", consoleUI.Emoji_YellowCircle, request.RunID, request.TestID)
+		o.ui.Warningf("Error: %s", err.Error())
+		o.ui.Println("")
+		return
+	}
+
+	o.ui.Infof("%s Test run %d, test %s trigger executed with success", consoleUI.Emoji_WhiteCheckMark, request.RunID, request.TestID)
+	o.ui.Println("")
+}
+
+func (o *verboseObserver) Error(err error) {
+	o.ui.Errorf("%s An unknown error happened on Tracetest agent.", consoleUI.Emoji_RedCircle)
+	o.ui.Errorf("Error: %s", err.Error())
+	o.ui.Println("")
+}
+
+func (o *verboseObserver) StartDataStoreConnection(request *proto.DataStoreConnectionTestRequest) {
+	o.ui.Infof("%s Testing connection to DataStore %s ...", consoleUI.Emoji_Magnifier, request.Datastore.Type)
+}
+
+func (o *verboseObserver) StartSpanReceive(spans []*v1.Span) {
+	o.ui.Infof("%s Receiving trace spans...", consoleUI.Emoji_Sparkles)
+}
+
+func (o *verboseObserver) StartTracePoll(request *proto.PollingRequest) {
+	o.ui.Infof("%s Polling traces and spans for test run %d, test %s ...", consoleUI.Emoji_Magnifier, request.RunID, request.TestID)
+}
+
+func (o *verboseObserver) StartTriggerExecution(request *proto.TriggerRequest) {
+	o.ui.Infof("%s Executing trigger for test run %d, test %s ...", consoleUI.Emoji_Sparkles, request.RunID, request.TestID)
+}

--- a/agent/ui/emoji.go
+++ b/agent/ui/emoji.go
@@ -1,0 +1,14 @@
+package ui
+
+import (
+	"github.com/kyokomi/emoji/v2"
+)
+
+var (
+	Emoji_Magnifier      = emoji.Sprint(":mag:")
+	Emoji_RedCircle      = emoji.Sprint(":red_circle:")
+	Emoji_Sparkles       = emoji.Sprint(":sparkles:")
+	Emoji_Truck          = emoji.Sprint(":truck:")
+	Emoji_WhiteCheckMark = emoji.Sprint(":white_check_mark:")
+	Emoji_YellowCircle   = emoji.Sprint(":large_yellow_circle:")
+)

--- a/agent/workers/poller.go
+++ b/agent/workers/poller.go
@@ -10,6 +10,7 @@ import (
 	"github.com/davecgh/go-spew/spew"
 	"github.com/fluidtruck/deepcopy"
 	"github.com/kubeshop/tracetest/agent/client"
+	"github.com/kubeshop/tracetest/agent/event"
 	"github.com/kubeshop/tracetest/agent/proto"
 	"github.com/kubeshop/tracetest/server/datastore"
 	"github.com/kubeshop/tracetest/server/tracedb"
@@ -25,6 +26,7 @@ type PollerWorker struct {
 	sentSpanIDs       *gocache.Cache[string, bool]
 	inmemoryDatastore tracedb.TraceDB
 	logger            *zap.Logger
+	observer          event.Observer
 }
 
 type PollerOption func(*PollerWorker)
@@ -32,6 +34,12 @@ type PollerOption func(*PollerWorker)
 func WithInMemoryDatastore(datastore tracedb.TraceDB) PollerOption {
 	return func(pw *PollerWorker) {
 		pw.inmemoryDatastore = datastore
+	}
+}
+
+func WithObserver(observer event.Observer) PollerOption {
+	return func(pw *PollerWorker) {
+		pw.observer = observer
 	}
 }
 
@@ -59,6 +67,8 @@ func (w *PollerWorker) SetLogger(logger *zap.Logger) {
 
 func (w *PollerWorker) Poll(ctx context.Context, request *proto.PollingRequest) error {
 	w.logger.Debug("Received polling request", zap.Any("request", request))
+	w.observer.StartTracePoll(request)
+
 	err := w.poll(ctx, request)
 	if err != nil {
 		w.logger.Error("Error polling", zap.Error(err))
@@ -74,15 +84,19 @@ func (w *PollerWorker) Poll(ctx context.Context, request *proto.PollingRequest) 
 			},
 		}
 
+		w.observer.EndTracePoll(request, err)
 		w.logger.Debug("Sending polling error", zap.Any("response", errorResponse))
 		sendErr := w.client.SendTrace(ctx, errorResponse)
 
 		if sendErr != nil {
 			w.logger.Error("Error sending polling error", zap.Error(sendErr))
+			w.observer.Error(sendErr)
+
 			return fmt.Errorf("could not report polling error back to the server: %w. Original error: %s", sendErr, err.Error())
 		}
 	}
 
+	w.observer.EndTracePoll(request, nil)
 	return err
 }
 

--- a/agent/workers/trigger.go
+++ b/agent/workers/trigger.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/kubeshop/tracetest/agent/client"
 	"github.com/kubeshop/tracetest/agent/collector"
+	"github.com/kubeshop/tracetest/agent/event"
 	"github.com/kubeshop/tracetest/agent/proto"
 	agentTrigger "github.com/kubeshop/tracetest/agent/workers/trigger"
 	"github.com/kubeshop/tracetest/server/pkg/id"
@@ -20,6 +21,7 @@ type TriggerWorker struct {
 	client     *client.Client
 	registry   *agentTrigger.Registry
 	traceCache collector.TraceCache
+	observer   event.Observer
 }
 
 type TriggerOption func(*TriggerWorker)
@@ -27,6 +29,12 @@ type TriggerOption func(*TriggerWorker)
 func WithTraceCache(cache collector.TraceCache) TriggerOption {
 	return func(tw *TriggerWorker) {
 		tw.traceCache = cache
+	}
+}
+
+func WithTriggerObserver(observer event.Observer) TriggerOption {
+	return func(tw *TriggerWorker) {
+		tw.observer = observer
 	}
 }
 
@@ -59,9 +67,13 @@ func (w *TriggerWorker) SetLogger(logger *zap.Logger) {
 
 func (w *TriggerWorker) Trigger(ctx context.Context, triggerRequest *proto.TriggerRequest) error {
 	w.logger.Debug("Trigger request received", zap.Any("triggerRequest", triggerRequest))
+	w.observer.StartTriggerExecution(triggerRequest)
+
 	err := w.trigger(ctx, triggerRequest)
 	if err != nil {
 		w.logger.Error("Trigger error", zap.Error(err))
+		w.observer.EndTriggerExecution(triggerRequest, err)
+
 		sendErr := w.client.SendTriggerResponse(ctx, &proto.TriggerResponse{
 			RequestID:           triggerRequest.RequestID,
 			AgentIdentification: w.client.SessionConfiguration().AgentIdentification,
@@ -76,9 +88,13 @@ func (w *TriggerWorker) Trigger(ctx context.Context, triggerRequest *proto.Trigg
 
 		if sendErr != nil {
 			w.logger.Error("Could not report trigger error back to the server", zap.Error(sendErr))
+			w.observer.Error(sendErr)
+
 			return fmt.Errorf("could not report trigger error back to the server: %w. Original error: %s", sendErr, err.Error())
 		}
 	}
+
+	w.observer.EndTriggerExecution(triggerRequest, nil)
 
 	return err
 }

--- a/cli/cmd/start_cmd.go
+++ b/cli/cmd/start_cmd.go
@@ -34,6 +34,7 @@ var startCmd = &cobra.Command{
 			AgentApiKey:    saveParams.agentApiKey,
 			Token:          saveParams.token,
 			Mode:           agentConfig.Mode(saveParams.mode),
+			LogLevel:       saveParams.logLevel,
 		}
 
 		cfg, err := agentConfig.LoadConfig()
@@ -58,6 +59,7 @@ func init() {
 	startCmd.Flags().StringVarP(&saveParams.token, "token", "", defaultToken, "token authentication key")
 	startCmd.Flags().StringVarP(&saveParams.endpoint, "endpoint", "e", defaultEndpoint, "set the value for the endpoint, so the CLI won't ask for this value")
 	startCmd.Flags().StringVarP(&saveParams.mode, "mode", "m", "desktop", "set how the agent will start")
+	startCmd.Flags().StringVarP(&saveParams.logLevel, "log-level", "l", "debug", "set the agent log level")
 	rootCmd.AddCommand(startCmd)
 }
 
@@ -68,4 +70,5 @@ type saveParameters struct {
 	agentApiKey    string
 	token          string
 	mode           string
+	logLevel       string
 }

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/alecthomas/participle/v2 v2.0.0-alpha8
 	github.com/alexeyco/simpletable v1.0.0
 	github.com/alitto/pond v1.8.3
+	github.com/avast/retry-go v3.0.0+incompatible
 	github.com/aws/aws-sdk-go v1.44.196
 	github.com/brianvoe/gofakeit/v6 v6.17.0
 	github.com/compose-spec/compose-go v1.20.0
@@ -39,6 +40,7 @@ require (
 	github.com/jackc/pgx/v5 v5.4.2
 	github.com/jhump/protoreflect v1.12.0
 	github.com/json-iterator/go v1.1.12
+	github.com/kyokomi/emoji/v2 v2.2.12
 	github.com/labstack/gommon v0.3.0
 	github.com/mitchellh/mapstructure v1.5.1-0.20220423185008-bf980b35cac4
 	github.com/nats-io/nats.go v1.31.0
@@ -96,8 +98,6 @@ require (
 	github.com/Microsoft/go-winio v0.5.2 // indirect
 	github.com/PuerkitoBio/purell v1.1.1 // indirect
 	github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578 // indirect
-	github.com/Shopify/toxiproxy v2.1.4+incompatible // indirect
-	github.com/avast/retry-go v3.0.0+incompatible // indirect
 	github.com/cenkalti/backoff/v4 v4.2.1 // indirect
 	github.com/containerd/console v1.0.3 // indirect
 	github.com/cpuguy83/go-md2man/v2 v2.0.2 // indirect
@@ -198,7 +198,6 @@ require (
 	google.golang.org/genproto/googleapis/api v0.0.0-20230711160842-782d3b101e98 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20230711160842-782d3b101e98 // indirect
 	gopkg.in/ini.v1 v1.67.0 // indirect
-	gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 // indirect
 )
 
 // Temporary fix until we manage to merge the patch to the gnomock repo (https://github.com/orlangure/gnomock/pull/534)

--- a/go.sum
+++ b/go.sum
@@ -1269,6 +1269,8 @@ github.com/ktrysmt/go-bitbucket v0.6.4/go.mod h1:9u0v3hsd2rqCHRIpbir1oP7F58uo5dq
 github.com/kylelemons/godebug v0.0.0-20160406211939-eadb3ce320cb/go.mod h1:B69LEHPfb2qLo0BaaOLcbitczOKLWTsrBG9LczfCD4k=
 github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0SNc=
 github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=
+github.com/kyokomi/emoji/v2 v2.2.12 h1:sSVA5nH9ebR3Zji1o31wu3yOwD1zKXQA2z0zUyeit60=
+github.com/kyokomi/emoji/v2 v2.2.12/go.mod h1:JUcn42DTdsXJo1SWanHh4HKDEyPaR5CqkmoirZZP9qE=
 github.com/labstack/echo/v4 v4.2.1/go.mod h1:AA49e0DZ8kk5jTOOCKNuPR6oTnBS0dYiM4FW1e6jwpg=
 github.com/labstack/gommon v0.3.0 h1:JEeO0bvc78PKdyHxloTKiF8BD5iGrH8T6MSeGvSgob0=
 github.com/labstack/gommon v0.3.0/go.mod h1:MULnywXg0yavhxWKc+lOruYdAhDwPK9wf0OL7NoOu+k=


### PR DESCRIPTION
This PR aims to add a verbose mode suite for `k8s` and `docker` setups, that logs what is happening with the agent.

## Checklist

- [x] tested locally
- [x] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Loom video

Add your loom video here if your work can be visualized
