### PR TITLE
fix(frontend): minor UI issues

### DIFF
--- a/web/src/components/Inputs/TestSelection/TestItem.tsx
+++ b/web/src/components/Inputs/TestSelection/TestItem.tsx
@@ -20,9 +20,11 @@ const TestItem = ({test, onDelete, sortableId}: IProps) => {
   return (
     <S.TestItemContainer ref={setNodeRef} style={style} {...attributes}>
       <S.DragHandle {...listeners} />
-      <S.TestLink to={`/test/${test.id}`} target="_blank">
-        <span>{test.name}</span>
-      </S.TestLink>
+      <S.TestNameContainer>
+        <S.TestLink to={`/test/${test.id}`} target="_blank">
+          <span>{test.name}</span>
+        </S.TestLink>
+      </S.TestNameContainer>
       <S.DeleteIcon onClick={() => onDelete(sortableId)} />
     </S.TestItemContainer>
   );

--- a/web/src/components/Inputs/TestSelection/TestsSelection.styled.ts
+++ b/web/src/components/Inputs/TestSelection/TestsSelection.styled.ts
@@ -40,6 +40,9 @@ export const ItemListContainer = styled.ul`
 export const TestLink = styled(Link)`
   && {
     color: ${({theme}) => theme.color.text};
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
 
     &:hover,
     &:visited,
@@ -47,4 +50,8 @@ export const TestLink = styled(Link)`
       color: ${({theme}) => theme.color.text};
     }
   }
+`;
+
+export const TestNameContainer = styled.div`
+  overflow: hidden;
 `;

--- a/web/src/components/RunDetailTrigger/RunDetailTrigger.tsx
+++ b/web/src/components/RunDetailTrigger/RunDetailTrigger.tsx
@@ -14,7 +14,7 @@ import TestRun, {isRunStateFinished} from 'models/TestRun.model';
 import TestRunEvent from 'models/TestRunEvent.model';
 import {useTest} from 'providers/Test/Test.provider';
 import {useTestRun} from 'providers/TestRun/TestRun.provider';
-import {useMemo, useState} from 'react';
+import {useEffect, useMemo, useState} from 'react';
 import TestService from 'services/Test.service';
 import {TDraftTest} from 'types/Test.types';
 import * as S from './RunDetailTrigger.styled';
@@ -46,6 +46,10 @@ const RunDetailTrigger = ({test, run: {id, state, triggerResult, triggerTime}, r
   const isDisabled = isLoading || !stateIsFinished;
 
   useShortcutWithDefault(form);
+
+  useEffect(() => {
+    form.setFieldsValue(initialValues);
+  }, [form, initialValues]);
 
   return (
     <S.Container>

--- a/web/src/components/SkipTraceCollectionInfo/SkipTraceCollectionInfo.tsx
+++ b/web/src/components/SkipTraceCollectionInfo/SkipTraceCollectionInfo.tsx
@@ -1,6 +1,6 @@
 import {InfoCircleOutlined} from '@ant-design/icons';
 import {Typography} from 'antd';
-import {Link} from 'react-router-dom';
+import Link from 'components/Link';
 import * as S from './SkipTraceCollectionInfo.styled';
 
 interface IProps {


### PR DESCRIPTION
This PR fixes a couple of minor UI issues:
- skip trace collection setting was not updated in the trigger section
- test suite UI was breaking the layout for larger test suites names 
- link to trigger settings tab was not using the proper Link component

## Fixes

- fixes https://github.com/kubeshop/tracetest-cloud/issues/294
- fixes https://github.com/kubeshop/tracetest/issues/3065

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Loom video

https://www.loom.com/share/a084800f1deb434390f04e64f646b0ba?sid=18ad0992-13d0-418a-b18f-1336f990ed50
