### PR TITLE
feat(cli): deprecate `endpoint` flag in favor of `server-url`

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -227,7 +227,7 @@ jobs:
 
           ./scripts/wait-for-port.sh 11633
 
-          ./dist/tracetest configure -g --endpoint http://localhost:11633
+          ./dist/tracetest configure -g --server-url http://localhost:11633
           ./dist/tracetest run test -f examples/${{ matrix.example_dir }}/tests/list-tests.yaml || (cat /tmp/docker-log; exit 1)
 
   smoke-test-cli:

--- a/cli/cmd/configure_cmd.go
+++ b/cli/cmd/configure_cmd.go
@@ -31,7 +31,7 @@ var configureCmd = &cobra.Command{
 			return "", err
 		}
 
-		if flagProvided(cmd, "endpoint") {
+		if flagProvided(cmd, "server-url") {
 			flags.Endpoint = configParams.ServerURL
 		}
 
@@ -78,7 +78,7 @@ type configureParameters struct {
 	EnvironmentID  string
 }
 
-func (p configureParameters) Validate(cmd *cobra.Command, args []string) []error {
+func (p *configureParameters) Validate(cmd *cobra.Command, args []string) []error {
 	var errors []error
 
 	p.ServerURL = overrideEndpoint

--- a/cli/cmd/configure_cmd.go
+++ b/cli/cmd/configure_cmd.go
@@ -32,7 +32,7 @@ var configureCmd = &cobra.Command{
 		}
 
 		if flagProvided(cmd, "endpoint") {
-			flags.Endpoint = configParams.Endpoint
+			flags.Endpoint = configParams.ServerURL
 		}
 
 		if flagProvided(cmd, "token") {
@@ -59,7 +59,7 @@ func flagProvided(cmd *cobra.Command, name string) bool {
 
 func init() {
 	configureCmd.PersistentFlags().BoolVarP(&configParams.Global, "global", "g", false, "configuration will be saved in your home dir")
-	configureCmd.PersistentFlags().StringVarP(&configParams.Endpoint, "endpoint", "e", "", "set the value for the endpoint, so the CLI won't ask for this value")
+	// configureCmd.PersistentFlags().StringVarP(&configParams.Endpoint, "server-url`", "s", "", "set the value for the endpoint, so the CLI won't ask for this value")
 
 	configureCmd.PersistentFlags().StringVarP(&configParams.Token, "token", "t", "", "set authetication with token, so the CLI won't ask you for authentication")
 	configureCmd.PersistentFlags().StringVarP(&configParams.EnvironmentID, "environment", "", "", "set environmentID, so the CLI won't ask you for it")
@@ -70,7 +70,7 @@ func init() {
 }
 
 type configureParameters struct {
-	Endpoint       string
+	ServerURL      string
 	Global         bool
 	CI             bool
 	Token          string
@@ -81,18 +81,19 @@ type configureParameters struct {
 func (p configureParameters) Validate(cmd *cobra.Command, args []string) []error {
 	var errors []error
 
-	if cmd.Flags().Lookup("endpoint").Changed {
-		if p.Endpoint == "" {
+	p.ServerURL = overrideEndpoint
+	if cmd.Flags().Lookup("server-url").Changed {
+		if p.ServerURL == "" {
 			errors = append(errors, paramError{
-				Parameter: "endpoint",
-				Message:   "endpoint cannot be empty",
+				Parameter: "server-url",
+				Message:   "server-url cannot be empty",
 			})
 		} else {
-			_, err := url.Parse(p.Endpoint)
+			_, err := url.Parse(p.ServerURL)
 			if err != nil {
 				errors = append(errors, paramError{
-					Parameter: "endpoint",
-					Message:   "endpoint is not a valid URL",
+					Parameter: "server-url",
+					Message:   "server-url is not a valid URL",
 				})
 			}
 		}

--- a/docs/docs/ci-cd-automation/github-actions-pipeline.mdx
+++ b/docs/docs/ci-cd-automation/github-actions-pipeline.mdx
@@ -61,7 +61,7 @@ jobs:
       run: curl -L https://raw.githubusercontent.com/kubeshop/tracetest/main/install-cli.sh | bash
 
     - name: Configure Tracetest CLI
-      run: tracetest configure -g --endpoint http://localhost:11633
+      run: tracetest configure -g --server-url http://localhost:11633
 
     - name: Run tests via the Tracetest CLI
       run: |
@@ -101,7 +101,7 @@ jobs:
       run: curl -L https://raw.githubusercontent.com/kubeshop/tracetest/main/install-cli.sh | bash
 
     - name: Configure Tracetest CLI
-      run: tracetest configure -g --endpoint http://localhost:11633
+      run: tracetest configure -g --server-url http://localhost:11633
 
     - name: Run tests via the Tracetest CLI
       run: |
@@ -400,7 +400,7 @@ First, [install the CLI](https://docs.tracetest.io/getting-started/installation#
 Then, configure the CLI:
 
 ```bash
-tracetest configure --endpoint http://localhost:11633
+tracetest configure --server-url http://localhost:11633
 ```
 
 Once configured, you can run a test against the Tracetest instance via the terminal.

--- a/docs/docs/ci-cd-automation/tekton-pipeline.mdx
+++ b/docs/docs/ci-cd-automation/tekton-pipeline.mdx
@@ -253,7 +253,7 @@ spec:
       image: kubeshop/tracetest:v0.11.9 # The official Tracetest image comes with the Tracetest CLI installed
       script: |
         # Configure and Run Tracetest CLI
-        tracetest configure -g --endpoint http://tracetest.tracetest.svc.cluster.local:11633/
+        tracetest configure -g --server-url http://tracetest.tracetest.svc.cluster.local:11633/
         tracetest run test -f /workspace/test-api.yaml
       volumeMounts:
       - name: custom
@@ -371,7 +371,7 @@ metadata:
 spec:
   serviceAccountName: tekton-robot
   triggers:
-    - name: install-and-run-tracetest-trigger 
+    - name: install-and-run-tracetest-trigger
       bindings:
       - ref: install-and-run-tracetest-binding
       template:

--- a/docs/docs/cli/configuring-your-cli.mdx
+++ b/docs/docs/cli/configuring-your-cli.mdx
@@ -27,10 +27,10 @@ Configure your CLI to connect to your Tracetest server.
 tracetest configure
 ```
 
-If you want to set values without having to answer questions from a prompt, you can provide the flag `--endpoint` to define the server endpoint.
+If you want to set values without having to answer questions from a prompt, you can provide the flag `--server-url` to define the server endpoint.
 
 ```sh
-tracetest configure --endpoint http://my-tracetest-server:11633
+tracetest configure --server-url http://my-tracetest-server:11633
 ```
 
 ### Test List

--- a/docs/docs/examples-tutorials/recipes/running-tracetest-with-aws-terraform.mdx
+++ b/docs/docs/examples-tutorials/recipes/running-tracetest-with-aws-terraform.mdx
@@ -290,7 +290,7 @@ The final output from the Terraform command should be a list of endpoints that i
 Now that all of the required services and infra have been created, you can start running some Trace-based testing by doing the following:
 
 1. From the Terraform output you can copy the `api_endpoint` and replace the `<your_api_endpoint>` placeholder from the `tests/test.yaml` file.
-2. Configure the [Tracetest CLI](https://docs.tracetest.io/cli/configuring-your-cli) to point to the public load balancer endpoint with `tracetest configure --endpoint <tracetest_url>`.
+2. Configure the [Tracetest CLI](https://docs.tracetest.io/cli/configuring-your-cli) to point to the public load balancer endpoint with `tracetest configure --server-url <tracetest_url>`.
 3. Run the test YAML file using the CLI `tracetest run test -f tests/test.yaml`.
 4. Follow the link to find the results.
 

--- a/docs/docs/examples-tutorials/recipes/running-tracetest-with-datadog.mdx
+++ b/docs/docs/examples-tutorials/recipes/running-tracetest-with-datadog.mdx
@@ -262,7 +262,7 @@ To start both OpenTelemetry and Tracetest, run this command:
 docker-compose -f docker-compose.yaml -f tracetest/docker-compose.yaml up
 ```
 
-This will start your Tracetest instance on `http://localhost:11633/`. 
+This will start your Tracetest instance on `http://localhost:11633/`.
 
 Open the URL and [start creating tests in the Web UI](https://docs.tracetest.io/web-ui/creating-tests)! Make sure to use the endpoints within your Docker network like `http://frontend:8084/` when creating tests.
 
@@ -288,7 +288,7 @@ First, [install the CLI](https://docs.tracetest.io/getting-started/installation#
 Then, configure the CLI:
 
 ```bash
-tracetest configure --endpoint http://localhost:11633
+tracetest configure --server-url http://localhost:11633
 ```
 
 Once configured, you can run a test against the Tracetest instance via the terminal.

--- a/docs/docs/examples-tutorials/recipes/running-tracetest-with-dynatrace.mdx
+++ b/docs/docs/examples-tutorials/recipes/running-tracetest-with-dynatrace.mdx
@@ -328,7 +328,7 @@ First, [install the CLI](https://docs.tracetest.io/getting-started/installation#
 Then, configure the CLI:
 
 ```bash
-tracetest configure --endpoint http://localhost:11633
+tracetest configure --server-url http://localhost:11633
 ```
 
 Once configured, you can run a test against the Tracetest instance via the terminal.

--- a/docs/docs/examples-tutorials/recipes/running-tracetest-with-honeycomb.mdx
+++ b/docs/docs/examples-tutorials/recipes/running-tracetest-with-honeycomb.mdx
@@ -295,7 +295,7 @@ First, [install the CLI](https://docs.tracetest.io/getting-started/installation#
 Then, configure the CLI:
 
 ```bash
-tracetest configure --endpoint http://localhost:11633
+tracetest configure --server-url http://localhost:11633
 ```
 
 Once configured, you can run a test against the Tracetest instance via the terminal.

--- a/docs/docs/examples-tutorials/recipes/running-tracetest-with-lightstep.mdx
+++ b/docs/docs/examples-tutorials/recipes/running-tracetest-with-lightstep.mdx
@@ -267,7 +267,7 @@ First, [install the CLI](https://docs.tracetest.io/getting-started/installation#
 Then, configure the CLI:
 
 ```bash
-tracetest configure --endpoint http://localhost:11633
+tracetest configure --server-url http://localhost:11633
 ```
 
 Once configured, you can run a test against the Tracetest instance via the terminal.

--- a/docs/docs/examples-tutorials/recipes/running-tracetest-with-new-relic.mdx
+++ b/docs/docs/examples-tutorials/recipes/running-tracetest-with-new-relic.mdx
@@ -276,7 +276,7 @@ First, [install the CLI](https://docs.tracetest.io/getting-started/installation#
 Then, configure the CLI:
 
 ```bash
-tracetest configure --endpoint http://localhost:11633
+tracetest configure --server-url http://localhost:11633
 ```
 
 Once configured, you can run a test against the Tracetest instance via the terminal.

--- a/docs/docs/examples-tutorials/recipes/running-tracetest-with-signoz-pokeshop.mdx
+++ b/docs/docs/examples-tutorials/recipes/running-tracetest-with-signoz-pokeshop.mdx
@@ -124,10 +124,10 @@ The `docker-compose.yaml` file includes the definitions for all of the required 
 ```yaml
 version: "3"
 
-#... 
+#...
 
 services:
-  #... 
+  #...
 
   # Demo
   postgres:
@@ -574,7 +574,7 @@ First, [install the CLI](https://docs.tracetest.io/getting-started/installation#
 Then, configure the CLI:
 
 ```bash
-tracetest configure --endpoint http://localhost:11633
+tracetest configure --server-url http://localhost:11633
 ```
 
 Once configured, you can run a test against the Tracetest instance via the terminal.

--- a/docs/docs/examples-tutorials/recipes/running-tracetest-with-step-functions-terraform.mdx
+++ b/docs/docs/examples-tutorials/recipes/running-tracetest-with-step-functions-terraform.mdx
@@ -169,7 +169,7 @@ The output from the previous command should look similar to this:
 Now that all of the required services and infra have been created, you can start running trace-based testing by doing the following:
 
 1. Run this `sam list stack-outputs --stack-name <your_app_name>` command where you can copy the `StepFunctionsAPIUrl` value and add the `<your_api_endpoint>` placeholder from the `tests/incident.yaml` and `tests/exam.yaml` files.
-2. From the Terraform output, configure the [Tracetest CLI](https://docs.tracetest.io/cli/configuring-your-cli) to point to the public load balancer endpoint with `tracetest configure --endpoint <tracetest_url>`.
+2. From the Terraform output, configure the [Tracetest CLI](https://docs.tracetest.io/cli/configuring-your-cli) to point to the public load balancer endpoint with `tracetest configure --server-url <tracetest_url>`.
 3. Run the tests YAML file using the CLI.
 
 ```bash

--- a/docs/docs/examples-tutorials/recipes/running-tracetest-without-a-trace-data-store-with-manual-instrumentation.mdx
+++ b/docs/docs/examples-tutorials/recipes/running-tracetest-without-a-trace-data-store-with-manual-instrumentation.mdx
@@ -309,7 +309,7 @@ To start both the Node.js services and Tracetest we will run this command:
 docker-compose -f docker-compose.yaml -f tracetest/docker-compose.yaml up # add --build if the images are not built already
 ```
 
-This will start your Tracetest instance on `http://localhost:11633/`. 
+This will start your Tracetest instance on `http://localhost:11633/`.
 
 Open the URL and [start creating tests in the Web UI](https://docs.tracetest.io/web-ui/creating-tests)! Make sure to use the `http://app:8080/books` URL in your test creation, because your Node.js app and Tracetest are in the same network.
 
@@ -329,7 +329,7 @@ First, [install the CLI](https://docs.tracetest.io/getting-started/installation#
 Then, configure the CLI:
 
 ```bash
-tracetest configure --endpoint http://localhost:11633
+tracetest configure --server-url http://localhost:11633
 ```
 
 Once configured, you can run a test against the Tracetest instance via the terminal.

--- a/examples/quick-start-github-actions/.github/workflows/start-and-test-on-main.yaml
+++ b/examples/quick-start-github-actions/.github/workflows/start-and-test-on-main.yaml
@@ -22,7 +22,7 @@ jobs:
       run: curl -L https://raw.githubusercontent.com/kubeshop/tracetest/main/install-cli.sh | bash
 
     - name: Configure Tracetest CLI
-      run: tracetest configure -g --endpoint http://localhost:11633
+      run: tracetest configure -g --server-url http://localhost:11633
 
     - name: Run tests via the Tracetest CLI
       run: |

--- a/examples/quick-start-github-actions/.github/workflows/start-and-test-on-schedule.yaml
+++ b/examples/quick-start-github-actions/.github/workflows/start-and-test-on-schedule.yaml
@@ -20,7 +20,7 @@ jobs:
       run: curl -L https://raw.githubusercontent.com/kubeshop/tracetest/main/install-cli.sh | bash
 
     - name: Configure Tracetest CLI
-      run: tracetest configure -g --endpoint http://localhost:11633
+      run: tracetest configure -g --server-url http://localhost:11633
 
     - name: Run tests via the Tracetest CLI
       run: |

--- a/examples/quick-start-net-core/README.md
+++ b/examples/quick-start-net-core/README.md
@@ -7,7 +7,7 @@ This is a simple quick start on how to configure a .NET Core API to use OpenTele
 ## Steps
 
 1. [Install the tracetest CLI](https://github.com/kubeshop/tracetest/blob/main/docs/installing.md#cli-installation)
-2. Run `tracetest configure --endpoint http://localhost:11633` on a terminal to configure the CLI to send all commands to that address
+2. Run `tracetest configure --server-url http://localhost:11633` on a terminal to configure the CLI to send all commands to that address
 3. Run the project by using docker-compose: `docker-compose up -d` (Linux) or `docker compose up -d` (Mac)
 4. Test if it works by running: `tracetest run test -f tests/test.yaml`. This would execute a test against the .NET Core API that will send spans to Jaeger to be fetched from the Tracetest server.
 

--- a/examples/quick-start-pokeshop/README.md
+++ b/examples/quick-start-pokeshop/README.md
@@ -9,6 +9,6 @@ This examples' objective is to show how you can:
 ## Steps
 
 1. [Install the tracetest CLI](https://docs.tracetest.io/installing/)
-2. Run `tracetest configure --endpoint http://localhost:11633` on a terminal
+2. Run `tracetest configure --server-url http://localhost:11633` on a terminal
 3. Run the project by using docker-compose: `docker-compose up -d` (Linux) or `docker compose up -d` (Mac)
 4. Test if it works by running: `tracetest run test -f tests/test.yaml`. This would trigger a test that will send and retrieve spans from the OpenTelemetry Collector instance. View the test on `http://localhost:11633`.

--- a/examples/quick-start-tekton/install-and-run-tracetest.yaml
+++ b/examples/quick-start-tekton/install-and-run-tracetest.yaml
@@ -36,7 +36,7 @@ spec:
       # The official Tracetest image comes with the Tracetest CLI installed
       script: |
         # Configure and Run Tracetest CLI
-        tracetest configure -g --endpoint http://tracetest.tracetest.svc.cluster.local:11633/
+        tracetest configure -g --server-url http://tracetest.tracetest.svc.cluster.local:11633/
         tracetest run test --file /workspace/test-api.yaml --required-gates test-specs --output pretty
       volumeMounts:
       - name: custom

--- a/examples/tracetest-amazon-x-ray-adot/README.md
+++ b/examples/tracetest-amazon-x-ray-adot/README.md
@@ -7,7 +7,7 @@ This repository objective is to show how you can configure your Tracetest instan
 ## Steps
 
 1. [Install the tracetest CLI](https://docs.tracetest.io/installing/)
-2. Run `tracetest configure --endpoint http://localhost:11633` on a terminal
+2. Run `tracetest configure --server-url http://localhost:11633` on a terminal
 3. Update the `.env` file adding a valid set of AWS credentials
 4. Run the project by using docker-compose: `docker-compose up -d` (Linux) or `docker compose up -d` (Mac)
 5. Test if it works by running: `tracetest run test -f tests/test.yaml`. This would trigger a test that will send and retrieve spans from the X-Ray instance that is running on your machine.

--- a/examples/tracetest-amazon-x-ray-pokeshop/README.md
+++ b/examples/tracetest-amazon-x-ray-pokeshop/README.md
@@ -7,7 +7,7 @@ This repository objective is to show how you can configure your Tracetest instan
 ## Steps
 
 1. [Install the tracetest CLI](https://docs.tracetest.io/installing/)
-2. Run `tracetest configure --endpoint http://localhost:11633` on a terminal
+2. Run `tracetest configure --server-url http://localhost:11633` on a terminal
 3. Update the `.env` file adding a valid set of AWS credentials
 4. Update the `tracetest.provision.yaml` file adding a valid set of AWS credentials
 5. Run the project by using docker-compose: `docker-compose up -d` (Linux) or `docker compose up -d` (Mac)

--- a/examples/tracetest-amazon-x-ray/README.md
+++ b/examples/tracetest-amazon-x-ray/README.md
@@ -7,7 +7,7 @@ This repository objective is to show how you can configure your Tracetest instan
 ## Steps
 
 1. [Install the tracetest CLI](https://docs.tracetest.io/installing/)
-2. Run `tracetest configure --endpoint http://localhost:11633` on a terminal
+2. Run `tracetest configure --server-url http://localhost:11633` on a terminal
 3. Update the `.env` file adding a valid set of AWS credentials
 4. Update the `tracetest.provision.yaml` file adding a valid set of AWS credentials
 5. Run the project by using docker-compose: `docker-compose up -d` (Linux) or `docker compose up -d` (Mac)

--- a/examples/tracetest-aws-step-functions/README.md
+++ b/examples/tracetest-aws-step-functions/README.md
@@ -6,7 +6,7 @@ This is a simple quick start on how to configure a .NET State Machine (AWS Step 
 
 1. [Install the tracetest CLI](https://github.com/kubeshop/tracetest/blob/main/docs/installing.md#cli-installation)
 2. From the `infra` folder run `terraform init` and `terraform apply` and accept the changes
-3. From the terraform outputs, grab the `tracetest_url` and run `tracetest configure --endpoint <tracetest_url>` on a terminal to configure the CLI to send all commands to that address
+3. From the terraform outputs, grab the `tracetest_url` and run `tracetest configure --server-url <tracetest_url>` on a terminal to configure the CLI to send all commands to that address
 4. From the `src` folder run `sam build` and `sam deploy --guided`
 5. Follow the instructions from the guided deployment
 ![functions](./assets/functions.png)

--- a/examples/tracetest-aws-step-functions/infra/README.md
+++ b/examples/tracetest-aws-step-functions/infra/README.md
@@ -8,7 +8,7 @@ This is a simple quick start on how to configure a Node.js lambda function API t
 
 1. [Install the tracetest CLI](https://github.com/kubeshop/tracetest/blob/main/docs/installing.md#cli-installation)
 2. Run `terraform init`, `terraform apply` and accept the changes
-3. From the terraform outputs, grab the `tracetes_url` and run `tracetest configure --endpoint <tracetest_url>` on a terminal to configure the CLI to send all commands to that address
+3. From the terraform outputs, grab the `tracetes_url` and run `tracetest configure --server-url <tracetest_url>` on a terminal to configure the CLI to send all commands to that address
 4. From the terraform outputs, grab the `api_endpoint` and update the `<your_api_endpoint>` section from `test/test.yaml`
 5. Test if it works by running: `tracetest run test -f tests/test.yaml`. This would execute a test against the Node.js API Gateway endpoint that will send spans to Jaeger to be fetched from the Tracetest server.
 

--- a/examples/tracetest-aws-terraform-serverless/README.md
+++ b/examples/tracetest-aws-terraform-serverless/README.md
@@ -6,7 +6,7 @@ This is a simple quick start on how to configure a Node.js lambda function API t
 
 1. [Install the tracetest CLI](https://github.com/kubeshop/tracetest/blob/main/docs/installing.md#cli-installation)
 2. Run `terraform init`, `terraform apply` and accept the changes
-3. From the terraform outputs, grab the `tracetes_url` and run `tracetest configure --endpoint <tracetest_url>` on a terminal to configure the CLI to send all commands to that address
+3. From the terraform outputs, grab the `tracetes_url` and run `tracetest configure --server-url <tracetest_url>` on a terminal to configure the CLI to send all commands to that address
 4. From the terraform outputs, grab the `api_endpoint` and update the `<your_api_endpoint>` section from `tests/test.yaml`
 5. Test if it works by running: `tracetest run test -f tests/test.yaml`. This would execute a test against the Node.js API Gateway endpoint that will send spans to Jaeger to be fetched from the Tracetest server.
 

--- a/examples/tracetest-azure-app-insights-collector/README.md
+++ b/examples/tracetest-azure-app-insights-collector/README.md
@@ -7,7 +7,7 @@ This repository objective is to show how you can configure your Tracetest instan
 ## Steps
 
 1. [Install the tracetest CLI](https://docs.tracetest.io/installing/)
-2. Run `tracetest configure --endpoint http://localhost:11633` on a terminal
+2. Run `tracetest configure --server-url http://localhost:11633` on a terminal
 3. Update the `.env` file adding a valid set the valid App Insights Instrumentation Key
 4. Run the project by using docker-compose: `docker compose -f ./docker-compose.yaml -f ./tracetest/docker-compose.yaml up -d`
 5. Test if it works by running: `tracetest run test -f tests/test.yaml`. This would trigger a test that will send spans to Azure Monitor API and directly to Tracetest that is running on your machine.

--- a/examples/tracetest-azure-app-insights-pokeshop/README.md
+++ b/examples/tracetest-azure-app-insights-pokeshop/README.md
@@ -7,7 +7,7 @@ This repository objective is to show how you can configure your Tracetest instan
 ## Steps
 
 1. [Install the tracetest CLI](https://docs.tracetest.io/installing/)
-2. Run `tracetest configure --endpoint http://localhost:11633` on a terminal
+2. Run `tracetest configure --server-url http://localhost:11633` on a terminal
 3. Update the `.env` file adding a valid set the valid App Insights Instrumentation Key
 4. Update the `tracetest.provision.yaml` file adding a valid set the Azure ARM Id and secret token
 5. Run the project by using docker-compose: `docker compose -f ./docker-compose.yaml -f ./tracetest/docker-compose.yaml up -d`

--- a/examples/tracetest-azure-app-insights/README.md
+++ b/examples/tracetest-azure-app-insights/README.md
@@ -7,7 +7,7 @@ This repository objective is to show how you can configure your Tracetest instan
 ## Steps
 
 1. [Install the tracetest CLI](https://docs.tracetest.io/installing/)
-2. Run `tracetest configure --endpoint http://localhost:11633` on a terminal
+2. Run `tracetest configure --server-url http://localhost:11633` on a terminal
 3. Update the `.env` file adding a valid set the valid App Insights Connection String
 4. Update the `tracetest.provision.yaml` file adding a valid set the Azure ARM Id and secret token
 5. Run the project by using docker-compose: `docker compose -f ./docker-compose.yaml -f ./tracetest/docker-compose.yaml up -d`

--- a/examples/tracetest-core-k6/README.md
+++ b/examples/tracetest-core-k6/README.md
@@ -7,7 +7,7 @@ For more detailed information about the K6 Tracetest Binary take a look a the [d
 ## Steps
 
 1. [Install the Tracetest CLI](https://docs.tracetest.io/installing/)
-2. Run `tracetest configure --endpoint http://localhost:11633` on a terminal
+2. Run `tracetest configure --server-url http://localhost:11633` on a terminal
 3. Run the project by using docker-compose: `docker-compose up -d` (Linux) or `docker compose up -d` (Mac)
 4. Test if it works by running: `tracetest run test -f tests/test.yaml`. This will create and run a test with trace id as trigger
 5. In as separate folder outside of the the Tracetest repo, build the k6 binary with the extension by using `xk6 build v0.42.0 --with github.com/kubeshop/xk6-tracetest`

--- a/examples/tracetest-grafana-tempo-pokeshop/README.md
+++ b/examples/tracetest-grafana-tempo-pokeshop/README.md
@@ -10,7 +10,7 @@ This examples' objective is to show how you can:
 ## Steps
 
 1. [Install the tracetest CLI](https://docs.tracetest.io/installing/)
-2. Run `tracetest configure --endpoint http://localhost:11633` on a terminal
+2. Run `tracetest configure --server-url http://localhost:11633` on a terminal
 3. Run the project by using docker-compose: `docker-compose up -d` (Linux) or `docker compose up -d` (Mac)
 4. Test if it works by running: `tracetest run test -f tests/test.yaml`. This would trigger a test that will send and retrieve spans from the Grafana Tempo instance that is running on your machine. View the test on `http://localhost:11633`.
 5. View traces in Grafana on `http://localhost:3000`. Use this TraceQL query:

--- a/examples/tracetest-jaeger/README.md
+++ b/examples/tracetest-jaeger/README.md
@@ -5,6 +5,6 @@ This repository objective is to show how you can configure your tracetest instan
 ## Steps
 
 1. [Install the tracetest CLI](https://docs.tracetest.io/installing/)
-2. Run `tracetest configure --endpoint http://localhost:11633` on a terminal
+2. Run `tracetest configure --server-url http://localhost:11633` on a terminal
 3. Run the project by using docker-compose: `docker-compose up` (Linux) or `docker compose up` (Mac)
 4. Test if it works by running: `tracetest run test -f tests/list-tests.yaml`. This would trigger a test that will send and retrieve spans from the opensearch instance that is running on your machine.

--- a/examples/tracetest-lightstep-otel-demo/README.md
+++ b/examples/tracetest-lightstep-otel-demo/README.md
@@ -228,7 +228,7 @@ First, [install the CLI](https://docs.tracetest.io/getting-started/installation#
 Then, configure the CLI:
 
 ```bash
-tracetest configure --endpoint http://localhost:11633
+tracetest configure --server-url http://localhost:11633
 ```
 
 Once configured, you can run a test against the Tracetest instance via the terminal.

--- a/examples/tracetest-new-relic-otel-demo/README.md
+++ b/examples/tracetest-new-relic-otel-demo/README.md
@@ -229,7 +229,7 @@ First, [install the CLI](https://docs.tracetest.io/getting-started/installation#
 Then, configure the CLI:
 
 ```bash
-tracetest configure --endpoint http://localhost:11633
+tracetest configure --server-url http://localhost:11633
 ```
 
 Once configure, you can run a test against the Tracetest instance via the terminal.

--- a/examples/tracetest-opensearch/README.md
+++ b/examples/tracetest-opensearch/README.md
@@ -5,7 +5,7 @@ This repository objective is to show how you can configure your Tracetest instan
 ## Steps
 
 1. [Install Tracetest CLI](https://docs.tracetest.io/installing/)
-2. Run `tracetest configure --endpoint http://localhost:11633` on a terminal to configure the CLI to send all commands to that address
+2. Run `tracetest configure --server-url http://localhost:11633` on a terminal to configure the CLI to send all commands to that address
 3. Run the project by using docker-compose: `docker-compose up` (Linux) or `docker compose up` (Mac)
 4. Test if it works by running: `tracetest run test -f tests/list-tests.yaml`. This would trigger a test that will send and retrieve spans from the OpenSearch instance that is running on your machine.
 

--- a/examples/tracetest-provisioning-env/README.md
+++ b/examples/tracetest-provisioning-env/README.md
@@ -5,6 +5,6 @@ This repository objective is to show how you can provision a Tracetest instance 
 ## Steps
 
 1. [Install the Tracetest CLI](https://docs.tracetest.io/installing/)
-2. Run `tracetest configure --endpoint http://localhost:11633` on a terminal
+2. Run `tracetest configure --server-url http://localhost:11633` on a terminal
 3. Run the project by using docker-compose: `docker-compose up` (Linux) or `docker compose up` (Mac)
 4. Test if it works by running: `tracetest run test -f tests/list-tests.yaml`. This would trigger a test that will send and retrieve spans from the Jaeger instance that is running on your machine.

--- a/examples/tracetest-signalfx/README.md
+++ b/examples/tracetest-signalfx/README.md
@@ -5,7 +5,7 @@ This repository objective is to show how you can configure your tracetest instan
 ## Steps
 
 1. [Install the tracetest CLI](https://docs.tracetest.io/installing/)
-2. Run `tracetest configure --endpoint http://localhost:11633` on a terminal to configure the CLI to send all commands to that address
+2. Run `tracetest configure --server-url http://localhost:11633` on a terminal to configure the CLI to send all commands to that address
 3. Update the `collector.config.yaml` and `tracetest-config.yaml` with the `token` and `realm` of your SignalFX account.
 4. Run the project by using docker-compose: `docker-compose up` (Linux) or `docker compose up` (Mac)
 5. Test if it works by running: `tracetest run test -f tests/list-tests.yaml`. This would trigger a test that will send and retrieve spans from the opensearch instance that is running on your machine.

--- a/examples/tracetest-signoz-pokeshop/README.md
+++ b/examples/tracetest-signoz-pokeshop/README.md
@@ -11,7 +11,7 @@ This examples' objective is to show how you can:
 ## Steps
 
 1. [Install the tracetest CLI.](https://docs.tracetest.io/installing/)
-2. Run `tracetest configure --endpoint http://localhost:11633` on a terminal.
+2. Run `tracetest configure --server-url http://localhost:11633` on a terminal.
 3. Run the project by using docker-compose: `docker-compose up -d` (Linux) or `docker compose up -d` (Mac).
 4. Test if it works by running: `tracetest run test -f tests/test.yaml`. This would trigger a test that will send trace spans to both the SigNoz instance and Tracetest instance that are running on your machine. View the test on `http://localhost:11633`.
 5. View traces in SigNoz on `http://localhost:3301`. Use this query:

--- a/examples/tracetest-signoz/README.md
+++ b/examples/tracetest-signoz/README.md
@@ -5,6 +5,6 @@ This repository objective is to show how you can configure your Tracetest instan
 ## Steps
 
 1. [Install the tracetest CLI](https://docs.tracetest.io/installing/)
-2. Run `tracetest configure --endpoint http://localhost:11633` on a terminal
+2. Run `tracetest configure --server-url http://localhost:11633` on a terminal
 3. Run the project by using docker-compose: `docker-compose up` (Linux) or `docker compose up` (Mac)
 4. Test if it works by running: `tracetest test run -d tracetest/tests/list-tests.yaml`. This would trigger a test that will send and retrieve spans from the Signoz instance that is running on your machine.

--- a/examples/tracetest-synthetic-monitoring/.github/workflows/synthetic-monitoring.yaml
+++ b/examples/tracetest-synthetic-monitoring/.github/workflows/synthetic-monitoring.yaml
@@ -38,7 +38,7 @@ jobs:
         run: curl -L https://raw.githubusercontent.com/kubeshop/tracetest/main/install-cli.sh | bash
 
       - name: Configure Tracetest CLI
-        run: tracetest configure -g --endpoint http://localhost:11633
+        run: tracetest configure -g --server-url http://localhost:11633
 
       - name: Run syntethic monitoring tests
         id: monitoring

--- a/examples/tracetest-tempo/README.md
+++ b/examples/tracetest-tempo/README.md
@@ -5,7 +5,7 @@ This repository objective is to show how you can configure your tracetest instan
 ## Steps
 
 1. [Install the tracetest CLI](https://github.com/kubeshop/tracetest/blob/main/docs/installing.md#cli-installation)
-2. Run `tracetest configure --endpoint http://localhost:11633` on a terminal to configure the CLI to send all commands to that address
+2. Run `tracetest configure --server-url http://localhost:11633` on a terminal to configure the CLI to send all commands to that address
 3. Run the project by using docker-compose: `docker-compose up` (Linux) or `docker compose up` (Mac)
 4. Test if it works by running: `tracetest run test -f tests/list-tests.yaml`. This would trigger a test that will send and retrieve spans from the opensearch instance that is running on your machine.
 

--- a/go.mod
+++ b/go.mod
@@ -80,6 +80,7 @@ require (
 	go.opentelemetry.io/proto/otlp v1.0.0
 	go.uber.org/zap v1.26.0
 	golang.org/x/exp v0.0.0-20230713183714-613f0c0eb8a1
+	golang.org/x/sync v0.3.0
 	golang.org/x/text v0.14.0
 	google.golang.org/grpc v1.58.3
 	google.golang.org/protobuf v1.31.0
@@ -190,7 +191,6 @@ require (
 	go.uber.org/multierr v1.11.0 // indirect
 	golang.org/x/crypto v0.17.0 // indirect
 	golang.org/x/net v0.17.0 // indirect
-	golang.org/x/sync v0.3.0 // indirect
 	golang.org/x/sys v0.15.0 // indirect
 	golang.org/x/term v0.15.0 // indirect
 	golang.org/x/xerrors v0.0.0-20220907171357-04be3eba64a2 // indirect


### PR DESCRIPTION
This PR deprecates the `endpoint` flag from the `configure` command and uses it by the global `server-url` flag

## Changes

-

## Fixes

-

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Loom video

Add your loom video here if your work can be visualized
