### PR TITLE
feat(server): minimize run list response size

### DIFF
--- a/server/http/controller.go
+++ b/server/http/controller.go
@@ -251,7 +251,7 @@ func (c *controller) GetTestRuns(ctx context.Context, testID string, take, skip 
 	}
 
 	return openapi.Response(200, paginated[openapi.TestRun]{
-		items: c.mappers.Out.Runs(runs),
+		items: c.mappers.Out.RunsSimplified(runs),
 		count: count,
 	}), nil
 }

--- a/server/http/mappings/tests.go
+++ b/server/http/mappings/tests.go
@@ -338,6 +338,17 @@ func (m OpenAPI) Runs(in []test.Run) []openapi.TestRun {
 	return runs
 }
 
+func (m OpenAPI) RunsSimplified(in []test.Run) []openapi.TestRun {
+	runs := make([]openapi.TestRun, len(in))
+	for i, t := range in {
+		// remove non requried fields
+		t.Trace = nil
+		runs[i] = m.Run(&t)
+	}
+
+	return runs
+}
+
 // in
 type Model struct {
 	comparators           comparator.Registry


### PR DESCRIPTION
This PR reduces the response size of the list test runs endpoint by removing the trace attribute. This attribute is not used on listing and makes the FE slow
