### PR TITLE
feat(frontend): indicate tabs with info in trigger

### DIFF
--- a/web/src/components/TestHeader/TestHeader.tsx
+++ b/web/src/components/TestHeader/TestHeader.tsx
@@ -1,5 +1,4 @@
 import ResourceCardActions from 'components/ResourceCard/ResourceCardActions';
-import {useDashboard} from 'providers/Dashboard/Dashboard.provider';
 import * as S from './TestHeader.styled';
 import VariableSetSelector from '../VariableSetSelector/VariableSetSelector';
 
@@ -7,6 +6,7 @@ interface IProps {
   description: string;
   id: string;
   shouldEdit: boolean;
+  onBack(): void;
   onEdit(): void;
   onDelete(): void;
   onDuplicate(): void;
@@ -14,33 +14,29 @@ interface IProps {
   runButton: React.ReactNode;
 }
 
-const TestHeader = ({description, id, shouldEdit, onEdit, onDelete, onDuplicate, title, runButton}: IProps) => {
-  const {navigate} = useDashboard();
-
-  return (
-    <S.Container $isWhite>
-      <S.Section>
-        <a onClick={() => navigate(-1)} data-cy="test-header-back-button">
-          <S.BackIcon />
-        </a>
-        <div>
-          <S.Title data-cy="test-details-name">{title}</S.Title>
-          <S.Text>{description}</S.Text>
-        </div>
-      </S.Section>
-      <S.Section>
-        <VariableSetSelector />
-        {runButton}
-        <ResourceCardActions
-          id={id}
-          onDuplicate={onDuplicate}
-          onDelete={onDelete}
-          onEdit={onEdit}
-          shouldEdit={shouldEdit}
-        />
-      </S.Section>
-    </S.Container>
-  );
-};
+const TestHeader = ({description, id, shouldEdit, onBack, onEdit, onDelete, onDuplicate, title, runButton}: IProps) => (
+  <S.Container $isWhite>
+    <S.Section>
+      <a onClick={onBack} data-cy="test-header-back-button">
+        <S.BackIcon />
+      </a>
+      <div>
+        <S.Title data-cy="test-details-name">{title}</S.Title>
+        <S.Text>{description}</S.Text>
+      </div>
+    </S.Section>
+    <S.Section>
+      <VariableSetSelector />
+      {runButton}
+      <ResourceCardActions
+        id={id}
+        onDuplicate={onDuplicate}
+        onDelete={onDelete}
+        onEdit={onEdit}
+        shouldEdit={shouldEdit}
+      />
+    </S.Section>
+  </S.Container>
+);
 
 export default TestHeader;

--- a/web/src/components/TestHeader/__tests__/TestHeader.test.tsx
+++ b/web/src/components/TestHeader/__tests__/TestHeader.test.tsx
@@ -5,6 +5,7 @@ import TestHeader from '../TestHeader';
 test('SpanAttributesTable', () => {
   const test = TestMock.model();
 
+  const onBack = jest.fn;
   const onDelete = jest.fn;
   const onEdit = jest.fn;
   const shouldEdit = true;
@@ -14,6 +15,7 @@ test('SpanAttributesTable', () => {
       description={test.description}
       id={test.id}
       shouldEdit={shouldEdit}
+      onBack={onBack}
       onEdit={onEdit}
       onDelete={onDelete}
       title={test.name}

--- a/web/src/components/TestPlugins/FormFactory.tsx
+++ b/web/src/components/TestPlugins/FormFactory.tsx
@@ -2,7 +2,6 @@ import Rest from 'components/TestPlugins/Forms/Rest';
 import Grpc from 'components/TestPlugins/Forms/Grpc';
 import Kafka from 'components/TestPlugins/Forms/Kafka';
 import {TriggerTypes} from 'constants/Test.constants';
-import {TDraftTestForm} from 'types/Test.types';
 
 const FormFactoryMap = {
   [TriggerTypes.http]: Rest,
@@ -12,10 +11,6 @@ const FormFactoryMap = {
   [TriggerTypes.cypress]: () => null,
   [TriggerTypes.playwright]: () => null,
 };
-
-export interface IFormProps {
-  form: TDraftTestForm;
-}
 
 interface IProps {
   type: TriggerTypes;

--- a/web/src/components/TestPlugins/Forms/Grpc/Grpc.tsx
+++ b/web/src/components/TestPlugins/Forms/Grpc/Grpc.tsx
@@ -4,12 +4,18 @@ import GrpcService from 'services/Triggers/Grpc.service';
 import {SupportedEditors} from 'constants/Editor.constants';
 import {Editor, FileUpload} from 'components/Inputs';
 import {Auth, Metadata, SkipTraceCollection} from 'components/Fields';
+import TriggerTab from 'components/TriggerTab';
 import useQueryTabs from 'hooks/useQueryTabs';
+import {TDraftTest} from 'types/Test.types';
 
 const RequestDetailsForm = () => {
   const [methodList, setMethodList] = useState<string[]>([]);
-  const form = Form.useFormInstance();
+  const form = Form.useFormInstance<TDraftTest>();
   const protoFile = Form.useWatch('protoFile', form);
+  const authType = Form.useWatch(['auth', 'type'], form);
+  const message = Form.useWatch('message', form);
+  const metadata = Form.useWatch('metadata', form);
+  const skipTraceCollection = Form.useWatch('skipTraceCollection', form);
 
   useEffect(() => {
     const getMethodList = async () => {
@@ -30,7 +36,11 @@ const RequestDetailsForm = () => {
 
   return (
     <Tabs defaultActiveKey={activeKey} onChange={setActiveKey} activeKey={activeKey}>
-      <Tabs.TabPane forceRender tab="Service definition" key="service-definition">
+      <Tabs.TabPane
+        forceRender
+        tab={<TriggerTab hasContent={!!protoFile} label="Service definition" />}
+        key="service-definition"
+      >
         <Form.Item data-cy="protoFile" name="protoFile" label="Upload Protobuf File">
           <FileUpload />
         </Form.Item>
@@ -46,11 +56,11 @@ const RequestDetailsForm = () => {
         </Form.Item>
       </Tabs.TabPane>
 
-      <Tabs.TabPane forceRender tab="Auth" key="auth">
+      <Tabs.TabPane forceRender tab={<TriggerTab hasContent={!!authType} label="Auth" />} key="auth">
         <Auth />
       </Tabs.TabPane>
 
-      <Tabs.TabPane forceRender tab="Message" key="message">
+      <Tabs.TabPane forceRender tab={<TriggerTab hasContent={!!message} label="Message" />} key="message">
         <Form.Item data-cy="message" name="message" style={{marginBottom: 0}}>
           <Editor
             type={SupportedEditors.Interpolation}
@@ -61,11 +71,11 @@ const RequestDetailsForm = () => {
         </Form.Item>
       </Tabs.TabPane>
 
-      <Tabs.TabPane forceRender tab="Metadata" key="metadata">
+      <Tabs.TabPane forceRender tab={<TriggerTab totalItems={metadata?.length} label="Metadata" />} key="metadata">
         <Metadata />
       </Tabs.TabPane>
 
-      <Tabs.TabPane forceRender tab="Settings" key="settings">
+      <Tabs.TabPane forceRender tab={<TriggerTab hasContent={!!skipTraceCollection} label="Settings" />} key="settings">
         <SkipTraceCollection />
       </Tabs.TabPane>
     </Tabs>

--- a/web/src/components/TestPlugins/Forms/Kafka/Kafka.tsx
+++ b/web/src/components/TestPlugins/Forms/Kafka/Kafka.tsx
@@ -1,20 +1,29 @@
 import {Form, Tabs} from 'antd';
 import {KeyValueList, PlainAuth, SSL, SkipTraceCollection} from 'components/Fields';
 import {Editor} from 'components/Inputs';
+import TriggerTab from 'components/TriggerTab';
 import useQueryTabs from 'hooks/useQueryTabs';
 import {SupportedEditors} from 'constants/Editor.constants';
+import {TDraftTest} from 'types/Test.types';
 import * as S from './Kafka.styled';
 
 const Kafka = () => {
   const [activeKey, setActiveKey] = useQueryTabs('auth', 'triggerTab');
+  const form = Form.useFormInstance<TDraftTest>();
+  const authType = Form.useWatch(['authentication', 'type'], form);
+  const messageValue = Form.useWatch('messageValue', form);
+  const topic = Form.useWatch('topic', form);
+  const headers = Form.useWatch('headers', form);
+  const sslVerification = Form.useWatch('sslVerification', form);
+  const skipTraceCollection = Form.useWatch('skipTraceCollection', form);
 
   return (
     <Tabs defaultActiveKey={activeKey} onChange={setActiveKey} activeKey={activeKey}>
-      <Tabs.TabPane forceRender tab="Auth" key="auth">
+      <Tabs.TabPane forceRender tab={<TriggerTab hasContent={!!authType} label="Auth" />} key="auth">
         <PlainAuth />
       </Tabs.TabPane>
 
-      <Tabs.TabPane forceRender tab="Message" key="message">
+      <Tabs.TabPane forceRender tab={<TriggerTab hasContent={!!messageValue} label="Message" />} key="message">
         <Form.Item label="Key" data-cy="message-key" name="messageKey">
           <Editor type={SupportedEditors.Interpolation} placeholder="my-message-name" />
         </Form.Item>
@@ -29,13 +38,13 @@ const Kafka = () => {
         </Form.Item>
       </Tabs.TabPane>
 
-      <Tabs.TabPane forceRender tab="Topic" key="topic">
+      <Tabs.TabPane forceRender tab={<TriggerTab hasContent={!!topic} label="Topic" />} key="topic">
         <Form.Item data-cy="topic" name="topic" rules={[{required: true, message: 'Please enter a topic'}]}>
           <Editor type={SupportedEditors.Interpolation} placeholder="my-topic" />
         </Form.Item>
       </Tabs.TabPane>
 
-      <Tabs.TabPane forceRender tab="Headers" key="headers">
+      <Tabs.TabPane forceRender tab={<TriggerTab totalItems={headers?.length} label="Headers" />} key="headers">
         <KeyValueList
           name="headers"
           label=""
@@ -46,7 +55,11 @@ const Kafka = () => {
         />
       </Tabs.TabPane>
 
-      <Tabs.TabPane forceRender tab="Settings" key="settings">
+      <Tabs.TabPane
+        forceRender
+        tab={<TriggerTab hasContent={!!sslVerification || !!skipTraceCollection} label="Settings" />}
+        key="settings"
+      >
         <S.SettingsContainer>
           <SSL formID="kafka" />
           <SkipTraceCollection />

--- a/web/src/components/TestPlugins/Forms/Rest/Rest.tsx
+++ b/web/src/components/TestPlugins/Forms/Rest/Rest.tsx
@@ -1,26 +1,34 @@
 import {Form, Tabs} from 'antd';
 import {DEFAULT_HEADERS} from 'constants/Test.constants';
 import {Body} from 'components/Inputs';
+import TriggerTab from 'components/TriggerTab';
 import useQueryTabs from 'hooks/useQueryTabs';
 import {Auth, SSL, KeyValueList, SkipTraceCollection} from 'components/Fields';
+import {TDraftTest} from 'types/Test.types';
 import * as S from './Rest.styled';
 
 const Rest = () => {
   const [activeKey, setActiveKey] = useQueryTabs('auth', 'triggerTab');
+  const form = Form.useFormInstance<TDraftTest>();
+  const authType = Form.useWatch(['auth', 'type'], form);
+  const body = Form.useWatch('body', form);
+  const headers = Form.useWatch('headers', form);
+  const sslVerification = Form.useWatch('sslVerification', form);
+  const skipTraceCollection = Form.useWatch('skipTraceCollection', form);
 
   return (
     <Tabs defaultActiveKey={activeKey} activeKey={activeKey} onChange={setActiveKey}>
-      <Tabs.TabPane forceRender tab="Auth" key="auth">
+      <Tabs.TabPane forceRender tab={<TriggerTab hasContent={!!authType} label="Auth" />} key="auth">
         <Auth />
       </Tabs.TabPane>
 
-      <Tabs.TabPane forceRender tab="Body" key="body">
+      <Tabs.TabPane forceRender tab={<TriggerTab hasContent={!!body} label="Body" />} key="body">
         <Form.Item name="body" noStyle>
           <Body />
         </Form.Item>
       </Tabs.TabPane>
 
-      <Tabs.TabPane forceRender tab="Headers" key="headers">
+      <Tabs.TabPane forceRender tab={<TriggerTab totalItems={headers?.length} label="Headers" />} key="headers">
         <KeyValueList
           name="headers"
           label=""
@@ -31,7 +39,11 @@ const Rest = () => {
         />
       </Tabs.TabPane>
 
-      <Tabs.TabPane forceRender tab="Settings" key="settings">
+      <Tabs.TabPane
+        forceRender
+        tab={<TriggerTab hasContent={!!sslVerification || !!skipTraceCollection} label="Settings" />}
+        key="settings"
+      >
         <S.SettingsContainer>
           <SSL formID="rest" />
           <SkipTraceCollection />

--- a/web/src/components/TriggerTab/TriggerTab.styled.ts
+++ b/web/src/components/TriggerTab/TriggerTab.styled.ts
@@ -8,5 +8,5 @@ export const Badge = styled(AntdBadge)`
 `;
 
 export const Text = styled(Typography.Text)`
-  color: ${({theme}) => theme.color.success};
+  color: ${({theme}) => theme.color.primary};
 `;

--- a/web/src/components/TriggerTab/TriggerTab.styled.ts
+++ b/web/src/components/TriggerTab/TriggerTab.styled.ts
@@ -1,0 +1,12 @@
+import {Badge as AntdBadge, Typography} from 'antd';
+import styled from 'styled-components';
+
+export const Badge = styled(AntdBadge)`
+  .ant-badge-status-text {
+    margin-left: 0;
+  }
+`;
+
+export const Text = styled(Typography.Text)`
+  color: ${({theme}) => theme.color.success};
+`;

--- a/web/src/components/TriggerTab/TriggerTab.tsx
+++ b/web/src/components/TriggerTab/TriggerTab.tsx
@@ -1,3 +1,4 @@
+import {useTheme} from 'styled-components';
 import * as S from './TriggerTab.styled';
 
 interface IProps {
@@ -7,11 +8,15 @@ interface IProps {
 }
 
 const TriggerTab = ({hasContent, label, totalItems}: IProps) => {
+  const {
+    color: {primary},
+  } = useTheme();
+
   return (
     <div>
       {`${label} `}
       {!!totalItems && <S.Text>({totalItems})</S.Text>}
-      {hasContent && <S.Badge status="success" />}
+      {hasContent && <S.Badge color={primary} />}
     </div>
   );
 };

--- a/web/src/components/TriggerTab/TriggerTab.tsx
+++ b/web/src/components/TriggerTab/TriggerTab.tsx
@@ -1,0 +1,19 @@
+import * as S from './TriggerTab.styled';
+
+interface IProps {
+  hasContent?: boolean;
+  label: string;
+  totalItems?: number;
+}
+
+const TriggerTab = ({hasContent, label, totalItems}: IProps) => {
+  return (
+    <div>
+      {`${label} `}
+      {!!totalItems && <S.Text>({totalItems})</S.Text>}
+      {hasContent && <S.Badge status="success" />}
+    </div>
+  );
+};
+
+export default TriggerTab;

--- a/web/src/components/TriggerTab/index.ts
+++ b/web/src/components/TriggerTab/index.ts
@@ -1,0 +1,2 @@
+// eslint-disable-next-line no-restricted-exports
+export {default} from './TriggerTab';

--- a/web/src/pages/Test/Content.tsx
+++ b/web/src/pages/Test/Content.tsx
@@ -46,6 +46,7 @@ const Content = () => {
           test.trigger.entryPoint
         }`}
         id={test.id}
+        onBack={() => navigate('/tests')}
         onDelete={() => onDeleteResource(test.id, test.name, ResourceType.Test)}
         onEdit={onEdit}
         onDuplicate={handleOnDuplicate}

--- a/web/src/pages/TestSuite/Content.tsx
+++ b/web/src/pages/TestSuite/Content.tsx
@@ -45,6 +45,7 @@ const Content = () => {
       <TestHeader
         description={testSuite.description}
         id={testSuite.id}
+        onBack={() => navigate('/testsuites')}
         onDelete={() => onDelete(testSuite.id, testSuite.name)}
         onEdit={onEdit}
         onDuplicate={handleOnDuplicate}

--- a/web/src/redux/Router.middleware.ts
+++ b/web/src/redux/Router.middleware.ts
@@ -53,7 +53,7 @@ const RouterMiddleware = () => ({
         const prevPathname = prevLocation?.pathname ?? '';
 
         if (!prevPathname.match(runUrlRegex) && !prevPathname.includes('/create')) {
-          const defaultPath = currLocation?.pathname?.includes('testsuite') ? '/testsuites' : '/';
+          const defaultPath = currLocation?.pathname?.includes('testsuite') ? '/testsuites' : '/tests';
           dispatch(runOriginPathAdded(prevLocation?.pathname ?? defaultPath));
         }
       },

--- a/web/src/redux/slices/User.slice.ts
+++ b/web/src/redux/slices/User.slice.ts
@@ -4,7 +4,7 @@ import {IUserState, TUserPreferenceKey, TUserPreferenceValue} from 'types/User.t
 
 export const initialState: IUserState = {
   preferences: UserPreferencesService.get(),
-  runOriginPath: '/',
+  runOriginPath: '/tests',
 };
 
 interface ISetUserPreferencesProps {


### PR DESCRIPTION
This PR adds the components to indicate which tabs have information on them on the trigger page. It also fixes a small navigation issue in our test suite detail page.

## Changes

- TriggerTab component and logic to detect tabs with information
- fix navigation issue

## Fixes

- fixes https://github.com/kubeshop/tracetest-cloud/issues/326
- fixes https://github.com/kubeshop/tracetest-cloud-frontend/issues/186

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Screenshot

![2024-01-25 13 31 58](https://github.com/kubeshop/tracetest/assets/3879892/cfe708bd-b0af-4053-8717-3a2e0b85d7b2)