### PR TITLE
fix(server): add context event properties

### DIFF
--- a/server/analytics/analytics.go
+++ b/server/analytics/analytics.go
@@ -1,9 +1,12 @@
 package analytics
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"os"
+
+	"github.com/kubeshop/tracetest/server/http/middleware"
 )
 
 type Tracker interface {
@@ -67,6 +70,11 @@ func SendEvent(name, category, clientID string, data *map[string]string) error {
 	}
 
 	return err
+}
+
+func SendEventWithProperties(name, category, clientID string, data map[string]string, ctx context.Context) error {
+	eventData := InjectProperties(data, middleware.EventPropertiesFromContext(ctx))
+	return SendEvent(name, category, clientID, &eventData)
 }
 
 func InjectProperties(data map[string]string, properties string) map[string]string {

--- a/server/analytics/analytics.go
+++ b/server/analytics/analytics.go
@@ -1,12 +1,9 @@
 package analytics
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"os"
-
-	"github.com/kubeshop/tracetest/server/http/middleware"
 )
 
 type Tracker interface {
@@ -70,11 +67,6 @@ func SendEvent(name, category, clientID string, data *map[string]string) error {
 	}
 
 	return err
-}
-
-func SendEventWithProperties(name, category, clientID string, data map[string]string, ctx context.Context) error {
-	eventData := InjectProperties(data, middleware.EventPropertiesFromContext(ctx))
-	return SendEvent(name, category, clientID, &eventData)
 }
 
 func InjectProperties(data map[string]string, properties string) map[string]string {

--- a/server/executor/assertion_runner.go
+++ b/server/executor/assertion_runner.go
@@ -6,8 +6,8 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/kubeshop/tracetest/server/analytics"
 	"github.com/kubeshop/tracetest/server/expression"
+	"github.com/kubeshop/tracetest/server/http/middleware"
 	"github.com/kubeshop/tracetest/server/model/events"
 	"github.com/kubeshop/tracetest/server/pkg/maps"
 	"github.com/kubeshop/tracetest/server/pkg/pipeline"
@@ -78,7 +78,7 @@ func (e *defaultAssertionRunner) runAssertionsAndUpdateResult(ctx context.Contex
 		}
 
 		run = run.AssertionFailed(err)
-		analytics.SendEventWithProperties("test_run_finished", "error", "", map[string]string{"finalState": string(run.State)}, ctx)
+		middleware.SendEventWithProperties("test_run_finished", "error", "", map[string]string{"finalState": string(run.State)}, ctx)
 
 		return test.Run{}, e.updater.Update(ctx, run)
 	}
@@ -135,7 +135,7 @@ func (e *defaultAssertionRunner) executeAssertions(ctx context.Context, req Job)
 		allPassed,
 	)
 
-	analytics.SendEventWithProperties("test_run_finished", "successful", "", map[string]string{"finalState": string(run.State)}, ctx)
+	middleware.SendEventWithProperties("test_run_finished", "successful", "", map[string]string{"finalState": string(run.State)}, ctx)
 
 	return run, nil
 }

--- a/server/executor/assertion_runner.go
+++ b/server/executor/assertion_runner.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/kubeshop/tracetest/server/analytics"
 	"github.com/kubeshop/tracetest/server/expression"
-	"github.com/kubeshop/tracetest/server/http/middleware"
 	"github.com/kubeshop/tracetest/server/model/events"
 	"github.com/kubeshop/tracetest/server/pkg/maps"
 	"github.com/kubeshop/tracetest/server/pkg/pipeline"
@@ -79,9 +78,7 @@ func (e *defaultAssertionRunner) runAssertionsAndUpdateResult(ctx context.Contex
 		}
 
 		run = run.AssertionFailed(err)
-		eventData := map[string]string{"finalState": string(run.State)}
-		eventData = analytics.InjectProperties(eventData, middleware.EventPropertiesFromContext(ctx))
-		analytics.SendEvent("test_run_finished", "error", "", &eventData)
+		analytics.SendEventWithProperties("test_run_finished", "error", "", map[string]string{"finalState": string(run.State)}, ctx)
 
 		return test.Run{}, e.updater.Update(ctx, run)
 	}
@@ -138,9 +135,7 @@ func (e *defaultAssertionRunner) executeAssertions(ctx context.Context, req Job)
 		allPassed,
 	)
 
-	eventData := map[string]string{"finalState": string(run.State)}
-	eventData = analytics.InjectProperties(eventData, middleware.EventPropertiesFromContext(ctx))
-	analytics.SendEvent("test_run_finished", "successful", "", &eventData)
+	analytics.SendEventWithProperties("test_run_finished", "successful", "", map[string]string{"finalState": string(run.State)}, ctx)
 
 	return run, nil
 }

