### PR TITLE
fix: skip open attribute list step on e2e

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -163,7 +163,7 @@ jobs:
 
       - name: Setup node
         # if cache miss
-        if: steps.cache-web-build.outputs.cache-hit != 'true'
+        # if: steps.cache-web-build.outputs.cache-hit != 'true'
         uses: actions/setup-node@v3
         with:
           node-version: 16
@@ -173,7 +173,7 @@ jobs:
       - name: Cache dependencies
         id: cache-nodemodules
         # if cache miss
-        if: steps.cache-web-build.outputs.cache-hit != 'true'
+        # if: steps.cache-web-build.outputs.cache-hit != 'true'
         uses: actions/cache@v3
         with:
           path: |
@@ -185,10 +185,10 @@ jobs:
       - name: Install dependencies
         run: cd web/; npm ci
         # if cache miss for build and deps
-        if: steps.cache-web-build.outputs.cache-hit != 'true' &&  steps.cache-nodemodules.outputs.cache-hit != 'true'
+        # if: steps.cache-web-build.outputs.cache-hit != 'true' &&  steps.cache-nodemodules.outputs.cache-hit != 'true'
 
       - run: cd web; CI= npm run build
-        if: steps.cache-web-build.outputs.cache-hit != 'true'
+        # if: steps.cache-web-build.outputs.cache-hit != 'true'
 
       # go+docker
       - name: Cache Build

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -146,80 +146,45 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: set cache keys
-        shell: bash
-        run: |
-          echo "WEB_CACHE_KEY=$(git log --pretty=tformat:"%H" -n1 web)" >> $GITHUB_ENV
-          echo "SERVER_CACHE_KEY=$(git log --pretty=tformat:"%H" -n1 server)" >> $GITHUB_ENV
-          echo "CLI_CACHE_KEY=$(git log --pretty=tformat:"%H" -n1 cli)" >> $GITHUB_ENV
-
       # web
-      - name: Cache Web Build
-        id: cache-web-build
-        uses: actions/cache@v3
-        with:
-          path: web/build/
-          key: web-build-${{ env.WEB_CACHE_KEY }}
-
       - name: Setup node
-        # if cache miss
-        # if: steps.cache-web-build.outputs.cache-hit != 'true'
         uses: actions/setup-node@v3
         with:
           node-version: 16
           cache: npm
           cache-dependency-path: web/package-lock.json
 
-      - name: Cache dependencies
-        id: cache-nodemodules
-        # if cache miss
-        # if: steps.cache-web-build.outputs.cache-hit != 'true'
-        uses: actions/cache@v3
-        with:
-          path: |
-            web/node_modules
-            /home/runner/.cache/Cypress
-          key: npm--${{ hashFiles('web/package-lock.json') }}
-          restore-keys: npm-
-
       - name: Install dependencies
         run: cd web/; npm ci
-        # if cache miss for build and deps
-        # if: steps.cache-web-build.outputs.cache-hit != 'true' &&  steps.cache-nodemodules.outputs.cache-hit != 'true'
 
-      - run: cd web; CI= npm run build
-        # if: steps.cache-web-build.outputs.cache-hit != 'true'
+      - name: Build UI
+        run: cd web; CI= npm run build
 
       # go+docker
-      - name: Cache Build
-        id: cache-docker-build
-        uses: actions/cache@v3
-        with:
-          path: dist/
-          key: dist-${{env.SERVER_CACHE_KEY }}-${{env.CLI_CACHE_KEY }}-${{ hashFiles('.goreleaser.dev.yaml', 'Dockerfile') }}
       - name: Setup go
-        if: steps.cache-docker-build.outputs.cache-hit != 'true'
         uses: actions/setup-go@v3
         with:
           go-version-file: "go.mod"
           cache: true
           cache-dependency-path: "go.mod"
-      - uses: goreleaser/goreleaser-action@v4
-        if: steps.cache-docker-build.outputs.cache-hit != 'true'
+
+      - name: Release Go binaries
+        uses: goreleaser/goreleaser-action@v4
         with:
           distribution: goreleaser-pro
           version: v1.22.0
           args: release --skip=announce --snapshot -f .goreleaser.dev.yaml
+
       - name: Move binaries to known location
-        if: steps.cache-docker-build.outputs.cache-hit != 'true'
         run: |
           find ./dist -name 'tracetest' -exec cp {} ./dist \;
           find ./dist -name 'tracetest-server' -exec cp {} ./dist \;
           chmod +x ./dist/tracetest ./dist/tracetest-server
