### PR TITLE
fix(cli): improve error message for invalid server url

### DIFF
--- a/cli/cmd/middleware.go
+++ b/cli/cmd/middleware.go
@@ -29,17 +29,27 @@ func WithResultHandler(runFn RunFn) CobraRunFn {
 	}
 }
 
-func OnError(err error) {
-	errorMessage := handleErrorMessage(err)
+type errorMessageRenderer interface {
+	Render()
+}
 
-	fmt.Fprintf(os.Stderr, `
+const defaultErrorFormat = `
 Version
 %s
 
 An error ocurred when executing the command
 
 %s
-`, versionText, errorMessage)
+`
+
+func OnError(err error) {
+	errorMessage := handleErrorMessage(err)
+
+	if renderer, ok := err.(errorMessageRenderer); ok {
+		renderer.Render()
+	} else {
+		fmt.Fprintf(os.Stderr, defaultErrorFormat, versionText, errorMessage)
+	}
 	ExitCLI(1)
 }
 

--- a/cli/config/config.go
+++ b/cli/config/config.go
@@ -51,6 +51,10 @@ func (c Config) URL() string {
 	return fmt.Sprintf("%s://%s", c.Scheme, strings.TrimSuffix(c.Endpoint, "/"))
 }
 
+func (c Config) FullURL() string {
+	return fmt.Sprintf("%s%s", c.URL(), c.ServerPath)
+}
+
 func (c Config) UI() string {
 	if c.UIEndpoint != "" && !c.EndpointOverriden {
 		return fmt.Sprintf("%s/organizations/%s/environments/%s", strings.TrimSuffix(c.UIEndpoint, "/"), c.OrganizationID, c.EnvironmentID)


### PR DESCRIPTION
This PR shows a more friendly message when the given server url is not reachable.

## Before

![Screenshot 2024-01-31 at 16 06 47](https://github.com/kubeshop/tracetest/assets/314548/93d3fb8a-a85c-4e2d-88f6-e6201af7a44d)

## After

![Screenshot 2024-01-31 at 16 08 02](https://github.com/kubeshop/tracetest/assets/314548/9a921e55-4a12-46cc-bc78-d13788b2ff99)


## Changes

-

## Fixes

-

## Checklist

- [ ] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Loom video

Add your loom video here if your work can be visualized
