### PR TITLE
fix: host network configuration on linux

### DIFF
--- a/examples/tracetest-agent/pokeshop/docker-compose.yaml
+++ b/examples/tracetest-agent/pokeshop/docker-compose.yaml
@@ -108,3 +108,5 @@ services:
       - "/otel-local-config.yaml"
     volumes:
       - ./collector.config.yaml:/otel-local-config.yaml
+    extra_hosts:
+      - "host.docker.internal:host-gateway"


### PR DESCRIPTION
Docker on Linux doesn't understand `host.docker.internal` automatically. We need to add it as an extra host using `extra_hosts`. This was caught by @mrasu in the issue #3393.

## Changes

-

## Fixes

-

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Loom video

Add your loom video here if your work can be visualized
