### PR TITLE
fix: add timeout to github action

### DIFF
--- a/.github/workflows/scheduled-jobs.yml
+++ b/.github/workflows/scheduled-jobs.yml
@@ -11,6 +11,7 @@ jobs:
   pokeshop-trace-based-tests:
     name: Run trace based tests for Pokeshop
     runs-on: ubuntu-latest
+    timeout-minutes: 10
 
     steps:
       - name: Checkout
@@ -64,6 +65,7 @@ jobs:
   otel-demo-trace-based-tests:
     name: Run trace based tests for Open Telemetry demo
     runs-on: ubuntu-latest
+    timeout-minutes: 10
 
     steps:
       - name: Checkout


### PR DESCRIPTION
This PR adds a timeout for our Synthetic Monitoring action.

## Changes

- Adds timeout to `.github/workflows/scheduled-jobs.yml`

## Checklist

- [ ] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
