### PR TITLE
fix(server): correct query with tenant id for test run events

### DIFF
--- a/server/testdb/test_run_event.go
+++ b/server/testdb/test_run_event.go
@@ -101,12 +101,17 @@ const getTestRunEventsQuery = `
 		"data_store_connection",
 		"polling",
 		"outputs"
-	FROM test_run_events WHERE "test_id" = $1 AND "run_id" = $2 ORDER BY "created_at" ASC;
+	FROM test_run_events
+	WHERE
+		"test_id" = $1
+		AND "run_id" = $2
+		AND "tenant_id" = $3
+	ORDER BY "created_at" ASC;
 `
 
 func (td *postgresDB) GetTestRunEvents(ctx context.Context, testID id.ID, runID int) ([]model.TestRunEvent, error) {
-	query, params := sqlutil.Tenant(ctx, getTestRunEventsQuery, testID, runID)
-	rows, err := td.db.QueryContext(ctx, query, params...)
+	params := sqlutil.TenantInsert(ctx, testID, runID)
+	rows, err := td.db.QueryContext(ctx, getTestRunEventsQuery, params...)
 	if err != nil {
 		return []model.TestRunEvent{}, fmt.Errorf("could not query test runs: %w", err)
 	}


### PR DESCRIPTION
This PR fixes the read query for test run events when the tenant ID is set in the context

## Changes

-

## Fixes

-

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Loom video

Add your loom video here if your work can be visualized
