### PR TITLE
fix(cli): configure for non interactive environments

### DIFF
--- a/cli/config/configurator.go
+++ b/cli/config/configurator.go
@@ -21,7 +21,7 @@ type Configurator struct {
 	ui             cliUI.UI
 	onFinish       onFinishFn
 	errorHandlerFn errorHandlerFn
-	flags          agentConfig.Flags
+	flags          *agentConfig.Flags
 	finalServerURL string
 }
 
@@ -38,7 +38,7 @@ func NewConfigurator(resources *resourcemanager.Registry) Configurator {
 		errorHandlerFn: func(ctx context.Context, err error) {
 			ui.Exit(err.Error())
 		},
-		flags: agentConfig.Flags{},
+		flags: &agentConfig.Flags{},
 	}
 }
 
@@ -55,11 +55,19 @@ func (c Configurator) WithErrorHandler(fn errorHandlerFn) Configurator {
 }
 
 func (c Configurator) Start(ctx context.Context, prev *Config, flags agentConfig.Flags) error {
-	c.flags = flags
-	serverURL, err := c.getServerURL(prev, flags)
-	c.finalServerURL = serverURL
-	if err != nil {
-		return err
+	c.flags = &flags
+	var serverURL string
+
+	// if token is passed, we cannot assume an interactive environment,
+	// so fallback to last used
+	if c.flags.Token != "" {
+		serverURL = lastUsedURL(prev)
+	} else {
+		serverURL, err := c.getServerURL(prev)
+		c.finalServerURL = serverURL
+		if err != nil {
+			return err
+		}
 	}
 
 	cfg, err := c.createConfig(serverURL)
@@ -77,7 +85,7 @@ func (c Configurator) Start(ctx context.Context, prev *Config, flags agentConfig
 		return nil
 	}
 
-	if flags.CI {
+	if c.flags.CI {
 		_, err = Save(ctx, cfg)
 		if err != nil {
 			return err
@@ -85,7 +93,7 @@ func (c Configurator) Start(ctx context.Context, prev *Config, flags agentConfig
 		return nil
 	}
 
-	_, err = c.handleOAuth(ctx, cfg, prev, flags)
+	_, err = c.handleOAuth(ctx, cfg, prev)
 	if err != nil {
 		return err
 	}
@@ -93,19 +101,22 @@ func (c Configurator) Start(ctx context.Context, prev *Config, flags agentConfig
 	return nil
 }
 
-func (c Configurator) getServerURL(prev *Config, flags agentConfig.Flags) (string, error) {
-	serverURL := flags.ServerURL
+func lastUsedURL(prev *Config) string {
+	possibleValues := []string{}
+	if prev != nil {
+		possibleValues = append(possibleValues, prev.UIEndpoint, prev.URL())
+	}
+	possibleValues = append(possibleValues, DefaultCloudEndpoint)
+
+	return getFirstNonEmptyString(possibleValues)
+}
+
+func (c Configurator) getServerURL(prev *Config) (string, error) {
+	serverURL := c.flags.ServerURL
 
 	// if flag was passed, don't show prompt
-	if flags.ServerURL == "" {
-		possibleValues := []string{}
-		if prev != nil {
-			possibleValues = append(possibleValues, prev.UIEndpoint, prev.URL())
-		}
-		possibleValues = append(possibleValues, DefaultCloudEndpoint)
-
-		lastUsed := getFirstNonEmptyString(possibleValues)
-		serverURL = c.ui.TextInput("What tracetest server do you want to use?", lastUsed)
+	if c.flags.ServerURL == "" {
+		serverURL = c.ui.TextInput("What tracetest server do you want to use?", lastUsedURL(prev))
 	}
 
 	if err := validateServerURL(serverURL); err != nil {
@@ -178,7 +189,7 @@ func (c Configurator) populateConfigWithVersionInfo(ctx context.Context, cfg Con
 	return cfg, nil, false
 }
 
-func (c Configurator) handleOAuth(ctx context.Context, cfg Config, prev *Config, flags agentConfig.Flags) (Config, error) {
+func (c Configurator) handleOAuth(ctx context.Context, cfg Config, prev *Config) (Config, error) {
 	if prev != nil && cfg.UIEndpoint == prev.UIEndpoint {
 		if prev != nil && prev.Jwt != "" {
 			cfg.Jwt = prev.Jwt
@@ -186,22 +197,22 @@ func (c Configurator) handleOAuth(ctx context.Context, cfg Config, prev *Config,
 		}
 	}
 
-	if flags.Token != "" {
+	if c.flags.Token != "" {
 		var err error
-		cfg, err = c.exchangeToken(cfg, flags.Token)
+		cfg, err = c.exchangeToken(cfg, c.flags.Token)
 		if err != nil {
 			return Config{}, err
 		}
 	}
 
-	if flags.AgentApiKey != "" {
-		cfg.AgentApiKey = flags.AgentApiKey
-		c.showOrganizationSelector(ctx, prev, cfg, flags)
+	if c.flags.AgentApiKey != "" {
+		cfg.AgentApiKey = c.flags.AgentApiKey
+		c.showOrganizationSelector(ctx, prev, cfg)
 		return cfg, nil
 	}
 
 	if cfg.Jwt != "" {
-		c.showOrganizationSelector(ctx, prev, cfg, flags)
+		c.showOrganizationSelector(ctx, prev, cfg)
 		return cfg, nil
 	}
 
@@ -262,7 +273,7 @@ func (c Configurator) onOAuthSuccess(ctx context.Context, cfg Config, prev *Conf
 		cfg.Jwt = jwt
 		cfg.Token = token
 
-		c.showOrganizationSelector(ctx, prev, cfg, c.flags)
+		c.showOrganizationSelector(ctx, prev, cfg)
 	}
 }
 
@@ -270,9 +281,9 @@ func (c Configurator) onOAuthFailure(err error) {
 	c.errorHandlerFn(context.Background(), err)
 }
 
-func (c Configurator) showOrganizationSelector(ctx context.Context, prev *Config, cfg Config, flags agentConfig.Flags) {
-	cfg.OrganizationID = flags.OrganizationID
-	if cfg.OrganizationID == "" && flags.AgentApiKey == "" {
+func (c Configurator) showOrganizationSelector(ctx context.Context, prev *Config, cfg Config) {
+	cfg.OrganizationID = c.flags.OrganizationID
+	if cfg.OrganizationID == "" && c.flags.AgentApiKey == "" {
 		orgID, err := c.organizationSelector(ctx, cfg, prev)
 		if err != nil {
 			c.errorHandlerFn(ctx, err)
@@ -282,8 +293,8 @@ func (c Configurator) showOrganizationSelector(ctx context.Context, prev *Config
 		cfg.OrganizationID = orgID
 	}
 
-	cfg.EnvironmentID = flags.EnvironmentID
-	if cfg.EnvironmentID == "" && flags.AgentApiKey == "" {
+	cfg.EnvironmentID = c.flags.EnvironmentID
+	if cfg.EnvironmentID == "" && c.flags.AgentApiKey == "" {
 		envID, err := c.environmentSelector(ctx, cfg, prev)
 		if err != nil {
 			c.errorHandlerFn(ctx, err)

--- a/cli/config/configurator.go
+++ b/cli/config/configurator.go
@@ -63,12 +63,13 @@ func (c Configurator) Start(ctx context.Context, prev *Config, flags agentConfig
 	if c.flags.Token != "" {
 		serverURL = lastUsedURL(prev)
 	} else {
-		serverURL, err := c.getServerURL(prev)
-		c.finalServerURL = serverURL
+		var err error
+		serverURL, err = c.getServerURL(prev)
 		if err != nil {
 			return err
 		}
 	}
+	c.finalServerURL = serverURL
 
 	cfg, err := c.createConfig(serverURL)
 	if err != nil {

--- a/cli/config/selector.go
+++ b/cli/config/selector.go
@@ -17,12 +17,12 @@ type Entry struct {
 func (c Configurator) organizationSelector(ctx context.Context, cfg Config, prev *Config) (string, error) {
 	resource, err := c.resources.Get("organization")
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("cannot create organizations client: %w", err)
 	}
 
 	elements, err := getElements(ctx, resource, cfg)
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("cannot get organization: %w", err)
 	}
 
 	if len(elements) == 1 {


### PR DESCRIPTION
This PR fixes an issue on the CLI preventing the `configure` command to work on automated environments. The command was asking for user input (asking for server) even when the `--token` flag was passed. This flag allows us to infer a non interactive environment so we can use a reasonable fallback (cloud url or previously configured value from config file) if no `--server-url` is provided.

On top of this, there was some incorrect handling of the flags within the configurator. Flags were saved as an instance variable by value instead of reference, so when one method modifies a flag value, the change is lost at the end of the function scope (see comments on PR)

## Changes

-

## Fixes

-

## Checklist

- [ ] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Loom video

Add your loom video here if your work can be visualized
