### PR TITLE
feat(agent): add metrics to agent workers

### DIFF
--- a/.github/workflows/scheduled-jobs.yml
+++ b/.github/workflows/scheduled-jobs.yml
@@ -11,7 +11,7 @@ jobs:
   pokeshop-trace-based-tests:
     name: Run trace based tests for Pokeshop
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 20
 
     steps:
       - name: Checkout
@@ -67,7 +67,7 @@ jobs:
   pokeshop-serverless-trace-based-tests:
     name: Run trace based tests for Pokeshop Serverless
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 20
 
     steps:
       - name: Checkout
@@ -123,7 +123,7 @@ jobs:
   otel-demo-trace-based-tests:
     name: Run trace based tests for Open Telemetry demo
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 20
 
     steps:
       - name: Checkout

--- a/.github/workflows/scheduled-jobs.yml
+++ b/.github/workflows/scheduled-jobs.yml
@@ -11,18 +11,20 @@ jobs:
   pokeshop-trace-based-tests:
     name: Run trace based tests for Pokeshop
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 15
 
     steps:
       - name: Checkout
         uses: actions/checkout@v3
 
       - name: Configure Tracetest CLI
+        timeout-minutes: 5
         uses: kubeshop/tracetest-github-action@v1
         with:
           token: ${{secrets.TRACETEST_POKESHOP_TOKEN}}
 
       - name: Run synthetic monitoring tests
+        timeout-minutes: 10
         run: |
           tracetest run testsuite --file ./testing/synthetic-monitoring/pokeshop/_testsuite.yaml --vars ./testing/synthetic-monitoring/pokeshop/_variableset.yaml
 
@@ -65,18 +67,20 @@ jobs:
   pokeshop-serverless-trace-based-tests:
     name: Run trace based tests for Pokeshop Serverless
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 15
 
     steps:
       - name: Checkout
         uses: actions/checkout@v3
 
       - name: Configure Tracetest CLI
+        timeout-minutes: 5
         uses: kubeshop/tracetest-github-action@v1
         with:
           token: ${{secrets.TRACETEST_SERVERLESS_POKESHOP_TOKEN}}
 
       - name: Run synthetic monitoring tests
+        timeout-minutes: 10
         run: |
           tracetest run testsuite --file ./testing/synthetic-monitoring/pokeshop-serverless/_testsuite.yaml --vars ./testing/synthetic-monitoring/pokeshop-serverless/_variableset.yaml
 
@@ -119,18 +123,20 @@ jobs:
   otel-demo-trace-based-tests:
     name: Run trace based tests for Open Telemetry demo
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 15
 
     steps:
       - name: Checkout
         uses: actions/checkout@v3
 
       - name: Configure Tracetest CLI
+        timeout-minutes: 5
         uses: kubeshop/tracetest-github-action@v1
         with:
           token: ${{secrets.TRACETEST_OTELDEMO_TOKEN}}
 
       - name: Run synthetic monitoring tests
+        timeout-minutes: 10
         run: |
           tracetest run testsuite --file ./testing/synthetic-monitoring/otel-demo/_testsuite.yaml --vars ./testing/synthetic-monitoring/otel-demo/_variableset.yaml
 

--- a/agent/telemetry/common.go
+++ b/agent/telemetry/common.go
@@ -1,0 +1,37 @@
+package telemetry
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/kubeshop/tracetest/server/version"
+	"go.opentelemetry.io/otel/sdk/resource"
+	semconv "go.opentelemetry.io/otel/semconv/v1.21.0"
+)
+
+func getAgentServiceName(serviceName string) string {
+	return fmt.Sprintf("tracetest.agent-%s", serviceName)
+}
+
+func getResource(serviceName string) (*resource.Resource, error) {
+	hostname, err := os.Hostname()
+	if err != nil {
+		return nil, fmt.Errorf("could not get OS hostname: %w", err)
+	}
+
+	resource, err := resource.Merge(
+		resource.Default(),
+		resource.NewWithAttributes(
+			semconv.SchemaURL,
+			semconv.ServiceNameKey.String(serviceName),
+			semconv.HostName(hostname),
+			semconv.ServiceVersion(version.Version), // TODO: should we consider a version file for the agent?
+		),
+	)
+
+	if err != nil {
+		return nil, fmt.Errorf("could not merge resources: %w", err)
+	}
+
+	return resource, nil
+}

