### PR TITLE
fix(frontend): fix tracing backend selected tab

### DIFF
--- a/web/src/components/Inputs/DataStoreSelection/DataStoreSelection.tsx
+++ b/web/src/components/Inputs/DataStoreSelection/DataStoreSelection.tsx
@@ -23,7 +23,11 @@ const DataStoreSelection = ({onChange = noop, value = SupportedDataStores.JAEGER
   const configuredDataStoreType = dataStoreConfig.defaultDataStore.type;
 
   return (
-    <S.DataStoreListContainer tabPosition="left" onChange={dataStore => onChange(dataStore as SupportedDataStores)}>
+    <S.DataStoreListContainer
+      tabPosition="left"
+      onChange={dataStore => onChange(dataStore as SupportedDataStores)}
+      defaultActiveKey={value}
+    >
       {supportedDataStoreList.map(dataStore => {
         const isSelected = value === dataStore;
         const isConfigured = configuredDataStoreType === dataStore && dataStoreConfig.mode === ConfigMode.READY;


### PR DESCRIPTION
This PR fixes an UI issue that was preventing user to select the first tracing backend option in the settings page.

## Changes

- add default selected tab

## Fixes

-

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Screenshot

![2023-12-22 09 54 24](https://github.com/kubeshop/tracetest/assets/3879892/84b9e60d-1201-45af-97c1-2906073a3ca9)