### PR TITLE
fix(frontend): remove wizard css margin

### DIFF
--- a/web/src/components/Wizard/Content/Content.styled.ts
+++ b/web/src/components/Wizard/Content/Content.styled.ts
@@ -2,7 +2,7 @@ import {Typography} from 'antd';
 import styled, {css} from 'styled-components';
 
 export const Container = styled.div`
-  margin: 8px 0;
+  margin: 8px 0 0;
 
   .ant-tabs-card > .ant-tabs-nav .ant-tabs-tab,
   .ant-tabs-card > div > .ant-tabs-nav .ant-tabs-tab {


### PR DESCRIPTION
This PR removes the wizard margin-bottom value.

## Changes

- removes wizard margin-bottom

## Fixes

-

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