--- a/agent/telemetry/meter.go
+++ b/agent/telemetry/meter.go
@@ -3,9 +3,17 @@ package telemetry
 import (
 	"context"
 	"fmt"
+	"time"
 
+	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc"
 	"go.opentelemetry.io/otel/metric"
 	"go.opentelemetry.io/otel/metric/noop"
+	metricsdk "go.opentelemetry.io/otel/sdk/metric"
+)
+
+const (
+	metricsReaderInterval = 30 * time.Second
+	metricExporterTimeout = 5 * time.Second
 )
 
 func GetMeter(ctx context.Context, otelExporterEndpoint, serviceName string) (metric.Meter, error) {
@@ -14,7 +22,52 @@ func GetMeter(ctx context.Context, otelExporterEndpoint, serviceName string) (me
 		return noop.NewMeterProvider().Meter("noop"), nil
 	}
 
-	realServiceName := fmt.Sprintf("tracetestAgent_%s", serviceName)
+	realServiceName := getAgentServiceName(serviceName)
 
-	return nil, nil
+	provider, err := newMeterProvider(ctx, otelExporterEndpoint, realServiceName)
+	if err != nil {
+		return nil, fmt.Errorf("could not create meter provider: %w", err)
+	}
+
+	return provider.Meter("tracetest.agent"), nil
+}
+
+func newMeterProvider(ctx context.Context, otelExporterEndpoint, serviceName string) (metric.MeterProvider, error) {
+	resource, err := getResource(serviceName)
+	if err != nil {
+		return nil, fmt.Errorf("could not get resource: %w", err)
+	}
+
+	exporter, err := getMetricExporter(ctx, otelExporterEndpoint)
+	if err != nil {
+		return nil, fmt.Errorf("could not create metric exporter: %w", err)
+	}
+
+	periodicReader := metricsdk.NewPeriodicReader(
+		exporter,
+		metricsdk.WithInterval(metricsReaderInterval),
+	)
+
+	provider := metricsdk.NewMeterProvider(
+		metricsdk.WithResource(resource),
+		metricsdk.WithReader(periodicReader),
+	)
+
+	return provider, nil
+}
+
+func getMetricExporter(ctx context.Context, otelExporterEndpoint string) (*otlpmetricgrpc.Exporter, error) {
+	ctx, cancel := context.WithTimeout(ctx, metricExporterTimeout)
+	defer cancel()
+
+	exporter, err := otlpmetricgrpc.New(ctx,
+		otlpmetricgrpc.WithEndpoint(otelExporterEndpoint),
+		otlpmetricgrpc.WithCompressor("gzip"),
+		otlpmetricgrpc.WithInsecure(),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("could not create metric exporter: %w", err)
+	}
+
+	return exporter, nil
 }

--- a/agent/telemetry/meter.go
+++ b/agent/telemetry/meter.go
@@ -16,10 +16,14 @@ const (
 	metricExporterTimeout = 5 * time.Second
 )
 
