### PR TITLE
feat: Run Source

### DIFF
--- a/api/tests.yaml
+++ b/api/tests.yaml
@@ -1,7 +1,6 @@
 openapi: 3.0.0
 components:
   schemas:
-
     TestResourceList:
       type: object
       properties:

--- a/cli/runner/orchestrator.go
+++ b/cli/runner/orchestrator.go
@@ -335,16 +335,21 @@ func (a orchestrator) writeJUnitReport(ctx context.Context, r Runner, result Run
 	return err
 }
 
+var source = "cli"
+
 func getMetadata() map[string]string {
 	ci := cienvironment.DetectCIEnvironment()
 	if ci == nil {
-		return map[string]string{}
+		return map[string]string{
+			"source": source,
+		}
 	}
 
 	metadata := map[string]string{
 		"name":        ci.Name,
 		"url":         ci.URL,
 		"buildNumber": ci.BuildNumber,
+		"source":      source,
 	}
 
 	if ci.Git != nil {

--- a/server/executor/test_suite_runner.go
+++ b/server/executor/test_suite_runner.go
@@ -94,7 +94,7 @@ func (r persistentTransactionRunner) ProcessItem(ctx context.Context, job Job) {
 }
 
 func (r persistentTransactionRunner) runTransactionStep(ctx context.Context, tr testsuite.TestSuiteRun, step int, testObj test.Test) (testsuite.TestSuiteRun, error) {
-	testRun := r.testRunner.Run(ctx, testObj, tr.Metadata, tr.VariableSet, tr.RequiredGates)
+	testRun := r.testRunner.Run(ctx, testObj, tr.RunMetadata(step), tr.VariableSet, tr.RequiredGates)
 	tr, err := r.updateStepRun(ctx, tr, step, testRun)
 	if err != nil {
 		return testsuite.TestSuiteRun{}, fmt.Errorf("could not update transaction run: %w", err)

--- a/server/testsuite/testsuite_run_entities.go
+++ b/server/testsuite/testsuite_run_entities.go
@@ -68,3 +68,12 @@ func (tr TestSuiteRun) StepsGatesValidation() bool {
 
 	return true
 }
+
+func (tr TestSuiteRun) RunMetadata(step int) test.RunMetadata {
+	tr.Metadata["step"] = fmt.Sprintf("%d", step+1)
+	tr.Metadata["testsuite_run_id"] = fmt.Sprintf("%d", tr.ID)
+	tr.Metadata["testsuite_id"] = string(tr.TestSuiteID)
+	tr.Metadata["testsuite_version"] = fmt.Sprintf("%d", tr.TestSuiteVersion)
+
+	return tr.Metadata
+}

--- a/web/src/components/RunCard/TestRunCard.tsx
+++ b/web/src/components/RunCard/TestRunCard.tsx
@@ -27,7 +27,7 @@ const TestRunCard = ({
     state,
     createdAt,
     testVersion,
-    metadata,
+    metadata: {name, buildNumber, branch, url, source},
     testSuiteId,
     testSuiteRunId,
     linter,
@@ -37,10 +37,6 @@ const TestRunCard = ({
   linkTo,
 }: IProps) => {
   const {navigate} = useDashboard();
-  const metadataName = metadata?.name;
-  const metadataBuildNumber = metadata?.buildNumber;
-  const metadataBranch = metadata?.branch;
-  const metadataUrl = metadata?.url;
 
   const handleResultClick = (
     event: React.MouseEvent<HTMLDivElement, MouseEvent>,
@@ -64,13 +60,14 @@ const TestRunCard = ({
             </Tooltip>
 
             {isRunStateFinished(state) && <S.Text>&nbsp;• {executionTime}s</S.Text>}
+            {source && <S.Text>&nbsp;• Run via {source.toUpperCase()}</S.Text>}
 
-            {metadataName && (
-              <a href={metadataUrl} target="_blank" onClick={event => event.stopPropagation()}>
-                <S.Text $hasLink={Boolean(metadataUrl)}>&nbsp;• {`${metadataName} ${metadataBuildNumber}`}</S.Text>
+            {name && (
+              <a href={url} target="_blank" onClick={event => event.stopPropagation()}>
+                <S.Text $hasLink={Boolean(url)}>&nbsp;• {`${name} ${buildNumber}`}</S.Text>
               </a>
             )}
-            {metadataBranch && <S.Text>&nbsp;• Branch: {metadataBranch}</S.Text>}
+            {branch && <S.Text>&nbsp;• Branch: {branch}</S.Text>}
           </S.Row>
         </S.Info>
 
@@ -108,12 +105,7 @@ const TestRunCard = ({
         )}
 
         <div>
-          <RunActionsMenu
-            resultId={runId}
-            testId={testId}
-            testSuiteRunId={testSuiteRunId}
-            testSuiteId={testSuiteId}
-          />
+          <RunActionsMenu resultId={runId} testId={testId} testSuiteRunId={testSuiteRunId} testSuiteId={testSuiteId} />
         </div>
       </S.Container>
     </Link>

--- a/web/src/components/RunCard/TestSuiteRunCard.tsx
+++ b/web/src/components/RunCard/TestSuiteRunCard.tsx
@@ -15,68 +15,71 @@ interface IProps {
 }
 
 const TestSuiteRunCard = ({
-  run: {id: runId, createdAt, state, metadata, version, pass, fail, allStepsRequiredGatesPassed},
+  run: {
+    id: runId,
+    createdAt,
+    state,
+    metadata: {name, buildNumber, branch, url, source},
+    version,
+    pass,
+    fail,
+    allStepsRequiredGatesPassed,
+  },
   testSuiteId,
   linkTo,
-}: IProps) => {
-  const metadataName = metadata?.name;
-  const metadataBuildNumber = metadata?.buildNumber;
-  const metadataBranch = metadata?.branch;
-  const metadataUrl = metadata?.url;
-
-  return (
-    <Link to={linkTo}>
-      <S.Container $isWhite>
-        <TestSuiteRunStatusIcon state={state} hasFailedTests={!allStepsRequiredGatesPassed} />
-        <S.Info>
-          <div>
-            <S.Title>v{version}</S.Title>
-          </div>
-          <S.Row>
-            <Tooltip title={Date.format(createdAt)}>
-              <S.Text>{Date.getTimeAgo(createdAt)}</S.Text>
-            </Tooltip>
-            {/* Adding this latter when is available */}
-            {/* <S.Text>&nbsp;• 0s (executionTime missing from API)</S.Text> */}
-
-            {metadataName && (
-              <a href={metadataUrl} target="_blank" onClick={event => event.stopPropagation()}>
-                <S.Text $hasLink={Boolean(metadataUrl)}>&nbsp;• {`${metadataName} ${metadataBuildNumber}`}</S.Text>
-              </a>
-            )}
-            {metadataBranch && <S.Text>&nbsp;• Branch: {metadataBranch}</S.Text>}
-          </S.Row>
-        </S.Info>
-
-        {state !== TestStateEnum.FAILED && state !== TestStateEnum.FINISHED && (
-          <div>
-            <TestState testState={state} />
-          </div>
-        )}
-
-        {(state === TestStateEnum.FAILED || state === TestStateEnum.FINISHED) && (
-          <S.Row>
-            <Tooltip title="Passed assertions">
-              <S.HeaderDetail>
-                <S.HeaderDot $passed />
-                {pass}
-              </S.HeaderDetail>
-            </Tooltip>
-            <Tooltip title="Failed assertions">
-              <S.HeaderDetail>
-                <S.HeaderDot $passed={false} />
-                {fail}
-              </S.HeaderDetail>
-            </Tooltip>
-          </S.Row>
-        )}
-
+}: IProps) => (
+  <Link to={linkTo}>
+    <S.Container $isWhite>
+      <TestSuiteRunStatusIcon state={state} hasFailedTests={!allStepsRequiredGatesPassed} />
+      <S.Info>
         <div>
-          <TestSuiteRunActionsMenu runId={runId} testSuiteId={testSuiteId} />
+          <S.Title>v{version}</S.Title>
         </div>
-      </S.Container>
-    </Link>
-  );
-};
+        <S.Row>
+          <Tooltip title={Date.format(createdAt)}>
+            <S.Text>{Date.getTimeAgo(createdAt)}</S.Text>
+          </Tooltip>
+          {source && <S.Text>&nbsp;• Run via {source.toUpperCase()}</S.Text>}
+          {/* Adding this latter when is available */}
+          {/* <S.Text>&nbsp;• 0s (executionTime missing from API)</S.Text> */}
+
+          {name && (
+            <a href={url} target="_blank" onClick={event => event.stopPropagation()}>
+              <S.Text $hasLink={Boolean(url)}>&nbsp;• {`${name} ${buildNumber}`}</S.Text>
+            </a>
+          )}
+          {branch && <S.Text>&nbsp;• Branch: {branch}</S.Text>}
+        </S.Row>
+      </S.Info>
+
+      {state !== TestStateEnum.FAILED && state !== TestStateEnum.FINISHED && (
+        <div>
+          <TestState testState={state} />
+        </div>
+      )}
+
+      {(state === TestStateEnum.FAILED || state === TestStateEnum.FINISHED) && (
+        <S.Row>
+          <Tooltip title="Passed assertions">
+            <S.HeaderDetail>
+              <S.HeaderDot $passed />
+              {pass}
+            </S.HeaderDetail>
+          </Tooltip>
+          <Tooltip title="Failed assertions">
+            <S.HeaderDetail>
+              <S.HeaderDot $passed={false} />
+              {fail}
+            </S.HeaderDetail>
+          </Tooltip>
+        </S.Row>
+      )}
+
+      <div>
+        <TestSuiteRunActionsMenu runId={runId} testSuiteId={testSuiteId} />
+      </div>
+    </S.Container>
+  </Link>
+);
 
 export default TestSuiteRunCard;

--- a/web/src/components/RunDetailLayout/HeaderLeft.tsx
+++ b/web/src/components/RunDetailLayout/HeaderLeft.tsx
@@ -18,8 +18,19 @@ interface IProps {
 }
 
 const HeaderLeft = ({name, triggerType, origin}: IProps) => {
-  const {run: {createdAt, testSuiteId, testSuiteRunId, executionTime, trace, traceId, testVersion} = {}, run} =
-    useTestRun();
+  const {
+    run: {
+      createdAt,
+      testSuiteId,
+      testSuiteRunId,
+      executionTime,
+      trace,
+      traceId,
+      testVersion,
+      metadata: {source} = {},
+    } = {},
+    run,
+  } = useTestRun();
   const {onEdit, isEditLoading: isLoading, test} = useTest();
   const createdTimeAgo = Date.getTimeAgo(createdAt ?? '');
   const {navigate} = useDashboard();
@@ -33,8 +44,8 @@ const HeaderLeft = ({name, triggerType, origin}: IProps) => {
   const description = useMemo(() => {
     return (
       <>
-        v{testVersion} • {triggerType} • Ran {createdTimeAgo}
-        {testSuiteId && testSuiteRunId && (
+        v{testVersion} • {triggerType} • Ran {createdTimeAgo} • {source && <>Run via {source.toUpperCase()}</>}
+        {testSuiteId && !!testSuiteRunId && (
           <>
             {' '}
             •{' '}
@@ -45,7 +56,7 @@ const HeaderLeft = ({name, triggerType, origin}: IProps) => {
         )}
       </>
     );
-  }, [triggerType, createdTimeAgo, testSuiteId, testSuiteRunId, testVersion]);
+  }, [testVersion, triggerType, createdTimeAgo, source, testSuiteId, testSuiteRunId]);
 
   return (
     <S.Section $justifyContent="flex-start">

--- a/web/src/components/RunDetailTriggerResponse/ResponseMetadata.tsx
+++ b/web/src/components/RunDetailTriggerResponse/ResponseMetadata.tsx
@@ -1,0 +1,31 @@
+import {useTestRun} from 'providers/TestRun/TestRun.provider';
+import {useMemo} from 'react';
+import * as S from './RunDetailTriggerResponse.styled';
+import KeyValueRow from '../KeyValueRow';
+
+const ResponseMetadata = () => {
+  const {
+    run: {metadata},
+  } = useTestRun();
+
+  const entries = useMemo(() => Object.entries(metadata).filter(([, value]) => !!value), [metadata]);
+
+  if (!entries.length) {
+    return (
+      <S.EmptyContainer>
+        <S.EmptyIcon />
+        <S.EmptyTitle>There are no metadata entries used in this test</S.EmptyTitle>
+      </S.EmptyContainer>
+    );
+  }
+
+  return (
+    <S.ResponseVarsContainer>
+      {entries.map(([key, value]) => (
+        <KeyValueRow key={key} keyName={key} value={value} />
+      ))}
+    </S.ResponseVarsContainer>
+  );
+};
+
+export default ResponseMetadata;

--- a/web/src/components/RunDetailTriggerResponse/RunDetailTriggerResponse.tsx
+++ b/web/src/components/RunDetailTriggerResponse/RunDetailTriggerResponse.tsx
@@ -18,11 +18,13 @@ import ResponseVariableSet from './ResponseVariableSet';
 import ResponseHeaders from './ResponseHeaders';
 import * as S from './RunDetailTriggerResponse.styled';
 import {IPropsComponent} from './RunDetailTriggerResponseFactory';
+import ResponseMetadata from './ResponseMetadata';
 
 const TabsKeys = {
   Body: 'body',
   Headers: 'headers',
   VariableSet: 'variable-set',
+  Metadata: 'metadata',
 };
 
 const tracetestTriggerSelector = 'span[tracetest.span.type="general" name="Tracetest trigger"]';
@@ -145,6 +147,9 @@ const RunDetailTriggerResponse = ({
           </Tabs.TabPane>
           <Tabs.TabPane key={TabsKeys.VariableSet} tab="Variable Set">
             <ResponseVariableSet />
+          </Tabs.TabPane>
+          <Tabs.TabPane key={TabsKeys.Metadata} tab="Metadata">
+            <ResponseMetadata />
           </Tabs.TabPane>
         </Tabs>
       </S.TabsContainer>

--- a/web/src/components/VariableSet/VariableSetForm.tsx
+++ b/web/src/components/VariableSet/VariableSetForm.tsx
@@ -31,7 +31,6 @@ const VariableSetForm = ({form, initialValues, onSubmit, onValidate}: IProps) =>
       <Form.Item
         label="Description"
         name="description"
-        rules={[{required: true, message: 'Please input a description'}]}
       >
         <Input />
       </Form.Item>

--- a/web/src/models/RunMetadata.model.ts
+++ b/web/src/models/RunMetadata.model.ts
@@ -1,0 +1,44 @@
+import {Model} from 'types/Common.types';
+
+export type TRawRunMetadata = Record<string, string>;
+
+export enum KnownSources {
+  WEB = 'web',
+  CLI = 'cli',
+  API = 'api',
+  K6 = 'k6',
+  UNKNOWN = 'unknown',
+}
+
+type TKnownSources = KnownSources | string;
+
+type RunMetadata = Model<
+  Record<string, string>,
+  {
+    name: string;
+    buildNumber: string;
+    branch: string;
+    url: string;
+    source: TKnownSources;
+  }
+>;
+
+function RunMetadata({
+  name = '',
+  buildNumber = '',
+  branch = '',
+  url = '',
+  source = '',
+  ...rest
+}: TRawRunMetadata): RunMetadata {
+  return {
+    name,
+    buildNumber,
+    branch,
+    url,
+    source,
+    ...rest,
+  };
+}
+
+export default RunMetadata;

--- a/web/src/models/TestRun.model.ts
+++ b/web/src/models/TestRun.model.ts
@@ -8,6 +8,7 @@ import TestRunOutput from './TestRunOutput.model';
 import Trace from './Trace.model';
 import TriggerResult from './TriggerResult.model';
 import RequiredGatesResult from './RequiredGatesResult.model';
+import RunMetadata from './RunMetadata.model';
 
 export type TRawTestRun = Modify<
   TTestSchemas['TestRun'],
@@ -35,6 +36,7 @@ type TestRun = Model<
     linter: LinterResult;
     requiredGatesResult: RequiredGatesResult;
     testSuiteRunId: number;
+    metadata: RunMetadata;
   }
 >;
 
@@ -140,7 +142,7 @@ const TestRun = ({
     totalAssertionCount: getTestResultCount(result),
     failedAssertionCount: getTestResultCount(result, 'failed'),
     passedAssertionCount: getTestResultCount(result, 'passed'),
-    metadata,
+    metadata: RunMetadata(metadata),
     outputs: outputs?.map(rawOutput => TestRunOutput(rawOutput)),
     variableSet: VariableSet.fromRun(variableSet),
     testSuiteId,

--- a/web/src/models/TestSuiteRun.model.ts
+++ b/web/src/models/TestSuiteRun.model.ts
@@ -1,6 +1,7 @@
 import {Model, TTestSuiteSchemas} from 'types/Common.types';
 import VariableSet from './VariableSet.model';
 import TestRun from './TestRun.model';
+import RunMetadata from './RunMetadata.model';
 
 export type TRawTestSuiteRunResourceRun = TTestSuiteSchemas['TestSuiteRun'];
 type TestSuiteRun = Model<
@@ -8,7 +9,7 @@ type TestSuiteRun = Model<
   {
     steps: TestRun[];
     variableSet?: VariableSet;
-    metadata?: {[key: string]: string};
+    metadata: RunMetadata;
   }
 >;
 
@@ -37,7 +38,7 @@ const TestSuiteRun = ({
     steps: steps.map(step => TestRun(step)),
     variableSet: VariableSet.fromRun(variableSet),
     allStepsRequiredGatesPassed,
-    metadata,
+    metadata: RunMetadata(metadata),
     version,
     pass,
     fail,

--- a/web/src/redux/apis/Tracetest/endpoints/TestRun.endpoint.ts
+++ b/web/src/redux/apis/Tracetest/endpoints/TestRun.endpoint.ts
@@ -8,6 +8,7 @@ import SelectedSpans, {TRawSelectedSpans} from 'models/SelectedSpans.model';
 import Test from 'models/Test.model';
 import TestRun, {TRawTestRun} from 'models/TestRun.model';
 import TestRunEvent, {TRawTestRunEvent} from 'models/TestRunEvent.model';
+import {KnownSources} from 'models/RunMetadata.model';
 import {TRawTestSpecs} from 'models/TestSpecs.model';
 import {TTestApiEndpointBuilder} from '../Tracetest.api';
 
@@ -23,6 +24,9 @@ export const testRunEndpoints = (builder: TTestApiEndpointBuilder) => ({
       body: {
         variableSetId,
         variables,
+        metadata: {
+          source: KnownSources.WEB,
+        },
       },
     }),
     invalidatesTags: (response, error, {testId}) => [

--- a/web/src/redux/apis/Tracetest/endpoints/TestSuiteRun.endpoint.ts
+++ b/web/src/redux/apis/Tracetest/endpoints/TestSuiteRun.endpoint.ts
@@ -4,6 +4,7 @@ import {PaginationResponse} from 'hooks/usePagination';
 import {TVariableSetValue} from 'models/VariableSet.model';
 import RunError from 'models/RunError.model';
 import TestSuiteRun, {TRawTestSuiteRunResourceRun} from 'models/TestSuiteRun.model';
+import {KnownSources} from 'models/RunMetadata.model';
 import {getTotalCountFromHeaders} from 'utils/Common';
 import {TTestApiEndpointBuilder} from '../Tracetest.api';
 
@@ -15,7 +16,7 @@ export const testSuiteRunEndpoints = (builder: TTestApiEndpointBuilder) => ({
     query: ({testSuiteId, variableSetId, variables = []}) => ({
       url: `/testsuites/${testSuiteId}/run`,
       method: HTTP_METHOD.POST,
-      body: {variableSetId, variables},
+      body: {variableSetId, variables, metadata: {source: KnownSources.WEB}},
     }),
     invalidatesTags: (result, error, {testSuiteId}) => [
       {type: TracetestApiTags.TESTSUITE_RUN, id: `${testSuiteId}-LIST`},


### PR DESCRIPTION
This PR adds the run source information for both test and test suite runs

## Changes

- Adds source as part of metadata
- Adds new metadata model
- Updates metadata logic to add more values from the test suite runner
- Adds metadata tab for test runs

## Fixes

- https://github.com/kubeshop/tracetest-cloud-frontend/issues/139
- https://github.com/kubeshop/tracetest-cloud-frontend/issues/130

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Loom video

https://www.loom.com/share/ec83bf4c312e45e3a5029352bbcd7164

