### PR TITLE
fix(frontend): improve syntax highlighter performance

### DIFF
--- a/web/src/components/RunDetailTriggerResponse/ResponseBody.tsx
+++ b/web/src/components/RunDetailTriggerResponse/ResponseBody.tsx
@@ -1,9 +1,9 @@
 import AttributeActions from 'components/AttributeActions';
+import CodeBlock from 'components/CodeBlock';
 import {isRunStateFinished} from 'models/TestRun.model';
 import {TSpanFlatAttribute} from 'types/Span.types';
 import {TTestRunState} from 'types/TestRun.types';
 import SkeletonResponse from './SkeletonResponse';
-import CodeBlock from '../CodeBlock';
 import * as S from './RunDetailTriggerResponse.styled';
 
 interface IProps {


### PR DESCRIPTION
This PR fixes a performance issue related to the `react-syntax-highlighter` package used to render the response body of a test. We were having issues when dealing with `html` types because the package does not support html as a language (see available languages [here](https://github.com/react-syntax-highlighter/react-syntax-highlighter/blob/HEAD/AVAILABLE_LANGUAGES_HLJS.MD)). Also, there are some performance problems described [here](https://github.com/react-syntax-highlighter/react-syntax-highlighter/issues/302) that we are fixing by using a memoization approach.

## Changes

- fix html language type
- memoize syntax highlighter component

## Fixes

- #3397

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Demo

![2023-11-23 16 19 56](https://github.com/kubeshop/tracetest/assets/3879892/9d7127fb-84b8-4d54-bc91-ab51b58f472d)