### PR TITLE
fix: incrementing test version without any change

### DIFF
--- a/server/test/test_entities.go
+++ b/server/test/test_entities.go
@@ -164,6 +164,14 @@ type (
 	}
 )
 
+func (t Test) GetSpecs() Specs {
+	if t.Specs == nil {
+		return Specs{}
+	}
+
+	return t.Specs
+}
+
 func (t Test) GetID() id.ID {
 	return t.ID
 }

--- a/server/test/test_repository.go
+++ b/server/test/test_repository.go
@@ -313,7 +313,6 @@ func (r *repository) readRow(ctx context.Context, row scanner) (Test, error) {
 	if fail != nil {
 		test.Summary.LastRun.Fails = *fail
 	}
-
 	return test, nil
 }
 
@@ -455,7 +454,7 @@ func testHasChanged(oldTest Test, newTest Test) (bool, error) {
 		return false, err
 	}
 
-	definitionHasChanged, err := testFieldHasChanged(oldTest.Specs, newTest.Specs)
+	definitionHasChanged, err := testFieldHasChanged(oldTest.GetSpecs(), newTest.GetSpecs())
 	if err != nil {
 		return false, err
 	}


### PR DESCRIPTION
This PR fixes a bug with how version change is calculated. Our algorithm checks for the relevant parts of the test and compares the JSON encoded version of each, since that's the easiest way to do it. The problem is that some times, empty fields can have different representations in go, which result in different JSON encoded values.

In this particular case, every time I applied this test:
```yaml
type: Test
spec:
  id: test1234
  name: Untitled
  trigger:
    type: http
    httpRequest:
      method: GET
      url: https://google.com
      headers:
      - key: Content-Type
        value: application/json
```

it was creating a new version, which is incorrect. The problem was that when comparing the new version with the one from DB, both have empty `Spec`, but one is a `nil` slice (JSON encoded as `"null"`) and the other one is an empty slice (JSON encoded as `[]`). So the final check was `if "nil" == "[]"`, which is an incorrect interpretation.

To fix this, we use a getter function to normalize nil specs as empty slices.

## Changes

-

## Fixes

-

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Loom video

Add your loom video here if your work can be visualized
