### PR TITLE
feat: make the assertion engine return a different error when no spans

### DIFF
--- a/server/expression/data_store.go
+++ b/server/expression/data_store.go
@@ -45,7 +45,7 @@ func (ds AttributeDataStore) Get(name string) (string, error) {
 		// It's probably a nil span and we never got a matching selector,
 		// so instead of returning a resolution error, let's return a non-matching
 		// span error instead
-		return "", fmt.Errorf(`there are no matching spans to retrieve the attribute "%s" from`, name)
+		return "", fmt.Errorf(`there are no matching spans to retrieve the attribute "%s" from. To fix this error, create a selector matching at least one span.`, name)
 	}
 
 	value := ds.Span.Attributes.Get(name)

--- a/server/expression/data_store.go
+++ b/server/expression/data_store.go
@@ -41,6 +41,13 @@ func (ds AttributeDataStore) getFromAlias(name string) (string, error) {
 }
 
 func (ds AttributeDataStore) Get(name string) (string, error) {
+	if !ds.Span.ID.IsValid() {
+		// It's probably a nil span and we never got a matching selector,
+		// so instead of returning a resolution error, let's return a non-matching
+		// span error instead
+		return "", fmt.Errorf(`there are no matching spans to retrieve the attribute "%s" from`, name)
+	}
+
 	value := ds.Span.Attributes.Get(name)
 	if value == "" {
 		return ds.getFromAlias(name)

--- a/server/expression/executor_test.go
+++ b/server/expression/executor_test.go
@@ -164,6 +164,7 @@ func TestStringInterpolationExecution(t *testing.T) {
 			ShouldPass: true,
 			AttributeDataStore: expression.AttributeDataStore{
 				Span: traces.Span{
+					ID: id.NewRandGenerator().SpanID(),
 					Attributes: traces.NewAttributes(map[string]string{
 						"text": "this run took 25ms",
 					}),
@@ -188,6 +189,7 @@ func TestFilterExecution(t *testing.T) {
 			ShouldPass: true,
 			AttributeDataStore: expression.AttributeDataStore{
 				Span: traces.Span{
+					ID: id.NewRandGenerator().SpanID(),
 					Attributes: traces.NewAttributes(map[string]string{
 						"tracetest.response.body": `{"id": 8, "name": "john doe"}`,
 					}),
@@ -408,6 +410,7 @@ func TestResolveStatementAttributeExecution(t *testing.T) {
 
 			AttributeDataStore: expression.AttributeDataStore{
 				Span: traces.Span{
+					ID: id.NewRandGenerator().SpanID(),
 					Attributes: traces.NewAttributes(map[string]string{
 						"my_attribute": "42",
 					}),
@@ -427,6 +430,7 @@ func TestResolveStatementStringInterpolationExecution(t *testing.T) {
 			ShouldPass: true,
 			AttributeDataStore: expression.AttributeDataStore{
 				Span: traces.Span{
+					ID: id.NewRandGenerator().SpanID(),
 					Attributes: traces.NewAttributes(map[string]string{
 						"text": "this run took 25ms",
 					}),
@@ -451,6 +455,7 @@ func TestResolveStatementFilterExecution(t *testing.T) {
 			ShouldPass: true,
 			AttributeDataStore: expression.AttributeDataStore{
 				Span: traces.Span{
+					ID: id.NewRandGenerator().SpanID(),
 					Attributes: traces.NewAttributes(map[string]string{
 						"tracetest.response.body": `{"id": 8, "name": "john doe"}`,
 					}),
@@ -512,6 +517,7 @@ func TestFailureCases(t *testing.T) {
 
 			AttributeDataStore: expression.AttributeDataStore{
 				Span: traces.Span{
+					ID: id.NewRandGenerator().SpanID(),
 					Attributes: traces.NewAttributes(map[string]string{
 						"attr1": "1",
 						"attr2": "2",

--- a/server/expression/executor_test.go
+++ b/server/expression/executor_test.go
@@ -141,7 +141,7 @@ func TestAttributeExecution(t *testing.T) {
 			Name:                 "should_return_error_when_no_matching_spans",
 			Query:                "attr:dapr-app-id = 42",
 			ShouldPass:           false,
-			ExpectedErrorMessage: `resolution error: there are no matching spans to retrieve the attribute "dapr-app-id" from`,
+			ExpectedErrorMessage: `resolution error: there are no matching spans to retrieve the attribute "dapr-app-id" from. To fix this error, create a selector matching at least one span.`,
 
 			AttributeDataStore: expression.AttributeDataStore{
 				Span: traces.Span{


### PR DESCRIPTION
This PR makes the assertion engine return the following error when you try to run an assertion against an attribute when no spans match the selector:

```
resolution error: there are no matching spans to retrieve the attribute "attribute-name" from. To fix this error, create a selector matching at least one span.
```

Related thread message: https://tracetest-community.slack.com/archives/C06CF48NS79/p1708377604787339?thread_ts=1708367051.955759&cid=C06CF48NS79

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [x] added a test