### PR TITLE
fix: reconnect agent when grpc connection is closing

### DIFF
--- a/agent/client/client.go
+++ b/agent/client/client.go
@@ -213,6 +213,7 @@ func isConnectionError(err error) bool {
 		// From time to time, the server can start sending those errors to the
 		// agent. This mitigates the risk of an agent getting stuck in an error state
 		"unexpected HTTP status code received from server: 500",
+		"the client connection is closing",
 	}
 	for _, possibleErr := range possibleErrors {
 		if strings.Contains(err.Error(), possibleErr) {


### PR DESCRIPTION
This PR makes the agent reconnect when the grpc connection is closing.

![image](https://github.com/kubeshop/tracetest/assets/2704737/570b5011-c32f-4ae0-b9db-8b7ab14b9fef)


## Checklist

- [ ] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Loom video

Add your loom video here if your work can be visualized
