### PR TITLE
feat: Import Definition

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -41,6 +41,7 @@
         "fast-xml-parser": "4.2.4",
         "history": "5.2.0",
         "html-react-parser": "3.0.4",
+        "js-yaml": "4.1.0",
         "less": "4.1.3",
         "lodash": "4.17.21",
         "markdown-it": "13.0.1",
@@ -2693,11 +2694,6 @@
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
-    "node_modules/@eslint/eslintrc/node_modules/argparse": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
-    },
     "node_modules/@eslint/eslintrc/node_modules/globals": {
       "version": "13.12.1",
       "resolved": "https://registry.npmjs.org/globals/-/globals-13.12.1.tgz",
@@ -2718,17 +2714,6 @@
       "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
       "engines": {
         "node": ">= 4"
-      }
-    },
-    "node_modules/@eslint/eslintrc/node_modules/js-yaml": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
-      "dependencies": {
-        "argparse": "^2.0.1"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
       }
     },
     "node_modules/@eslint/eslintrc/node_modules/type-fest": {
@@ -2799,6 +2784,14 @@
         "node": ">=8"
       }
     },
+    "node_modules/@istanbuljs/load-nyc-config/node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
     "node_modules/@istanbuljs/load-nyc-config/node_modules/camelcase": {
       "version": "5.3.1",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
@@ -2817,6 +2810,18 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml": {
+      "version": "3.14.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+      "dependencies": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
       }
     },
     "node_modules/@istanbuljs/load-nyc-config/node_modules/locate-path": {
@@ -9710,12 +9715,9 @@
       "integrity": "sha512-e0hDa9H2Z9AwFkk2qDlwhoMYE4eToKarchkQHovNdLTCYMHZHeRjI71crOh+dio4K6u1IcwubQqo79Ga4CyAQA=="
     },
     "node_modules/argparse": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-      "dependencies": {
-        "sprintf-js": "~1.0.2"
-      }
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
     },
     "node_modules/aria-query": {
       "version": "4.2.2",
@@ -13953,11 +13955,6 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
-    "node_modules/eslint/node_modules/argparse": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
-    },
     "node_modules/eslint/node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -14020,17 +14017,6 @@
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/eslint/node_modules/js-yaml": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
-      "dependencies": {
-        "argparse": "^2.0.1"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
       }
     },
     "node_modules/eslint/node_modules/supports-color": {
@@ -18733,12 +18719,11 @@
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
     },
     "node_modules/js-yaml": {
-      "version": "3.14.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
-      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
       "dependencies": {
-        "argparse": "^1.0.7",
-        "esprima": "^4.0.0"
+        "argparse": "^2.0.1"
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
@@ -19464,11 +19449,6 @@
       "bin": {
         "markdown-it": "bin/markdown-it.js"
       }
-    },
-    "node_modules/markdown-it/node_modules/argparse": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
     },
     "node_modules/markdown-it/node_modules/entities": {
       "version": "3.0.1",
@@ -20319,24 +20299,6 @@
       "engines": {
         "node": ">= 14.0.0",
         "npm": ">= 7.0.0"
-      }
-    },
-    "node_modules/openapi-typescript/node_modules/argparse": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true
-    },
-    "node_modules/openapi-typescript/node_modules/js-yaml": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
-      "dev": true,
-      "dependencies": {
-        "argparse": "^2.0.1"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
       }
     },
     "node_modules/openapi-typescript/node_modules/mime": {
@@ -24429,7 +24391,7 @@
     "node_modules/sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
+      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g=="
     },
     "node_modules/sshpk": {
       "version": "1.17.0",
@@ -24948,6 +24910,14 @@
         "node": ">=4.0.0"
       }
     },
+    "node_modules/svgo/node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
     "node_modules/svgo/node_modules/css-select": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/css-select/-/css-select-2.1.0.tgz",
@@ -24992,6 +24962,18 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.1.tgz",
       "integrity": "sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w=="