+func GetNoopMeter() metric.Meter {
+	return noop.NewMeterProvider().Meter("noop")
+}
+
 func GetMeter(ctx context.Context, otelExporterEndpoint, serviceName string) (metric.Meter, error) {
 	if otelExporterEndpoint == "" {
 		// fallback, return noop
-		return noop.NewMeterProvider().Meter("noop"), nil
+		return GetNoopMeter(), nil
 	}
 
 	realServiceName := getAgentServiceName(serviceName)

--- a/agent/telemetry/meter.go
+++ b/agent/telemetry/meter.go
@@ -1,0 +1,20 @@
+package telemetry
+
+import (
+	"context"
+	"fmt"
+
+	"go.opentelemetry.io/otel/metric"
+	"go.opentelemetry.io/otel/metric/noop"
+)
+
+func GetMeter(ctx context.Context, otelExporterEndpoint, serviceName string) (metric.Meter, error) {
+	if otelExporterEndpoint == "" {
+		// fallback, return noop
+		return noop.NewMeterProvider().Meter("noop"), nil
+	}
+
+	realServiceName := fmt.Sprintf("tracetestAgent_%s", serviceName)
+
+	return nil, nil
+}

--- a/agent/telemetry/tracer.go
+++ b/agent/telemetry/tracer.go
@@ -16,10 +16,14 @@ import (
 
 const spanExporterTimeout = 1 * time.Minute
 
+func GetNoopTracer() trace.Tracer {
+	return trace.NewNoopTracerProvider().Tracer("noop")
+}
+
 func GetTracer(ctx context.Context, otelExporterEndpoint, serviceName string) (trace.Tracer, error) {
 	if otelExporterEndpoint == "" {
 		// fallback, return noop
-		return trace.NewNoopTracerProvider().Tracer("noop"), nil
+		return GetNoopTracer(), nil
 	}
 
 	realServiceName := getAgentServiceName(serviceName)

--- a/agent/workers/poller.go
+++ b/agent/workers/poller.go
@@ -12,6 +12,7 @@ import (
 	"github.com/kubeshop/tracetest/agent/client"
 	"github.com/kubeshop/tracetest/agent/event"
 	"github.com/kubeshop/tracetest/agent/proto"
+	"github.com/kubeshop/tracetest/agent/telemetry"
 	"github.com/kubeshop/tracetest/server/datastore"
 	"github.com/kubeshop/tracetest/server/executor"
 	"github.com/kubeshop/tracetest/server/tracedb"
@@ -77,7 +78,8 @@ func NewPollerWorker(client *client.Client, opts ...PollerOption) *PollerWorker 
 		sentSpanIDs: gocache.New[string, bool](),
 		logger:      zap.NewNop(),
 		observer:    event.NewNopObserver(),
-		tracer:      trace.NewNoopTracerProvider().Tracer("noop"),
+		tracer:      telemetry.GetNoopTracer(),
+		meter:       telemetry.GetNoopMeter(),
 	}
 
 	for _, opt := range opts {

--- a/agent/workers/poller.go
+++ b/agent/workers/poller.go
@@ -17,6 +17,7 @@ import (
 	"github.com/kubeshop/tracetest/server/tracedb"
 	"github.com/kubeshop/tracetest/server/tracedb/connection"
 	"github.com/kubeshop/tracetest/server/traces"
+	"go.opentelemetry.io/otel/metric"
 	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/zap"
 )
@@ -29,6 +30,7 @@ type PollerWorker struct {
 	observer               event.Observer
 	stoppableProcessRunner StoppableProcessRunner
 	tracer                 trace.Tracer
+	meter                  metric.Meter
 }
 
 type PollerOption func(*PollerWorker)
@@ -63,6 +65,12 @@ func WithPollerTracer(tracer trace.Tracer) PollerOption {
 	}
 }
 
+func WithPollerMeter(meter metric.Meter) PollerOption {
+	return func(pw *PollerWorker) {
+		pw.meter = meter
+	}
+}
+
 func NewPollerWorker(client *client.Client, opts ...PollerOption) *PollerWorker {
 	pollerWorker := &PollerWorker{
 		client:      client,
@@ -82,6 +90,11 @@ func NewPollerWorker(client *client.Client, opts ...PollerOption) *PollerWorker 
 func (w *PollerWorker) Poll(ctx context.Context, request *proto.PollingRequest) error {
 	ctx, span := w.tracer.Start(ctx, "PollingRequest Worker operation")
 	defer span.End()
+
+	runCounter, _ := w.meter.Int64Counter("tracetest.agent.pollerworker.runs")
+	runCounter.Add(ctx, 1)
+
+	errorCounter, _ := w.meter.Int64Counter("tracetest.agent.pollerworker.errors")
 
 	w.logger.Debug("Received polling request", zap.Any("request", request))
 	w.observer.StartTracePoll(request)
@@ -120,9 +133,13 @@ func (w *PollerWorker) Poll(ctx context.Context, request *proto.PollingRequest) 
 
 			formattedErr := fmt.Errorf("could not report polling error back to the server: %w. Original error: %s", sendErr, err.Error())
 			span.RecordError(formattedErr)
+			errorCounter.Add(ctx, 1)
 
 			return formattedErr
 		}
+
+		span.RecordError(err)
+		errorCounter.Add(ctx, 1)
 	}
 
 	w.observer.EndTracePoll(request, nil)

--- a/agent/workers/stopper.go
+++ b/agent/workers/stopper.go
@@ -5,6 +5,8 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/kubeshop/tracetest/agent/telemetry"
+
 	"github.com/kubeshop/tracetest/agent/event"
 	"github.com/kubeshop/tracetest/agent/proto"
 	"go.opentelemetry.io/otel/metric"
@@ -56,7 +58,8 @@ func NewStopperWorker(opts ...StopperOption) *StopperWorker {
 	worker := &StopperWorker{
 		logger:   zap.NewNop(),
 		observer: event.NewNopObserver(),
-		tracer:   trace.NewNoopTracerProvider().Tracer("noop"),
+		tracer:   telemetry.GetNoopTracer(),
+		meter:    telemetry.GetNoopMeter(),
 	}
 
 	for _, opt := range opts {

--- a/agent/workers/stopper.go
+++ b/agent/workers/stopper.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/kubeshop/tracetest/agent/event"
 	"github.com/kubeshop/tracetest/agent/proto"
+	"go.opentelemetry.io/otel/metric"
 	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/zap"
 )
@@ -16,6 +17,7 @@ type StopperWorker struct {
 	observer       event.Observer
 	cancelContexts *cancelCauseFuncMap
 	tracer         trace.Tracer
+	meter          metric.Meter
 }
 
 type StopperOption func(*StopperWorker)
@@ -38,10 +40,23 @@ func WithStopperTracer(tracer trace.Tracer) StopperOption {
 	}
 }
 
+func WithStopperMeter(meter metric.Meter) StopperOption {
+	return func(tw *StopperWorker) {
+		tw.meter = meter
+	}
+}
+
+func WithStopperLogger(logger *zap.Logger) StopperOption {
+	return func(tw *StopperWorker) {
+		tw.logger = logger
+	}
+}
+
 func NewStopperWorker(opts ...StopperOption) *StopperWorker {
 	worker := &StopperWorker{
 		logger:   zap.NewNop(),
 		observer: event.NewNopObserver(),
+		tracer:   trace.NewNoopTracerProvider().Tracer("noop"),
 	}
 
 	for _, opt := range opts {
@@ -51,13 +66,14 @@ func NewStopperWorker(opts ...StopperOption) *StopperWorker {
 	return worker
 }
 
-func (w *StopperWorker) SetLogger(logger *zap.Logger) {
-	w.logger = logger
-}
-
 func (w *StopperWorker) Stop(ctx context.Context, stopRequest *proto.StopRequest) error {
 	ctx, span := w.tracer.Start(ctx, "StopRequest Worker operation")
 	defer span.End()
+
+	runCounter, _ := w.meter.Int64Counter("tracetest.agent.stopworker.runs")
+	runCounter.Add(ctx, 1)
+
+	errorCounter, _ := w.meter.Int64Counter("tracetest.agent.stopworker.errors")
 
 	w.logger.Debug("Stop request received", zap.Any("stopRequest", stopRequest))
 	w.observer.StartStopRequest(stopRequest)
@@ -69,6 +85,8 @@ func (w *StopperWorker) Stop(ctx context.Context, stopRequest *proto.StopRequest
 		w.logger.Error(err.Error(), zap.String("testID", stopRequest.TestID), zap.Int32("runID", stopRequest.RunID))
 		w.observer.EndStopRequest(stopRequest, err)
 		span.RecordError(err)
+
+		errorCounter.Add(ctx, 1)
 
 		return err
 	}

--- a/agent/workers/testconnnection.go
+++ b/agent/workers/testconnnection.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"log"
 
+	"github.com/kubeshop/tracetest/agent/telemetry"
+
 	"github.com/kubeshop/tracetest/agent/client"
 	"github.com/kubeshop/tracetest/agent/event"
 	"github.com/kubeshop/tracetest/agent/proto"
@@ -52,9 +54,10 @@ func WithTestConnectionMeter(meter metric.Meter) TestConnectionOption {
 func NewTestConnectionWorker(client *client.Client, opts ...TestConnectionOption) *TestConnectionWorker {
 	worker := &TestConnectionWorker{
 		client:   client,
-		tracer:   trace.NewNoopTracerProvider().Tracer("noop"),
+		tracer:   telemetry.GetNoopTracer(),
 		logger:   zap.NewNop(),
 		observer: event.NewNopObserver(),
+		meter:    telemetry.GetNoopMeter(),
 	}
 
 	for _, opt := range opts {

--- a/agent/workers/trigger.go
+++ b/agent/workers/trigger.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/kubeshop/tracetest/agent/telemetry"
+
 	"github.com/kubeshop/tracetest/agent/client"
 	"github.com/kubeshop/tracetest/agent/collector"
 	"github.com/kubeshop/tracetest/agent/event"
@@ -80,7 +82,8 @@ func NewTriggerWorker(client *client.Client, opts ...TriggerOption) *TriggerWork
 		client:   client,
 		logger:   zap.NewNop(),
 		observer: event.NewNopObserver(),
-		tracer:   trace.NewNoopTracerProvider().Tracer("noop"),
+		tracer:   telemetry.GetNoopTracer(),
+		meter:    telemetry.GetNoopMeter(),
 	}
 
 	for _, opt := range opts {

--- a/server/telemetry/metrics.go
+++ b/server/telemetry/metrics.go
@@ -70,7 +70,7 @@ func getOtelMetricsCollectorExporter(ctx context.Context, exporterConfig *config
 		otlpmetricgrpc.WithInsecure(),
 	)
 	if err != nil {
-		return nil, fmt.Errorf("could not create trace exporter: %w", err)
+		return nil, fmt.Errorf("could not create metric exporter: %w", err)
 	}
 
 	return exporter, nil


### PR DESCRIPTION
This PR adds metrics for the agent actions. We are adding `run` and `error` counters for the following actions: `test connection`, `test stop`, `trigger` and `polling`.

## Changes

- added meter on workers
- updated telemetry reporting for traces and metrics

## Fixes

- updated timeouts for synthetic monitoring

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test