### PR TITLE
chore(backend): Removing Analyzer Rules as default

### DIFF
--- a/server/executor/testrunner/testrunner_entities.go
+++ b/server/executor/testrunner/testrunner_entities.go
@@ -21,8 +21,6 @@ var DefaultTestRunner = TestRunner{
 	Name: "default",
 	RequiredGates: []RequiredGate{
 		RequiredGateTestSpecs,
-		RequiredGateAnalyzerRules,
-		RequiredGateAnalyzerScore,
 	},
 }
 

--- a/server/executor/testrunner/testrunner_repository_test.go
+++ b/server/executor/testrunner/testrunner_repository_test.go
@@ -33,9 +33,7 @@ func TestTestRunnerResource(t *testing.T) {
 				"id": "current",
 				"name": "default",
 				"requiredGates": [
-					"test-specs",
-					"analyzer-rules",
-					"analyzer-score"
+					"test-specs"
 				]
 			}
 		}`,


### PR DESCRIPTION
This PR removes the analyzer-rules as the default required gate for test runs, to avoid failing tests based on that configuration for new users.

## Changes

- Removes analyzer rules as the default required gates

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
