### PR TITLE
chore(frontend): Updating the default test run tab

### DIFF
--- a/web/src/components/RunDetailLayout/RunDetailLayout.tsx
+++ b/web/src/components/RunDetailLayout/RunDetailLayout.tsx
@@ -34,7 +34,7 @@ const renderTab = (title: string, testId: string, runId: number, mode: string) =
 );
 
 const RunDetailLayout = ({test: {id, name, trigger, skipTraceCollection}, test}: IProps) => {
-  const {mode = RunDetailModes.TRIGGER} = useParams();
+  const {mode = RunDetailModes.TEST} = useParams();
   const {isError, run, runEvents} = useTestRun();
   useDocumentTitle(`${name} - ${run.state}`);
   const runOriginPath = useAppSelector(UserSelectors.selectRunOriginPath);


### PR DESCRIPTION
This PR updates the default run result tab to be the test instead of the trigger

## Changes

- Updates default tab for the test run page

## Fixes

- https://github.com/kubeshop/tracetest-cloud/issues/448

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
