### PR TITLE
docs(announcement-bar): update for kubecon

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -118,8 +118,10 @@ const config = {
         id: 'announcement',
         // content:
         //   '<a target="_blank" rel="noopener noreferrer" href="https://www.youtube.com/live/2MSDy3XHjtE?si=VlK7cxJOsgKi5QTE&t=1132">Tracetest is the official testing harness for the OpenTelemetry Demo! 🚀</a>',
+        // content:
+        //   '<a target="_blank" rel="noopener noreferrer" href="https://tracetest.io/pricing">Tracetest Open Beta is Live. Try it! Give us feedback! 🙌</a>',
         content:
-          '<a target="_blank" rel="noopener noreferrer" href="https://tracetest.io/pricing">Tracetest Open Beta is Live. Try it! Give us feedback! 🙌</a>',
+          '<a target="_blank" rel="noopener noreferrer" href="https://tracetest.io/blog/tracetest-is-going-to-kubecon-cloudnativecon-europe-in-paris">Tracetest is going to KubeCon + CloudNativeCon Europe in Paris 🇫🇷</a>',
         isCloseable: false,
       },  
       navbar: {


### PR DESCRIPTION
This PR updates the announcement top bar on the docs to link to a blog post about Tracetest going to KubeCon EU.

## Changes

-

## Fixes

-

## Checklist

- [ ] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Loom video

Add your loom video here if your work can be visualized
