### PR TITLE
fix: panic when log level is not defined

### DIFF
--- a/agent/runner/runstrategy_dashboard.go
+++ b/agent/runner/runstrategy_dashboard.go
@@ -44,6 +44,11 @@ func (s *Runner) RunDashboardStrategy(ctx context.Context, cfg agentConfig.Confi
 }
 
 func (s *Runner) disableLogger() func() {
+	if s.loggerLevel == nil {
+		// logger is not active, so it's safe to do nothing
+		return func() {}
+	}
+
 	oldLevel := s.loggerLevel.Level()
 	s.loggerLevel.SetLevel(zap.PanicLevel)
 


### PR DESCRIPTION
This PR fixes a panic in the agent dashboard when `TRACETEST_DEV` is not set.

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Loom video

Add your loom video here if your work can be visualized
