### PR TITLE
chore: Updating license for agent and the rest of the code

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,21 +1,8 @@
-MIT License
+Source code in this repository is variously licensed under the Tracetest 
+Community License (TCL) and the MIT license.
 
-Copyright (c) 2022 Kubeshop
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+Source code in a given file is licensed under the applicable license 
+for that source code. Source code is licensed under the MIT license 
+unless otherwise indicated in the header referenced at the beginning 
+of the file or specified by a LICENSE file in the same containing 
+folder as the file.

--- a/agent/LICENSE
+++ b/agent/LICENSE
@@ -1,0 +1,391 @@
+Tracetest Community License Agreement
+
+Please read this Tracetest Community License Agreement (the “Agreement”) 
+carefully before using Tracetest (as defined below), which is offered by 
+Tracetest or its affiliated Legal Entities (“Tracetest”).
+
+By accessing, installing, downloading or in any manner using Tracetest, 
+You agree that You have read and agree to be bound by the terms of this 
+Agreement. If You are accessing Tracetest on behalf of a Legal Entity, 
+You represent and warrant that You have the authority to agree to these 
+terms on its behalf and the right to bind that Legal Entity to this 
+Agreement. Use of Tracetest is expressly conditioned upon Your assent to 
+all the terms of this Agreement, as well as the other Tracetest agreements, 
+including the Tracetest Privacy Policy and Tracetest Terms and Conditions, 
+accessible at: https://app.tracetest.io/privacy-policy.html and 
+https://app.tracetest.io/terms-of-service.html. 
+
+1. Definitions. In addition to other terms defined elsewhere in this Agreement 
+and in the other Tracetest agreements, the terms below have the following 
+meanings.
+
+(a) “Tracetest” shall mean the Test Orchestration and Execution software 
+provided by Tracetest, including both Tracetest Core and Tracetest Pro, as 
+defined below.
+
+(b) “Tracetest Core” shall mean the version and features of Tracetest designated 
+as free of charge at https://tracetest.io/pricing and available at 
+https://github.com/kubeshop/tracetest pursuant to the terms of the MIT license. 
+
+(c) “Tracetest Pro” shall mean the version of Tracetest which includes the 
+additional paid features of Tracetest designated at 
+https://tracetest.io/pricing and made available by Tracetest, also at 
+https://github.com/kubeshop/tracetest, the use of which is subject to additional 
+terms set out below.
+
+(d) “Contribution” shall mean any work of authorship, including the original 
+version of the Work and any modifications or additions to that Work or 
+Derivative Works thereof, that is intentionally submitted to Tracetest for 
+inclusion in the Work by the copyright owner or by an individual or Legal Entity 
+authorized to submit on behalf of the copyright owner. For the purposes of this 
+definition, “submitted” means any form of electronic, verbal, or written 
+communication sent to Tracetest or its representatives, including but not 
+limited to communication on electronic mailing lists, source code control 
+systems, and issue tracking systems that are managed by, or on behalf of, 
+Tracetest for the purpose of discussing and improving the Work, but excluding 
+communication that is conspicuously marked or otherwise designated in writing 
+by the copyright owner as “Not a Contribution.”
+
+(e) “Contributor” shall mean any copyright owner or individual or Legal Entity 
+authorized by the copyright owner, other than Tracetest, from whom Tracetest 
+receives a Contribution that Tracetest subsequently incorporates within the Work.
+
+(f) “Derivative Works” shall mean any work, whether in Source or Object form, 
+that is based on (or derived from) the Work, such as a translation, abridgement, 
+condensation, or any other recasting, transformation, or adaptation for which 
+the editorial revisions, annotations, elaborations, or other modifications 
+represent, as a whole, an original work of authorship. For the purposes of this 
+License, Derivative Works shall not include works that remain separable from, or 
+merely link (or bind by name) to the interfaces of, the Work and Derivative 
+Works thereof. You may create certain Derivative Works of Tracetest Pro (“Pro 
+Derivative Works”, as defined below) provided that such Pro Derivative Works 
+are solely created, distributed, and accessed for Your internal use, and are 
+not created, distributed, or accessed in such a way that the Pro Derivative 
+Works would modify, circumvent, or otherwise bypass controls implemented, if 
+any, to ensure that Tracetest Pro users comply  with the terms of the Paid Pro 
+License. Notwithstanding anything contained herein to the contrary, You may not 
+modify or alter the Source of Tracetest Pro absent Tracetest’s prior express 
+written permission. If You have any questions about creating Pro Derivative 
+Works or otherwise modifying or redistributing Tracetest Pro, please contact 
+Tracetest at support@Tracetest.io. 
+
+(g) “Legal Entity” shall mean the union of the acting entity and all other 
+entities that control, are controlled by, or are under common control with that 
+entity. For the purposes of this definition, “control” means (i) the power, 
+direct or indirect, to cause the direction or management of such entity, whether 
+by contract or otherwise, or (ii) ownership of fifty percent (50%) or more of 
+the outstanding shares, or (iii) beneficial ownership of such entity.
+
+(h) “License” shall mean the terms and conditions for use, reproduction, and 
+distribution of a Work as defined by this Agreement.
+
+(i) “Licensor” shall mean Tracetest or a Contributor, as applicable.
+
+(j) “Object” form shall mean any form resulting from mechanical transformation 
+or translation of a Source form, including but not limited to compiled object 
+code, generated documentation, and conversions to other media types.
+
+(k) “Source” form shall mean the preferred form for making modifications, 
+including but not limited to software source code, documentation source, and 
+configuration files.
+
+(l) “Third Party Works” shall mean Works, including Contributions, and other 
+technology owned by a person or Legal Entity other than Tracetest, as indicated 
+by a copyright notice that is included in or attached to such Works or technology.
+
+(m) “Work” shall mean the work of authorship, whether in Source or Object form, 
+made available under a License, as indicated by a copyright notice that is 
+included in or attached to the work.
+
+(n) “You” (or “Your”) shall mean an individual or Legal Entity exercising 
+permissions granted by this License.
+
+2. Licenses.
+
+(a) License to Tracetest Core. The License for the applicable version of 
+Tracetest Core can be found on the Tracetest Licensing FAQs page and in the 
+applicable license file within the Tracetest GitHub repository(ies). Tracetest 
+Core is a no-cost, entry-level license and as such, contains the following 
+disclaimers: NOTWITHSTANDING ANYTHING TO THE CONTRARY HEREIN, Tracetest CORE 
+IS PROVIDED “AS IS” AND “AS AVAILABLE”, AND ALL EXPRESS OR IMPLIED WARRANTIES 
+ARE EXCLUDED AND DISCLAIMED, INCLUDING WITHOUT LIMITATION THE IMPLIED WARRANTIES 
+OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, NON-INFRINGEMENT, AND ANY 
+WARRANTIES ARISING BY STATUTE OR OTHERWISE IN LAW OR FROM COURSE OF DEALING, 
+COURSE OF PERFORMANCE, OR USE IN TRADE. For clarity, the terms of this Agreement, 
+other than the relevant definitions in Section 1 and this Section 2(a) do not 
+apply to Tracetest Core.
+
+(b) License to Tracetest Pro.
+
+(i) Grant of Copyright License: Subject to the terms of this Agreement, Licensor 
+hereby grants to You a worldwide, non-exclusive, non-transferable limited 
+license to reproduce, prepare Pro Derivative Works (as defined below) of, 
+publicly display, publicly perform, sublicense, and distribute Tracetest Pro for 
+Your business purposes, for so long as You are not in violation of this 
+Section 2(b) and are current on all payments required by Section 4 below.
+
+(ii) Grant of Patent License: Subject to the terms of this Agreement, Licensor 
+hereby grants to You a worldwide, non-exclusive, non-transferable limited patent 
+license to make, have made, use, and import Tracetest Pro, where such license 
+applies only to those patent claims licensable by Licensor that are necessarily 
+infringed by their Contribution(s) alone or by combination of their 
+Contribution(s) with the Work to which such Contribution(s) was submitted. If You 
+institute patent litigation against any entity (including a cross-claim or 
+counterclaim in a lawsuit) alleging that the Work or a Contribution incorporated 
+within the Work constitutes direct or contributory patent infringement, then any 
+patent licenses granted to You under this License for that Work shall terminate 
+as of the date such litigation is filed.
+
+(iii) License to Third Party Works: From time to time Tracetest may use, or 
+provide You access to, Third Party Works in connection with Tracetest Pro. You 
+acknowledge and agree that in addition to this Agreement, Your use of Third Party 
+Works is subject to all other terms and conditions set forth in the License 
+provided with or contained in such Third Party Works. Some Third Party Works may 
+be licensed to You solely for use with Tracetest Pro under the terms of a third 
+party License, or as otherwise notified by Tracetest, and not under the terms of 
+this Agreement. You agree that the owners and third party licensors of Third 
+Party Works are intended third party beneficiaries to this Agreement, and You 
+agree to abide by all third party terms and conditions and licenses.
+
+3. Support. From time to time, in its sole discretion, Tracetest may offer 
+professional services or support for Tracetest, which may now or in the future be 
+subject to additional fees, as outlined at https://tracetest.io/pricing. 
+
+4. Fees for Tracetest Pro or Tracetest Support.
+
+(a) Fees. The License to Tracetest Pro is conditioned upon Your entering into a 
+subscription agreement with Tracetest for its use (a “Paid Pro License”) and 
+timely paying Tracetest for such Paid Pro License; provided that features of 
+Tracetest Pro that are features of Tracetest Core and are not designated as “Pro 
+features” at https://tracetest.io/pricing may be used for free under the terms of 
+the Agreement without a Paid Pro License. Tracetest Pro may at its discretion 
+include within Tracetest Pro certain Source code solely intended to determine 
+Your compliance with the Paid Pro License which may be accessed without a Paid 
+Pro License, provided that under no circumstances may You modify Tracetest Pro 
+to circumvent the Paid Pro License requirement. Any professional services or 
+support for Tracetest may also be subject to Your payment of fees, which will be 
+specified by Tracetest when you sign up to receive such professional services or 
+support. Tracetest reserves the right to change the fees at any time with prior 
+written notice; for recurring fees, any such adjustments will take effect as of 
+the next pay period.
+
+(b) Overdue Payments and Taxes. Overdue payments are subject to a service charge 
+equal to the lesser of 1.5% per month or the maximum legal interest rate allowed 
+by law, and You shall pay all Tracetest reasonable costs of collection, including 
+court costs and attorneys’ fees. Fees are stated and payable in U.S. dollars and 
+are exclusive of all sales, use, value added and similar taxes, duties, 
+withholdings and other governmental assessments (but excluding taxes based on 
+Tracetest income) that may be levied on the transactions contemplated by this 
+Agreement in any jurisdiction, all of which are Your responsibility unless you 
+have provided Tracetest with a valid tax-exempt certificate. If You owe Tracetest 
+overdue payments, Tracetest reserves the right to revoke any license(s) granted 
+by this Agreement and revoke to Your access to Tracetest Core and to Tracetest Pro. 
+
+(c) Record-keeping and Audit. If fees for Tracetest Pro are based on the number 
+of environments running on Tracetest Pro or another use-based unit of measurement, 
+including number of users, You must maintain complete and accurate records with 
+respect Your use of Tracetest Pro and will provide such records to Tracetest for 
+inspection or audit upon Tracetest’s reasonable request. If an inspection or 
+audit uncovers additional usage by You for which fees are owed under this 
+Agreement, then You shall pay for such additional usage at Tracetest’s 
+then-current rates.
+
+5. Trial License. If You have signed up for a trial or evaluation of Tracetest 
+Pro, Your License to Tracetest Pro is granted without charge for the trial or 
+evaluation period specified when You signed up, or if no term was specified, for 
+forty-five (45) calendar days, provided that Your License is granted solely for 
+purposes of Your internal evaluation of Tracetest Pro during the trial or 
+evaluation period (a “Trial License”). You may not use Tracetest Pro or any 
+Tracetest Pro features under a Trial License more than once in any twelve (12) 
+month period. Tracetest may revoke a Trial License at any time and for any reason. 
+Sections 3, 4, 9 and 11 of this Agreement do not apply to Trial Licenses.
+
+6. Redistribution. You may reproduce and distribute copies of the Work or 
+Derivative Works thereof in any medium, with or without modifications, and in 
+Source or Object form, provided that You meet the following conditions:
+
+(a) You must give any other recipients of the Work or Derivative Works a copy of 
+this License; and
+
+(b) You must cause any modified files to carry prominent notices stating that 
+You changed the files; and
+
+(c) You must retain, in the Source form of any Derivative Works that You 
+distribute, including for internal purposes at Your Legal Entities, all 
+copyright, patent, trademark, and attribution notices from the Source form of 
+the Work, excluding those notices that do not pertain to any part of the 
+Derivative Works; and
+
+(d) If the Work includes a “NOTICE” or equivalent text file as part of its 
+distribution, then any Derivative Works that You distribute must include a 
+readable copy of the attribution notices contained within such NOTICE file, 
+excluding those notices that do not pertain to any part of the Derivative Works, 
+in at least one of the following places: within a NOTICE text file distributed 
+as part of the Derivative Works; within the Source form or documentation, if 
+provided along with the Derivative Works; or, within a display generated by the 
+Derivative Works, if and wherever such third-party notices normally appear. The 
+contents of the NOTICE or equivalent files are for informational purposes only 
+and do not modify the License. You may add Your own attribution notices within 
+Derivative Works that You distribute for Your internal use, alongside or as an 
+addendum to the NOTICE text from the Work, provided that such additional 
+attribution notices cannot be construed as modifying the License.
+
+You may not create Derivative Works, including Pro Derivative Works (as defined 
+below), which add Your own copyright statements or provide additional or 
+different license terms and conditions for use, reproduction, or distribution of 
+Your modifications, or for any such Derivative Works as a whole. All Derivative 
+Works, including Your use, reproduction, and distribution of the Work, must 
+comply in all respects with the conditions stated in this License.
+
+(e) Pro Derivative Works: Derivative Works of Tracetest Pro (“Pro Derivative 
+Works”) may only be made, reproduced and distributed, without modifications, in 
+Source or Object form, provided that such Pro Derivative Works are solely for 
+Your internal use. Each Pro Derivative Work shall be governed by this Agreement, 
+shall include a License to Tracetest Pro, and thus will be subject to the payment 
+of fees to Tracetest by any user of the Pro Derivative Work.
+
+7. Submission of Contributions. Unless You explicitly state otherwise, any 
+Contribution submitted for inclusion in Tracetest Pro by You to Tracetest shall be 
+under the terms and conditions of this Agreement, without any additional terms 
+or conditions, payments of royalties or otherwise to Your benefit. Tracetest may 
+at any time, at its sole discretion, elect for the Contribution to be subject to 
+the Paid Pro License. If You wish to reserve any rights regarding Your 
+Contribution, You must contact Tracetest at support@Tracetest.io prior to 
+submitting the Contribution. 
+
+8. Trademarks. This License does not grant permission to use the trade names, 
+trademarks, service marks, or product names of Licensor, except as required for 
+reasonable and customary use in describing the origin of the Work and reproducing 
+the content of the NOTICE or equivalent file.
+
+9. Limited Warranty.
+
+(a) Warranties. Subject to the terms of the Paid Pro License, or any other 
+agreement between You and Tracetest which governs the terms of Your access to 
+Tracetest Pro, Tracetest warrants to You that: (i) Tracetest Pro will materially 
+perform in accordance with the applicable documentation for thirty (30) days 
+after initial delivery to You; and (ii) any professional services performed by 
+Tracetest under this Agreement will be performed in a workmanlike manner, in 
+accordance with general industry standards.
+
+(b) Exclusions. Tracetest’s warranties in this Section 9 do not extend to problems 
+that result from: (i) Your failure to implement updates issued by Tracetest during 
+the warranty period; (ii) any alterations or additions (including Pro Derivative 
+Works and Contributions) to Tracetest not performed by or at the direction of 
+Tracetest; (iii) failures that are not reproducible by Tracetest; (iv) operation 
+of Tracetest Pro in violation of this Agreement or not in accordance with its 
+documentation; (v) failures caused by software, hardware, or products not 
+licensed or provided by Tracetest hereunder; or (vi) Third Party Works.
+
+(c) Remedies. In the event of a breach of a warranty under this Section 9, 
+Tracetest will, at its discretion and cost, either repair, replace or re-perform 
+the applicable Works or services or refund a portion of fees previously paid to 
+Tracetest that are associated with the defective Works or services. This is Your 
+exclusive remedy, and Tracetest’s sole liability, arising in connection with the 
+limited warranties herein and shall, in all cases, be limited to the fees paid 
+to Tracetest in the three (3) months preceding the delivery of the defective Works 
+or services.
+
+10. Disclaimer of Warranty. Except as set out in Section 9, unless required by 
+applicable law, Licensor provides the Work (and each Contributor provides its 
+Contributions) on an “AS IS” BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, 
+either express or implied, arising out of course of dealing, course of 
+performance, or usage in trade, including, without limitation, any warranties 
+or conditions of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, CORRECTNESS, 
+RELIABILITY, or FITNESS FOR A PARTICULAR PURPOSE, all of which are hereby 
+disclaimed. You are solely responsible for determining the appropriateness of 
+using or redistributing Works and assume any risks associated with Your exercise 
+of permissions under the applicable License for such Works.
+
+11. Limited Indemnity.
+
+(a) Indemnity. Tracetest will defend, indemnify and hold You harmless against 
+any third party claims, liabilities or expenses incurred (including reasonable 
+attorneys’ fees), as well as amounts finally awarded in a settlement or a 
+non-appealable judgement by a court (“Losses”), to the extent arising from any 
+claim or allegation by a third party that Tracetest Pro infringes or 
+misappropriates a valid United States patent, copyright, or trade secret right 
+of a third party; provided that You give Tracetest: (i) prompt written notice of 
+any such claim or allegation; (ii) sole control of the defense and settlement 
+thereof; and (iii) reasonable cooperation and assistance in such defense or 
+settlement. If any Work within Tracetest Pro becomes or in Tracetest’s opinion is 
+likely to become, the subject of an injunction, Tracetest may, at its option, 
+(A) procure for You the right to continue using such Work, (B) replace or modify 
+such Work so that it becomes non-infringing without substantially compromising 
+its functionality, or, if (A) and (B) are not commercially practicable, then (C) 
+terminate Your license to the allegedly infringing Work and refund to You a 
+prorated portion of the prepaid and unearned fees for such infringing Work. The 
+foregoing comprises the entire liability of Tracetest with respect to infringement 
+of patents, copyrights, trade secrets, or other intellectual property rights.
+
+(b) Exclusions. The foregoing obligations on Tracetest shall not apply to: (i) 
+Works modified by any party other than Tracetest (including Pro Derivative Works 
+and Contributions) where the alleged infringement relates to such modification, 
+(ii) Works combined or bundled with any products, processes, or materials not 
+provided by Tracetest where the alleged infringement relates to such combination, 
+(iii) use of a version of Tracetest Pro other than the version that was current at 
+the time of such use, as long as a non-infringing version had been released at 
+the time of the alleged infringement, (iv) any Works created to Your 
+specifications, (v) infringement or misappropriation of any proprietary or 
+intellectual property right in which You have an interest, or (vi) Third Party 
+Works. You will defend, indemnify, and hold Tracetest harmless against any Losses 
+arising from any such claim or allegation as described in the scenarios in this 
+Section 11(b), subject to conditions reciprocal to those in Section 11(a).
+
+12. Limitation of Liability. In no event and under no legal or equitable theory, 
+whether in tort (including negligence), contract, or otherwise, unless required 
+by applicable law (such as deliberate and grossly negligent acts), and 
+notwithstanding anything in this Agreement to the contrary, shall Licensor or 
+any Contributor be liable to You for (i) any amounts in excess, in the aggregate, 
+of the fees paid by You to Tracetest under this Agreement in the twelve (12) 
+months preceding the date the first cause of liability arose, or (ii) any 
+indirect, special, incidental, punitive, exemplary, reliance, or consequential 
+damages of any character arising as a result of this Agreement or out of the use 
+or inability to use the Work (including but not limited to damages for loss of 
+goodwill, profits, data or data use, work stoppage, computer failure or 
+malfunction, cost of procurement of substitute goods, technology or services, 
+or any and all other commercial damages or losses), even if such Licensor or 
+Contributor has been advised of the possibility of such damages. THESE 
+LIMITATIONS SHALL APPLY NOTWITHSTANDING THE FAILURE OF THE ESSENTIAL PURPOSE OF 
+ANY LIMITED REMEDY.
+
+13. General.
+
+(a) Relationship of Parties. You and Tracetest are independent contractors, and 
+nothing herein shall be deemed to constitute either party as the agent or 
+representative of the other or both parties as joint venturers or partners for 
+any purpose.
+
+(b) Export Control. You shall comply with the U.S. Foreign Corrupt Practices Act 
+and all applicable export laws, restrictions and regulations of the U.S. 
+Department of Commerce, U.S. Department of Treasury, and any other applicable 
+U.S. and foreign authority(ies).
+
+(c) Assignment. This Agreement and the rights and obligations herein may not be 
+assigned or transferred, in whole or in part, by You without the prior written 
+consent of Tracetest. Any assignment in violation of this provision is void. This 
+Agreement shall be binding upon, and inure to the benefit of, the successors and 
+permitted assigns of the parties.
+
+(d) Governing Law. This Agreement shall be governed by and construed under the 
+laws of the State of Delaware and the United States without regard to conflicts 
+of laws provisions thereof, and without regard to the Uniform Computer 
+Information Transactions Act.
+
+(e) Attorneys’ Fees. In any action or proceeding to enforce rights under this 
+Agreement, the prevailing party shall be entitled to recover its costs, expenses, 
+and attorneys’ fees.
+
+(f) Severability. If any provision of this Agreement is held to be invalid, 
+illegal, or unenforceable in any respect, that provision shall be limited or 
+eliminated to the minimum extent necessary so that this Agreement otherwise 
+remains in full force and effect and enforceable.
+
+(g) Entire Agreement; Waivers; Modification. This Agreement constitutes the 
+entire agreement between the parties relating to the subject matter hereof and 
+supersedes all proposals, understandings, or discussions, whether written or 
+oral, relating to the subject matter of this Agreement and all past dealing or 
+industry custom. The failure of either party to enforce its rights under this 
+Agreement at any time for any period shall not be construed as a waiver of such 
+rights. No changes, modifications or waivers to this Agreement will be effective 
+unless in writing and signed by both parties.

--- a/licenses/MIT.txt
+++ b/licenses/MIT.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2022 Kubeshop
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
This PR updates the licenses used for the overall code and the agent, making the separation between what it will be MIT and the agent that will be switched to a TLC license

## Changes

- updates license between agent and the rest of the code

## Fixes

- https://github.com/kubeshop/tracetest-cloud/issues/498

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [x] updated the docs
- [ ] added a test