+    },
+    "node_modules/svgo/node_modules/js-yaml": {
+      "version": "3.14.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+      "dependencies": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
     },
     "node_modules/svgo/node_modules/nth-check": {
       "version": "1.0.2",
@@ -28800,11 +28782,6 @@
         "strip-json-comments": "^3.1.1"
       },
       "dependencies": {
-        "argparse": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-          "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
-        },
         "globals": {
           "version": "13.12.1",
           "resolved": "https://registry.npmjs.org/globals/-/globals-13.12.1.tgz",
@@ -28817,14 +28794,6 @@
           "version": "4.0.6",
           "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
           "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg=="
-        },
-        "js-yaml": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-          "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
-          "requires": {
-            "argparse": "^2.0.1"
-          }
         },
         "type-fest": {
           "version": "0.20.2",
@@ -28877,6 +28846,14 @@
         "resolve-from": "^5.0.0"
       },
       "dependencies": {
+        "argparse": {
+          "version": "1.0.10",
+          "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+          "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+          "requires": {
+            "sprintf-js": "~1.0.2"
+          }
+        },
         "camelcase": {
           "version": "5.3.1",
           "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
@@ -28889,6 +28866,15 @@
           "requires": {
             "locate-path": "^5.0.0",
             "path-exists": "^4.0.0"
+          }
+        },
+        "js-yaml": {
+          "version": "3.14.1",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+          "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+          "requires": {
+            "argparse": "^1.0.7",
+            "esprima": "^4.0.0"
           }
         },
         "locate-path": {
@@ -32980,12 +32966,9 @@
       "integrity": "sha512-e0hDa9H2Z9AwFkk2qDlwhoMYE4eToKarchkQHovNdLTCYMHZHeRjI71crOh+dio4K6u1IcwubQqo79Ga4CyAQA=="
     },
     "argparse": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-      "requires": {
-        "sprintf-js": "~1.0.2"
-      }
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
     },
     "aria-query": {
       "version": "4.2.2",
@@ -35668,11 +35651,6 @@
             "color-convert": "^2.0.1"
           }
         },
-        "argparse": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-          "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
-        },
         "chalk": {
           "version": "4.1.2",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -35712,14 +35690,6 @@
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
           "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
-        },
-        "js-yaml": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-          "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
-          "requires": {
-            "argparse": "^2.0.1"
-          }
         },
         "supports-color": {
           "version": "7.2.0",
@@ -39580,12 +39550,11 @@
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
     },
     "js-yaml": {
-      "version": "3.14.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
-      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
       "requires": {
-        "argparse": "^1.0.7",
-        "esprima": "^4.0.0"
+        "argparse": "^2.0.1"
       }
     },
     "jsbn": {
@@ -40134,11 +40103,6 @@
         "uc.micro": "^1.0.5"
       },
       "dependencies": {
-        "argparse": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-          "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
-        },
         "entities": {
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/entities/-/entities-3.0.1.tgz",
@@ -40769,21 +40733,6 @@
         "yargs-parser": "^21.0.1"
       },
       "dependencies": {
-        "argparse": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-          "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-          "dev": true
-        },
-        "js-yaml": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-          "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
-          "dev": true,
-          "requires": {
-            "argparse": "^2.0.1"
-          }
-        },
         "mime": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/mime/-/mime-3.0.0.tgz",
@@ -43696,7 +43645,7 @@
     "sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
