### PR TITLE
fix(frontend): remove guided tour popover

### DIFF
--- a/web/cypress/e2e/Home/CreateTestFromCurl.spec.ts
+++ b/web/cypress/e2e/Home/CreateTestFromCurl.spec.ts
@@ -22,7 +22,6 @@ describe('Create test from CURL Command', () => {
     cy.get(`[data-cy="import-test-submit"]`).click();
     cy.submitCreateForm();
     cy.matchTestRunPageUrl();
-    cy.cancelOnBoarding();
     cy.get('[data-cy=overlay-input-overlay]').should('contain.text', POKEMON_HTTP_ENDPOINT);
     cy.deleteTest(true);
   });

--- a/web/cypress/e2e/Home/CreateTestFromPostman.spec.ts
+++ b/web/cypress/e2e/Home/CreateTestFromPostman.spec.ts
@@ -14,7 +14,6 @@ describe('Create test from Postman Collection', () => {
     cy.get(`[data-cy="import-test-submit"]`).click();
     cy.submitCreateForm();
     cy.matchTestRunPageUrl();
-    cy.cancelOnBoarding();
     cy.get('[data-cy=overlay-input-overlay]').should('contain.text', 'create Test');
     cy.deleteTest(true);
   });

--- a/web/cypress/support/commands.ts
+++ b/web/cypress/support/commands.ts
@@ -114,7 +114,6 @@ Cypress.Commands.add('makeSureUserIsOnTestDetailPage', () => {
 
 Cypress.Commands.add('makeSureUserIsOnTracePage', () => {
   cy.matchTestRunPageUrl();
-  cy.cancelOnBoarding();
 });
 
 Cypress.Commands.add('cancelOnBoarding', () => {

--- a/web/src/providers/GuidedTour/GuidedTour.provider.tsx
+++ b/web/src/providers/GuidedTour/GuidedTour.provider.tsx
@@ -1,6 +1,5 @@
-import {Button, notification, Space} from 'antd';
 import {noop} from 'lodash';
-import React, {createContext, useCallback, useContext, useEffect, useMemo, useState} from 'react';
+import React, {createContext, useCallback, useContext, useMemo, useState} from 'react';
 import Joyride from 'react-joyride';
 import {useLocation} from 'react-router-dom';
 
@@ -8,15 +7,10 @@ import StepContent from 'components/GuidedTour/StepContent';
 import {CallbackByGuidedTour, StepsByGuidedTour} from 'components/GuidedTour/steps';
 import {switchTestRunMode} from 'components/GuidedTour/testRunSteps';
 import {IGuidedTourState} from 'constants/GuidedTour';
-import {useAppDispatch, useAppSelector} from 'redux/hooks';
-import {setUserPreference} from 'redux/slices/User.slice';
-import UserSelectors from 'selectors/User.selectors';
 import HomeAnalyticsService from 'services/Analytics/HomeAnalytics.service';
 import GuidedTourService from 'services/GuidedTour.service';
-import {useNotification} from '../Notification/Notification.provider';
 
 const {onGuidedTourClick} = HomeAnalyticsService;
-const NOTIFICATION_KEY = 'guided-tour-notification';
 
 interface IContext {
   isGuidedTourRunning: boolean;
@@ -37,62 +31,14 @@ interface IProps {
 export const useGuidedTour = () => useContext(Context);
 
 const GuidedTourProvider = ({children}: IProps) => {
-  const dispatch = useAppDispatch();
   const pathname = useLocation().pathname;
   const tourByPathname = GuidedTourService.getByPathName(pathname);
-  const {showNotification} = useNotification();
   const [guidedTourState, setGuidedTourState] = useState<IGuidedTourState>({
     callback: noop,
     run: false,
     stepIndex: 0,
     steps: [],
   });
-  const showGuidedTourNotification = useAppSelector(state =>
-    UserSelectors.selectUserPreference(state, 'showGuidedTourNotification')
-  );
-
-  useEffect(() => {
-    if (!tourByPathname || !showGuidedTourNotification) return;
-
-    const onSkip = () => {
-      notification.close(NOTIFICATION_KEY);
-      dispatch(setUserPreference({key: 'showGuidedTourNotification', value: false}));
-    };
-
-    const onStart = () => {
-      onGuidedTourClick(); // Analytics
-      onSkip();
-      switchTestRunMode(0);
-      setGuidedTourState(prev => ({
-        ...prev,
-        callback: CallbackByGuidedTour[tourByPathname](setGuidedTourState),
-        run: true,
-        stepIndex: 0,
-        steps: StepsByGuidedTour[tourByPathname],
-      }));
-    };
-
-    const btn = (
-      <Space>
-        <Button data-cy="guided-tour-cancel-notification" ghost onClick={onSkip} type="primary">
-          No thanks
-        </Button>
-        <Button onClick={onStart} type="primary">
-          Show me around
-        </Button>
-      </Space>
-    );
-
-    showNotification({
-      type: 'open',
-      description: 'Walk through Tracetest features',
-      duration: 0,
-      btn,
-      key: NOTIFICATION_KEY,
-      title: 'Do you want to take a quick tour of Tracetest?',
-      onClose: onSkip,
-    });
-  }, [dispatch, showGuidedTourNotification, showNotification, tourByPathname]);
 
   const onStart = useCallback(() => {
     if (!tourByPathname) return;


### PR DESCRIPTION
This PR removes the Guided Tour Popover from the test run detail page.

## Changes

- remove popover

## Fixes

- fixes https://github.com/kubeshop/tracetest/issues/3448

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