--- a/server/executor/assertion_runner.go
+++ b/server/executor/assertion_runner.go
@@ -79,10 +79,9 @@ func (e *defaultAssertionRunner) runAssertionsAndUpdateResult(ctx context.Contex
 		}
 
 		run = run.AssertionFailed(err)
-		analytics.SendEvent("test_run_finished", "error", "", &map[string]string{
-			"finalState": string(run.State),
-			"tenant_id":  middleware.TenantIDFromContext(ctx),
-		})
+		eventData := map[string]string{"finalState": string(run.State)}
+		eventData = analytics.InjectProperties(eventData, middleware.EventPropertiesFromContext(ctx))
+		analytics.SendEvent("test_run_finished", "error", "", &eventData)
 
 		return test.Run{}, e.updater.Update(ctx, run)
 	}
@@ -139,10 +138,9 @@ func (e *defaultAssertionRunner) executeAssertions(ctx context.Context, req Job)
 		allPassed,
 	)
 
-	analytics.SendEvent("test_run_finished", "successful", "", &map[string]string{
-		"finalState": string(run.State),
-		"tenant_id":  middleware.TenantIDFromContext(ctx),
-	})
+	eventData := map[string]string{"finalState": string(run.State)}
+	eventData = analytics.InjectProperties(eventData, middleware.EventPropertiesFromContext(ctx))
+	analytics.SendEvent("test_run_finished", "successful", "", &eventData)
 
 	return run, nil
 }

--- a/server/executor/linter_runner.go
+++ b/server/executor/linter_runner.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/kubeshop/tracetest/server/analytics"
+	"github.com/kubeshop/tracetest/server/http/middleware"
 	"github.com/kubeshop/tracetest/server/linter"
 	"github.com/kubeshop/tracetest/server/linter/analyzer"
 	"github.com/kubeshop/tracetest/server/model/events"
@@ -129,7 +129,7 @@ func (e *defaultLinterRunner) onError(ctx context.Context, job Job, run test.Run
 		log.Printf("[linterRunner] Test %s Run %d: fail to emit TracelinterError event: %s\n", job.Test.ID, job.Run.ID, anotherErr.Error())
 	}
 
-	analytics.SendEventWithProperties("test_run_finished", "error", "", map[string]string{"finalState": string(run.State)}, ctx)
+	middleware.SendEventWithProperties("test_run_finished", "error", "", map[string]string{"finalState": string(run.State)}, ctx)
 
 	run = run.LinterError(err)
 	return run, e.updater.Update(ctx, run)

