### PR TITLE
fix(server): fixing profiler config

### DIFF
--- a/server/cmd/serve.go
+++ b/server/cmd/serve.go
@@ -39,7 +39,7 @@ var serveCmd = &cobra.Command{
 
 		profilerConfig := cfg.ApplicationProfiler()
 		if profilerConfig.Enabled {
-			telemetry.StartProfiler(profilerConfig.Name, profilerConfig.Endpoint, profilerConfig.SamplingRate)
+			telemetry.StartProfiler(profilerConfig.Name, profilerConfig.Environment, profilerConfig.Endpoint, profilerConfig.SamplingRate)
 		}
 
 		wg.Add(1)

--- a/server/config/exporters.go
+++ b/server/config/exporters.go
@@ -42,6 +42,7 @@ type (
 		Enabled      bool   `yaml:",omitempty" mapstructure:"enabled"`
 		Endpoint     string `yaml:",omitempty" mapstructure:"endpoint"`
 		SamplingRate int    `yaml:",omitempty" mapstructure:"samplingRate"`
+		Environment  string `yaml:",omitempty" mapstructure:"environment"`
 	}
 )
 

--- a/server/config/validate.go
+++ b/server/config/validate.go
@@ -37,7 +37,6 @@ func (c *AppConfig) Validate() error {
 			err,
 			fmt.Errorf("invalid config value for '%s': %s", opt.key, optErr.Error()),
 		)
-
 	}
 
 	return err

--- a/server/telemetry/profiler.go
+++ b/server/telemetry/profiler.go
@@ -12,7 +12,7 @@ const (
 	BlockProfileFractionRate = 5
 )
 
-func StartProfiler(applicationName, telemetryServer string, samplingPercentage int) {
+func StartProfiler(applicationName, applicationEnvironment, telemetryServer string, samplingPercentage int) {
 	samplingRate := 100 / samplingPercentage
 
 	runtime.SetMutexProfileFraction(samplingRate)
@@ -25,11 +25,13 @@ func StartProfiler(applicationName, telemetryServer string, samplingPercentage i
 		ServerAddress: telemetryServer,
 
 		// you can disable logging by setting this to nil
-		Logger: pyroscope.StandardLogger,
+		// Logger: pyroscope.StandardLogger,
+		Logger: nil,
 
 		// you can provide static tags via a map:
 		Tags: map[string]string{
-			"hostname": os.Getenv("HOSTNAME"),
+			"hostname":    os.Getenv("HOSTNAME"),
+			"environment": applicationEnvironment,
 		},
 
 		ProfileTypes: []pyroscope.ProfileType{


### PR DESCRIPTION
This PR fixes small configs on the profiler to avoid logging too much data. Also, we are tagging the profiler per environment.

## Changes

- Update profiler config

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test