### PR TITLE
fix(frontend): remove variable set description validation

### DIFF
--- a/web/src/services/VariableSet.service.ts
+++ b/web/src/services/VariableSet.service.ts
@@ -8,8 +8,8 @@ const VariableSetService = () => ({
     };
   },
 
-  validateDraft({name = '', description = '', values = []}: VariableSet) {
-    return !!name && !!description && !!values.length;
+  validateDraft({name = '', values = []}: VariableSet) {
+    return !!name && !!values.length;
   },
 });
 


### PR DESCRIPTION
This PR fixes a bug with the description field of a `VariableSet`. It's not required anymore but it was still part of the validation service.

## Changes

- remove description as required for VariableSet

## Fixes

-

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test