### PR TITLE
Update running-tracetest-with-datadog.mdx

### DIFF
--- a/docs/docs/examples-tutorials/recipes/running-tracetest-with-datadog.mdx
+++ b/docs/docs/examples-tutorials/recipes/running-tracetest-with-datadog.mdx
@@ -40,7 +40,7 @@ The `docker-compose.yaml` file and `.env` file in the root directory are for the
 
 The `docker-compose.yaml` file, `collector.config.yaml`, `tracetest-provision.yaml`, and `tracetest-config.yaml` in the `tracetest` directory are for setting up Tracetest and the OpenTelemetry Collector.
 
-The `tracetest` directory is self-contained and will run all the prerequisites for enabling OpenTelemetry traces and trace-based testing with Tracetest, as well as routing all traces the OpenTelemetry Demo generates to Lightstep.
+The `tracetest` directory is self-contained and will run all the prerequisites for enabling OpenTelemetry traces and trace-based testing with Tracetest, as well as routing all traces the OpenTelemetry Demo generates to Datadog.
 
 ### Docker Compose Network
 


### PR DESCRIPTION
This PR...

## Changes

-

## Fixes

- In the documentation of the page - OpenTelemetry Demo and Datadog. **_It's mentioned as Lightstep instead of Datadog_** under point "**2. Tracetest**" in "**Project Directory**" section
Reference- https://docs.tracetest.io/examples-tutorials/recipes/running-tracetest-with-datadog#2-tracetest 

## Checklist

- [ ] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Loom video

Add your loom video here if your work can be visualized
