### PR TITLE
agent: add log to print error that is making the agent reconnect

### DIFF
--- a/agent/client/client.go
+++ b/agent/client/client.go
@@ -188,6 +188,7 @@ func (c *Client) handleDisconnectionError(inputErr error) (bool, error) {
 		return false, inputErr
 	}
 
+	log.Printf("Reconnecting agent due to error: %s", inputErr.Error())
 	err := retry.Do(func() error {
 		return c.reconnect()
 	})


### PR DESCRIPTION
This PR adds a log message when the agent reconnects

## Checklist

- [ ] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Loom video

Add your loom video here if your work can be visualized
