### PR TITLE
fix: environment URL in CLI

### DIFF
--- a/agent/runner/runstrategy_desktop.go
+++ b/agent/runner/runstrategy_desktop.go
@@ -51,7 +51,7 @@ You can`
 	options := []consoleUI.Option{{
 		Text: "Open Tracetest in a browser to this environment",
 		Fn: func(_ consoleUI.ConsoleUI) {
-			s.ui.OpenBrowser(fmt.Sprintf("%sorganizations/%s/environments/%s/dashboard", uiEndpoint, claims["organization_id"], claims["environment_id"]))
+			s.ui.OpenBrowser(fmt.Sprintf("%sorganizations/%s/environments/%s", uiEndpoint, claims["organization_id"], claims["environment_id"]))
 		},
 	}, {
 		Text: "Stop this agent",

--- a/web/src/components/Router/Router.tsx
+++ b/web/src/components/Router/Router.tsx
@@ -1,5 +1,6 @@
 import {Navigate, Route, Routes} from 'react-router-dom';
 
+import Layout from 'components/Layout/Layout';
 import VariableSet from 'pages/VariableSet';
 import Home from 'pages/Home';
 import TestSuites from 'pages/TestSuites';
@@ -11,32 +12,36 @@ import TestSuiteRunOverview from 'pages/TestSuiteRunOverview';
 import TestSuiteRunAutomate from 'pages/TestSuiteRunAutomate';
 import AutomatedTestRun from 'pages/AutomatedTestRun';
 import CreateTest from 'pages/CreateTest';
-import Layout from 'components/Layout/Layout';
+import {useDashboard} from 'providers/Dashboard/Dashboard.provider';
 
-const Router = () => (
-  <Routes>
-    <Route element={<Layout hasMenu />}>
-      <Route path="/" element={<Home />} />
-      <Route path="/testsuites" element={<TestSuites />} />
-      <Route path="/variablesets" element={<VariableSet />} />
-      <Route path="/settings" element={<Settings />} />
-    </Route>
+const Router = () => {
+  const {baseUrl} = useDashboard();
 
-    <Route element={<Layout />}>
-      <Route path="/test/create/:triggerType" element={<CreateTest />} />
-      <Route path="/test/:testId" element={<Test />} />
-      <Route path="/test/:testId/run/:runId" element={<RunDetail />} />
-      <Route path="/test/:testId/run/:runId/:mode" element={<RunDetail />} />
-      <Route path="/test/:testId/run" element={<AutomatedTestRun />} />
+  return (
+    <Routes>
+      <Route element={<Layout hasMenu />}>
+        <Route path="/" element={<Home />} />
+        <Route path="/testsuites" element={<TestSuites />} />
+        <Route path="/variablesets" element={<VariableSet />} />
+        <Route path="/settings" element={<Settings />} />
+      </Route>
 
-      <Route path="/testsuite/:testSuiteId" element={<TestSuite />} />
-      <Route path="/testsuite/:testSuiteId/run/:runId" element={<TestSuiteRunOverview />} />
-      <Route path="/testsuite/:testSuiteId/run/:runId/overview" element={<TestSuiteRunOverview />} />
-      <Route path="/testsuite/:testSuiteId/run/:runId/automate" element={<TestSuiteRunAutomate />} />
-    </Route>
+      <Route element={<Layout />}>
+        <Route path="/test/create/:triggerType" element={<CreateTest />} />
+        <Route path="/test/:testId" element={<Test />} />
+        <Route path="/test/:testId/run/:runId" element={<RunDetail />} />
+        <Route path="/test/:testId/run/:runId/:mode" element={<RunDetail />} />
+        <Route path="/test/:testId/run" element={<AutomatedTestRun />} />
 
-    <Route path="*" element={<Navigate to="/" />} />
-  </Routes>
-);
+        <Route path="/testsuite/:testSuiteId" element={<TestSuite />} />
+        <Route path="/testsuite/:testSuiteId/run/:runId" element={<TestSuiteRunOverview />} />
+        <Route path="/testsuite/:testSuiteId/run/:runId/overview" element={<TestSuiteRunOverview />} />
+        <Route path="/testsuite/:testSuiteId/run/:runId/automate" element={<TestSuiteRunAutomate />} />
+      </Route>
+
+      <Route path="*" element={<Navigate to={baseUrl} />} />
+    </Routes>
+  );
+};
 
 export default Router;

--- a/web/src/components/Router/Router.tsx
+++ b/web/src/components/Router/Router.tsx
@@ -39,7 +39,7 @@ const Router = () => {
         <Route path="/testsuite/:testSuiteId/run/:runId/automate" element={<TestSuiteRunAutomate />} />
       </Route>
 
-      <Route path="*" element={<Navigate to={baseUrl} />} />
+      <Route path="*" element={<Navigate to={baseUrl || '/'} />} />
     </Routes>
   );
 };


### PR DESCRIPTION
This PR fixes the environment URL generated by the CLI start command. It also adds a fix in the FE router to handle redirects when the path does not match any route.

## Changes

- fix environment URL in CLI
- fix FE router to handle not matched routes

## Fixes

- fixes https://github.com/kubeshop/tracetest-cloud-frontend/issues/161

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
