### PR TITLE
fix: remove some possible panics

### DIFF
--- a/server/tracedb/azureappinsights.go
+++ b/server/tracedb/azureappinsights.go
@@ -214,6 +214,10 @@ func parseSpans(table *azquery.Table) ([]traces.Span, error) {
 
 	for _, eventRow := range eventRows {
 		parentSpan := spanMap[eventRow.ParentID()]
+		if parentSpan == nil {
+			continue
+		}
+
 		event, err := parseEvent(eventRow)
 		if err != nil {
 			return []traces.Span{}, err

--- a/server/tracedb/elasticsearchdb.go
+++ b/server/tracedb/elasticsearchdb.go
@@ -137,6 +137,11 @@ func getClusterInfo(client *elasticsearch.Client) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("error getting cluster info response: %s", err)
 	}
+
+	if res == nil {
+		return "", fmt.Errorf("could not get response")
+	}
+
 	defer res.Body.Close()
 
 	// Check response status

--- a/server/tracedb/signalfxdb.go
+++ b/server/tracedb/signalfxdb.go
@@ -114,6 +114,10 @@ func (db signalfxDB) getSegmentsTimestamps(ctx context.Context, traceID string) 
 		return []int64{}, fmt.Errorf("could not execute request: %w", err)
 	}
 
+	if response == nil {
+		return []int64{}, fmt.Errorf("could not get response")
+	}
+
 	if response.StatusCode != http.StatusOK {
 		return []int64{}, fmt.Errorf("service responded with a non ok status code: %s", strconv.Itoa(response.StatusCode))
 	}
@@ -146,6 +150,10 @@ func (db signalfxDB) getSegmentSpans(ctx context.Context, traceID string, timest
 	response, err := db.httpClient.Do(request)
 	if err != nil {
 		return []signalFXSpan{}, fmt.Errorf("could not execute request: %w", err)
+	}
+
+	if response == nil {
+		return []signalFXSpan{}, fmt.Errorf("could not get response")
 	}
 
 	if response.StatusCode != 200 {

--- a/server/tracedb/tempodb.go
+++ b/server/tracedb/tempodb.go
@@ -121,9 +121,12 @@ func httpGetTraceByID(ctx context.Context, traceID string, client *datasource.Ht
 		return traces.Trace{}, err
 	}
 	resp, err := client.Request(ctx, fmt.Sprintf("/api/traces/%s", trID), http.MethodGet, "")
-
 	if err != nil {
 		return traces.Trace{}, handleError(err)
+	}
+
+	if resp == nil {
+		return traces.Trace{}, fmt.Errorf("could not get response")
 	}
 
 	if resp.StatusCode == 404 {

--- a/server/traces/otel_converter.go
+++ b/server/traces/otel_converter.go
@@ -121,12 +121,24 @@ func spanKind(span *v1.Span) SpanKind {
 func getAttributeValue(value *v11.AnyValue) string {
 	switch v := value.GetValue().(type) {
 	case *v11.AnyValue_StringValue:
+		if v == nil {
+			return ""
+		}
+
 		return v.StringValue
 
 	case *v11.AnyValue_IntValue:
+		if v == nil {
+			return "0"
+		}
+
 		return fmt.Sprintf("%d", v.IntValue)
 
 	case *v11.AnyValue_DoubleValue:
+		if v == nil {
+			return "0.0"
+		}
+
 		if v.DoubleValue != 0.0 {
 			isFloatingPoint := math.Abs(v.DoubleValue-math.Abs(v.DoubleValue)) > 0.0
 			if isFloatingPoint {
@@ -137,6 +149,10 @@ func getAttributeValue(value *v11.AnyValue) string {
 		}
 
 	case *v11.AnyValue_BoolValue:
+		if v == nil {
+			return "false"
+		}
+
 		return fmt.Sprintf("%t", v.BoolValue)
 	}
 
@@ -166,6 +182,10 @@ func CreateTraceID(id []byte) trace.TraceID {
 
 func DecodeTraceID(id string) trace.TraceID {
 	bytes, _ := hex.DecodeString(id)
+	if len(bytes) < 16 {
+		return trace.TraceID{}
+	}
+
 	var tid [16]byte
 	copy(tid[:], bytes[:16])
 	return trace.TraceID(tid)

--- a/server/traces/span_entitiess.go
+++ b/server/traces/span_entitiess.go
@@ -302,7 +302,7 @@ func decodeChildren(parent *Span, children []encodedSpan, cache spanCache) ([]*S
 	}
 	res := make([]*Span, len(children))
 	for i, c := range children {
-		if span, ok := cache.Get(c.ID); ok {
+		if span, ok := cache.Get(c.ID); ok && span != nil {
 			res[i] = span
 			continue
 		}


### PR DESCRIPTION
This PR solves some of the possible panics we might get when running tracetest. I used [nilaway](https://github.com/uber-go/nilaway) to detect them. I was going to integrate it on our pipeline, however, it still shows some false positive cases of panics, so I decided to postpone this action.

## Changes

-

## Fixes

-

## Checklist

- [ ] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Loom video

Add your loom video here if your work can be visualized
