### PR TITLE
feat(cli): add open telemetry support for Tracetest agent

### DIFF
--- a/agent/client/client.go
+++ b/agent/client/client.go
@@ -15,6 +15,8 @@ import (
 	"github.com/kubeshop/tracetest/agent/proto"
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
+
+	"go.opentelemetry.io/otel/trace"
 )
 
 const (
@@ -43,6 +45,7 @@ type Client struct {
 	done          chan bool
 
 	logger *zap.Logger
+	tracer trace.Tracer
 
 	stopListener                func(context.Context, *proto.StopRequest) error
 	triggerListener             func(context.Context, *proto.TriggerRequest) error
@@ -98,7 +101,7 @@ func (c *Client) Start(ctx context.Context) error {
 		return err
 	}
 
-	err = c.startHearthBeat(ctx)
+	err = c.startHeartBeat(ctx)
 	if err != nil {
 		return err
 	}

--- a/agent/client/options.go
+++ b/agent/client/options.go
@@ -3,6 +3,7 @@ package client
 import (
 	"time"
 
+	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/zap"
 )
 
@@ -29,5 +30,11 @@ func WithPingPeriod(period time.Duration) Option {
 func WithLogger(logger *zap.Logger) Option {
 	return func(c *Client) {
 		c.logger = logger
+	}
+}
+
+func WithTracer(tracer trace.Tracer) Option {
+	return func(c *Client) {
+		c.tracer = tracer
 	}
 }

--- a/agent/client/workflow_ping.go
+++ b/agent/client/workflow_ping.go
@@ -8,7 +8,7 @@ import (
 	"github.com/kubeshop/tracetest/agent/proto"
 )
 
-func (c *Client) startHearthBeat(ctx context.Context) error {
+func (c *Client) startHeartBeat(ctx context.Context) error {
 	client := proto.NewOrchestratorClient(c.conn)
 	ticker := time.NewTicker(c.config.PingPeriod)
 

--- a/agent/config/config.go
+++ b/agent/config/config.go
@@ -11,9 +11,11 @@ import (
 )
 
 type Config struct {
-	APIKey    string `mapstructure:"api_key"`
-	Name      string `mapstructure:"agent_name"`
-	ServerURL string `mapstructure:"server_url"`
+	APIKey            string `mapstructure:"api_key"`
+	Name              string `mapstructure:"agent_name"`
+	ServerURL         string `mapstructure:"server_url"`
+	CollectorEndpoint string `mapstructure:"collector_endpoint"`
+	Mode              string `mapstructure:"mode"`
 
 	OTLPServer OtlpServer `mapstructure:"otlp_server"`
 }
@@ -45,6 +47,8 @@ func LoadConfig() (Config, error) {
 	vp.SetDefault("AGENT_NAME", getHostname())
 	vp.SetDefault("API_KEY", "")
 	vp.SetDefault("SERVER_URL", "https://app.tracetest.io")
+	vp.SetDefault("COLLECTOR_ENDPOINT", "")
+	vp.SetDefault("MODE", "")
 	vp.SetDefault("OTLP_SERVER.GRPC_PORT", 4317)
 	vp.SetDefault("OTLP_SERVER.HTTP_PORT", 4318)
 

--- a/agent/config/flags.go
+++ b/agent/config/flags.go
@@ -8,12 +8,13 @@ const (
 )
 
 type Flags struct {
-	ServerURL      string
-	OrganizationID string
-	EnvironmentID  string
-	CI             bool
-	AgentApiKey    string
-	Token          string
-	Mode           Mode
-	LogLevel       string
+	ServerURL         string
+	OrganizationID    string
+	EnvironmentID     string
+	CI                bool
+	AgentApiKey       string
+	Token             string
+	Mode              Mode
+	LogLevel          string
+	CollectorEndpoint string
 }

--- a/agent/runner/session.go
+++ b/agent/runner/session.go
@@ -37,7 +37,7 @@ func (s *Session) WaitUntilDisconnected() {
 func StartSession(ctx context.Context, cfg config.Config, observer event.Observer, logger *zap.Logger) (*Session, error) {
 	observer = event.WrapObserver(observer)
 
-	tracer, err := telemetry.GetTracer(ctx, config.CollectorEndpoint, config.Name)
+	tracer, err := telemetry.GetTracer(ctx, cfg.CollectorEndpoint, cfg.Name)
 	if err != nil {
 		observer.Error(err)
 		return nil, err

--- a/agent/telemetry/tracer.go
+++ b/agent/telemetry/tracer.go
@@ -1,0 +1,83 @@
+package telemetry
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc"
+	"go.opentelemetry.io/otel/propagation"
+	"go.opentelemetry.io/otel/sdk/resource"
+	sdkTrace "go.opentelemetry.io/otel/sdk/trace"
+	semconv "go.opentelemetry.io/otel/semconv/v1.4.0"
+	"go.opentelemetry.io/otel/trace"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+)
+
+const spanExporterTimeout = 1 * time.Minute
+
+func GetTracer(ctx context.Context, otelExporterEndpoint, serviceName string) (trace.Tracer, error) {
+	realServiceName := fmt.Sprintf("tracetestAgent_%s", serviceName)
+
+	spanExporter, err := newSpanExporter(ctx, otelExporterEndpoint)
+	if err != nil {
+		return nil, fmt.Errorf("failed to setup span exporter: %w", err)
+	}
+
+	traceProvider, err := newTraceProvider(ctx, spanExporter, realServiceName)
+	if err != nil {
+		return nil, fmt.Errorf("failed to setup trace provider: %w", err)
+	}
+
+	return traceProvider.Tracer(realServiceName), nil
+}
+
+func newSpanExporter(ctx context.Context, otelExporterEndpoint string) (sdkTrace.SpanExporter, error) {
+	ctx, cancel := context.WithTimeout(ctx, spanExporterTimeout)
+	defer cancel()
+
+	conn, err := grpc.DialContext(ctx, otelExporterEndpoint, grpc.WithTransportCredentials(insecure.NewCredentials()), grpc.WithBlock())
+	if err != nil {
+		return nil, fmt.Errorf("failed to create gRPC connection to collector: %w", err)
+	}
+
+	traceExporter, err := otlptracegrpc.New(ctx, otlptracegrpc.WithGRPCConn(conn))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create trace exporter: %w", err)
+	}
+
+	return traceExporter, nil
+}
+
+func newTraceProvider(ctx context.Context, spanExporter sdkTrace.SpanExporter, serviceName string) (*sdkTrace.TracerProvider, error) {
+	defaultResource := resource.Default()
+
+	mergedResource, err := resource.Merge(
+		defaultResource,
+		resource.NewWithAttributes(
+			defaultResource.SchemaURL(),
+			semconv.ServiceNameKey.String(serviceName),
+		),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create otel resource: %w", err)
+	}
+
+	tp := sdkTrace.NewTracerProvider(
+		sdkTrace.WithBatcher(spanExporter),
+		sdkTrace.WithResource(mergedResource),
+	)
+
+	otel.SetTracerProvider(tp)
+
+	otel.SetTextMapPropagator(
+		propagation.NewCompositeTextMapPropagator(
+			propagation.TraceContext{},
+			propagation.Baggage{},
+		),
+	)
+
+	return tp, nil
+}

--- a/agent/telemetry/tracer.go
+++ b/agent/telemetry/tracer.go
@@ -19,6 +19,11 @@ import (
 const spanExporterTimeout = 1 * time.Minute
 
 func GetTracer(ctx context.Context, otelExporterEndpoint, serviceName string) (trace.Tracer, error) {
+	if otelExporterEndpoint == "" {
+		// fallback, return noop
+		return trace.NewNoopTracerProvider().Tracer("noop"), nil
+	}
+
 	realServiceName := fmt.Sprintf("tracetestAgent_%s", serviceName)
 
 	spanExporter, err := newSpanExporter(ctx, otelExporterEndpoint)

--- a/agent/workers/poller.go
+++ b/agent/workers/poller.go
@@ -39,7 +39,7 @@ func WithInMemoryDatastore(datastore tracedb.TraceDB) PollerOption {
 	}
 }
 
-func WithObserver(observer event.Observer) PollerOption {
+func WithPollerObserver(observer event.Observer) PollerOption {
 	return func(pw *PollerWorker) {
 		pw.observer = observer
 	}
@@ -48,6 +48,12 @@ func WithObserver(observer event.Observer) PollerOption {
 func WithPollerStoppableProcessRunner(stoppableProcessRunner StoppableProcessRunner) PollerOption {
 	return func(pw *PollerWorker) {
 		pw.stoppableProcessRunner = stoppableProcessRunner
+	}
+}
+
+func WithPollerLogger(logger *zap.Logger) PollerOption {
+	return func(pw *PollerWorker) {
+		pw.logger = logger
 	}
 }
 
@@ -68,10 +74,6 @@ func NewPollerWorker(client *client.Client, opts ...PollerOption) *PollerWorker 
 	}
 
 	return pollerWorker
-}
-
-func (w *PollerWorker) SetLogger(logger *zap.Logger) {
-	w.logger = logger
 }
 
 func (w *PollerWorker) Poll(ctx context.Context, request *proto.PollingRequest) error {

--- a/agent/workers/trigger.go
+++ b/agent/workers/trigger.go
@@ -54,6 +54,12 @@ func WithSensor(sensor sensors.Sensor) TriggerOption {
 	}
 }
 
+func WithTriggerLogger(logger *zap.Logger) TriggerOption {
+	return func(tw *TriggerWorker) {
+		tw.logger = logger
+	}
+}
+
 func NewTriggerWorker(client *client.Client, opts ...TriggerOption) *TriggerWorker {
 	// TODO: use a real tracer
 	tracer := trace.NewNoopTracerProvider().Tracer("noop")
@@ -76,10 +82,6 @@ func NewTriggerWorker(client *client.Client, opts ...TriggerOption) *TriggerWork
 	}
 
 	return worker
-}
-
-func (w *TriggerWorker) SetLogger(logger *zap.Logger) {
-	w.logger = logger
 }
 
 func (w *TriggerWorker) Trigger(ctx context.Context, triggerRequest *proto.TriggerRequest) error {

--- a/cli/config/configurator.go
+++ b/cli/config/configurator.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"os"
 	"strings"
 
 	"github.com/golang-jwt/jwt"
@@ -161,14 +162,34 @@ func (e invalidServerErr) Render() {
 	e.ui.Error(msg)
 }
 
+func (c Configurator) populateConfigWithDevConfig(ctx context.Context, cfg *Config) {
+	cfg.AgentEndpoint = os.Getenv("TRACETEST_DEV_AGENT_ENDPOINT")
+	if cfg.AgentEndpoint == "" {
+		cfg.AgentEndpoint = "localhost:8091"
+	}
+
+	cfg.UIEndpoint = os.Getenv("TRACETEST_DEV_UI_ENDPOINT")
+	if cfg.UIEndpoint == "" {
+		cfg.UIEndpoint = "http://localhost:3000"
+	}
+
+	cfg.Scheme = os.Getenv("TRACETEST_DEV_SCHEME")
+	if cfg.Scheme == "" {
+		cfg.Scheme = "http"
+	}
+
+	cfg.Endpoint = os.Getenv("TRACETEST_DEV_ENDPOINT")
+	if cfg.Endpoint == "" {
+		cfg.Endpoint = "localhost:11633"
+	}
+
+	cfg.ServerPath = os.Getenv("TRACETEST_DEV_SERVER_PATH")
+}
+
 func (c Configurator) populateConfigWithVersionInfo(ctx context.Context, cfg Config) (_ Config, _ error, isOSS bool) {
 	cliVersion := Version
 	if cliVersion == "dev" {
-		cfg.AgentEndpoint = "localhost:8091"
-		cfg.UIEndpoint = "http://localhost:3000"
-		cfg.Scheme = "http"
-		cfg.Endpoint = "localhost:11633"
-		cfg.ServerPath = ""
+		c.populateConfigWithDevConfig(ctx, &cfg)
 
 		c.ui.Success("Configured Tracetest CLI in development mode")
 

--- a/cli/config/configurator.go
+++ b/cli/config/configurator.go
@@ -162,6 +162,19 @@ func (e invalidServerErr) Render() {
 }
 
 func (c Configurator) populateConfigWithVersionInfo(ctx context.Context, cfg Config) (_ Config, _ error, isOSS bool) {
+	cliVersion := Version
+	if cliVersion == "dev" {
+		cfg.AgentEndpoint = "localhost:8091"
+		cfg.UIEndpoint = "http://localhost:3000"
+		cfg.Scheme = "http"
+		cfg.Endpoint = "localhost:11633"
+		cfg.ServerPath = ""
+
+		c.ui.Success("Configured Tracetest CLI in development mode")
+
+		return cfg, nil, false
+	}
+
 	client := GetAPIClient(cfg)
 	version, err := getVersionMetadata(ctx, client)
 	if err != nil {

--- a/go.sum
+++ b/go.sum
@@ -1945,8 +1945,6 @@ go.opentelemetry.io/collector/semconv v0.80.0/go.mod h1:TlYPtzvsXyHOgr5eATi43qEM
 go.opentelemetry.io/contrib v0.20.0/go.mod h1:G/EtFaa6qaN7+LxqfIAT3GiZa7Wv5DTBUzl5H4LY0Kc=
 go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.20.0/go.mod h1:oVGt1LRbBOBq1A5BQLlUg9UaU/54aiHw8cgjV3aWZ/E=
 go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.28.0/go.mod h1:vEhqr0m4eTc+DWxfsXoXue2GBgV2uUwVznkGIHW/e5w=
-go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.44.0 h1:b8xjZxHbLrXAum4SxJd1Rlm7Y/fKaB+6ACI7/e5EfSA=
-go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.44.0/go.mod h1:1ei0a32xOGkFoySu7y1DAHfcuIhC0pNZpvY2huXuMy4=
 go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.45.0 h1:RsQi0qJ2imFfCvZabqzM9cNXBG8k6gXMv1A0cXRmH6A=
 go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.45.0/go.mod h1:vsh3ySueQCiKPxFLvjWC4Z135gIa34TQ/NSqkDTZYUM=
 go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.20.0/go.mod h1:2AboqHi0CiIZU0qwhtUfCYD1GeUzvvIXWNkhDt7ZMG4=


### PR DESCRIPTION
This PR adds support for OTel Collector on Tracetest Agent.

## Changes

- Added capability of setting verbose mode via env vars
- Added option to inform the address of an OTel Collector to send observability telemetry

## Checklist

- [ ] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [x] added a test