### PR TITLE
fix(server): Return  type for browser spans

### DIFF
--- a/server/traces/trace_entities.go
+++ b/server/traces/trace_entities.go
@@ -130,7 +130,16 @@ func getRootSpan(allRoots []*Span) *Span {
 	return root
 }
 
+// TODO: this is temp while we decide what to do with browser spans and how to handle them
+func isBrowserSpan(attrs Attributes) bool {
+	return attrs.Get("event_type") != "" || attrs.Get(TracetestMetadataFieldType) != "documentLoad"
+}
+
 func spanType(attrs Attributes) string {
+	if isBrowserSpan(attrs) {
+		return "general"
+	}
+
 	// based on https://github.com/open-telemetry/opentelemetry-specification/tree/main/specification/trace/semantic_conventions
 	// using the first required attribute for each type
 	for key := range attrs.Values() {
@@ -149,6 +158,7 @@ func spanType(attrs Attributes) string {
 			return "exception"
 		}
 	}
+
 	return "general"
 }
 

--- a/server/traces/trace_entities.go
+++ b/server/traces/trace_entities.go
@@ -132,7 +132,7 @@ func getRootSpan(allRoots []*Span) *Span {
 
 // TODO: this is temp while we decide what to do with browser spans and how to handle them
 func isBrowserSpan(attrs Attributes) bool {
-	return attrs.Get("event_type") != "" || attrs.Get(TracetestMetadataFieldType) != "documentLoad"
+	return attrs.Get("event_type") != "" || attrs.Get(TracetestMetadataFieldType) == "documentLoad"
 }
 
 func spanType(attrs Attributes) string {

--- a/server/traces/trace_entities.go
+++ b/server/traces/trace_entities.go
@@ -132,7 +132,7 @@ func getRootSpan(allRoots []*Span) *Span {
 
 // TODO: this is temp while we decide what to do with browser spans and how to handle them
 func isBrowserSpan(attrs Attributes) bool {
-	return attrs.Get("event_type") != "" || attrs.Get(TracetestMetadataFieldType) == "documentLoad"
+	return attrs.Get("event_type") != "" || attrs.Get(TracetestMetadataFieldName) == "documentLoad"
 }
 
 func spanType(attrs Attributes) string {

--- a/server/traces/traces_test.go
+++ b/server/traces/traces_test.go
@@ -555,10 +555,27 @@ func TestBrowserSpan(t *testing.T) {
 		"http.url":   "http://localhost:1663",
 	})
 
-	spans := []traces.Span{span}
-	trace := traces.NewTrace("trace", spans)
+	trace := traces.NewTrace("trace", []traces.Span{span})
 
 	assert.Equal(t, trace.Spans()[0].Attributes.Get(traces.TracetestMetadataFieldType), "general")
+
+	span2 := newSpan("documentLoad")
+	span2.Attributes = attributesFromMap(map[string]string{
+		"http.url": "http://localhost:1663",
+	})
+
+	trace2 := traces.NewTrace("trace", []traces.Span{span2})
+
+	assert.Equal(t, trace2.Spans()[0].Attributes.Get(traces.TracetestMetadataFieldType), "general")
+
+	span3 := newSpan("GET /api/v1/trace")
+	span3.Attributes = attributesFromMap(map[string]string{
+		"http.url": "http://localhost:1663",
+	})
+
+	trace3 := traces.NewTrace("trace", []traces.Span{span3})
+
+	assert.Equal(t, trace3.Spans()[0].Attributes.Get(traces.TracetestMetadataFieldType), "http")
 }
 
 func attributesFromMap(input map[string]string) traces.Attributes {

--- a/server/traces/traces_test.go
+++ b/server/traces/traces_test.go
@@ -548,6 +548,19 @@ func TestUnmarshalLargeTrace(t *testing.T) {
 	assert.Greater(t, len(trace.Flat), 0)
 }
 
+func TestBrowserSpan(t *testing.T) {
+	span := newSpan("click")
+	span.Attributes = attributesFromMap(map[string]string{
+		"event_type": "click",
+		"http.url":   "http://localhost:1663",
+	})
+
+	spans := []traces.Span{span}
+	trace := traces.NewTrace("trace", spans)
+
+	assert.Equal(t, trace.Spans()[0].Attributes.Get(traces.TracetestMetadataFieldType), "general")
+}
+
 func attributesFromMap(input map[string]string) traces.Attributes {
 	attributes := traces.NewAttributes()
 	for key, value := range input {


### PR DESCRIPTION
This PR updates the check for browser spans to return `general` while we decide what to do next.

## Changes

- Adds a check for browser spans and returns `general` type

## Fixes

- [browser spans show as HTTP#320](https://github.com/kubeshop/tracetest-cloud/issues/320)

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [x] added a test
