### PR TITLE
chore: add example of instana integration with otlp

### DIFF
--- a/examples/quick-start-instana-nodejs/.gitignore
+++ b/examples/quick-start-instana-nodejs/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+.DS_Store
+.env

--- a/examples/quick-start-instana-nodejs/api/Dockerfile
+++ b/examples/quick-start-instana-nodejs/api/Dockerfile
@@ -1,0 +1,11 @@
+FROM node:slim
+WORKDIR /usr/src/app
+
+COPY package*.json ./
+
+RUN npm install
+COPY . .
+
+EXPOSE 8080
+
+CMD [ "npm", "run", "with-grpc-tracer" ]

--- a/examples/quick-start-instana-nodejs/api/app.js
+++ b/examples/quick-start-instana-nodejs/api/app.js
@@ -1,0 +1,10 @@
+const express = require("express")
+const app = express()
+app.get("/", (req, res) => {
+  setTimeout(() => {
+    res.send("Hello World")
+  }, 1000);
+})
+app.listen(8080, () => {
+  console.log(`Listening for requests on http://localhost:8080`)
+})

--- a/examples/quick-start-instana-nodejs/api/package.json
+++ b/examples/quick-start-instana-nodejs/api/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "quick-start-nodejs",
+  "version": "1.0.0",
+  "description": "",
+  "main": "app.js",
+  "scripts": {
+    "with-grpc-tracer":"node -r ./tracing.otel.grpc.js app.js",
+    "with-http-tracer":"node -r ./tracing.otel.http.js app.js"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "@opentelemetry/auto-instrumentations-node": "^0.33.1",
+    "@opentelemetry/exporter-trace-otlp-grpc": "^0.34.0",
+    "@opentelemetry/exporter-trace-otlp-http": "^0.33.0",
+    "@opentelemetry/sdk-node": "^0.33.0",
+    "express": "^4.18.2"
+  }
+}

--- a/examples/quick-start-instana-nodejs/api/tracing.otel.grpc.js
+++ b/examples/quick-start-instana-nodejs/api/tracing.otel.grpc.js
@@ -1,0 +1,10 @@
+const opentelemetry = require('@opentelemetry/sdk-node')
+const { getNodeAutoInstrumentations } = require('@opentelemetry/auto-instrumentations-node')
+const { OTLPTraceExporter } = require('@opentelemetry/exporter-trace-otlp-grpc');
+
+const sdk = new opentelemetry.NodeSDK({
+  traceExporter: new OTLPTraceExporter({ url: 'http://otel-collector:4317' }),
+  instrumentations: [getNodeAutoInstrumentations()],
+  serviceName: 'quick-start-nodejs'
+})
+sdk.start()

--- a/examples/quick-start-instana-nodejs/api/tracing.otel.http.js
+++ b/examples/quick-start-instana-nodejs/api/tracing.otel.http.js
@@ -1,0 +1,9 @@
+const opentelemetry = require('@opentelemetry/sdk-node')
+const { getNodeAutoInstrumentations } = require('@opentelemetry/auto-instrumentations-node')
+const { OTLPTraceExporter } = require('@opentelemetry/exporter-trace-otlp-http')
+
+const sdk = new opentelemetry.NodeSDK({
+  traceExporter: new OTLPTraceExporter({ url: 'http://otel-collector:4318/v1/traces' }),
+  instrumentations: [getNodeAutoInstrumentations()],
+})
+sdk.start()