--- a/server/executor/linter_runner.go
+++ b/server/executor/linter_runner.go
@@ -6,7 +6,6 @@ import (
 	"log"
 
 	"github.com/kubeshop/tracetest/server/analytics"
-	"github.com/kubeshop/tracetest/server/http/middleware"
 	"github.com/kubeshop/tracetest/server/linter"
 	"github.com/kubeshop/tracetest/server/linter/analyzer"
 	"github.com/kubeshop/tracetest/server/model/events"
@@ -130,9 +129,7 @@ func (e *defaultLinterRunner) onError(ctx context.Context, job Job, run test.Run
 		log.Printf("[linterRunner] Test %s Run %d: fail to emit TracelinterError event: %s\n", job.Test.ID, job.Run.ID, anotherErr.Error())
 	}
 
-	eventData := map[string]string{"finalState": string(run.State)}
-	eventData = analytics.InjectProperties(eventData, middleware.EventPropertiesFromContext(ctx))
-	analytics.SendEvent("test_run_finished", "error", "", &eventData)
+	analytics.SendEventWithProperties("test_run_finished", "error", "", map[string]string{"finalState": string(run.State)}, ctx)
 
 	run = run.LinterError(err)
 	return run, e.updater.Update(ctx, run)

--- a/server/executor/linter_runner.go
+++ b/server/executor/linter_runner.go
@@ -130,10 +130,9 @@ func (e *defaultLinterRunner) onError(ctx context.Context, job Job, run test.Run
 		log.Printf("[linterRunner] Test %s Run %d: fail to emit TracelinterError event: %s\n", job.Test.ID, job.Run.ID, anotherErr.Error())
 	}
 
-	analytics.SendEvent("test_run_finished", "error", "", &map[string]string{
-		"finalState": string(run.State),
-		"tenant_id":  middleware.TenantIDFromContext(ctx),
-	})
+	eventData := map[string]string{"finalState": string(run.State)}
+	eventData = analytics.InjectProperties(eventData, middleware.EventPropertiesFromContext(ctx))
+	analytics.SendEvent("test_run_finished", "error", "", &eventData)
 
 	run = run.LinterError(err)
 	return run, e.updater.Update(ctx, run)

--- a/server/executor/queue.go
+++ b/server/executor/queue.go
@@ -515,6 +515,11 @@ func (b tenantPropagator) Inject(ctx context.Context, carrier propagation.TextMa
 	if instanceID != nil {
 		carrier.Set("instanceID", instanceID.(string))
 	}
+
+	eventProperties := middleware.EventPropertiesFromContext(ctx)
+	if eventProperties != "" {
+		carrier.Set(string(middleware.EventPropertiesKey), eventProperties)
+	}
 }
 
 // Extract returns a copy of parent with the baggage from the carrier added.
@@ -529,6 +534,11 @@ func (b tenantPropagator) Extract(parent context.Context, carrier propagation.Te
 	instanceID := carrier.Get("instanceID")
 	if instanceID != "" {
 		resultingCtx = context.WithValue(resultingCtx, "instanceID", instanceID)
+	}
+
+	eventProperties := carrier.Get(string(middleware.EventPropertiesKey))
+	if eventProperties != "" {
+		resultingCtx = context.WithValue(resultingCtx, middleware.EventPropertiesKey, eventProperties)
 	}
 
 	return resultingCtx

--- a/server/executor/trace_poller.go
+++ b/server/executor/trace_poller.go
@@ -7,8 +7,8 @@ import (
 	"log"
 	"time"
 
-	"github.com/kubeshop/tracetest/server/analytics"
 	"github.com/kubeshop/tracetest/server/executor/pollingprofile"
+	"github.com/kubeshop/tracetest/server/http/middleware"
 	"github.com/kubeshop/tracetest/server/model/events"
 	"github.com/kubeshop/tracetest/server/pkg/pipeline"
 	"github.com/kubeshop/tracetest/server/subscription"
@@ -202,7 +202,7 @@ func (tp tracePoller) handleTraceDBError(ctx context.Context, job Job, err error
 	}
 
 	run = run.TraceFailed(err)
-	analytics.SendEventWithProperties("test_run_finished", "error", "", map[string]string{"finalState": string(run.State)}, ctx)
+	middleware.SendEventWithProperties("test_run_finished", "error", "", map[string]string{"finalState": string(run.State)}, ctx)
 
 	tp.handleDBError(tp.updater.Update(ctx, run))
 

--- a/server/executor/trace_poller.go
+++ b/server/executor/trace_poller.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/kubeshop/tracetest/server/analytics"
 	"github.com/kubeshop/tracetest/server/executor/pollingprofile"
-	"github.com/kubeshop/tracetest/server/http/middleware"
 	"github.com/kubeshop/tracetest/server/model/events"
 	"github.com/kubeshop/tracetest/server/pkg/pipeline"
 	"github.com/kubeshop/tracetest/server/subscription"
@@ -203,9 +202,7 @@ func (tp tracePoller) handleTraceDBError(ctx context.Context, job Job, err error
 	}
 
 	run = run.TraceFailed(err)
-	eventData := map[string]string{"finalState": string(run.State)}
-	eventData = analytics.InjectProperties(eventData, middleware.EventPropertiesFromContext(ctx))
-	analytics.SendEvent("test_run_finished", "error", "", &eventData)
+	analytics.SendEventWithProperties("test_run_finished", "error", "", map[string]string{"finalState": string(run.State)}, ctx)
 
 	tp.handleDBError(tp.updater.Update(ctx, run))
 

--- a/server/executor/trace_poller.go
+++ b/server/executor/trace_poller.go
@@ -203,10 +203,9 @@ func (tp tracePoller) handleTraceDBError(ctx context.Context, job Job, err error
 	}
 
 	run = run.TraceFailed(err)
-	analytics.SendEvent("test_run_finished", "error", "", &map[string]string{
-		"finalState": string(run.State),
-		"tenant_id":  middleware.TenantIDFromContext(ctx),
-	})
+	eventData := map[string]string{"finalState": string(run.State)}
+	eventData = analytics.InjectProperties(eventData, middleware.EventPropertiesFromContext(ctx))
+	analytics.SendEvent("test_run_finished", "error", "", &eventData)
 
 	tp.handleDBError(tp.updater.Update(ctx, run))
 

--- a/server/executor/tracepollerworker/evaluator_worker.go
+++ b/server/executor/tracepollerworker/evaluator_worker.go
@@ -10,7 +10,6 @@ import (
 	"github.com/kubeshop/tracetest/server/analytics"
 	"github.com/kubeshop/tracetest/server/datastore"
 	"github.com/kubeshop/tracetest/server/executor"
-	"github.com/kubeshop/tracetest/server/http/middleware"
 	"github.com/kubeshop/tracetest/server/model/events"
 	"github.com/kubeshop/tracetest/server/pkg/pipeline"
 	"github.com/kubeshop/tracetest/server/resourcemanager"
@@ -103,9 +102,7 @@ func (w *tracePollerEvaluatorWorker) ProcessItem(ctx context.Context, job execut
 		populateSpan(span, job, reason, &successful)
 
 		run := job.Run.TraceFailed(err)
-		eventData := map[string]string{"finalState": string(run.State)}
-		eventData = analytics.InjectProperties(eventData, middleware.EventPropertiesFromContext(ctx))
-		analytics.SendEvent("test_run_finished", "error", "", &eventData)
+		analytics.SendEventWithProperties("test_run_finished", "error", "", map[string]string{"finalState": string(run.State)}, ctx)
 
 		handleDBError(w.state.updater.Update(ctx, run))
 

--- a/server/executor/tracepollerworker/evaluator_worker.go
+++ b/server/executor/tracepollerworker/evaluator_worker.go
@@ -7,9 +7,9 @@ import (
 	"log"
 	"time"
 
-	"github.com/kubeshop/tracetest/server/analytics"
 	"github.com/kubeshop/tracetest/server/datastore"
 	"github.com/kubeshop/tracetest/server/executor"
+	"github.com/kubeshop/tracetest/server/http/middleware"
 	"github.com/kubeshop/tracetest/server/model/events"
 	"github.com/kubeshop/tracetest/server/pkg/pipeline"
 	"github.com/kubeshop/tracetest/server/resourcemanager"
@@ -102,7 +102,7 @@ func (w *tracePollerEvaluatorWorker) ProcessItem(ctx context.Context, job execut
 		populateSpan(span, job, reason, &successful)
 
 		run := job.Run.TraceFailed(err)
-		analytics.SendEventWithProperties("test_run_finished", "error", "", map[string]string{"finalState": string(run.State)}, ctx)
+		middleware.SendEventWithProperties("test_run_finished", "error", "", map[string]string{"finalState": string(run.State)}, ctx)
 
 		handleDBError(w.state.updater.Update(ctx, run))
 

--- a/server/executor/tracepollerworker/evaluator_worker.go
+++ b/server/executor/tracepollerworker/evaluator_worker.go
@@ -103,10 +103,9 @@ func (w *tracePollerEvaluatorWorker) ProcessItem(ctx context.Context, job execut
 		populateSpan(span, job, reason, &successful)
 
 		run := job.Run.TraceFailed(err)
-		analytics.SendEvent("test_run_finished", "error", "", &map[string]string{
-			"finalState": string(run.State),
-			"tenant_id":  middleware.TenantIDFromContext(ctx),
-		})
+		eventData := map[string]string{"finalState": string(run.State)}
+		eventData = analytics.InjectProperties(eventData, middleware.EventPropertiesFromContext(ctx))
+		analytics.SendEvent("test_run_finished", "error", "", &eventData)
 
 		handleDBError(w.state.updater.Update(ctx, run))
 

--- a/server/executor/trigger_result_processor_worker.go
+++ b/server/executor/trigger_result_processor_worker.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 
 	"github.com/kubeshop/tracetest/server/analytics"
-	"github.com/kubeshop/tracetest/server/http/middleware"
 	"github.com/kubeshop/tracetest/server/model"
 	"github.com/kubeshop/tracetest/server/model/events"
 	"github.com/kubeshop/tracetest/server/pkg/pipeline"
@@ -128,9 +127,7 @@ func (r triggerResultProcessorWorker) handleExecutionResult(run test.Run, ctx co
 	if run.TriggerResult.Error != nil {
 		run = run.TriggerFailed(fmt.Errorf(run.TriggerResult.Error.ErrorMessage))
 
-		eventData := map[string]string{"finalState": string(run.State)}
-		eventData = analytics.InjectProperties(eventData, middleware.EventPropertiesFromContext(ctx))
-		analytics.SendEvent("test_run_finished", "error", "", &eventData)
+		analytics.SendEventWithProperties("test_run_finished", "error", "", map[string]string{"finalState": string(run.State)}, ctx)
 
 		return run
 	}

--- a/server/executor/trigger_result_processor_worker.go
+++ b/server/executor/trigger_result_processor_worker.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/kubeshop/tracetest/server/analytics"
+	"github.com/kubeshop/tracetest/server/http/middleware"
 	"github.com/kubeshop/tracetest/server/model"
 	"github.com/kubeshop/tracetest/server/model/events"
 	"github.com/kubeshop/tracetest/server/pkg/pipeline"
@@ -127,7 +127,7 @@ func (r triggerResultProcessorWorker) handleExecutionResult(run test.Run, ctx co
 	if run.TriggerResult.Error != nil {
 		run = run.TriggerFailed(fmt.Errorf(run.TriggerResult.Error.ErrorMessage))
 
-		analytics.SendEventWithProperties("test_run_finished", "error", "", map[string]string{"finalState": string(run.State)}, ctx)
+		middleware.SendEventWithProperties("test_run_finished", "error", "", map[string]string{"finalState": string(run.State)}, ctx)
 
 		return run
 	}

--- a/server/executor/trigger_result_processor_worker.go
+++ b/server/executor/trigger_result_processor_worker.go
@@ -128,10 +128,9 @@ func (r triggerResultProcessorWorker) handleExecutionResult(run test.Run, ctx co
 	if run.TriggerResult.Error != nil {
 		run = run.TriggerFailed(fmt.Errorf(run.TriggerResult.Error.ErrorMessage))
 
-		analytics.SendEvent("test_run_finished", "error", "", &map[string]string{
-			"finalState": string(run.State),
-			"tenant_id":  middleware.TenantIDFromContext(ctx),
-		})
+		eventData := map[string]string{"finalState": string(run.State)}
+		eventData = analytics.InjectProperties(eventData, middleware.EventPropertiesFromContext(ctx))
+		analytics.SendEvent("test_run_finished", "error", "", &eventData)
 
 		return run
 	}

--- a/server/http/middleware/analytics.go
+++ b/server/http/middleware/analytics.go
@@ -1,0 +1,59 @@
+package middleware
+
+import (
+	"context"
+	"net/http"
+	"regexp"
+
+	"github.com/gorilla/mux"
+	"github.com/kubeshop/tracetest/server/analytics"
+)
+
+var (
+	matchFirstCap     = regexp.MustCompile("(.)([A-Z][a-z]+)")
+	matchAllCap       = regexp.MustCompile("([a-z0-9])([A-Z])")
+	matchResourceName = regexp.MustCompile(`(\w)(\.)(\w)`)
+)
+
+const EventPropertiesKey key = "x-event-properties"
+
+func AnalyticsMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		routeName := mux.CurrentRoute(r).GetName()
+		machineID := r.Header.Get("x-client-id")
+		source := r.Header.Get("x-source")
+		eventProperties := r.Header.Get("x-event-properties")
+
+		eventData := map[string]string{
+			"source": source,
+		}
+		eventData = analytics.InjectProperties(eventData, eventProperties)
+
+		if routeName != "" {
+			analytics.SendEvent(toWords(routeName), "test", machineID, &eventData)
+		}
+
+		ctx := r.Context()
+		ctx = context.WithValue(ctx, EventPropertiesKey, eventProperties)
+		next.ServeHTTP(w, r.WithContext(ctx))
+	})
+}
+
+func toWords(str string) string {
+	if matchResourceName.MatchString(str) {
+		return str
+	}
+	words := matchFirstCap.ReplaceAllString(str, "${1} ${2}")
+	words = matchAllCap.ReplaceAllString(words, "${1} ${2}")
+	return words
+}
+
+func EventPropertiesFromContext(ctx context.Context) string {
+	eventProperties := ctx.Value(EventPropertiesKey)
+
+	if eventProperties == nil {
+		return ""
+	}
+
+	return eventProperties.(string)
+}

--- a/server/http/middleware/analytics.go
+++ b/server/http/middleware/analytics.go
@@ -57,3 +57,8 @@ func EventPropertiesFromContext(ctx context.Context) string {
 
 	return eventProperties.(string)
 }
+
+func SendEventWithProperties(name, category, clientID string, data map[string]string, ctx context.Context) error {
+	eventData := analytics.InjectProperties(data, EventPropertiesFromContext(ctx))
+	return analytics.SendEvent(name, category, clientID, &eventData)
+}


### PR DESCRIPTION
This PR adds event properties in the context so it can be accessed from workers.

## Changes

-

## Fixes

-

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