+
       - name: Export docker image
-        if: steps.cache-docker-build.outputs.cache-hit != 'true'
         run: |
           docker save --output dist/image.tar "kubeshop/tracetest:$TAG"
+
       - name: Upload assets
         uses: actions/upload-artifact@v3
         with:

--- a/run.sh
+++ b/run.sh
@@ -45,7 +45,7 @@ build() {
 }
 
 up() {
-  docker compose $opts up -d --remove-orphans
+  docker compose $opts up --detach --remove-orphans --quiet-pull
 }
 
 stop() {

--- a/web/cypress/e2e/TestRunDetail/Outputs.spec.ts
+++ b/web/cypress/e2e/TestRunDetail/Outputs.spec.ts
@@ -7,7 +7,7 @@ describe('Outputs', () => {
     // Open output flow from the Trace view (attributes)
     cy.selectRunDetailMode(2);
     cy.get('[data-cy=trace-node-database]', {timeout: 25000}).first().click({force: true});
-    cy.get('[data-cy=toggle-drawer-SPAN_DETAILS]', {timeout: 25000}).click({force: true});
+    // cy.get('[data-cy=toggle-drawer-SPAN_DETAILS]', {timeout: 25000}).click({force: true});
     cy.get('[data-cy=attributes-search-container] input').type('db.name');
     cy.get('[data-cy=attribute-row-db-name] .ant-dropdown-trigger').click();
     cy.contains('Create test output').click();
@@ -46,7 +46,7 @@ describe('Outputs', () => {
     // Open output flow from the Trace view (attributes)
     cy.selectRunDetailMode(2);
     cy.get('[data-cy=trace-node-database]', {timeout: 25000}).first().click({force: true});
-    cy.get('[data-cy=toggle-drawer-SPAN_DETAILS]', {timeout: 25000}).click({force: true});
+    // cy.get('[data-cy=toggle-drawer-SPAN_DETAILS]', {timeout: 25000}).click({force: true});
     cy.get('[data-cy=attributes-search-container] input').type('db.name');
     cy.get('[data-cy=attribute-row-db-name] .ant-dropdown-trigger').click();
     cy.contains('Create test output').click();
@@ -89,7 +89,7 @@ describe('Outputs', () => {
     // Open output flow from the Trace view (attributes)
     cy.selectRunDetailMode(2);
     cy.get('[data-cy=trace-node-database]', {timeout: 25000}).first().click({force: true});
-    cy.get('[data-cy=toggle-drawer-SPAN_DETAILS]', {timeout: 25000}).click({force: true});
+    // cy.get('[data-cy=toggle-drawer-SPAN_DETAILS]', {timeout: 25000}).click({force: true});
     cy.get('[data-cy=attributes-search-container] input').type('db.name');
     cy.get('[data-cy=attribute-row-db-name] .ant-dropdown-trigger').click();
     cy.contains('Create test output').click();

--- a/web/cypress/e2e/TestRunDetail/TestRunDetail.spec.ts
+++ b/web/cypress/e2e/TestRunDetail/TestRunDetail.spec.ts
@@ -7,7 +7,7 @@ describe('Test Run Detail Views', () => {
   it('Trace view -> show the attribute list for a specific span', () => {
     cy.selectRunDetailMode(2);
     cy.get('[data-cy=trace-node-http]').click();
-    cy.get('[data-cy=toggle-drawer-SPAN_DETAILS]').click();
+    // cy.get('[data-cy=toggle-drawer-SPAN_DETAILS]').click();
 
     cy.get('[data-cy=attribute-list]').should('be.visible');
     cy.get('[data-cy=attribute-row-http-method]').should('be.visible');
@@ -16,7 +16,7 @@ describe('Test Run Detail Views', () => {
   it('Trace view -> attribute list', () => {
     cy.selectRunDetailMode(2);
     cy.get('[data-cy=trace-node-http]').click();
-    cy.get('[data-cy=toggle-drawer-SPAN_DETAILS]').click();
+    // cy.get('[data-cy=toggle-drawer-SPAN_DETAILS]').click();
 
     cy.get('[data-cy=attribute-list]').should('be.visible');
   });


### PR DESCRIPTION
This PR fixes our Cypress e2e tests that are breaking due to a behavior change on our UI. Since we already open the Attribute list on the Trace and Test tabs, there is no need of having of clicking on the expand button to show the list.

## Fixes

- Update e2e to skip open attribute list step

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test