### PR TITLE
migration: migrate agent and no-tracing to otlp tracing backend

### DIFF
--- a/server/migrations/36_migrate_users_to_opentelemetry.sql
+++ b/server/migrations/36_migrate_users_to_opentelemetry.sql
@@ -4,7 +4,7 @@
 -- This means that all users using "no tracing mode" and "agent" tracing backends will become
 -- "otlp" tracing backends
 
--- If there's an "agent" datastore, replace it with an "otlp" datastore instead
+-- If there's an "agent" tracing backend, replace it with an "otlp" tracing backend instead
 UPDATE data_stores
     SET "name" = 'otlp', "type" = 'otlp', "values" = '{}'::jsonb
 from (
@@ -12,7 +12,7 @@ from (
 ) migration_target
 WHERE data_stores.id = migration_target.id;
 
--- If there's no "current" datastore, add one for otlp. This ensures that if user is on
+-- If there's no "current" tracing backend, add one for otlp. This ensures that if user is on
 -- "No tracing mode", it will be migrated to "OpenTelemetry".
 INSERT INTO
     data_stores (id, "name", "type", is_default, "values", created_at, tenant_id)

--- a/server/migrations/36_migrate_users_to_opentelemetry.sql
+++ b/server/migrations/36_migrate_users_to_opentelemetry.sql
@@ -1,0 +1,22 @@
+-- We are going to deprecate "no tracing mode" and "agent" tracing backends
+-- So we need to migrate all users to a valid trace backend.
+--
+-- This means that all users using "no tracing mode" and "agent" tracing backends will become
+-- "otlp" tracing backends
+
+-- If there's an "agent" datastore, replace it with an "otlp" datastore instead
+UPDATE data_stores
+    SET "name" = 'otlp', "type" = 'otlp', "values" = '{}'::jsonb
+from (
+    SELECT id, "type" FROM data_stores WHERE "type" = 'agent'
+) migration_target
+WHERE data_stores.id = migration_target.id;
+
+-- If there's no "current" datastore, add one for otlp. This ensures that if user is on
+-- "No tracing mode", it will be migrated to "OpenTelemetry".
+INSERT INTO
+    data_stores (id, "name", "type", is_default, "values", created_at, tenant_id)
+VALUES ('current', 'otlp', 'otlp', true, '{}'::jsonb, now(), '')
+ON CONFLICT DO NOTHING;
+
+


### PR DESCRIPTION
This PR migrates all users using the `agent` datastore to `otlp` and also create the `otlp` datastore in case the user doesn't have any datastore (using Tracetest in `no tracing mode`)

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Loom video

Add your loom video here if your work can be visualized
