### PR TITLE
fix(frontend): fix test specs container and attribute tooltip

### DIFF
--- a/web/src/components/ResizablePanels/Splitter.tsx
+++ b/web/src/components/ResizablePanels/Splitter.tsx
@@ -49,7 +49,14 @@ const Splitter = ({
     <S.SplitterContainer id={id} key={id} className={className} onMouseDown={onMouseDown} onTouchStart={onTouchStart}>
       <S.ButtonContainer>
         {isToolTipVisible ? (
-          <Tooltip title={tooltip} visible trigger={[]} placement={tooltipPlacement} overlayClassName="splitter">
+          <Tooltip
+            title={tooltip}
+            visible
+            trigger={[]}
+            placement={tooltipPlacement}
+            overlayClassName="splitter"
+            getPopupContainer={node => node.parentElement ?? document.body}
+          >
             {button}
           </Tooltip>
         ) : (

--- a/web/src/components/RunDetailTest/RunDetailTest.styled.ts
+++ b/web/src/components/RunDetailTest/RunDetailTest.styled.ts
@@ -40,6 +40,11 @@ export const TabsContainer = styled.div`
   .ant-tabs-small > .ant-tabs-nav .ant-tabs-tab {
     padding: 0 0 8px;
   }
+
+  .ant-tabs,
+  .ant-tabs .ant-tabs-content {
+    height: 100%;
+  }
 `;
 
 export const CountBadge = styled(Badge)`

--- a/web/src/components/TestOutputForm/TestOutputForm.styled.ts
+++ b/web/src/components/TestOutputForm/TestOutputForm.styled.ts
@@ -4,7 +4,10 @@ import styled from 'styled-components';
 
 export const Container = styled.div`
   background-color: ${({theme}) => theme.color.white};
+  height: 100%;
+  overflow-y: auto;
   padding: 24px;
+  position: relative;
 `;
 
 export const Title = styled(Typography.Title).attrs({level: 2})`

--- a/web/src/components/TestSpecForm/TestSpecForm.styled.ts
+++ b/web/src/components/TestSpecForm/TestSpecForm.styled.ts
@@ -55,7 +55,10 @@ export const DeleteCheckIcon = styled(DeleteOutlined)`
 
 export const AssertionForm = styled.div`
   background-color: ${({theme}) => theme.color.white};
+  height: 100%;
+  overflow-y: auto;
   padding: 24px;
+  position: relative;
 `;
 
 export const AssertionFormTitle = styled(Typography.Title).attrs({level: 2})``;


### PR DESCRIPTION
This PR fixes styles for the test specs and test outputs container. It also adds a fix for the Attribute tooltip to avoid showing it in the trigger or automate tab.

## Changes

- container styles
- set pop up container for attribute tooltip

## Fixes

- fixes https://github.com/kubeshop/tracetest-cloud-frontend/issues/146
- fixes https://github.com/kubeshop/tracetest-cloud-frontend/issues/89

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Screenshots

![2023-11-24 12 02 16](https://github.com/kubeshop/tracetest/assets/3879892/2e94b2ea-47f6-4adb-bfd9-34771e8c3b7a)

<img width="1468" alt="Screenshot 2023-11-24 at 12 01 36" src="https://github.com/kubeshop/tracetest/assets/3879892/97517385-8042-4819-a1c6-349073e72b62">