### PR TITLE
fix(frontend): ui cleanup and improvements

### DIFF
--- a/web/src/components/ResourceCard/Box.tsx
+++ b/web/src/components/ResourceCard/Box.tsx
@@ -1,0 +1,31 @@
+import {Tooltip} from 'antd';
+import {ResourceType} from 'types/Resource.type';
+import {abbreviateNumber} from 'utils/Common';
+import * as S from './ResourceCard.styled';
+
+const INITIAL_TIER = 1000;
+
+interface IProps {
+  num: number;
+  type: ResourceType;
+}
+
+const Box = ({num, type}: IProps) => {
+  if (num < INITIAL_TIER) {
+    return (
+      <S.Box $type={type}>
+        <S.BoxTitle level={4}>{num}</S.BoxTitle>
+      </S.Box>
+    );
+  }
+
+  return (
+    <S.Box $type={type}>
+      <Tooltip title={num}>
+        <S.BoxTitle level={4}>{abbreviateNumber(num)}</S.BoxTitle>
+      </Tooltip>
+    </S.Box>
+  );
+};
+
+export default Box;

--- a/web/src/components/ResourceCard/TestCard.tsx
+++ b/web/src/components/ResourceCard/TestCard.tsx
@@ -6,6 +6,7 @@ import TracetestAPI from 'redux/apis/Tracetest';
 import {ResourceType} from 'types/Resource.type';
 import Test from 'models/Test.model';
 import TestRun from 'models/TestRun.model';
+import Box from './Box';
 import * as S from './ResourceCard.styled';
 import ResourceCardActions from './ResourceCardActions';
 import ResourceCardRuns from './ResourceCardRuns';
