### PR TITLE
feat(frontend): change datastore to tracing backend

### DIFF
--- a/web/src/components/Inputs/DataStoreSelection/DataStoreSelection.tsx
+++ b/web/src/components/Inputs/DataStoreSelection/DataStoreSelection.tsx
@@ -57,8 +57,8 @@ const DataStoreSelection = ({onChange = noop, value = SupportedDataStores.JAEGER
                   <Popover
                     content={
                       <div>
-                        In localMode only the Agent data store can be used. <br /> If you want to connect to a different
-                        data store <br /> please create a new environment
+                        In localMode only the Agent Tracing Backend can be used. <br /> If you want to connect to a
+                        different Tracing Backend <br /> please create a new environment
                       </div>
                     }
                     placement="right"

--- a/web/src/components/NoTracingPopover/NoTracingPopover.tsx
+++ b/web/src/components/NoTracingPopover/NoTracingPopover.tsx
@@ -10,8 +10,8 @@ const NoTracingPopover = () => {
         <div>
           <S.Title>Tracing is not configured.</S.Title>
           <S.Text>
-            Tracetest needs configuration information about your backend trace data store so it can collect the trace
-            after a test run. Please configure your data store now.
+            Tracetest needs configuration information about your Tracing Backend so it can collect the trace after a
+            test run. Please configure your Tracing Backend now.
           </S.Text>
         </div>
         <S.ButtonContainer>

--- a/web/src/components/RunEvents/RunEventDataStore.tsx
+++ b/web/src/components/RunEvents/RunEventDataStore.tsx
@@ -12,11 +12,11 @@ const RunEventDataStore = ({event}: IPropsEvent) => (
     {!!event.dataStoreConnection && (
       <S.Content>
         {event.dataStoreConnection?.allPassed ? (
-          <Typography.Title level={3}>Data store configuration is valid.</Typography.Title>
+          <Typography.Title level={3}>Tracing Backend configuration is valid.</Typography.Title>
         ) : (
           <S.InvalidDataStoreContainer>
             <Typography.Title level={3} style={{margin: 0}}>
-              Data store configuration is not valid.
+              Tracing Backend configuration is not valid.
             </Typography.Title>
             <Typography.Text>
               You can go to the <Link to="/settings">settings page</Link> to fix it.

--- a/web/src/components/Settings/DataStoreForm/DataStoreForm.tsx
+++ b/web/src/components/Settings/DataStoreForm/DataStoreForm.tsx
@@ -79,7 +79,7 @@ const DataStoreForm = ({
           <S.TopContainer>
             <S.Description>
               Tracetest needs configuration information to be able to retrieve your trace from your distributed tracing
-              solution. Select your tracing data store and enter the configuration info.
+              solution. Select your Tracing Backend and enter the configuration info.
             </S.Description>
             {dataStoreType && <DataStoreComponentFactory dataStoreType={dataStoreType} />}
           </S.TopContainer>
@@ -93,7 +93,7 @@ const DataStoreForm = ({
                 onClick={onDeleteConfig}
                 danger
               >
-                {`Delete ${SupportedDataStoresToName[dataStoreConfig.defaultDataStore.type]} Data Store`}
+                {`Delete ${SupportedDataStoresToName[dataStoreConfig.defaultDataStore.type]} Tracing Backend`}
               </AllowButton>
             ) : (
               <div />
@@ -109,7 +109,7 @@ const DataStoreForm = ({
                 type="primary"
                 onClick={() => form.submit()}
               >
-                Save and Set as DataStore
+                Save and Set as Tracing Backend
               </AllowButton>
             </S.SaveContainer>
           </S.ButtonsContainer>

--- a/web/src/components/SetupAlert/SetupAlert.tsx
+++ b/web/src/components/SetupAlert/SetupAlert.tsx
@@ -10,7 +10,7 @@ const SetupAlert = () => {
     <S.Container
       message={
         <S.Message>
-          <S.TextBold>No trace data store configured.</S.TextBold>
+          <S.TextBold>No Tracing Backend configured.</S.TextBold>
           <S.Text>Let us know the details of your existing tracing solution so we can gather the trace.</S.Text>
           <Link to="/settings">
             <S.WarningButton>Setup</S.WarningButton>

--- a/web/src/pages/Home/ConfigCTA.tsx
+++ b/web/src/pages/Home/ConfigCTA.tsx
@@ -15,10 +15,10 @@ const ConfigCTA = ({onSkip}: IProps) => {
     <S.ConfigContainer align="middle">
       <Col span={12} offset={6}>
         <S.ConfigContent>
-          <S.ConfigIcon alt="tracing data stores" src={icon} />
-          <Typography.Title>Configure your trace data store</Typography.Title>
+          <S.ConfigIcon alt="Tracing Backend" src={icon} />
+          <Typography.Title>Configure your Tracing Backend</Typography.Title>
           <Typography.Text>
-            Tracetest utilizes the trace collected by your existing OpenTelemetry compatible trace data store to apply
+            Tracetest utilizes the trace collected by your existing OpenTelemetry compatible Tracing Backend to apply
             assertions against. Do you want to configure this now?
           </Typography.Text>
           <S.ConfigFooter>

--- a/web/src/pages/Settings/Content.tsx
+++ b/web/src/pages/Settings/Content.tsx
@@ -36,7 +36,7 @@ const Content = () => {
             setQuery([['tab', newTab]]);
           }}
         >
-          <Tabs.TabPane key={TabsKeys.DataStore} tab="Configure Data Store">
+          <Tabs.TabPane key={TabsKeys.DataStore} tab="Tracing Backend">
             <DataStore />
           </Tabs.TabPane>
           <Tabs.TabPane key={TabsKeys.Analytics} tab="Analytics">

--- a/web/src/providers/DataStore/DataStore.provider.tsx
+++ b/web/src/providers/DataStore/DataStore.provider.tsx
@@ -56,13 +56,13 @@ const DataStoreProvider = ({children}: IProps) => {
         !!defaultDataStore.id && draft.dataStoreType !== defaultDataStore.type
           ? `Saving will delete your previous configuration of the ${
               SupportedDataStoresToName[defaultDataStore.type || SupportedDataStores.JAEGER]
-            } data store`
+            } Tracing Backend.`
           : '';
 
       onOpen({
         title: (
           <>
-            <p>Are you sure you want to save this Data Store configuration?</p>
+            <p>Are you sure you want to save this Tracing Backend configuration?</p>
             <p>{warningMessage}</p>
           </>
         ),
@@ -81,7 +81,7 @@ const DataStoreProvider = ({children}: IProps) => {
   const onDeleteConfig = useCallback(async () => {
     onOpen({
       title:
-        "Tracetest will remove the trace data store configuration information and enter the 'No-Tracing Mode'. You can still run tests against the responses until you configure a new trace data store.",
+        "Tracetest will remove the Tracing Backend configuration information and enter the 'No-Tracing Mode'. You can still run tests against the responses until you configure a new Tracing Backend.",
       heading: 'Save Confirmation',
       okText: 'Save',
       onConfirm: async () => {

--- a/web/src/providers/DataStore/hooks/useDataStoreNotification.tsx
+++ b/web/src/providers/DataStore/hooks/useDataStoreNotification.tsx
@@ -14,7 +14,7 @@ const useDataStoreNotification = () => {
           type: 'info',
           title: <Typography.Title level={2}>No Automated Test</Typography.Title>,
           description:
-            'Please note that configuring your OpenTelemetry Collector to send spans to Tracetest is just the first step. To enable successful testing, save this data store, and then try running a Tracetest test against your application under test. Note that there is no automated test since the OpenTelemetry Collector sends traces to Tracetest.',
+            'Please note that configuring your OpenTelemetry Collector to send spans to Tracetest is just the first step. To enable successful testing, save this Tracing Backend, and then try running a Tracetest test against your application under test. Note that there is no automated test since the OpenTelemetry Collector sends traces to Tracetest.',
         });
       }
 
@@ -38,7 +38,7 @@ const useDataStoreNotification = () => {
   const showSuccessNotification = useCallback(() => {
     return showNotification({
       type: 'success',
-      title: 'Data Store saved',
+      title: 'Tracing Backend saved',
       description: 'Your configuration was added',
     });
   }, [showNotification]);

--- a/web/src/services/EventLog.service.ts
+++ b/web/src/services/EventLog.service.ts
@@ -12,7 +12,9 @@ const eventToString = ({title, description}: TestRunEvent): string => {
 const dataStoreEventToString = (event: TestRunEvent): string => {
   const {dataStoreConnection: {allPassed, ...dataStoreConnection} = ConnectionResult({})} = event;
   const baseText = eventToString(event);
-  const configValidText = allPassed ? 'Data store configuration is valid.' : 'Data store configuration is not valid.';
+  const configValidText = allPassed
+    ? 'Tracing Backend configuration is valid.'
+    : 'Tracing Backend configuration is not valid.';
 
   const connectionStepsDetailsText = Object.entries(dataStoreConnection || {})
     .map(([key, {message, error}]) => `${key.toUpperCase()} - ${message} ${error ? ` - ${error}` : ''}`, '')


### PR DESCRIPTION
This PR changes the term `DataStore` to `Tracing Backend`.

## Changes

-

## Fixes

-

## Checklist

- [ ] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Loom video

Add your loom video here if your work can be visualized
