### PR TITLE
chore(agent): splitting telemetry code

### DIFF
--- a/agent/client/mocks/grpc_server.go
+++ b/agent/client/mocks/grpc_server.go
@@ -10,7 +10,7 @@ import (
 	"github.com/avast/retry-go"
 	"github.com/kubeshop/tracetest/agent/client"
 	"github.com/kubeshop/tracetest/agent/proto"
-	"github.com/kubeshop/tracetest/server/telemetry"
+	"github.com/kubeshop/tracetest/agent/telemetry"
 	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
 	"go.opentelemetry.io/otel/propagation"
 	"google.golang.org/grpc"

--- a/agent/client/workflow_listen_for_ds_connection_tests.go
+++ b/agent/client/workflow_listen_for_ds_connection_tests.go
@@ -7,7 +7,7 @@ import (
 	"time"
 
 	"github.com/kubeshop/tracetest/agent/proto"
-	"github.com/kubeshop/tracetest/server/telemetry"
+	"github.com/kubeshop/tracetest/agent/telemetry"
 	"go.uber.org/zap"
 )
 

--- a/agent/client/workflow_listen_for_otlp_connection_tests.go
+++ b/agent/client/workflow_listen_for_otlp_connection_tests.go
@@ -7,7 +7,7 @@ import (
 	"time"
 
 	"github.com/kubeshop/tracetest/agent/proto"
-	"github.com/kubeshop/tracetest/server/telemetry"
+	"github.com/kubeshop/tracetest/agent/telemetry"
 	"go.uber.org/zap"
 )
 

--- a/agent/client/workflow_listen_for_poll_requests.go
+++ b/agent/client/workflow_listen_for_poll_requests.go
@@ -7,7 +7,7 @@ import (
 	"time"
 
 	"github.com/kubeshop/tracetest/agent/proto"
-	"github.com/kubeshop/tracetest/server/telemetry"
+	"github.com/kubeshop/tracetest/agent/telemetry"
 	"go.uber.org/zap"
 )
 

--- a/agent/client/workflow_listen_for_trigger_requests.go
+++ b/agent/client/workflow_listen_for_trigger_requests.go
@@ -7,7 +7,7 @@ import (
 	"time"
 
 	"github.com/kubeshop/tracetest/agent/proto"
-	"github.com/kubeshop/tracetest/server/telemetry"
+	"github.com/kubeshop/tracetest/agent/telemetry"
 	"go.uber.org/zap"
 )
 

--- a/agent/telemetry/common.go
+++ b/agent/telemetry/common.go
@@ -1,13 +1,19 @@
 package telemetry
 
 import (
+	"context"
 	"fmt"
 	"os"
 
 	"github.com/kubeshop/tracetest/server/version"
+	"go.opentelemetry.io/otel/propagation"
 	"go.opentelemetry.io/otel/sdk/resource"
 	semconv "go.opentelemetry.io/otel/semconv/v1.21.0"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
 )
+
+var propagator = propagation.NewCompositeTextMapPropagator(propagation.TraceContext{}, propagation.Baggage{})
 
 func getAgentServiceName(serviceName string) string {
 	return fmt.Sprintf("tracetest.agent-%s", serviceName)
@@ -34,4 +40,54 @@ func getResource(serviceName string) (*resource.Resource, error) {
 	}
 
 	return resource, nil
+}
+
+func InjectContextIntoStream(ctx context.Context, stream grpc.ServerStream) error {
+	header := make(metadata.MD)
+	propagator.Inject(ctx, &metadataSupplier{metadata: &header})
+
+	err := stream.SetHeader(header)
+	if err != nil {
+		return fmt.Errorf("could not set header: %w", err)
+	}
+
+	return nil
+}
+
+func ExtractContextFromStream(stream grpc.ClientStream) (context.Context, error) {
+	ctx := stream.Context()
+	header, err := stream.Header()
+	if err != nil {
+		return ctx, fmt.Errorf("coult not get header from stream: %w", err)
+	}
+
+	ctx = propagator.Extract(ctx, &metadataSupplier{metadata: &header})
+	return ctx, nil
+}
+
+type metadataSupplier struct {
+	metadata *metadata.MD
+}
+
+// assert that metadataSupplier implements the TextMapCarrier interface.
+var _ propagation.TextMapCarrier = &metadataSupplier{}
+
+func (s *metadataSupplier) Get(key string) string {
+	values := s.metadata.Get(key)
+	if len(values) == 0 {
+		return ""
+	}
+	return values[0]
+}
+
+func (s *metadataSupplier) Set(key string, value string) {
+	s.metadata.Set(key, value)
+}
+
+func (s *metadataSupplier) Keys() []string {
+	out := make([]string, 0, len(*s.metadata))
+	for key := range *s.metadata {
+		out = append(out, key)
+	}
+	return out
 }


### PR DESCRIPTION
This PR removes the usage of the telemetry package from the server code and moves into the agent

## Changes

- Moves telemetry code to the agent namespac

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