+      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g=="
     },
     "sshpk": {
       "version": "1.17.0",
@@ -44078,6 +44027,14 @@
         "util.promisify": "~1.0.0"
       },
       "dependencies": {
+        "argparse": {
+          "version": "1.0.10",
+          "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+          "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+          "requires": {
+            "sprintf-js": "~1.0.2"
+          }
+        },
         "css-select": {
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/css-select/-/css-select-2.1.0.tgz",
@@ -44117,6 +44074,15 @@
               "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.1.tgz",
               "integrity": "sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w=="
             }
+          }
+        },
+        "js-yaml": {
+          "version": "3.14.1",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+          "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+          "requires": {
+            "argparse": "^1.0.7",
+            "esprima": "^4.0.0"
           }
         },
         "nth-check": {

--- a/web/package.json
+++ b/web/package.json
@@ -37,6 +37,7 @@
     "fast-xml-parser": "4.2.4",
     "history": "5.2.0",
     "html-react-parser": "3.0.4",
+    "js-yaml": "4.1.0",
     "less": "4.1.3",
     "lodash": "4.17.21",
     "markdown-it": "13.0.1",

--- a/web/src/components/ImportModal/ImportModal.tsx
+++ b/web/src/components/ImportModal/ImportModal.tsx
@@ -4,7 +4,6 @@ import {TDraftTest} from 'types/Test.types';
 import {ImportTypes} from 'constants/Test.constants';
 import ImportService from 'services/Import.service';
 import {useDashboard} from 'providers/Dashboard/Dashboard.provider';
-import {ImportTypeToPlugin} from 'constants/Plugins.constants';
 import {useCreateTest} from 'providers/CreateTest/CreateTest.provider';
 import {ImportSelector} from 'components/Inputs';
 import ImportFactory from 'components/TestPlugins/ImportFactory';
@@ -36,7 +35,7 @@ const ImportModal = ({isOpen, onClose}: IProps) => {
   const handleImport = useCallback(
     async (values: TDraftTest) => {
       const draft = await ImportService.getRequest(type, values);
-      const plugin = ImportTypeToPlugin[type];
+      const plugin = await ImportService.getPlugin(type, values);
 
       onInitialValues(draft);
       navigate(`/test/create/${plugin.type}`);
@@ -66,7 +65,7 @@ const ImportModal = ({isOpen, onClose}: IProps) => {
         layout="vertical"
         name={FORM_ID}
         onFinish={handleImport}
-        initialValues={{importType: ImportTypes.curl}}
+        initialValues={{importType: ImportTypes.definition}}
         onValuesChange={(_: any, values) => handleChange(values)}
       >
         <S.Container>

--- a/web/src/components/ImportModal/Tip.tsx
+++ b/web/src/components/ImportModal/Tip.tsx
@@ -6,7 +6,7 @@ const Tip = () => (
     <Typography.Title level={3} type="secondary">
       <BulbOutlined /> What are the supported formats?
     </Typography.Title>
-    <Typography.Text type="secondary">We support cURL & Postman. OpenAPI is coming soon!</Typography.Text>
+    <Typography.Text type="secondary">We support Tracetest Definition, cURL & Postman. OpenAPI is coming soon!</Typography.Text>
   </>
 );
 

--- a/web/src/components/Inputs/Editor/CurlCommand/CurlCommand.tsx
+++ b/web/src/components/Inputs/Editor/CurlCommand/CurlCommand.tsx
@@ -13,6 +13,7 @@ const CurlCommand = ({value, onChange}: IEditorProps) => {
       extensions={[StreamLanguage.define(shell)]}
       spellCheck={false}
       placeholder="curl -X POST http://site.com"
+      autoFocus
     />
   );
 };

--- a/web/src/components/Inputs/Editor/Definition/Definition.tsx
+++ b/web/src/components/Inputs/Editor/Definition/Definition.tsx
@@ -1,0 +1,32 @@
+import CodeMirror from '@uiw/react-codemirror';
+import {StreamLanguage} from '@codemirror/language';
+import {yaml} from '@codemirror/legacy-modes/mode/yaml';
+import {IEditorProps} from '../Editor';
+
+const placeholder = `type: Test
+spec:
+  name: My Test
+  trigger:
+    type: http
+    httpRequest:
+      method: GET
+      url: google.com
+`;
+
+const Definition = ({value, onChange}: IEditorProps) => {
+  return (
+    <CodeMirror
+      value={value}
+      onChange={onChange}
+      data-cy="definition-editor"
+      basicSetup={{indentOnInput: true}}
+      extensions={[StreamLanguage.define(yaml)]}
+      spellCheck={false}
+      placeholder={placeholder}
+      minHeight="200px"
+      autoFocus
+    />
+  );
+};
+
+export default Definition;

--- a/web/src/components/Inputs/Editor/Definition/index.ts
+++ b/web/src/components/Inputs/Editor/Definition/index.ts
@@ -1,0 +1,2 @@
+// eslint-disable-next-line no-restricted-exports
+export {default} from './Definition';

--- a/web/src/components/Inputs/Editor/Editor.tsx
+++ b/web/src/components/Inputs/Editor/Editor.tsx
@@ -11,6 +11,7 @@ const EditorMap = {
   [SupportedEditors.Selector]: lazy(() => import('./Selector')),
   [SupportedEditors.Interpolation]: lazy(() => import('./Interpolation')),
   [SupportedEditors.CurlCommand]: lazy(() => import('./CurlCommand')),
+  [SupportedEditors.Definition]: lazy(() => import('./Definition')),
 } as const;
 
 export interface IEditorProps {

--- a/web/src/components/Inputs/ImportSelector/ImportSelector.tsx
+++ b/web/src/components/Inputs/ImportSelector/ImportSelector.tsx
@@ -3,7 +3,7 @@ import {ImportTypes} from 'constants/Test.constants';
 import ImportCard from './ImportCard';
 import * as S from './ImportSelector.styled';
 
-const importList = [ImportTypes.curl, ImportTypes.postman];
+const importList = [ImportTypes.definition, ImportTypes.curl, ImportTypes.postman];
 
 interface IProps {
   value?: ImportTypes;

--- a/web/src/components/TestPlugins/ImportFactory.tsx
+++ b/web/src/components/TestPlugins/ImportFactory.tsx
@@ -3,10 +3,12 @@ import {TDraftTestForm} from 'types/Test.types';
 import Postman from './Imports/Postman';
 import Curl from './Imports/Curl';
 import useShortcut from './hooks/useShortcut';
+import Definition from './Imports/Definition';
 
 const ImportFactoryMap = {
   [ImportTypes.postman]: Postman,
   [ImportTypes.curl]: Curl,
+  [ImportTypes.definition]: Definition,
 };
 
 export interface IFormProps {

--- a/web/src/components/TestPlugins/Imports/Definition/Definition.styled.ts
+++ b/web/src/components/TestPlugins/Imports/Definition/Definition.styled.ts
@@ -1,0 +1,31 @@
+import {DeleteOutlined} from '@ant-design/icons';
+import {Typography} from 'antd';
+import styled from 'styled-components';
+
+export const Row = styled.div`
+  display: flex;
+`;
+
+export const Label = styled(Typography.Text).attrs({as: 'div'})`
+  margin-bottom: 8px;
+`;
+
+export const URLInputContainer = styled.div`
+  display: flex;
+  align-items: flex-start;
+
+  .ant-form-item {
+    margin: 0;
+  }
+`;
+
+export const HeaderContainer = styled.div`
+  align-items: center;
+  display: flex;
+  margin-bottom: 8px;
+`;
+
+export const DeleteIcon = styled(DeleteOutlined)`
+  color: ${({theme}) => theme.color.textSecondary};
+  font-size: ${({theme}) => theme.size.md};
+`;

--- a/web/src/components/TestPlugins/Imports/Definition/Definition.tsx
+++ b/web/src/components/TestPlugins/Imports/Definition/Definition.tsx
@@ -1,0 +1,28 @@
+import {Form} from 'antd';
+import {Editor} from 'components/Inputs';
+import {SupportedEditors} from 'constants/Editor.constants';
+import DefinitionService from 'services/Importers/Definition.service';
+
+const Definition = () => {
+  return (
+    <Form.Item
+      label="Paste Tracetest Definition"
+      name="definition"
+      rules={[
+        {required: true, message: 'Please enter a valid Tracetest Definition'},
+        {
+          validator: (_, definition) => {
+            const errors = DefinitionService.validate(definition);
+            if (errors.length) return Promise.reject(new Error(errors.join(', ')));
+
+            return Promise.resolve();
+          },
+        },
+      ]}
+    >
+      <Editor type={SupportedEditors.Definition} />
+    </Form.Item>
+  );
+};
+
+export default Definition;

--- a/web/src/components/TestPlugins/Imports/Definition/index.ts
+++ b/web/src/components/TestPlugins/Imports/Definition/index.ts
@@ -1,0 +1,2 @@
+// eslint-disable-next-line no-restricted-exports
+export {default} from './Definition';

--- a/web/src/constants/Editor.constants.ts
+++ b/web/src/constants/Editor.constants.ts
@@ -70,6 +70,7 @@ export enum SupportedEditors {
   Interpolation = 'interpolation-editor',
   Expression = 'expression-editor',
   CurlCommand = 'curlCommand-editor',
+  Definition = 'definition-editor',
 }
 
 export const operatorList = [

--- a/web/src/constants/Plugins.constants.ts
+++ b/web/src/constants/Plugins.constants.ts
@@ -1,6 +1,6 @@
 import {IPlugin} from 'types/Plugins.types';
 import {SupportedPlugins} from './Common.constants';
-import {ImportTypes, TriggerTypes} from './Test.constants';
+import {TriggerTypes} from './Test.constants';
 
 export enum ComponentNames {
   SelectPlugin = 'SelectPlugin',
@@ -60,9 +60,4 @@ export const TriggerTypeToPlugin = {
   [TriggerTypes.grpc]: Plugins.GRPC,
   [TriggerTypes.kafka]: Plugins.Kafka,
   [TriggerTypes.traceid]: Plugins.TraceID,
-} as const;
-
-export const ImportTypeToPlugin = {
-  [ImportTypes.curl]: Plugins.REST,
-  [ImportTypes.postman]: Plugins.REST,
 } as const;

--- a/web/src/constants/Test.constants.ts
+++ b/web/src/constants/Test.constants.ts
@@ -15,6 +15,7 @@ export enum TriggerTypes {
 export enum ImportTypes {
   postman = 'postman',
   curl = 'curl',
+  definition = 'definition',
 }
 
 export enum SortBy {

--- a/web/src/models/Test.model.ts
+++ b/web/src/models/Test.model.ts
@@ -1,3 +1,4 @@
+import {load} from 'js-yaml';
 import {Model, TTestSchemas} from 'types/Common.types';
 import TestOutput from './TestOutput.model';
 import TestSpecs from './TestSpecs.model';
@@ -46,6 +47,11 @@ Test.FromRawTest = ({
     summary: Summary(summary),
     outputs: outputs.map((rawOutput, index) => TestOutput(rawOutput, index)),
   };
+};
+
+Test.FromDefinition = (definition: string): Test => {
+  const raw: TRawTestResource = load(definition);
+  return Test(raw);
 };
 
 export default Test;

--- a/web/src/services/Import.service.ts
+++ b/web/src/services/Import.service.ts
@@ -1,11 +1,14 @@
 import {ImportTypes} from 'constants/Test.constants';
 import {TDraftTest} from 'types/Test.types';
+import {IPlugin} from 'types/Plugins.types';
 import CurlService from './Importers/Curl.service';
 import PostmanService from './Importers/Postman.service';
+import DefinitionService from './Importers/Definition.service';
 
 const ImportServiceMap = {
   [ImportTypes.curl]: CurlService,
   [ImportTypes.postman]: PostmanService,
+  [ImportTypes.definition]: DefinitionService,
 } as const;
 
 const ImportService = () => ({
@@ -15,6 +18,10 @@ const ImportService = () => ({
 
   async validateDraft(type: ImportTypes, draft: TDraftTest): Promise<boolean> {
     return ImportServiceMap[type].validateDraft(draft);
+  },
+
+  async getPlugin(type: ImportTypes, draft: TDraftTest): Promise<IPlugin> {
+    return ImportServiceMap[type].getPlugin(draft);
   },
 });
 

--- a/web/src/services/Importers/Curl.service.ts
+++ b/web/src/services/Importers/Curl.service.ts
@@ -1,6 +1,7 @@
 import parseCurl from 'parse-curl';
 import {ICurlValues, IImportService} from 'types/Test.types';
 import Validator from 'utils/Validator';
+import {Plugins} from 'constants/Plugins.constants';
 import {HTTP_METHOD} from 'constants/Common.constants';
 
 interface ICurlTriggerService extends IImportService {
@@ -25,6 +26,10 @@ const CurlTriggerService = (): ICurlTriggerService => ({
 
     const {url, method} = this.getRequestFromCommand(command);
     return Validator.required(url) && Validator.required(method);
+  },
+
+  getPlugin() {
+    return Plugins.REST;
   },
 
   getRequestFromCommand(command) {

--- a/web/src/services/Importers/Definition.service.ts
+++ b/web/src/services/Importers/Definition.service.ts
@@ -1,0 +1,65 @@
+import {load} from 'js-yaml';
+import {IDefinitionValues, IImportService} from 'types/Test.types';
+import {TriggerTypeToPlugin} from 'constants/Plugins.constants';
+import Test, {TRawTestResource} from 'models/Test.model';
+import TestService from '../Test.service';
+import {isJson} from '../../utils/Common';
+
+interface IDefinitionImportService extends IImportService {
+  validate(definition: string): string[];
+  load(raw: string): TRawTestResource;
+}
+
+const DefinitionImportService = (): IDefinitionImportService => ({
+  async getRequest(values) {
+    const {definition} = values as IDefinitionValues;
+
+    const test = Test.FromDefinition(definition);
+    return TestService.getInitialValues(test);
+  },
+
+  async validateDraft(draft) {
+    const {definition} = draft as IDefinitionValues;
+
+    return !this.validate(definition).length;
+  },
+
+  getPlugin(draft) {
+    const {definition} = draft as IDefinitionValues;
+    const {spec = {}}: TRawTestResource = this.load(definition);
+
+    const triggerType = spec.trigger?.type;
+    return TriggerTypeToPlugin[triggerType!];
+  },
+
+  load(raw) {
+    if (isJson(raw)) return JSON.parse(raw) as TRawTestResource;
+
+    return load(raw) as TRawTestResource;
+  },
+
+  validate(raw) {
+    const {type, spec = {}}: TRawTestResource = this.load(raw);
+    const errors = [];
+
+    if (type !== 'Test') {
+      errors.push(`Invalid type: ${type}`);
+    }
+
+    if (!spec.name) {
+      errors.push(`Missing Name`);
+    }
+
+    if (!spec.trigger) {
+      errors.push(`Missing trigger`);
+    }
+
+    if (!spec.trigger?.type) {
+      errors.push('Missing trigger type');
+    }
+
+    return errors;
+  },
+});
+
+export default DefinitionImportService();

--- a/web/src/services/Importers/Postman.service.tsx
+++ b/web/src/services/Importers/Postman.service.tsx
@@ -1,6 +1,7 @@
 import {Collection, Item, ItemGroup, Request, RequestAuthDefinition, VariableDefinition} from 'postman-collection';
 import {HTTP_METHOD} from 'constants/Common.constants';
 import {IImportService, IPostmanValues, TDraftTestForm, TRequestAuth} from 'types/Test.types';
+import {Plugins} from 'constants/Plugins.constants';
 import Validator from 'utils/Validator';
 import HttpService from '../Triggers/Http.service';
 
@@ -45,6 +46,11 @@ const Postman = (): IPostmanTriggerService => ({
     const draft = await this.valuesFromRequest(requests, variables, collectionTest || '');
     return !!draft && HttpService.validateDraft(draft);
   },
+
+  getPlugin() {
+    return Plugins.REST;
+  },
+
   valuesFromRequest(requests, variables, identifier) {
     const request = requests.find(({id}) => identifier === id);
     if (request) {

--- a/web/src/types/Test.types.ts
+++ b/web/src/types/Test.types.ts
@@ -7,6 +7,7 @@ import HttpRequest from 'models/HttpRequest.model';
 import TraceIDRequest from 'models/TraceIDRequest.model';
 import KafkaRequest from 'models/KafkaRequest.model';
 import {Model, TGrpcSchemas, THttpSchemas, TKafkaSchemas} from './Common.types';
+import {IPlugin} from './Plugins.types';
 
 export type TRequestAuth = THttpSchemas['HTTPRequest']['auth'];
 export type TMethod = THttpSchemas['HTTPRequest']['method'];
@@ -62,6 +63,10 @@ export interface ICurlValues extends IHttpValues {
   command: string;
 }
 
+export interface IDefinitionValues {
+  definition: string;
+}
+
 export interface IBasicValues {
   name: string;
   description: string;
@@ -74,6 +79,7 @@ export interface ITraceIDValues extends IHttpValues {
 }
 
 export type TTestRequestDetailsValues = IRpcValues | IHttpValues | IPostmanValues | ICurlValues | ITraceIDValues;
+
 export type TDraftTest<T = TTestRequestDetailsValues> = Partial<IBasicValues & T>;
 export type TDraftTestForm<T = TTestRequestDetailsValues> = FormInstance<TDraftTest<T>>;
 
@@ -85,6 +91,7 @@ export interface ITriggerService {
 }
 
 export interface IImportService {
-  getRequest(values: TDraftTest): Promise<TDraftTest>;
+  getRequest(draft: TDraftTest): Promise<TDraftTest>;
   validateDraft(draft: TDraftTest): Promise<boolean>;
+  getPlugin(draft: TDraftTest): IPlugin;
 }


### PR DESCRIPTION
This PR adds a way to import tests from a Tracetest Definition JSON/YAML

## Changes

- Adds new import plugin from Tracetest YAML
- New editor for definitions

## Fixes

- https://github.com/kubeshop/tracetest-cloud/issues/285

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Loom video

https://www.loom.com/share/8fcd59928872455dbde2f45d867447bc
https://www.loom.com/share/7524d24e967d4f62894e9022950d1327
