### PR TITLE
fix(server): fix span-naming and empty-attributes rules

### DIFF
--- a/server/linter/rules/ensure_span_naming_rule.go
+++ b/server/linter/rules/ensure_span_naming_rule.go
@@ -55,12 +55,10 @@ func (r ensureSpanNamingRule) validateSpanName(ctx context.Context, span *traces
 
 func (r ensureSpanNamingRule) validateHTTPSpanName(ctx context.Context, span *traces.Span) analyzer.Result {
 	expectedName := ""
-	if span.Kind == traces.SpanKindServer {
-		expectedName = fmt.Sprintf("%s %s", span.Attributes.Get("http.method"), span.Attributes.Get("http.route"))
-	}
-
 	if span.Kind == traces.SpanKindClient {
 		expectedName = span.Attributes.Get("http.method")
+	} else {
+		expectedName = fmt.Sprintf("%s %s", span.Attributes.Get("http.method"), span.Attributes.Get("http.route"))
 	}
 
 	if span.Name != expectedName {

--- a/server/traces/span_entitiess.go
+++ b/server/traces/span_entitiess.go
@@ -340,7 +340,10 @@ func (span Span) setMetadataAttributes() Span {
 
 	if span.Status != nil {
 		span.Attributes.Set(TracetestMetadataFieldStatusCode, span.Status.Code)
-		span.Attributes.Set(TracetestMetadataFieldStatusDescription, span.Status.Description)
+
+		if span.Status.Description != "" {
+			span.Attributes.Set(TracetestMetadataFieldStatusDescription, span.Status.Description)
+		}
 	}
 
 	return span


### PR DESCRIPTION
This PR fixes a bug with the `span-naming` and `empty-attributes` rules in the trace analyzer. We were throwing analyzer errors about span naming problems for default `http` spans, and empty `tracetest.span.status_description` attributes.

## Changes

- add default validation for `http` spans
- include the `tracetest.span.status_description` attribute if it has a value

## Fixes

- fixes https://github.com/kubeshop/tracetest-cloud/issues/265

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Loom video

https://www.loom.com/share/94b6587e7b584f228b9fa6477af4217f?sid=55b817a3-28f5-48b6-86e2-024d96246b7e
