### PR TITLE
telemetry(server): add more info about response in HTTP spans

### DIFF
--- a/server/http/custom_routes.go
+++ b/server/http/custom_routes.go
@@ -14,7 +14,6 @@ import (
 	"github.com/kubeshop/tracetest/server/resourcemanager"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
-	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/propagation"
 	semconv "go.opentelemetry.io/otel/semconv/v1.10.0"
 	"go.opentelemetry.io/otel/trace"
@@ -222,7 +221,6 @@ func (c *customController) instrumentRoute(name string, route string, f http.Han
 
 		if responseWriter.StatusCode() >= 500 {
 			span.RecordError(fmt.Errorf("faulty server response"))
-			span.SetStatus(codes.Error, "status code returned by API is in the server error range")
 
 			attributes = append(attributes, attribute.String("http.response.body", string(responseBody)))
 		}

--- a/server/http/middleware/metrics.go
+++ b/server/http/middleware/metrics.go
@@ -46,16 +46,34 @@ var _ http.Handler = &httpMetricMiddleware{}
 
 type responseWriter struct {
 	http.ResponseWriter
-	statusCode int
+	responseBody []byte
+	statusCode   int
 }
 
 func NewStatusCodeCapturerWriter(w http.ResponseWriter) *responseWriter {
-	return &responseWriter{w, http.StatusOK}
+	return &responseWriter{
+		w,
+		[]byte{},
+		http.StatusOK,
+	}
 }
 
-func (lrw *responseWriter) WriteHeader(code int) {
-	lrw.statusCode = code
-	lrw.ResponseWriter.WriteHeader(code)
+func (w *responseWriter) WriteHeader(code int) {
+	w.statusCode = code
+	w.ResponseWriter.WriteHeader(code)
+}
+
+func (w *responseWriter) Write(body []byte) (int, error) {
+	w.responseBody = body
+	return w.ResponseWriter.Write(body)
+}
+
+func (w *responseWriter) StatusCode() int {
+	return w.statusCode
+}
+
+func (w *responseWriter) Body() []byte {
+	return w.responseBody
 }
 
 func NewMetricMiddleware(meter metric.Meter) mux.MiddlewareFunc {

--- a/server/resourcemanager/resource_manager.go
+++ b/server/resourcemanager/resource_manager.go
@@ -239,7 +239,6 @@ func (m *manager[T]) instrumentRoute(route *mux.Route) {
 
 		if responseWriter.StatusCode() >= 500 {
 			span.RecordError(fmt.Errorf("faulty server response"))
-			span.SetStatus(codes.Error, "status code returned by API is in the server error range")
 
 			attributes = append(attributes, attribute.String("http.response.body", string(responseBody)))
 		}


### PR DESCRIPTION
This PR adds more information about the response in case of errors in the backend. This is important to help us identify errors

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Loom video

Add your loom video here if your work can be visualized
