### PR TITLE
fix(frontend): attribute list open by default

### DIFF
--- a/web/src/components/RunDetailTest/SpanDetailsPanel.tsx
+++ b/web/src/components/RunDetailTest/SpanDetailsPanel.tsx
@@ -8,6 +8,7 @@ const panel = {
   name: 'SPAN_DETAILS',
   minSize: 25,
   maxSize: 320,
+  isDefaultOpen: true,
 };
 
 const SpanDetailsPanel = () => {

--- a/web/src/components/RunDetailTrace/SpanDetailsPanel.tsx
+++ b/web/src/components/RunDetailTrace/SpanDetailsPanel.tsx
@@ -17,6 +17,7 @@ const panel = {
   name: 'SPAN_DETAILS',
   minSize: 25,
   maxSize: 320,
+  isDefaultOpen: true,
 };
 
 const SpanDetailsPanel = ({run, testId}: IProps) => {


### PR DESCRIPTION
This PR updates the attribute list to be opened by default

## Changes

- Updates attr list to be opened by default

## Fixes

- https://github.com/kubeshop/tracetest/issues/3449

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

