### PR TITLE
fix(server): fixing context propagation on nats

### DIFF
--- a/server/pkg/pipeline/queue.go
+++ b/server/pkg/pipeline/queue.go
@@ -82,7 +82,9 @@ func (q Queue[T]) Enqueue(ctx context.Context, item T) {
 
 	workerCtx := context.Background()
 	if propagator := otel.GetTextMapPropagator(); propagator != nil {
-		var carrier propagation.HeaderCarrier
+		carrier := make(propagation.HeaderCarrier)
+		propagator.Inject(ctx, carrier)
+
 		workerCtx = propagator.Extract(workerCtx, carrier)
 	}
 


### PR DESCRIPTION
This PR fixes a propagation error that Core had on Nats, making operations that uses queue to have multiple traces instead of a single one.

## Checklist

- [ ] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
