### PR TITLE
chore: update observability to the rescue example files

### DIFF
--- a/examples/observability-to-the-rescue/tracetest/tests/test-with-error.yaml
+++ b/examples/observability-to-the-rescue/tracetest/tests/test-with-error.yaml
@@ -1,33 +1,30 @@
 type: Test
 spec:
-  id: yWoVaiuVR
+  id: 7uEPjAoIg
   name: Your API call with error
-  description: Test call that will fail on purpose, showing the error propagation problem in the Payment System
   trigger:
     type: http
     httpRequest:
-      url: http://your-api:10013/executePaymentOrder
       method: POST
+      url: http://your-api:10013/executePaymentOrder
+      body: |
+        {
+          "walletId": 4,
+          "yearsAsACustomer": 0
+        }
       headers:
       - key: Content-Type
         value: application/json
-      body: |-
-        {
-            "walletId": 4,
-            "yearsAsACustomer": 0
-        }
   specs:
-  - name: Your-API is OK
-    selector: span[name="POST /executePaymentOrder" http.target="/executePaymentOrder" http.method="POST"]
+  - selector: span[name="POST /executePaymentOrder" http.target="/executePaymentOrder" http.method="POST"]
+    name: Your-API is OK
     assertions:
     - attr:http.status_code = 200
-  - name: Payment-Executor is OK
-    selector: span[tracetest.span.type="http" name="POST" http.target="/payment/execute" http.method="POST"]
+  - selector: span[tracetest.span.type="http" name="POST" http.target="/payment/execute" http.method="POST"]
+    name: Payment-Executor is OK
     assertions:
     - attr:http.status_code = 200
-  - name: Risk-Analysis API calculation is returning OK
-    selector: span[name="/computeRisk" http.target="/computeRisk" http.method="POST"]
+  - selector: span[name="/computeRisk" http.target="/computeRisk" http.method="POST"]
+    name: Risk-Analysis API calculation is returning OK
     assertions:
     - attr:http.status_code = 200
-
-

--- a/examples/observability-to-the-rescue/tracetest/tests/test-with-success.yaml
+++ b/examples/observability-to-the-rescue/tracetest/tests/test-with-success.yaml
@@ -6,16 +6,16 @@ spec:
   trigger:
     type: http
     httpRequest:
-      url: http://your-api:10013/executePaymentOrder
       method: POST
+      url: http://your-api:10013/executePaymentOrder
+      body: |
+        {
+          "walletId": 4,
+          "yearsAsACustomer": 1
+        }
       headers:
       - key: Content-Type
         value: application/json
-      body: |-
-        {
-            "walletId": 4,
-            "yearsAsACustomer": 1
-        }
   specs:
   - name: Your-API is OK
     selector: span[name="POST /executePaymentOrder" http.target="/executePaymentOrder" http.method="POST"]


### PR DESCRIPTION
This PR updates the test files on our "Observability to the Rescue" example, that were broken due to the `|-` yaml syntax usage. 

## Changes

- Update Observability to the resue example

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test