### PR TITLE
feat: support `contains` to compare json objects

### DIFF
--- a/server/assertions/comparator/comparators.go
+++ b/server/assertions/comparator/comparators.go
@@ -8,8 +8,9 @@ type Comparator interface {
 }
 
 var (
-	ErrNoMatch  = fmt.Errorf("no match")
-	ErrNotFound = fmt.Errorf("not found")
+	ErrNoMatch   = fmt.Errorf("no match")
+	ErrNotFound  = fmt.Errorf("not found")
+	ErrWrongType = fmt.Errorf("wrong type")
 )
 
 type Registry interface {

--- a/server/expression/comparison.go
+++ b/server/expression/comparison.go
@@ -4,10 +4,17 @@ import (
 	"fmt"
 
 	"github.com/kubeshop/tracetest/server/assertions/comparator"
+	"github.com/kubeshop/tracetest/server/expression/types"
 	"github.com/kubeshop/tracetest/server/expression/value"
 )
 
 func compare(comparatorName string, leftValue, rightValue value.Value) error {
+	if rightValue.Value().Type == types.TypeJson && comparatorName == "contains" {
+		if leftValue.Value().Type == types.TypeJson || leftValue.Value().Type == types.TypeArray {
+			comparatorName = "json-contains"
+		}
+	}
+
 	comparatorFunction, err := comparator.DefaultRegistry().Get(comparatorName)
 	if err != nil {
 		return fmt.Errorf("comparator not supported: %w", err)
@@ -17,12 +24,7 @@ func compare(comparatorName string, leftValue, rightValue value.Value) error {
 		return compareArrayContains(leftValue, rightValue)
 	}
 
-	err = comparatorFunction.Compare(rightValue.String(), leftValue.String())
-	if err == comparator.ErrNoMatch {
-		return ErrNoMatch
-	}
-
-	return nil
+	return comparatorFunction.Compare(rightValue.String(), leftValue.String())
 }
 
 func compareArrayContains(array, expected value.Value) error {

--- a/server/expression/executor_test.go
+++ b/server/expression/executor_test.go
@@ -373,6 +373,48 @@ func TestArrayExecution(t *testing.T) {
 			Query:      `[31,35,39] contains 42`,
 			ShouldPass: false,
 		},
+		{
+			Name:       "should_identify_array_instead_of_json",
+			Query:      `["{}", "{}", "{}"] | type = "array"`,
+			ShouldPass: true,
+		},
+	}
+
+	executeTestCases(t, testCases)
+}
+
+func TestJSONExecution(t *testing.T) {
+	testCases := []executorTestCase{
+		{
+			Name:       "should_identify_json_input",
+			Query:      `'{"name": "john", "age": 32, "email": "john@company.com"}' | type = "json"`,
+			ShouldPass: true,
+		},
+		{
+			Name:       "should_be_able_to_compare_with_subset",
+			Query:      `'{"name": "john", "age": 32, "email": "john@company.com"}' contains '{"email": "john@company.com", "name": "john"}'`,
+			ShouldPass: true,
+		},
+		{
+			Name:       "should_be_able_to_compare_deep_objects_in_subset",
+			Query:      `'{"name": "john", "age": 32, "email": "john@company.com", "company": {"name": "Company", "address": "1234 Agora Street"}}' contains '{"email": "john@company.com", "name": "john", "company": {"name": "Company"}}'`,
+			ShouldPass: true,
+		},
+		{
+			Name:       "should_be_able_to_compare_array_of_json_objects",
+			Query:      `'[{"name": "john", "age": 32}, {"name": "Maria", "age": 63}]' contains '[{"age": 63}, {"age": 32}]'`,
+			ShouldPass: true,
+		},
+		{
+			Name:       "should_match_complete_arrays",
+			Query:      `'{"numbers": [0,1,2,3,4]}' contains '{"numbers": [0,1,2,3,4]}'`,
+			ShouldPass: true,
+		},
+		{
+			Name:       "should_fail_when_array_doesnt_match_size_and_order",
+			Query:      `'{"numbers": [0,1,2,3,4]}' contains '{"numbers": [0,1]}'`,
+			ShouldPass: false,
+		},
 	}
 
 	executeTestCases(t, testCases)

--- a/server/expression/types/types.go
+++ b/server/expression/types/types.go
@@ -1,6 +1,9 @@
 package types
 
-import "regexp"
+import (
+	"encoding/json"
+	"regexp"
+)
 
 type Type uint
 
@@ -12,11 +15,13 @@ const (
 	TypeDuration
 	TypeVariable
 	TypeArray
+	TypeJson
 )
 
 var typeNames = map[Type]string{
 	TypeNil:       "nil",
 	TypeString:    "string",
+	TypeJson:      "json",
 	TypeNumber:    "number",
 	TypeAttribute: "attribute",
 	TypeDuration:  "duration",
@@ -37,7 +42,16 @@ func GetType(value string) Type {
 		return TypeDuration
 	}
 
+	if err := json.Unmarshal([]byte(value), &map[string]any{}); err == nil {
+		return TypeJson
+	}
+
 	if arrayRegex.Match([]byte(value)) {
+		var jsonArray = []map[string]any{}
+		if err := json.Unmarshal([]byte(value), &jsonArray); err == nil {
+			return TypeJson
+		}
+
 		return TypeArray
 	}
 


### PR DESCRIPTION
This PR allows an expression to compare two json objects with a `subset` relationship. Related to #3684 

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [x] added a test

## Loom video

Check tests for details