@@ -37,9 +38,9 @@ const TestCard = ({onEdit, onDelete, onDuplicate, onRun, onViewAll, test}: IProp
     <S.Container $type={ResourceType.Test}>
       <S.TestContainer onClick={onClick}>
         {isCollapsed ? <RightOutlined data-cy={`collapse-test-${test.id}`} /> : <DownOutlined />}
-        <S.Box $type={ResourceType.Test}>
-          <S.BoxTitle level={2}>{test.summary.runs}</S.BoxTitle>
-        </S.Box>
+
+        <Box num={test.summary.runs} type={ResourceType.Test} />
+
         <S.TitleContainer>
           <S.Title level={3}>{test.name}</S.Title>
           <S.Text>

--- a/web/src/components/ResourceCard/TestSuiteCard.tsx
+++ b/web/src/components/ResourceCard/TestSuiteCard.tsx
@@ -7,6 +7,7 @@ import TracetestAPI from 'redux/apis/Tracetest';
 import {ResourceType} from 'types/Resource.type';
 import TestSuite from 'models/TestSuite.model';
 import TestSuiteRun from 'models/TestSuiteRun.model';
+import Box from './Box';
 import * as S from './ResourceCard.styled';
 import ResourceCardActions from './ResourceCardActions';
 import ResourceCardRuns from './ResourceCardRuns';
@@ -46,9 +47,9 @@ const TestSuiteCard = ({
     <S.Container $type={ResourceType.TestSuite}>
       <S.TestContainer onClick={onClick}>
         {isCollapsed ? <RightOutlined data-cy={`collapse-testsuite-${testSuiteId}`} /> : <DownOutlined />}
-        <S.Box $type={ResourceType.TestSuite}>
-          <S.BoxTitle level={2}>{summary.runs}</S.BoxTitle>
-        </S.Box>
+
+        <Box num={summary.runs} type={ResourceType.TestSuite} />
+
         <S.TitleContainer>
           <S.Title level={3}>{name}</S.Title>
           <S.Text>{description}</S.Text>

--- a/web/src/components/Resources/Content/Content.styled.ts
+++ b/web/src/components/Resources/Content/Content.styled.ts
@@ -3,7 +3,7 @@ import styled from 'styled-components';
 
 export const Body = styled.div`
   display: flex;
-  gap: 24px;
+  gap: 12px;
   width: 100%;
 `;
 

--- a/web/src/components/Resources/Content/Content.tsx
+++ b/web/src/components/Resources/Content/Content.tsx
@@ -15,43 +15,49 @@ const Content = () => {
         <S.Card>
           <S.Icon src={groupIcon} />
           <div>
-            <S.Title>Tests</S.Title>
+            <S.Title level={3}>Tests</S.Title>
             <S.Text>
               Haven&apos;t created a test yet? Go to the &apos;Tests&apos; page to kickstart your testing adventure.
             </S.Text>
-            <S.Link
-              onClick={e => {
-                e.preventDefault();
-                navigate(`/tests`);
-              }}
-            >
-              {' '}
-              Go to tests <ArrowRightOutlined />
-            </S.Link>
+            <div>
+              <S.Link
+                onClick={e => {
+                  e.preventDefault();
+                  navigate(`/tests`);
+                }}
+              >
+                {' '}
+                Go to tests <ArrowRightOutlined />
+              </S.Link>
+            </div>
           </div>
         </S.Card>
 
         <S.Card>
           <S.Icon src={pagesIcon} />
           <div>
-            <S.Title>Documentation</S.Title>
+            <S.Title level={3}>Documentation</S.Title>
             <S.Text>The ultimate technical resources and step-by-step guides that allows you to quickly start.</S.Text>
-            <S.Link target="_blank" href={DOCUMENTATION_URL}>
-              {' '}
-              View documentation <ArrowRightOutlined />
-            </S.Link>
+            <div>
+              <S.Link target="_blank" href={DOCUMENTATION_URL}>
+                {' '}
+                View documentation <ArrowRightOutlined />
+              </S.Link>
+            </div>
           </div>
         </S.Card>
 
         <S.Card>
           <S.Icon src={mediaIcon} />
           <div>
-            <S.Title>Community</S.Title>
+            <S.Title level={3}>Community</S.Title>
             <S.Text>Check the latest updates and support from the community.</S.Text>
-            <S.Link target="_blank" href={COMMUNITY_SLACK_URL}>
-              {' '}
-              Join our community <ArrowRightOutlined />
-            </S.Link>
+            <div>
+              <S.Link target="_blank" href={COMMUNITY_SLACK_URL}>
+                {' '}
+                Join our community <ArrowRightOutlined />
+              </S.Link>
+            </div>
           </div>
         </S.Card>
       </S.Body>

--- a/web/src/components/RunDetailAutomate/RunDetailAutomate.tsx
+++ b/web/src/components/RunDetailAutomate/RunDetailAutomate.tsx
@@ -54,7 +54,7 @@ function getMethods(triggerType: TriggerTypes) {
         },
         {
           id: 'typescript',
-          label: 'Typescript',
+          label: 'TypeScript',
           component: Typescript,
         },
       ];

--- a/web/src/components/RunStatusIcon/RunStatusIcon.styled.ts
+++ b/web/src/components/RunStatusIcon/RunStatusIcon.styled.ts
@@ -1,4 +1,10 @@
-import {CheckCircleFilled, InfoCircleFilled, LoadingOutlined, MinusCircleFilled} from '@ant-design/icons';
+import {
+  CheckCircleFilled,
+  ExclamationCircleFilled,
+  InfoCircleFilled,
+  LoadingOutlined,
+  MinusCircleFilled,
+} from '@ant-design/icons';
 import {Typography} from 'antd';
 import styled from 'styled-components';
 
@@ -12,6 +18,10 @@ export const IconFail = styled(MinusCircleFilled)`
 
 export const IconInfo = styled(InfoCircleFilled)`
   color: ${({theme}) => theme.color.textLight};
+`;
+
+export const IconWarning = styled(ExclamationCircleFilled)`
+  color: ${({theme}) => theme.color.warningYellow};
 `;
 
 export const SequenceText = styled.div`

--- a/web/src/components/RunStatusIcon/RunStatusIcon.tsx
+++ b/web/src/components/RunStatusIcon/RunStatusIcon.tsx
@@ -18,21 +18,23 @@ const Icon = ({state, requiredGatesResult: {passed}}: IProps) => {
     return <S.IconInfo />;
   }
 
-  if (isRunStateFailed(state) || !passed) {
+  if (isRunStateFailed(state)) {
+    return <S.IconWarning />;
+  }
+
+  if (!passed) {
     return <S.IconFail />;
   }
 
   return <S.IconSuccess />;
 };
 
-const RunStatusIcon = (props: IProps) => {
-  return (
-    <Tooltip title={() => <RunTooltipTitle {...props} />}>
-      <S.IconWrapper>
-        <Icon {...props} />
-      </S.IconWrapper>
-    </Tooltip>
-  );
-};
+const RunStatusIcon = (props: IProps) => (
+  <Tooltip title={() => <RunTooltipTitle {...props} />}>
+    <S.IconWrapper>
+      <Icon {...props} />
+    </S.IconWrapper>
+  </Tooltip>
+);
 
 export default RunStatusIcon;

--- a/web/src/components/RunStatusIcon/RunTooltipTitle.tsx
+++ b/web/src/components/RunStatusIcon/RunTooltipTitle.tsx
@@ -1,8 +1,23 @@
-import {useTheme} from 'styled-components';
+import {TestState} from 'constants/TestRun.constants';
 import TestRun, {isRunStateFailed, isRunStateFinished, isRunStateStopped} from 'models/TestRun.model';
 import RequiredGatesResult from 'models/RequiredGatesResult.model';
+import {useTheme} from 'styled-components';
+import {TTestRunState} from 'types/TestRun.types';
 import {ToTitle} from 'utils/Common';
 import * as S from './RunStatusIcon.styled';
+
+function getRunStateFailedMessage(state: TTestRunState) {
+  switch (state) {
+    case TestState.TRIGGER_FAILED:
+      return 'The run failed in the trigger stage';
+    case TestState.TRACE_FAILED:
+      return 'The run failed in fetching the trace';
+    case TestState.ASSERTION_FAILED:
+      return 'The run failed to execute the assertions';
+    default:
+      return 'The run execution failed';
+  }
+}
 
 interface IProps {
   state: TestRun['state'];
@@ -16,6 +31,9 @@ const RunTooltipTitle = ({requiredGatesResult: {required, requiredFailedGates, p
 
   const isStopped = isRunStateStopped(state);
   if (isStopped) return <>The run has been manually stopped</>;
+
+  const isFailed = isRunStateFailed(state);
+  if (isFailed) return <>{getRunStateFailedMessage(state)}</>;
 
   const isFinished = isRunStateFinished(state);
   const isSuccessful = isFinished && passed;
@@ -33,9 +51,6 @@ const RunTooltipTitle = ({requiredGatesResult: {required, requiredFailedGates, p
       </>
     );
   }
-
-  const isRunnerFailed = isRunStateFailed(state);
-  if (isRunnerFailed) return <>The run execution failed</>;
 
   const isGatesFailed = isFinished && !passed;
   if (isGatesFailed)

--- a/web/src/utils/Common.ts
+++ b/web/src/utils/Common.ts
@@ -100,3 +100,25 @@ export const withLowPriority =
 export const toPercent = (value: number) => {
   return `${value * 100}%`;
 };
+
+export const abbreviateNumber = (num: number): string => {
+  const symbols = ['', 'k', 'M', 'G', 'T', 'P', 'E'];
+
+  // tier to determine suffix
+  // eslint-disable-next-line no-bitwise
+  const tier = (Math.log10(num) / 3) | 0;
+
+  // if zero not need a suffix
+  if (tier === 0) return num.toString();
+
+  // get suffix
+  const suffix = symbols[tier];
+  if (!suffix) return num.toString();
+
+  // get scale
+  const scale = 10 ** (tier * 3);
+  const scaled = num / scale;
+  const rounded = scaled.toFixed(1);
+
+  return rounded + suffix;
+};


### PR DESCRIPTION
This PR adds UI improvements to the Tests list, Resources component in Home page and Automate tab.

## Changes

- fix TypeScript title
- change test run summary to include abbreviate number
- add new icon for failed trigger, trace and assertions status
- fix alignment for action links in resources

## Fixes

- fixes https://github.com/kubeshop/tracetest-cloud-frontend/issues/242 
- fixes https://github.com/kubeshop/tracetest-cloud-frontend/issues/251
- fixes https://github.com/kubeshop/tracetest-cloud-frontend/issues/252
- fixes https://github.com/kubeshop/tracetest-cloud-frontend/issues/250

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Screenshots

### Test list
- New test run summary with abbreviated number
- New icon for failed trigger, trace and assertions
<img width="1549" alt="Screenshot 2024-02-28 at 15 19 02" src="https://github.com/kubeshop/tracetest/assets/3879892/9821013b-f6da-4f6d-979d-6a83f360e259">

### Resources
<img width="1548" alt="Screenshot 2024-02-28 at 15 18 27" src="https://github.com/kubeshop/tracetest/assets/3879892/9da0994a-23d6-46f8-acf5-15b81fbc1441">