### PR TITLE
fix(server): take tenant_id into account for test run events

### DIFF
--- a/server/migrations/37_test_run_events_tenant.down.sql
+++ b/server/migrations/37_test_run_events_tenant.down.sql
@@ -1,0 +1,8 @@
+BEGIN;
+
+ALTER TABLE
+  test_run_events
+DROP
+  COLUMN tenant_id;
+
+COMMIT;

--- a/server/migrations/37_test_run_events_tenant.up.sql
+++ b/server/migrations/37_test_run_events_tenant.up.sql
@@ -1,0 +1,11 @@
+BEGIN;
+
+ALTER TABLE
+  test_run_events
+ADD
+  COLUMN tenant_id varchar
+;
+
+CREATE INDEX idx_test_run_events_tenant_id ON test_run_events(tenant_id);
+
+COMMIT;


### PR DESCRIPTION
This PR makes test run events to take the tenant id into account when creating and reading events.

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
