### PR TITLE
feat: Duplicate

### DIFF
--- a/web/src/components/ConfirmationModal/ConfirmationModal.tsx
+++ b/web/src/components/ConfirmationModal/ConfirmationModal.tsx
@@ -1,4 +1,5 @@
 import {Modal} from 'antd';
+import useKeyEvent, {Keys} from 'hooks/useKeyEvent';
 
 interface IProps {
   isOpen: boolean;
@@ -19,6 +20,8 @@ const ConfirmationModal = ({
   okText = 'Delete',
   cancelText = 'Cancel',
 }: IProps) => {
+  useKeyEvent([Keys.Enter], onConfirm);
+
   return (
     <Modal
       cancelText={cancelText}

--- a/web/src/components/ResourceCard/ResourceCardActions.tsx
+++ b/web/src/components/ResourceCard/ResourceCardActions.tsx
@@ -9,33 +9,34 @@ interface IProps {
   shouldEdit: boolean;
   onDelete(): void;
   onEdit(): void;
+  onDuplicate(): void;
 }
 
-const ResourceCardActions = ({id, shouldEdit = true, onDelete, onEdit}: IProps) => {
+const ResourceCardActions = ({id, shouldEdit = true, onDelete, onEdit, onDuplicate}: IProps) => {
   const {getIsAllowed} = useCustomization();
+  const canEdit = getIsAllowed(Operation.Edit);
 
-  const onDeleteClick = useCallback(
-    ({domEvent}) => {
-      domEvent?.stopPropagation();
-      onDelete();
-    },
-    [onDelete]
-  );
-
-  const onEditClick = useCallback(
-    ({domEvent}) => {
-      domEvent?.stopPropagation();
-      onEdit();
-    },
-    [onEdit]
+  const onAction = useCallback(
+    action =>
+      ({domEvent}: {domEvent: React.MouseEvent<HTMLElement> | React.KeyboardEvent<HTMLElement>}) => {
+        domEvent?.stopPropagation();
+        action();
+      },
+    []
   );
 
   const menuItems = useMemo(() => {
     const defaultItems = [
       {
+        key: 'duplicate',
+        label: <span data-cy="test-card-duplicate">Duplicate</span>,
+        onClick: onAction(onDuplicate),
+        disabled: !canEdit,
+      },
+      {
         key: 'delete',
         label: <span data-cy="test-card-delete">Delete</span>,
-        onClick: onDeleteClick,
+        onClick: onAction(onDelete),
         disabled: !getIsAllowed(Operation.Edit),
       },
     ];
@@ -45,13 +46,13 @@ const ResourceCardActions = ({id, shouldEdit = true, onDelete, onEdit}: IProps) 
           {
             key: 'edit',
             label: <span data-cy="test-card-edit">Edit</span>,
-            onClick: onEditClick,
+            onClick: onAction(onEdit),
             disabled: !getIsAllowed(Operation.Edit),
           },
           ...defaultItems,
         ]
       : defaultItems;
-  }, [getIsAllowed, onDeleteClick, onEditClick, shouldEdit]);
+  }, [canEdit, getIsAllowed, onAction, onDelete, onDuplicate, onEdit, shouldEdit]);
 
   return (
     <Dropdown overlay={<Menu items={menuItems} />} placement="bottomLeft" trigger={['click']}>

--- a/web/src/components/ResourceCard/TestCard.tsx
+++ b/web/src/components/ResourceCard/TestCard.tsx
@@ -18,11 +18,12 @@ interface IProps {
   onEdit(id: string, lastRunId: number, type: ResourceType): void;
   onDelete(id: string, name: string, type: ResourceType): void;
   onRun(test: Test, type: ResourceType): void;
+  onDuplicate(test: Test, type: ResourceType): void;
   onViewAll(id: string, type: ResourceType): void;
   test: Test;
 }
 
-const TestCard = ({onEdit, onDelete, onRun, onViewAll, test}: IProps) => {
+const TestCard = ({onEdit, onDelete, onDuplicate, onRun, onViewAll, test}: IProps) => {
   const queryParams = useMemo(() => ({take: 5, testId: test.id}), [test.id]);
   const {isCollapsed, isLoading, list, onClick} = useRuns<TestRun, {testId: string}>(
     useLazyGetRunListQuery,
@@ -65,6 +66,7 @@ const TestCard = ({onEdit, onDelete, onRun, onViewAll, test}: IProps) => {
             shouldEdit={shouldEdit}
             onDelete={() => onDelete(test.id, test.name, ResourceType.Test)}
             onEdit={() => onEdit(test.id, lastRunId, ResourceType.Test)}
+            onDuplicate={() => onDuplicate(test, ResourceType.Test)}
           />
         </S.Row>
       </S.TestContainer>

--- a/web/src/components/ResourceCard/TestSuiteCard.tsx
+++ b/web/src/components/ResourceCard/TestSuiteCard.tsx
@@ -19,6 +19,7 @@ interface IProps {
   onEdit(id: string, lastRunId: number, type: ResourceType): void;
   onDelete(id: string, name: string, type: ResourceType): void;
   onRun(testSuite: TestSuite, type: ResourceType): void;
+  onDuplicate(testSuite: TestSuite): void;
   onViewAll(id: string, type: ResourceType): void;
   testSuite: TestSuite;
 }
@@ -27,6 +28,7 @@ const TestSuiteCard = ({
   onEdit,
   onDelete,
   onRun,
+  onDuplicate,
   onViewAll,
   testSuite: {id: testSuiteId, summary, name, description},
   testSuite,
@@ -71,6 +73,7 @@ const TestSuiteCard = ({
             shouldEdit={shouldEdit}
             onDelete={() => onDelete(testSuiteId, name, ResourceType.TestSuite)}
             onEdit={() => onEdit(testSuiteId, lastRunId, ResourceType.TestSuite)}
+            onDuplicate={() => onDuplicate(testSuite)}
           />
         </S.Row>
       </S.TestContainer>

--- a/web/src/components/ResourceCard/__tests__/ResourceCardActions.test.tsx
+++ b/web/src/components/ResourceCard/__tests__/ResourceCardActions.test.tsx
@@ -8,6 +8,14 @@ test('ResourceCardActions', async () => {
   const onDelete = jest.fn();
   const testId = faker.datatype.uuid();
 
-  const {getByTestId} = render(<ResourceCardActions shouldEdit={shouldEdit} onEdit={onEdit} onDelete={onDelete} id={testId} />);
+  const {getByTestId} = render(
+    <ResourceCardActions
+      shouldEdit={shouldEdit}
+      onEdit={onEdit}
+      onDelete={onDelete}
+      id={testId}
+      onDuplicate={jest.fn()}
+    />
+  );
   await waitFor(() => getByTestId(`test-actions-button-${testId}`));
 });

--- a/web/src/components/ResourceCard/__tests__/TestCard.test.tsx
+++ b/web/src/components/ResourceCard/__tests__/TestCard.test.tsx
@@ -10,7 +10,14 @@ test('TestCard', async () => {
   const test = TestMock.model();
 
   const {getByTestId, getByText} = render(
-    <TestCard onEdit={onEdit} onDelete={onDelete} onRun={onRunTest} onViewAll={onClick} test={test} />
+    <TestCard
+      onEdit={onEdit}
+      onDelete={onDelete}
+      onRun={onRunTest}
+      onViewAll={onClick}
+      test={test}
+      onDuplicate={jest.fn()}
+    />
   );
   const mouseEvent = new MouseEvent('click', {bubbles: true});
   fireEvent(getByTestId(`test-actions-button-${test.id}`), mouseEvent);

--- a/web/src/components/TestHeader/TestHeader.tsx
+++ b/web/src/components/TestHeader/TestHeader.tsx
@@ -9,11 +9,12 @@ interface IProps {
   shouldEdit: boolean;
   onEdit(): void;
   onDelete(): void;
+  onDuplicate(): void;
   title: string;
   runButton: React.ReactElement;
 }
 
-const TestHeader = ({description, id, shouldEdit, onEdit, onDelete, title, runButton}: IProps) => {
+const TestHeader = ({description, id, shouldEdit, onEdit, onDelete, onDuplicate, title, runButton}: IProps) => {
   const {navigate} = useDashboard();
 
   return (
@@ -30,7 +31,13 @@ const TestHeader = ({description, id, shouldEdit, onEdit, onDelete, title, runBu
       <S.Section>
         <VariableSetSelector />
         {runButton}
-        <ResourceCardActions id={id} onDelete={onDelete} onEdit={onEdit} shouldEdit={shouldEdit} />
+        <ResourceCardActions
+          id={id}
+          onDuplicate={onDuplicate}
+          onDelete={onDelete}
+          onEdit={onEdit}
+          shouldEdit={shouldEdit}
+        />
       </S.Section>
     </S.Container>
   );

--- a/web/src/components/TestHeader/__tests__/TestHeader.test.tsx
+++ b/web/src/components/TestHeader/__tests__/TestHeader.test.tsx
@@ -10,7 +10,16 @@ test('SpanAttributesTable', () => {
   const shouldEdit = true;
 
   const {getByTestId} = render(
-    <TestHeader description={test.description} id={test.id} shouldEdit={shouldEdit} onEdit={onEdit} onDelete={onDelete} title={test.name} runButton={<div />} />
+    <TestHeader
+      description={test.description}
+      id={test.id}
+      shouldEdit={shouldEdit}
+      onEdit={onEdit}
+      onDelete={onDelete}
+      title={test.name}
+      runButton={<div />}
+      onDuplicate={jest.fn()}
+    />
   );
   expect(getByTestId('test-details-name')).toBeInTheDocument();
 });

--- a/web/src/hooks/useKeyEvent.ts
+++ b/web/src/hooks/useKeyEvent.ts
@@ -1,0 +1,34 @@
+import {useCallback, useEffect} from 'react';
+
+type TEvent = 'keydown' | 'keypress' | 'keyup';
+
+export enum Keys {
+  Enter = 'Enter',
+  Escape = 'Escape',
+}
+
+const useKeyEvent = (targetKey: string[], callback: () => void, events: TEvent[] = ['keydown']) => {
+  const onEvent = useCallback(
+    (e: KeyboardEvent) => {
+      if (targetKey.includes(e.key)) {
+        e.stopPropagation();
+        callback();
+      }
+    },
+    [callback, targetKey]
+  );
+
+  useEffect(() => {
+    events.forEach(event => {
+      window.addEventListener(event, onEvent);
+    });
+
+    return () => {
+      events.forEach(event => {
+        window.removeEventListener(event, onEvent);
+      });
+    };
+  }, [events, onEvent]);
+};
+
+export default useKeyEvent;

--- a/web/src/models/TestOutput.model.ts
+++ b/web/src/models/TestOutput.model.ts
@@ -14,13 +14,13 @@ type TestOutput = {
   error: string;
 };
 
-function TestOutput({name = '', selectorParsed = {}, value = ''}: TRawTestOutput, id = -1): TestOutput {
+function TestOutput({name = '', selectorParsed = {}, selector = '', value = ''}: TRawTestOutput, id = -1): TestOutput {
   return {
     id,
     isDeleted: false,
     isDraft: false,
     name,
-    selector: selectorParsed.query || '',
+    selector: selectorParsed.query || selector || '',
     value,
     valueRun: '',
     valueRunDraft: '',

--- a/web/src/pages/Home/TestsList.tsx
+++ b/web/src/pages/Home/TestsList.tsx
@@ -14,6 +14,7 @@ import {useDashboard} from 'providers/Dashboard/Dashboard.provider';
 import VariableSetSelector from 'components/VariableSetSelector/VariableSetSelector';
 import Test from 'models/Test.model';
 import ImportModal from 'components/ImportModal/ImportModal';
+import {useConfirmationModal} from 'providers/ConfirmationModal/ConfirmationModal.provider';
 import * as S from './Home.styled';
 import HomeFilters from './HomeFilters';
 import Loading from './Loading';
@@ -29,12 +30,13 @@ const Tests = () => {
   const [isCreateTestOpen, setIsCreateTestOpen] = useState(false);
   const [isImportTestOpen, setIsImportTestOpen] = useState(false);
   const [parameters, setParameters] = useState<TParameters>(defaultSort);
+  const {onOpen} = useConfirmationModal();
 
   const pagination = usePagination<Test, TParameters>(useGetTestListQuery, {
     ...parameters,
   });
   const onDelete = useDeleteResource();
-  const {runTest} = useTestCrud();
+  const {runTest, duplicate} = useTestCrud();
   const {navigate} = useDashboard();
 
   const handleOnRun = useCallback(
@@ -42,6 +44,18 @@ const Tests = () => {
       runTest({test});
     },
     [runTest]
+  );
+
+  const handleOnDuplicate = useCallback(
+    (test: Test) => {
+      onOpen({
+        heading: `Duplicate Test`,
+        title: `Create a duplicated version of Test: ${test.name}`,
+        okText: 'Duplicate',
+        onConfirm: () => duplicate(test),
+      });
+    },
+    [duplicate, onOpen]
   );
 
   const handleOnViewAll = useCallback((id: string) => {
@@ -106,6 +120,7 @@ const Tests = () => {
                 onDelete={onDelete}
                 onRun={handleOnRun}
                 onViewAll={handleOnViewAll}
+                onDuplicate={handleOnDuplicate}
                 test={test}
               />
             ))}

--- a/web/src/pages/Test/Content.tsx
+++ b/web/src/pages/Test/Content.tsx
@@ -1,4 +1,4 @@
-import {useMemo} from 'react';
+import {useCallback, useMemo} from 'react';
 import CreateButton from 'components/CreateButton';
 import PaginatedList from 'components/PaginatedList';
 import TestRunCard from 'components/RunCard/TestRunCard';
@@ -10,6 +10,7 @@ import {useDashboard} from 'providers/Dashboard/Dashboard.provider';
 import {useTest} from 'providers/Test/Test.provider';
 import useTestCrud from 'providers/Test/hooks/useTestCrud';
 import TracetestAPI from 'redux/apis/Tracetest';
+import {useConfirmationModal} from 'providers/ConfirmationModal/ConfirmationModal.provider';
 import {ResourceType} from 'types/Resource.type';
 import * as S from './Test.styled';
 
@@ -18,7 +19,8 @@ const {useGetRunListQuery} = TracetestAPI.instance;
 const Content = () => {
   const {test} = useTest();
   const onDeleteResource = useDeleteResource();
-  const {runTest, isLoadingRunTest} = useTestCrud();
+  const {runTest, isLoadingRunTest, duplicate} = useTestCrud();
+  const {onOpen} = useConfirmationModal();
   const params = useMemo(() => ({testId: test.id}), [test.id]);
   useDocumentTitle(`${test.name}`);
 
@@ -26,6 +28,15 @@ const Content = () => {
 
   const shouldEdit = test.summary.hasRuns;
   const onEdit = () => navigate(`/test/${test.id}/run/${test.summary.runs}`);
+
+  const handleOnDuplicate = useCallback(() => {
+    onOpen({
+      heading: `Duplicate Test`,
+      title: `Create a duplicated version of Test: ${test.name}`,
+      okText: 'Duplicate',
+      onConfirm: () => duplicate(test),
+    });
+  }, [duplicate, onOpen, test]);
 
   return (
     <S.Container $isWhite>
@@ -36,6 +47,7 @@ const Content = () => {
         id={test.id}
         onDelete={() => onDeleteResource(test.id, test.name, ResourceType.Test)}
         onEdit={onEdit}
+        onDuplicate={handleOnDuplicate}
         shouldEdit={shouldEdit}
         title={`${test.name} (v${test.version})`}
         runButton={

--- a/web/src/pages/TestSuite/Content.tsx
+++ b/web/src/pages/TestSuite/Content.tsx
@@ -8,6 +8,7 @@ import TestSuiteRun from 'models/TestSuiteRun.model';
 import {useDashboard} from 'providers/Dashboard/Dashboard.provider';
 import {useTestSuite} from 'providers/TestSuite/TestSuite.provider';
 import {useTestSuiteCrud} from 'providers/TestSuite';
+import {useConfirmationModal} from 'providers/ConfirmationModal/ConfirmationModal.provider';
 import TracetestAPI from 'redux/apis/Tracetest';
 import * as S from './TestSuite.styled';
 
@@ -15,7 +16,8 @@ const {useGetTestSuiteRunsQuery} = TracetestAPI.instance;
 
 const Content = () => {
   const {onDelete, testSuite} = useTestSuite();
-  const {runTestSuite, isEditLoading} = useTestSuiteCrud();
+  const {runTestSuite, duplicate, isEditLoading} = useTestSuiteCrud();
+  const {onOpen} = useConfirmationModal();
   const params = useMemo(() => ({testSuiteId: testSuite.id}), [testSuite.id]);
 
   useDocumentTitle(`${testSuite.name}`);
@@ -29,6 +31,15 @@ const Content = () => {
   const shouldEdit = testSuite.summary.hasRuns;
   const onEdit = () => navigate(`/testsuite/${testSuite.id}/run/${testSuite.summary.runs}`);
 
+  const handleOnDuplicate = useCallback(() => {
+    onOpen({
+      heading: `Duplicate Test Suite`,
+      title: `Create a duplicated version of Test Suite: ${suite.name}`,
+      okText: 'Duplicate',
+      onConfirm: () => duplicate(testSuite),
+    });
+  }, [duplicate, onOpen, testSuite]);
+
   return (
     <S.Container $isWhite>
       <TestHeader
@@ -36,6 +47,7 @@ const Content = () => {
         id={testSuite.id}
         onDelete={() => onDelete(testSuite.id, testSuite.name)}
         onEdit={onEdit}
+        onDuplicate={handleOnDuplicate}
         shouldEdit={shouldEdit}
         title={`${testSuite.name} (v${testSuite.version})`}
         runButton={

--- a/web/src/pages/TestSuites/TestSuitesList.tsx
+++ b/web/src/pages/TestSuites/TestSuitesList.tsx
@@ -14,6 +14,7 @@ import HomeAnalyticsService from 'services/Analytics/HomeAnalytics.service';
 import {useDashboard} from 'providers/Dashboard/Dashboard.provider';
 import useTestSuiteCrud from 'providers/TestSuite/hooks/useTestSuiteCrud';
 import VariableSetSelector from 'components/VariableSetSelector/VariableSetSelector';
+import {useConfirmationModal} from 'providers/ConfirmationModal/ConfirmationModal.provider';
 import TestSuite from 'models/TestSuite.model';
 import * as S from './TestSuites.styled';
 import HomeFilters from '../Home/HomeFilters';
@@ -32,8 +33,9 @@ const Resources = () => {
   const {data: testListData} = useGetTestListQuery({});
   const pagination = usePagination<TestSuite, TParameters>(useGetTestSuiteListQuery, parameters);
   const onDelete = useDeleteResource();
-  const {runTestSuite} = useTestSuiteCrud();
+  const {runTestSuite, duplicate} = useTestSuiteCrud();
   const {navigate} = useDashboard();
+  const {onOpen} = useConfirmationModal();
 
   const handleOnRun = useCallback(
     (resource: TestSuite) => {
@@ -51,6 +53,18 @@ const Resources = () => {
       navigate(`/testsuite/${id}/run/${lastRunId}`);
     },
     [navigate]
+  );
+
+  const handleOnDuplicate = useCallback(
+    (suite: TestSuite) => {
+      onOpen({
+        heading: `Duplicate Test Suite`,
+        title: `Create a duplicated version of Test Suite: ${suite.name}`,
+        okText: 'Duplicate',
+        onConfirm: () => duplicate(suite),
+      });
+    },
+    [duplicate, onOpen]
   );
 
   return (
@@ -126,6 +140,7 @@ const Resources = () => {
                 onEdit={handleOnEdit}
                 onDelete={onDelete}
                 onRun={handleOnRun}
+                onDuplicate={handleOnDuplicate}
                 onViewAll={handleOnViewAll}
                 testSuite={suite}
               />

--- a/web/src/providers/CreateTest/CreateTest.provider.tsx
+++ b/web/src/providers/CreateTest/CreateTest.provider.tsx
@@ -1,12 +1,9 @@
 import {noop} from 'lodash';
 import useTestCrud from 'providers/Test/hooks/useTestCrud';
 import {createContext, useCallback, useContext, useMemo, useState} from 'react';
-import TracetestAPI from 'redux/apis/Tracetest';
 import TestService from 'services/Test.service';
 import {IPlugin} from 'types/Plugins.types';
 import {TDraftTest} from 'types/Test.types';
-
-const {useCreateTestMutation} = TracetestAPI.instance;
 
 interface IContext {
   initialValues: TDraftTest;
@@ -30,16 +27,14 @@ interface IProps {
 
 const CreateTestProvider = ({children}: IProps) => {
   const [initialValues, setInitialValues] = useState<TDraftTest>({name: 'Untitled'});
-  const [createTest, {isLoading: isLoadingCreateTest}] = useCreateTestMutation();
-  const {runTest, isEditLoading: isLoadingEditTest} = useTestCrud();
+  const {create, isLoadingCreateTest, isEditLoading: isLoadingEditTest} = useTestCrud();
 
   const onCreateTest = useCallback(
     async (draft: TDraftTest, plugin: IPlugin) => {
       const rawTest = await TestService.getRequest(plugin, draft);
-      const test = await createTest(rawTest).unwrap();
-      runTest({test});
+      await create(rawTest);
     },
-    [createTest, runTest]
+    [create]
   );
 
   const onInitialValues = useCallback(values => setInitialValues(values), []);

--- a/web/src/providers/CreateTestSuite/CreateTestSuite.provider.tsx
+++ b/web/src/providers/CreateTestSuite/CreateTestSuite.provider.tsx
@@ -1,14 +1,11 @@
 import {noop} from 'lodash';
 import {createContext, useCallback, useContext, useMemo} from 'react';
-import TracetestAPI from 'redux/apis/Tracetest';
 import {useAppDispatch, useAppSelector} from 'redux/hooks';
 import {initialState, reset, setDraft, setIsFormValid, setStepNumber} from 'redux/slices/CreateTestSuite.slice';
 import CreateTestSuitesSelectors from 'selectors/CreateTestSuite.selectors';
 import {ICreateTestStep} from 'types/Plugins.types';
 import {ICreateTestSuiteState, TDraftTestSuite} from 'types/TestSuite.types';
 import {useTestSuiteCrud} from '../TestSuite';
-
-const {useCreateTestSuiteMutation} = TracetestAPI.instance;
 
 interface IContext extends ICreateTestSuiteState {
   isLoading: boolean;

--- a/web/src/providers/CreateTestSuite/CreateTestSuite.provider.tsx
+++ b/web/src/providers/CreateTestSuite/CreateTestSuite.provider.tsx
@@ -43,8 +43,7 @@ export const useCreateTestSuite = () => useContext(Context);
 
 const CreateTestSuiteProvider = ({children}: IProps) => {
   const dispatch = useAppDispatch();
-  const [create, {isLoading: isLoadingCreate}] = useCreateTestSuiteMutation();
-  const {runTestSuite, isEditLoading} = useTestSuiteCrud();
+  const {isEditLoading, create, isLoadingCreate} = useTestSuiteCrud();
 
   const draft = useAppSelector(CreateTestSuitesSelectors.selectDraft);
   const stepNumber = useAppSelector(CreateTestSuitesSelectors.selectStepNumber);
@@ -55,10 +54,9 @@ const CreateTestSuiteProvider = ({children}: IProps) => {
 
   const onCreate = useCallback(
     async (values: TDraftTestSuite) => {
-      const suite = await create(values).unwrap();
-      runTestSuite(suite);
+      await create(values);
     },
-    [create, runTestSuite]
+    [create]
   );
 
   const onUpdate = useCallback(

--- a/web/src/services/Test.service.ts
+++ b/web/src/services/Test.service.ts
@@ -97,6 +97,11 @@ const TestService = () => ({
     const updatedTest = {...test, ...partialTest};
     return this.getRequest(plugin, testTriggerData, updatedTest);
   },
+
+  async getDuplicatedRawTest(test: Test, name: string): Promise<TRawTestResource> {
+    const raw = await this.getUpdatedRawTest(test, {});
+    return {...raw, spec: {...raw.spec, name}};
+  },
 });
 
 export default TestService();

--- a/web/src/services/TestSuite.service.ts
+++ b/web/src/services/TestSuite.service.ts
@@ -15,6 +15,12 @@ const TestSuiteService = () => ({
       steps: suite.fullSteps.map(step => step.id),
     };
   },
+
+  getDuplicatedDraftTestSuite(suite: TestSuite, name: string): TDraftTestSuite {
+    const draft = this.getInitialValues(suite);
+
+    return {...draft, name, id: undefined, version: undefined};
+  },
 });
 
 export default TestSuiteService();

--- a/web/src/types/TestSuite.types.ts
+++ b/web/src/types/TestSuite.types.ts
@@ -6,6 +6,8 @@ export type TDraftTestSuite = {
   steps?: string[];
   name?: string;
   description?: string;
+  id?: string;
+  version?: number;
 };
 
 export interface ICreateTestSuiteState {


### PR DESCRIPTION
This PR adds the duplicate action for tests and test suites, it triggers the confirmation modal before doing the actual duplication

## Changes

- Adds duplication logic for tests and test suites
- Adds listeners and confirmation modals for duplications

## Fixes

- https://github.com/kubeshop/tracetest/issues/3062

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Loom video

https://www.loom.com/share/6594163f31b24f0388d9d1a21669fc4c