### PR TITLE
feat(frontend): add wizard layout and architecture

### DIFF
--- a/web/cypress/e2e/Home/CancelTest.spec.ts
+++ b/web/cypress/e2e/Home/CancelTest.spec.ts
@@ -1,5 +1,5 @@
 describe('Cancel Create test', () => {
-  beforeEach(() => cy.visit('/'));
+  beforeEach(() => cy.visit('/tests'));
 
   it('should cancel a create test flow', () => {
     cy.openTestCreationModal();

--- a/web/cypress/e2e/Home/CreateTest.spec.ts
+++ b/web/cypress/e2e/Home/CreateTest.spec.ts
@@ -5,7 +5,7 @@ describe('Create test', () => {
   beforeEach(() => {
     cy.interceptHomeApiCall();
     cy.enableDemo();
-    cy.visit('/');
+    cy.visit('/tests');
   });
   afterEach(() => cy.deleteTest(true));
 

--- a/web/cypress/e2e/Home/CreateTestFromCurl.spec.ts
+++ b/web/cypress/e2e/Home/CreateTestFromCurl.spec.ts
@@ -3,7 +3,7 @@ import {POKEMON_HTTP_ENDPOINT} from '../constants/Test';
 describe('Create test from CURL Command', () => {
   beforeEach(() => {
     cy.enableDemo();
-    cy.visit('/');
+    cy.visit('/tests');
   });
 
   it('should create a basic GET test', () => {

--- a/web/cypress/e2e/Home/CreateTestFromPostman.spec.ts
+++ b/web/cypress/e2e/Home/CreateTestFromPostman.spec.ts
@@ -1,7 +1,7 @@
 describe('Create test from Postman Collection', () => {
   beforeEach(() => {
     cy.enableDemo();
-    cy.visit('/');
+    cy.visit('/tests');
   });
 
   it('should create a basic GET test', () => {

--- a/web/cypress/e2e/Home/CreateTestWithAuthentication.spec.ts
+++ b/web/cypress/e2e/Home/CreateTestWithAuthentication.spec.ts
@@ -2,7 +2,7 @@ describe('Create test with authentication', () => {
   beforeEach(() => {
     cy.interceptHomeApiCall();
     cy.enableDemo();
-    cy.visit('/');
+    cy.visit('/tests');
   });
 
   it('should create a basic GET test with api key authentication method', () => {

--- a/web/cypress/e2e/Home/ShowTestList.spec.ts
+++ b/web/cypress/e2e/Home/ShowTestList.spec.ts
@@ -1,5 +1,5 @@
 describe('Home', () => {
-  beforeEach(() => cy.visit('/'));
+  beforeEach(() => cy.visit('/tests'));
 
   it('should render the layout', () => {
     cy.get('[data-cy=menu-link]').should('be.visible');
@@ -12,7 +12,7 @@ describe('Home', () => {
 
   it('should run a test from the home page', () => {
     cy.createTest();
-    cy.visit('/');
+    cy.visit('/tests');
     cy.get('[data-cy^=test-run-button]:not([data-cy*=button-00])', {timeout: 10000}).first().click();
     cy.location('href').should('match', /\/test\/.*/i);
     cy.deleteTest();

--- a/web/cypress/e2e/VariableSet/VariableSet.spec.ts
+++ b/web/cypress/e2e/VariableSet/VariableSet.spec.ts
@@ -105,7 +105,7 @@ describe('VariableSets', () => {
   it.only('should create a test using variables from variableSet', () => {
     createVariableSet(variableSet1);
 
-    cy.visit('/');
+    cy.visit('/tests');
     cy.interceptHomeApiCall();
 
     // Select created variableSet

--- a/web/cypress/support/commands.ts
+++ b/web/cypress/support/commands.ts
@@ -10,13 +10,13 @@ export const getComparatorListId = (number: number) => `#assertion-form_assertio
 export const getValueFromList = (number: number) => `.cm-tooltip-autocomplete li:nth-child(${number})`;
 
 Cypress.Commands.add('createMultipleTestRuns', (id: string, count: number) => {
-  cy.visit('/');
+  cy.visit('/tests');
 
   for (let i = 0; i < count; i += 1) {
     cy.get(`[data-cy=test-run-button-${id}]`).click();
     cy.matchTestRunPageUrl();
 
-    cy.visit('/');
+    cy.visit('/tests');
   }
 });
 
@@ -33,7 +33,7 @@ Cypress.Commands.add('deleteTest', (shouldIntercept = false) => {
     if (shouldIntercept) {
       cy.interceptHomeApiCall();
     }
-    cy.visit(`/`);
+    cy.visit('/tests');
     cy.wait('@testList');
     cy.get('[data-cy=test-list]').should('exist', {timeout: 10000});
     cy.get(`[data-cy=test-actions-button-${localTestId}]`, {timeout: 10000}).should('be.visible');
@@ -195,7 +195,7 @@ Cypress.Commands.add('createTest', () => {
   cy.enableDemo();
   cy.interceptHomeApiCall();
   cy.clearLocalStorage();
-  cy.visit('/');
+  cy.visit('/tests');
   cy.clearLocalStorage();
   cy.openTestCreationModal();
   cy.clickNextOnCreateTestWizard();
@@ -260,7 +260,7 @@ Cypress.Commands.add('deleteTestSuite', () => {
 });
 
 Cypress.Commands.add('enableDemo', () => {
-  cy.visit(`/settings`);
+  cy.visit('/settings');
 
   cy.get('[id*=tab-demo]').click();
   cy.get('#demo_pokeshop_enabled').then(element => {
@@ -272,6 +272,6 @@ Cypress.Commands.add('enableDemo', () => {
       cy.get('[data-cy=demo-form-save-button]').click();
     }
 
-    cy.visit(`/`);
+    cy.visit('/tests');
   });
 });

--- a/web/src/components/Layout/Layout.tsx
+++ b/web/src/components/Layout/Layout.tsx
@@ -14,6 +14,7 @@ import VariableSetProvider from 'providers/VariableSet';
 import {useSettingsValues} from 'providers/SettingsValues/SettingsValues.provider';
 import MissingVariablesModalProvider from 'providers/MissingVariablesModal/MissingVariablesModal.provider';
 import NotificationProvider from 'providers/Notification/Notification.provider';
+import WizardProvider from 'providers/Wizard';
 import {ConfigMode} from 'types/DataStore.types';
 import * as S from './Layout.styled';
 import MenuBottom from './MenuBottom';
@@ -28,17 +29,23 @@ const menuItems = [
   {
     key: '0',
     icon: <ClusterOutlined />,
-    label: <Link to="/">Tests</Link>,
-    path: '/tests',
+    label: <Link to="/">Home</Link>,
+    path: '/',
   },
   {
     key: '1',
+    icon: <ClusterOutlined />,
+    label: <Link to="/tests">Tests</Link>,
+    path: '/tests',
+  },
+  {
+    key: '2',
     icon: <AppstoreAddOutlined />,
     label: <Link to="/testsuites">Test Suites</Link>,
     path: '/testsuites',
   },
   {
-    key: '2',
+    key: '3',
     icon: <GlobalOutlined />,
     label: <Link to="/variablesets">Variable Sets</Link>,
     path: '/variablesets',
@@ -62,61 +69,63 @@ const Layout = ({hasMenu = false}: IProps) => {
 
   return (
     <NotificationProvider>
-      <MissingVariablesModalProvider>
-        <FileViewerModalProvider>
-          <ConfirmationModalProvider>
-            <VariableSetProvider>
-              <GuidedTourProvider>
-                <CreateTestProvider>
-                  <S.Layout hasSider>
-                    {hasMenu && (
-                      <S.Sider width={256}>
-                        <S.LogoContainer>
-                          <Link to="/">
-                            <img alt="Tracetest logo" src={logoAsset} />
-                          </Link>
-                        </S.LogoContainer>
+      <WizardProvider>
+        <MissingVariablesModalProvider>
+          <FileViewerModalProvider>
+            <ConfirmationModalProvider>
+              <VariableSetProvider>
+                <GuidedTourProvider>
+                  <CreateTestProvider>
+                    <S.Layout hasSider>
+                      {hasMenu && (
+                        <S.Sider width={256}>
+                          <S.LogoContainer>
+                            <Link to="/">
+                              <img alt="Tracetest logo" src={logoAsset} />
+                            </Link>
+                          </S.LogoContainer>
 
-                        <S.SiderContent>
-                          <S.MenuContainer>
-                            <Menu
-                              defaultSelectedKeys={[
-                                menuItems.findIndex(value => value.path === pathname).toString() || '0',
-                              ]}
-                              items={menuItems}
-                              mode="inline"
-                              theme="dark"
-                            />
-                          </S.MenuContainer>
+                          <S.SiderContent>
+                            <S.MenuContainer>
+                              <Menu
+                                defaultSelectedKeys={[
+                                  menuItems.findIndex(value => value.path === pathname).toString() || '0',
+                                ]}
+                                items={menuItems}
+                                mode="inline"
+                                theme="dark"
+                              />
+                            </S.MenuContainer>
 
-                          <S.MenuContainer>
-                            <MenuBottom />
-                            <Menu
-                              defaultSelectedKeys={[
-                                footerMenuItems.findIndex(value => value.path === pathname).toString() || '0',
-                              ]}
-                              items={footerMenuItems}
-                              mode="inline"
-                              theme="dark"
-                            />
-                          </S.MenuContainer>
-                        </S.SiderContent>
-                      </S.Sider>
-                    )}
+                            <S.MenuContainer>
+                              <MenuBottom />
+                              <Menu
+                                defaultSelectedKeys={[
+                                  footerMenuItems.findIndex(value => value.path === pathname).toString() || '0',
+                                ]}
+                                items={footerMenuItems}
+                                mode="inline"
+                                theme="dark"
+                              />
+                            </S.MenuContainer>
+                          </S.SiderContent>
+                        </S.Sider>
+                      )}
 
-                    <S.Layout>
-                      <Header hasLogo={!hasMenu} isNoTracingMode={isNoTracingMode && !isLoading} />
-                      <S.Content $hasMenu={hasMenu}>
-                        <Outlet />
-                      </S.Content>
+                      <S.Layout>
+                        <Header hasLogo={!hasMenu} isNoTracingMode={isNoTracingMode && !isLoading} />
+                        <S.Content $hasMenu={hasMenu}>
+                          <Outlet />
+                        </S.Content>
+                      </S.Layout>
                     </S.Layout>
-                  </S.Layout>
-                </CreateTestProvider>
-              </GuidedTourProvider>
-            </VariableSetProvider>
-          </ConfirmationModalProvider>
-        </FileViewerModalProvider>
-      </MissingVariablesModalProvider>
+                  </CreateTestProvider>
+                </GuidedTourProvider>
+              </VariableSetProvider>
+            </ConfirmationModalProvider>
+          </FileViewerModalProvider>
+        </MissingVariablesModalProvider>
+      </WizardProvider>
     </NotificationProvider>
   );
 };

--- a/web/src/components/Layout/Layout.tsx
+++ b/web/src/components/Layout/Layout.tsx
@@ -1,4 +1,4 @@
-import {AppstoreAddOutlined, ClusterOutlined, GlobalOutlined, SettingOutlined} from '@ant-design/icons';
+import {AppstoreAddOutlined, ClusterOutlined, GlobalOutlined, HomeOutlined, SettingOutlined} from '@ant-design/icons';
 import {Menu} from 'antd';
 import {Outlet, useLocation} from 'react-router-dom';
 
@@ -28,7 +28,7 @@ interface IProps {
 const menuItems = [
   {
     key: '0',
-    icon: <ClusterOutlined />,
+    icon: <HomeOutlined />,
     label: <Link to="/">Home</Link>,
     path: '/',
   },

--- a/web/src/components/Router/Router.tsx
+++ b/web/src/components/Router/Router.tsx
@@ -12,6 +12,7 @@ import TestSuiteRunOverview from 'pages/TestSuiteRunOverview';
 import TestSuiteRunAutomate from 'pages/TestSuiteRunAutomate';
 import AutomatedTestRun from 'pages/AutomatedTestRun';
 import CreateTest from 'pages/CreateTest';
+import Wizard from 'pages/Wizard';
 import {useDashboard} from 'providers/Dashboard/Dashboard.provider';
 
 const Router = () => {
@@ -20,7 +21,8 @@ const Router = () => {
   return (
     <Routes>
       <Route element={<Layout hasMenu />}>
-        <Route path="/" element={<Home />} />
+        <Route path="/" element={<Wizard />} />
+        <Route path="/tests" element={<Home />} />
         <Route path="/testsuites" element={<TestSuites />} />
         <Route path="/variablesets" element={<VariableSet />} />
         <Route path="/settings" element={<Settings />} />

--- a/web/src/components/Wizard/Header/Header.styled.ts
+++ b/web/src/components/Wizard/Header/Header.styled.ts
@@ -1,0 +1,17 @@
+import {Typography} from 'antd';
+import styled from 'styled-components';
+
+export const Container = styled.div`
+  padding: 16px;
+  border-bottom: 1px solid ${({theme}) => theme.color.border};
+`;
+
+export const Title = styled(Typography.Title)`
+  && {
+    margin-bottom: 12px;
+  }
+`;
+
+export const Text = styled(Typography.Text)`
+  font-size: ${({theme}) => theme.size.sm};
+`;

--- a/web/src/components/Wizard/Header/Header.tsx
+++ b/web/src/components/Wizard/Header/Header.tsx
@@ -1,0 +1,23 @@
+import {Progress} from 'antd';
+import * as S from './Header.styled';
+
+function calculatePercent(activeStep: number, totalSteps: number) {
+  return Math.round((activeStep / totalSteps) * 100);
+}
+
+interface IProps {
+  activeStep: number;
+  totalSteps: number;
+}
+
+const Header = ({activeStep, totalSteps}: IProps) => (
+  <S.Container>
+    <S.Title>🚀 Setup guide</S.Title>
+    <Progress percent={calculatePercent(activeStep, totalSteps)} showInfo={false} />
+    <S.Text>
+      {activeStep} of {totalSteps} steps completed
+    </S.Text>
+  </S.Container>
+);
+
+export default Header;

--- a/web/src/components/Wizard/Header/index.ts
+++ b/web/src/components/Wizard/Header/index.ts
@@ -1,0 +1,2 @@
+// eslint-disable-next-line no-restricted-exports
+export {default} from './Header';

--- a/web/src/components/Wizard/StepFactory/StepFactory.tsx
+++ b/web/src/components/Wizard/StepFactory/StepFactory.tsx
@@ -1,0 +1,19 @@
+import {IWizardStep, IWizardStepComponentMap} from 'types/Wizard.types';
+
+const StepComponentMap: IWizardStepComponentMap = {
+  Step1: () => <div>Step 1</div>,
+  Step2: () => <div>Step 1</div>,
+  Step3: () => <div>Step 3</div>,
+};
+
+interface IProps {
+  step: IWizardStep;
+}
+
+const StepFactory = ({step: {component}}: IProps) => {
+  const Step = StepComponentMap[component];
+
+  return <Step />;
+};
+
+export default StepFactory;

--- a/web/src/components/Wizard/StepFactory/index.ts
+++ b/web/src/components/Wizard/StepFactory/index.ts
@@ -1,0 +1,2 @@
+// eslint-disable-next-line no-restricted-exports
+export {default} from './StepFactory';

--- a/web/src/components/Wizard/Steps/StepTab.tsx
+++ b/web/src/components/Wizard/Steps/StepTab.tsx
@@ -1,0 +1,24 @@
+import {CheckOutlined} from '@ant-design/icons';
+import {IWizardStep} from 'types/Wizard.types';
+import * as S from './Steps.styled';
+
+interface IProps {
+  index: number;
+  isActive: boolean;
+  step: IWizardStep;
+}
+
+const StepTab = ({index, isActive, step}: IProps) => (
+  <S.StepTabContainer $isActive={isActive}>
+    {step.status === 'complete' ? (
+      <S.StepTabCheck>
+        <CheckOutlined />
+      </S.StepTabCheck>
+    ) : (
+      <S.StepTabNumber>{index}</S.StepTabNumber>
+    )}
+    <S.StepTabTitle $isActive={isActive}>{step.name}</S.StepTabTitle>
+  </S.StepTabContainer>
+);
+
+export default StepTab;

--- a/web/src/components/Wizard/Steps/Steps.styled.ts
+++ b/web/src/components/Wizard/Steps/Steps.styled.ts
@@ -1,0 +1,53 @@
+import {Typography} from 'antd';
+import styled from 'styled-components';
+
+export const Container = styled.div`
+  margin: 8px 0;
+
+  .ant-tabs-card > .ant-tabs-nav .ant-tabs-tab,
+  .ant-tabs-card > div > .ant-tabs-nav .ant-tabs-tab {
+    border: none;
+    padding: 0;
+  }
+
+  .ant-tabs-tab .anticon {
+    margin-right: 0;
+  }
+`;
+
+export const StepTabContainer = styled.div<{$isActive: boolean}>`
+  background-color: ${({theme, $isActive}) => ($isActive ? theme.color.backgroundInteractive : theme.color.white)};
+  display: flex;
+  gap: 8px;
+  padding: 16px;
+  min-width: 300px;
+`;
+
+export const StepTabNumber = styled.div`
+  border: 2px solid ${({theme}) => theme.color.textSecondary};
+  border-radius: 50%;
+  color: ${({theme}) => theme.color.textSecondary};
+  font-size: ${({theme}) => theme.size.sm};
+  font-weight: 600;
+  height: 24px;
+  width: 24px;
+`;
+
+export const StepTabCheck = styled.div`
+  align-items: center;
+  background-color: ${({theme}) => theme.color.primary};
+  border-radius: 50%;
+  color: ${({theme}) => theme.color.white};
+  display: flex;
+  font-size: ${({theme}) => theme.size.sm};
+  height: 24px;
+  justify-content: center;
+  width: 24px;
+`;
+
+export const StepTabTitle = styled(Typography.Text)<{$isActive: boolean}>`
+  && {
+    font-size: ${({theme}) => theme.size.lg};
+    font-weight: ${({$isActive}) => ($isActive ? '600' : '400')};
+  }
+`;

--- a/web/src/components/Wizard/Steps/Steps.tsx
+++ b/web/src/components/Wizard/Steps/Steps.tsx
@@ -1,0 +1,32 @@
+import {Tabs} from 'antd';
+import {IWizardStep} from 'types/Wizard.types';
+import * as S from './Steps.styled';
+import StepTab from './StepTab';
+
+interface IProps {
+  activeStepId: string;
+  componentFactory({step}: {step: IWizardStep}): React.ReactElement;
+  steps: IWizardStep[];
+}
+
+const Steps = ({activeStepId, componentFactory: ComponentFactory, steps}: IProps) => (
+  <S.Container>
+    <Tabs
+      type="card"
+      activeKey={activeStepId}
+      tabPosition="left"
+      onTabClick={(key, event) => {
+        event.preventDefault();
+        // onGoTo(key);
+      }}
+    >
+      {steps.map((step, index) => (
+        <Tabs.TabPane tab={<StepTab index={index + 1} isActive={step.id === activeStepId} step={step} />} key={step.id}>
+          <ComponentFactory step={step} />
+        </Tabs.TabPane>
+      ))}
+    </Tabs>
+  </S.Container>
+);
+
+export default Steps;

--- a/web/src/components/Wizard/Steps/index.ts
+++ b/web/src/components/Wizard/Steps/index.ts
@@ -1,0 +1,2 @@
+// eslint-disable-next-line no-restricted-exports
+export {default} from './Steps';

--- a/web/src/pages/Wizard/Wizard.styled.ts
+++ b/web/src/pages/Wizard/Wizard.styled.ts
@@ -1,0 +1,24 @@
+import {Typography} from 'antd';
+import styled from 'styled-components';
+
+export const Container = styled.div`
+  padding: 24px;
+`;
+
+export const Header = styled.div`
+  margin-bottom: 16px;
+`;
+
+export const Body = styled.div`
+  background-color: ${({theme}) => theme.color.white};
+  border: 1px solid ${({theme}) => theme.color.border};
+  margin-bottom: 24px;
+`;
+
+export const Title = styled(Typography.Title)`
+  && {
+    margin-bottom: 6px;
+  }
+`;
+
+export const Text = styled(Typography.Text)``;

--- a/web/src/pages/Wizard/Wizard.tsx
+++ b/web/src/pages/Wizard/Wizard.tsx
@@ -1,0 +1,28 @@
+import withAnalytics from 'components/WithAnalytics/WithAnalytics';
+import Header from 'components/Wizard/Header';
+import StepFactory from 'components/Wizard/StepFactory';
+import Steps from 'components/Wizard/Steps';
+import {useWizard} from 'providers/Wizard';
+import * as S from './Wizard.styled';
+
+const Wizard = () => {
+  const {activeStep, activeStepId, steps} = useWizard();
+
+  return (
+    <S.Container>
+      <S.Header>
+        <S.Title>Welcome to Tracetest!</S.Title>
+        <S.Text>
+          Here&apos;s a guide to get started and help you test your modern applications with OpenTelemetry.
+        </S.Text>
+      </S.Header>
+
+      <S.Body>
+        <Header activeStep={activeStep} totalSteps={steps.length} />
+        <Steps activeStepId={activeStepId} componentFactory={StepFactory} steps={steps} />
+      </S.Body>
+    </S.Container>
+  );
+};
+
+export default withAnalytics(Wizard, 'wizard');

--- a/web/src/pages/Wizard/index.tsx
+++ b/web/src/pages/Wizard/index.tsx
@@ -1,0 +1,2 @@
+// eslint-disable-next-line no-restricted-exports
+export {default} from './Wizard';

--- a/web/src/providers/Wizard/Wizard.provider.tsx
+++ b/web/src/providers/Wizard/Wizard.provider.tsx
@@ -30,7 +30,6 @@ const initialSteps: IWizardStep[] = [
     name: 'Step 1',
     description: 'Step 1 description',
     component: 'Step1',
-    status: 'complete',
   },
   {
     id: 'step2',

--- a/web/src/providers/Wizard/Wizard.provider.tsx
+++ b/web/src/providers/Wizard/Wizard.provider.tsx
@@ -1,0 +1,81 @@
+import {noop} from 'lodash';
+import {createContext, useCallback, useContext, useMemo, useState} from 'react';
+import {IWizardState, IWizardStep} from 'types/Wizard.types';
+
+interface IContext extends IWizardState {
+  activeStepId: string;
+  isLoading: boolean;
+  onNext(): void;
+  onPrev(): void;
+}
+
+export const Context = createContext<IContext>({
+  activeStep: 0,
+  activeStepId: '',
+  steps: [],
+  isLoading: false,
+  onNext: noop,
+  onPrev: noop,
+});
+
+interface IProps {
+  children: React.ReactNode;
+}
+
+export const useWizard = () => useContext(Context);
+
+const initialSteps: IWizardStep[] = [
+  {
+    id: 'step1',
+    name: 'Step 1',
+    description: 'Step 1 description',
+    component: 'Step1',
+    status: 'complete',
+  },
+  {
+    id: 'step2',
+    name: 'Step 2',
+    description: 'Step 2 description',
+    component: 'Step2',
+  },
+  {
+    id: 'step3',
+    name: 'Step 3',
+    description: 'Step 3 description',
+    component: 'Step3',
+  },
+];
+
+const WizardProvider = ({children}: IProps) => {
+  const [activeStep, setActiveStep] = useState(0);
+  const [steps, setSteps] = useState<IWizardStep[]>(initialSteps);
+
+  const activeStepId = steps[activeStep]?.id;
+  const isFinalStep = activeStep === steps.length - 1;
+
+  const onNext = useCallback(() => {
+    if (!isFinalStep) {
+      setActiveStep(step => step + 1);
+    }
+  }, [isFinalStep]);
+
+  const onPrev = useCallback(() => {
+    setActiveStep(step => step - 1);
+  }, []);
+
+  const value = useMemo<IContext>(
+    () => ({
+      activeStep,
+      activeStepId,
+      steps,
+      isLoading: false, // TODO: implement loading
+      onNext,
+      onPrev,
+    }),
+    [activeStep, activeStepId, onNext, onPrev, steps]
+  );
+
+  return <Context.Provider value={value}>{children}</Context.Provider>;
+};
+
+export default WizardProvider;

--- a/web/src/providers/Wizard/index.ts
+++ b/web/src/providers/Wizard/index.ts
@@ -1,0 +1,2 @@
+// eslint-disable-next-line no-restricted-exports
+export {default, useWizard} from './Wizard.provider';

--- a/web/src/types/Wizard.types.ts
+++ b/web/src/types/Wizard.types.ts
@@ -1,0 +1,19 @@
+export interface IWizardState {
+  activeStep: number;
+  steps: IWizardStep[];
+}
+
+export interface IWizardStep {
+  id: string;
+  name: string;
+  description: string;
+  component: string; // enum?
+  status?: TWizardStepStatus;
+}
+
+type TWizardStepStatus = 'complete' | 'pending';
+
+interface IWizardStepComponentProps {}
+
+export interface IWizardStepComponentMap
+  extends Record<string, (props: IWizardStepComponentProps) => React.ReactElement> {}

--- a/web/src/types/Wizard.types.ts
+++ b/web/src/types/Wizard.types.ts
@@ -7,7 +7,7 @@ export interface IWizardStep {
   id: string;
   name: string;
   description: string;
-  component: string; // enum?
+  component: string;
   status?: TWizardStepStatus;
 }
 


### PR DESCRIPTION
This PR adds the layout for the Wizard and the initial architecture to render/control the steps.

## Changes

- wizard layout
- wizard architecture

## Fixes

- fixes https://github.com/kubeshop/tracetest-cloud/issues/375

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Screenshot

<img width="1504" alt="Screenshot 2024-01-11 at 16 45 59" src="https://github.com/kubeshop/tracetest/assets/3879892/2ae9bbd1-59cc-4edc-be4b-0c087b594f71">