### PR TITLE
Fix agent permissions start

### DIFF
--- a/agent/runner/runner.go
+++ b/agent/runner/runner.go
@@ -75,6 +75,11 @@ func (s *Runner) onStartAgent(ctx context.Context, cfg config.Config) {
 		s.ui.Error(err.Error())
 	}
 
+	if env.AgentApiKey == "" {
+		s.ui.Error("You are attempting to start the agent in an environment you do not have admin rights to. Please ask the administrator of this environment to grant you admin rights.")
+		return
+	}
+
 	err = s.StartAgent(ctx, cfg.AgentEndpoint, env.AgentApiKey, cfg.UIEndpoint)
 	if err != nil {
 		s.ui.Error(err.Error())


### PR DESCRIPTION
This PR adds an error message when the agent API key is not found in the last step where is required.

## Changes

- Adds error message for users that doesn't have access to start the agent for an env

## Fixes

- https://github.com/kubeshop/tracetest-cloud/issues/413

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Loom video

https://www.loom.com/share/8d3ee0ac59a54dc5bee6abfcca5d4b25