--- a/examples/quick-start-instana-nodejs/docker-compose.yaml
+++ b/examples/quick-start-instana-nodejs/docker-compose.yaml
@@ -1,0 +1,61 @@
+version: '3'
+services:
+  app:
+    image: quick-start-nodejs
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    build: ./api
+    ports:
+      - "8080:8080"
+
+  tracetest:
+    restart: unless-stopped
+    image: kubeshop/tracetest:${TAG:-latest}
+    platform: linux/amd64
+    ports:
+      - 11633:11633
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    volumes:
+      - type: bind
+        source: ./tracetest/tracetest.config.yaml
+        target: /app/tracetest.yaml
+      - type: bind
+        source: tracetest/tracetest-provision.yaml
+        target: /app/provision.yaml
+    command: --provisioning-file /app/provision.yaml
+    healthcheck:
+      test: ["CMD", "wget", "--spider", "localhost:11633"]
+      interval: 1s
+      timeout: 3s
+      retries: 60
+    depends_on:
+      postgres:
+        condition: service_healthy
+      otel-collector:
+        condition: service_started
+    environment:
+      TRACETEST_DEV: ${TRACETEST_DEV}
+
+  postgres:
+    image: postgres:14
+    environment:
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_USER: postgres
+    healthcheck:
+      test: pg_isready -U "$$POSTGRES_USER" -d "$$POSTGRES_DB"
+      interval: 1s
+      timeout: 5s
+      retries: 60
+
+  otel-collector:
+    image: otel/opentelemetry-collector-contrib:0.92.0
+    restart: unless-stopped
+    command:
+      - "--config"
+      - "/otel-local-config.yaml"
+    environment:
+      INSTANA_OTLP_GRPC_ENDPOINT: ${INSTANA_OTLP_GRPC_ENDPOINT}
+      INSTANA_API_KEY: ${INSTANA_API_KEY}
+    volumes:
+      - ./tracetest/collector.config.yaml:/otel-local-config.yaml

--- a/examples/quick-start-instana-nodejs/test-api.yaml
+++ b/examples/quick-start-instana-nodejs/test-api.yaml
@@ -1,0 +1,18 @@
+type: Test
+spec:
+  id: W656Q0c4g
+  name: http://app:8080
+  description: Calling Hello World API
+  trigger:
+    type: http
+    httpRequest:
+      url: http://app:8080
+      method: GET
+      headers:
+      - key: Content-Type
+        value: application/json
+  specs:
+  - selector: span[tracetest.span.type="http" name="GET /" http.target="/" http.method="GET"]
+    assertions:
+    - attr:http.status_code = 200
+    - attr:tracetest.span.duration < 2s

--- a/examples/quick-start-instana-nodejs/tracetest/collector.config.yaml
+++ b/examples/quick-start-instana-nodejs/tracetest/collector.config.yaml
@@ -1,0 +1,37 @@
+receivers:
+  otlp:
+    protocols:
+      http:
+      grpc:
+
+processors:
+  batch:
+    send_batch_max_size: 100
+    send_batch_size: 10
+    timeout: 10s
+
+exporters:
+  # OTLP for Tracetest
+  otlp/tracetest:
+    endpoint: tracetest:4317 # Send traces to Tracetest. Read more in docs here:  https://docs.tracetest.io/configuration/connecting-to-data-stores/opentelemetry-collector
+    tls:
+      insecure: true
+
+  # Instana exporter
+  # One example on how to set up a collector configuration for Instana can be seen here:
+  # https://www.ibm.com/docs/en/instana-observability/current?topic=opentelemetry-sending-data-instana-backend
+  otlp/instana:
+    endpoint: ${INSTANA_OTLP_GRPC_ENDPOINT}
+    headers:
+      x-instana-key: ${INSTANA_API_KEY}
+
+service:
+  pipelines:
+    traces/tracetest:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [otlp/tracetest]
+    traces/instana:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [otlp/instana]

--- a/examples/quick-start-instana-nodejs/tracetest/tracetest-provision.yaml
+++ b/examples/quick-start-instana-nodejs/tracetest/tracetest-provision.yaml
@@ -1,0 +1,6 @@
+---
+type: DataStore
+spec:
+  name: OTLP
+  type: otlp
+  default: true

--- a/examples/quick-start-instana-nodejs/tracetest/tracetest.config.yaml
+++ b/examples/quick-start-instana-nodejs/tracetest/tracetest.config.yaml
@@ -1,0 +1,21 @@
+postgres:
+  host: postgres
+  user: postgres
+  password: postgres
+  port: 5432
+  dbname: postgres
+  params: sslmode=disable
+
+telemetry:
+  exporters:
+    collector:
+      serviceName: tracetest
+      sampling: 100
+      exporter:
+        type: collector
+        collector:
+          endpoint: otel-collector:4317
+
+server:
+  telemetry:
+    exporter: collector


### PR DESCRIPTION
This PR creates an example of API that emits traces to Instana using OTLP.

PoC for https://github.com/kubeshop/tracetest/issues/3589

## Changes

- added `examples/quick-start-instana-nodejs` folder

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test