### PR TITLE
fix: make closing connection not reconnect and actually kill the routine

### DIFF
--- a/agent/client/client.go
+++ b/agent/client/client.go
@@ -197,7 +197,11 @@ func (c *Client) getName() (string, error) {
 }
 
 func isCancelledError(err error) bool {
-	return err != nil && strings.Contains(err.Error(), "context canceled")
+	if err == nil {
+		return false
+	}
+
+	return strings.Contains(err.Error(), "context canceled") || strings.Contains(err.Error(), "the client connection is closing")
 }
 
 func (c *Client) reconnect() error {
@@ -248,7 +252,6 @@ func isConnectionError(err error) bool {
 		// From time to time, the server can start sending those errors to the
 		// agent. This mitigates the risk of an agent getting stuck in an error state
 		"unexpected HTTP status code received from server: 500",
-		"the client connection is closing",
 	}
 	for _, possibleErr := range possibleErrors {
 		if strings.Contains(err.Error(), possibleErr) {


### PR DESCRIPTION
This PR...

## Changes

-

## Fixes

-

## Checklist

- [ ] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Loom video

Add your loom video here if your work can be visualized
