### PR TITLE
feat(cli): improve configure cmd ux

### DIFF
--- a/cli/cmd/configure_cmd.go
+++ b/cli/cmd/configure_cmd.go
@@ -27,6 +27,11 @@ var configureCmd = &cobra.Command{
 			CI: configParams.CI,
 		}
 
+		config, err := config.LoadConfig("")
+		if err != nil {
+			return "", err
+		}
+
 		if flagProvided(cmd, "server-url") || flagProvided(cmd, "endpoint") {
 			flags.ServerURL = configParams.ServerURL
 		}
@@ -43,7 +48,7 @@ var configureCmd = &cobra.Command{
 			flags.OrganizationID = configParams.OrganizationID
 		}
 
-		return "", configurator.Start(ctx, nil, flags)
+		return "", configurator.Start(ctx, &config, flags)
 	})),
 	PostRun: teardownCommand,
 }

--- a/cli/config/config.go
+++ b/cli/config/config.go
@@ -126,7 +126,7 @@ func loadConfig(configFile string) (Config, error) {
 	return config, nil
 }
 
-func ValidateServerURL(serverURL string) error {
+func validateServerURL(serverURL string) error {
 	if !strings.HasPrefix(serverURL, "http://") && !strings.HasPrefix(serverURL, "https://") {
 		return fmt.Errorf(`the server URL must start with the scheme, either "http://" or "https://"`)
 	}


### PR DESCRIPTION
This PR improves the UX of the cli configure by remembering the last used server, if applicable reuse the last used JWT, and default to the last used env/org when showing the options

## Changes

-

## Fixes

-

## Checklist

- [ ] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Loom video

https://www.loom.com/share/95ca3b8de0a846c0804687162dbe1eae