### PR TITLE
chore: Updating default wizard steps

### DIFF
--- a/server/wizard/wizard_repository.go
+++ b/server/wizard/wizard_repository.go
@@ -32,6 +32,9 @@ type scanner interface {
 var (
 	defaultWizard = &Wizard{
 		Steps: []Step{{
+			ID:    "agent",
+			State: StepStatusPending,
+		}, {
 			ID:    "tracing_backend",
 			State: StepStatusPending,
 		}, {

--- a/web/src/components/Wizard/Wrapper/Wrapper.tsx
+++ b/web/src/components/Wizard/Wrapper/Wrapper.tsx
@@ -4,13 +4,7 @@ import TracingBackend, {TracingBackendTab} from '../Steps/TracingBackend';
 import CreateTest, {CreateTestTab} from '../Steps/CreateTest';
 
 const steps: TWizardMap = {
-  agent: {
-    name: '',
-    description: '',
-    component: () => <div>Agent</div>,
-    tabComponent: () => <div>Agent tab</div>,
-    isEnabled: true,
-  },
+  agent: undefined,
   tracing_backend: {
     name: 'Configure access to your OTel traces',
     description: '',

--- a/web/src/providers/Wizard/Wizard.provider.tsx
+++ b/web/src/providers/Wizard/Wizard.provider.tsx
@@ -37,11 +37,13 @@ const WizardProvider = ({children, stepsMap}: IProps) => {
   const {data: wizard = Wizard()} = useGetWizardQuery({});
   const steps = useMemo<IWizardStep[]>(
     () =>
-      wizard.steps.map((step, index) => ({
-        ...step,
-        ...(stepsMap[step.id] || {}),
-        isEnabled: isStepEnabled(step, index, wizard.steps[index - 1]),
-      })),
+      wizard.steps
+        .filter(step => !!stepsMap[step.id])
+        .map((step, index) => ({
+          ...step,
+          ...(stepsMap[step.id]! || {}),
+          isEnabled: isStepEnabled(step, index, wizard.steps[index - 1]),
+        })),
     [stepsMap, wizard.steps]
   );
 

--- a/web/src/types/Wizard.types.ts
+++ b/web/src/types/Wizard.types.ts
@@ -18,4 +18,4 @@ export interface IWizardStepComponentProps {
 }
 
 export interface IWizardStep extends WizardStep, IWizardStepMetadata {}
-export type TWizardMap = Record<TWizardStepId, IWizardStepMetadata>;
+export type TWizardMap = Record<TWizardStepId, IWizardStepMetadata | undefined>;


### PR DESCRIPTION
This PR updates both the FE and backend to include the agent as step, but the FE will have checks to not render the component as it doesn't exist

## Changes

- Adds default agent step for the wizard
- Adds logic to avoid rendering undefined components

## Fixes

- https://github.com/kubeshop/tracetest-cloud/issues/393

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

