### PR TITLE
fix(docs): E2E docs fix

### DIFF
--- a/docs/docs/tools-and-integrations/cypress.mdx
+++ b/docs/docs/tools-and-integrations/cypress.mdx
@@ -236,14 +236,14 @@ describe('Home', { defaultCommandTimeout: 60000 }, () => {
 
 ### Setting the Environment Variables
 
-Copy the `.env.example` file to `.env` and add the Tracetest API token and agent tokens to the `TRACETEST_API_TOKEN` and `TRACETEST_AGENT_API_KEY` variables.
+Copy the `.env.template` file to `.env` and add the Tracetest API token and agent tokens to the `TRACETEST_API_TOKEN` and `TRACETEST_AGENT_API_KEY` variables.
 
 ### Starting the Pokeshop Demo App
 
 To start the Pokeshop Demo App, run the following command from the root directory:
 
 ```bash
-docker compose up -f docker-compose.yml -f docker-compose.e2e.yml
+docker compose -f docker-compose.yml -f docker-compose.e2e.yml up
 ```
 
 ### Running the Tests

--- a/docs/docs/tools-and-integrations/playwright.mdx
+++ b/docs/docs/tools-and-integrations/playwright.mdx
@@ -244,14 +244,14 @@ test("Playwright: deletes a pokemon", async ({ page }) => {
 
 ### Setting the Environment Variables
 
-Copy the `.env.example` file to `.env` and add the Tracetest API token and agent tokens to the `TRACETEST_API_TOKEN` and `TRACETEST_AGENT_API_KEY` variables.
+Copy the `.env.template` file to `.env` and add the Tracetest API token and agent tokens to the `TRACETEST_API_TOKEN` and `TRACETEST_AGENT_API_KEY` variables.
 
 ### Starting the Pokeshop Demo App
 
 To start the Pokeshop Demo App, run the following command from the root directory:
 
 ```bash
-docker compose up -f docker-compose.yml -f docker-compose.e2e.yml
+docker compose -f docker-compose.yml -f docker-compose.e2e.yml up
 ```
 
 ### Running the Tests


### PR DESCRIPTION
This PR fixes a couple issues with the e2e docs for the name of the environment variables file and the docker compose command.

## Changes

- Fixes wrong content for e2e docs

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

