### PR TITLE
chore: update synthetic monitoring with latest pokeshop changes

### DIFF
--- a/.github/workflows/scheduled-jobs.yml
+++ b/.github/workflows/scheduled-jobs.yml
@@ -23,7 +23,7 @@ jobs:
           tracetest configure --token ${{secrets.TRACETEST_POKESHOP_TOKEN}}
       - name: Run synthetic monitoring tests
         run: |
-          tracetest run testsuite --file ./testing/synthetic-monitoring/pokeshop/_testsuite.yaml
+          tracetest run testsuite --file ./testing/synthetic-monitoring/pokeshop/_testsuite.yaml --vars ./testing/synthetic-monitoring/pokeshop/_variableset.yaml
       - name: Send message on Slack in case of failure
         if: ${{ failure() }}
         uses: slackapi/slack-github-action@v1.24.0

--- a/testing/synthetic-monitoring/pokeshop/01-add-pokemon-with-api.yaml
+++ b/testing/synthetic-monitoring/pokeshop/01-add-pokemon-with-api.yaml
@@ -7,7 +7,7 @@ spec:
     type: http
     httpRequest:
       method: POST
-      url: http://demo-pokeshop/pokemon
+      url: ${var:POKESHOP_API_URL}/pokemon
       body: |
         {
           "name": "meowth",

--- a/testing/synthetic-monitoring/pokeshop/02-import-pokemon-with-queue.yaml
+++ b/testing/synthetic-monitoring/pokeshop/02-import-pokemon-with-queue.yaml
@@ -7,7 +7,7 @@ spec:
     type: http
     httpRequest:
       method: POST
-      url: http://demo-pokeshop/pokemon/import
+      url: ${var:POKESHOP_API_URL}/pokemon/import
       body: |
         {
           "id": 143

--- a/testing/synthetic-monitoring/pokeshop/03-import-pokemon-with-stream.yaml
+++ b/testing/synthetic-monitoring/pokeshop/03-import-pokemon-with-stream.yaml
@@ -7,7 +7,7 @@ spec:
     type: kafka
     kafka:
       brokerUrls:
-      - stream:9092
+      - ${var:POKESHOP_KAFKA_BROKER}
       topic: pokemon
       headers: []
       messageKey: snorlax-key

--- a/testing/synthetic-monitoring/pokeshop/04-list-pokemons.yaml
+++ b/testing/synthetic-monitoring/pokeshop/04-list-pokemons.yaml
@@ -7,7 +7,7 @@ spec:
     type: http
     httpRequest:
       method: GET
-      url: http://demo-pokeshop/pokemon?take=100&skip=0
+      url: ${var:POKESHOP_API_URL}/pokemon?take=100&skip=0
       headers:
       - key: Content-Type
         value: application/json

--- a/testing/synthetic-monitoring/pokeshop/_variableset.yaml
+++ b/testing/synthetic-monitoring/pokeshop/_variableset.yaml
@@ -1,0 +1,9 @@
+type: VariableSet
+spec:
+  id: tracetesting-vars
+  name: tracetesting-vars
+  values:
+    - key: POKESHOP_API_URL
+      value: https://demo-pokeshop.tracetest.io
+    - key: POKESHOP_KAFKA_BROKER
+      value: demo-pokeshop.tracetest.io:9092


### PR DESCRIPTION
This PR updates Pokeshop synthetic monitoring to run in a new URL.