### PR TITLE
fix: unescape filter argument before running filter

### DIFF
--- a/server/expression/executor.go
+++ b/server/expression/executor.go
@@ -341,7 +341,7 @@ func (e Executor) executeFilter(input value.Value, filter *Filter) (value.Value,
 			return value.Nil, err
 		}
 
-		args = append(args, resolvedArg.Value().Value)
+		args = append(args, resolvedArg.UnescappedString())
 	}
 
 	newValue, err := executeFilter(input, filter.Name, args)

--- a/server/expression/executor_test.go
+++ b/server/expression/executor_test.go
@@ -182,6 +182,13 @@ func TestStringInterpolationExecution(t *testing.T) {
 }
 
 func TestFilterExecution(t *testing.T) {
+	jsonResponseSpan := traces.Span{
+		ID:         id.NewRandGenerator().SpanID(),
+		Attributes: traces.NewAttributes(),
+	}
+
+	jsonResponseSpan.Attributes.Set("tracetest.response.body", `{"results":[{"count(*)":{"result":3}}]}`)
+
 	testCases := []executorTestCase{
 		{
 			Name:       "should_extract_id_from_json",
@@ -215,6 +222,14 @@ func TestFilterExecution(t *testing.T) {
 			Name:       "should_get_last_item_from_list",
 			Query:      `'{ "array": [1, 2, 5] }' | json_path '$.array[*]' | get_index 'last' = 5`,
 			ShouldPass: true,
+		},
+		{
+			Name:       "should_unescape_filter_arg",
+			Query:      `attr:tracetest.response.body | json_path '$.results[0][\'count(*)\'].result' = 3`,
+			ShouldPass: true,
+			AttributeDataStore: expression.AttributeDataStore{
+				Span: jsonResponseSpan,
+			},
 		},
 	}
 

--- a/server/expression/filters/json_path_test.go
+++ b/server/expression/filters/json_path_test.go
@@ -40,6 +40,11 @@ func TestJSONPath(t *testing.T) {
 			Query:          `$.array[*]..['id', 'name']`,
 			ExpectedOutput: `[38, "Tracetest", 39, "Kusk"]`,
 		},
+		{
+			JSON:           `{"results":[{"count(*)":{"result":3}}]}`,
+			Query:          `$.results[0]['count(*)'].result`,
+			ExpectedOutput: `3`,
+		},
 	}
 
 	for _, testCase := range testCases {

--- a/server/expression/filters/json_path_test.go
+++ b/server/expression/filters/json_path_test.go
@@ -40,11 +40,6 @@ func TestJSONPath(t *testing.T) {
 			Query:          `$.array[*]..['id', 'name']`,
 			ExpectedOutput: `[38, "Tracetest", 39, "Kusk"]`,
 		},
-		{
-			JSON:           `{"results":[{"count(*)":{"result":3}}]}`,
-			Query:          `$.results[0]['count(*)'].result`,
-			ExpectedOutput: `3`,
-		},
 	}
 
 	for _, testCase := range testCases {

--- a/server/expression/value/value.go
+++ b/server/expression/value/value.go
@@ -83,3 +83,11 @@ func (v Value) String() string {
 
 	return v.Value().Value
 }
+
+func (v Value) UnescappedString() string {
+	output := v.String()
+	output = strings.ReplaceAll(output, `\'`, `'`)
+	output = strings.ReplaceAll(output, `\"`, `"`)
+
+	return output
+}


### PR DESCRIPTION
This PR fixes a bug found where escaped characters would not be unescaped before used in the filters.

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [x] added a test

