### PR TITLE
feat: cli polling profile

### DIFF
--- a/api/tests.yaml
+++ b/api/tests.yaml
@@ -43,6 +43,9 @@ components:
         skipTraceCollection:
           type: boolean
           description: If true, the test will not collect a trace
+        pollingProfile:
+          type: string
+          description: ID of the polling profile to be used for this test
         specs:
           type: array
           items:

--- a/cli/openapi/model_test_.go
+++ b/cli/openapi/model_test_.go
@@ -29,6 +29,8 @@ type Test struct {
 	Trigger   *Trigger   `json:"trigger,omitempty"`
 	// If true, the test will not collect a trace
 	SkipTraceCollection *bool `json:"skipTraceCollection,omitempty"`
+	// ID of the polling profile to be used for this test
+	PollingProfile *string `json:"pollingProfile,omitempty"`
 	// specification of assertions that are going to be made
 	Specs []TestSpec `json:"specs,omitempty"`
 	// define test outputs, in a key/value format. The value is processed as an expression
@@ -277,6 +279,38 @@ func (o *Test) SetSkipTraceCollection(v bool) {
 	o.SkipTraceCollection = &v
 }
 
+// GetPollingProfile returns the PollingProfile field value if set, zero value otherwise.
+func (o *Test) GetPollingProfile() string {
+	if o == nil || isNil(o.PollingProfile) {
+		var ret string
+		return ret
+	}
+	return *o.PollingProfile
+}
+
+// GetPollingProfileOk returns a tuple with the PollingProfile field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *Test) GetPollingProfileOk() (*string, bool) {
+	if o == nil || isNil(o.PollingProfile) {
+		return nil, false
+	}
+	return o.PollingProfile, true
+}
+
+// HasPollingProfile returns a boolean if a field has been set.
+func (o *Test) HasPollingProfile() bool {
+	if o != nil && !isNil(o.PollingProfile) {
+		return true
+	}
+
+	return false
+}
+
+// SetPollingProfile gets a reference to the given string and assigns it to the PollingProfile field.
+func (o *Test) SetPollingProfile(v string) {
+	o.PollingProfile = &v
+}
+
 // GetSpecs returns the Specs field value if set, zero value otherwise.
 func (o *Test) GetSpecs() []TestSpec {
 	if o == nil || isNil(o.Specs) {
@@ -403,6 +437,9 @@ func (o Test) ToMap() (map[string]interface{}, error) {
 	}
 	if !isNil(o.SkipTraceCollection) {
 		toSerialize["skipTraceCollection"] = o.SkipTraceCollection
+	}
+	if !isNil(o.PollingProfile) {
+		toSerialize["pollingProfile"] = o.PollingProfile
 	}
 	if !isNil(o.Specs) {
 		toSerialize["specs"] = o.Specs

--- a/cli/preprocessor/test.go
+++ b/cli/preprocessor/test.go
@@ -69,13 +69,13 @@ func (t test) mapPollingProfiles(ctx context.Context, input fileutil.File, test 
 		return openapi.TestResource{}, fmt.Errorf("cannot read polling profile file: %w", err)
 	}
 
-	testFile, err := t.applyPollingProfileFunc(ctx, f)
+	pollingProfileFile, err := t.applyPollingProfileFunc(ctx, f)
 	if err != nil {
 		return openapi.TestResource{}, fmt.Errorf("cannot apply polling profile '%s': %w", *pollingProfilePath, err)
 	}
 
 	var pollingProfile openapi.PollingProfile
-	err = yaml.Unmarshal(testFile.Contents(), &pollingProfile)
+	err = yaml.Unmarshal(pollingProfileFile.Contents(), &pollingProfile)
 	if err != nil {
 		return openapi.TestResource{}, fmt.Errorf("cannot unmarshal updated pollingProfile '%s': %w", *pollingProfilePath, err)
 	}

--- a/cli/preprocessor/test.go
+++ b/cli/preprocessor/test.go
@@ -12,12 +12,14 @@ import (
 )
 
 type test struct {
-	logger *zap.Logger
+	logger                  *zap.Logger
+	applyPollingProfileFunc applyResourceFunc
 }
 
-func Test(logger *zap.Logger) test {
+func Test(logger *zap.Logger, applyPollingProfileFunc applyResourceFunc) test {
 	return test{
-		logger: cmdutil.GetLogger(),
+		logger:                  cmdutil.GetLogger(),
+		applyPollingProfileFunc: applyPollingProfileFunc,
 	}
 }
 
@@ -27,6 +29,12 @@ func (t test) Preprocess(ctx context.Context, input fileutil.File) (fileutil.Fil
 	if err != nil {
 		t.logger.Error("error parsing test", zap.String("content", string(input.Contents())), zap.Error(err))
 		return input, fmt.Errorf("could not unmarshal test yaml: %w", err)
+	}
+
+	test, err = t.mapPollingProfiles(ctx, input, test)
+	if err != nil {
+		t.logger.Error("error mapping polling profiles from test", zap.String("content", string(input.Contents())), zap.Error(err))
+		return input, fmt.Errorf("could not map polling profiles referenced in test yaml: %w", err)
 	}
 
 	test, err = t.consolidateGRPCFile(input, test)
@@ -40,6 +48,41 @@ func (t test) Preprocess(ctx context.Context, input fileutil.File) (fileutil.Fil
 	}
 
 	return fileutil.New(input.AbsPath(), marshalled), nil
+}
+
+func (t test) mapPollingProfiles(ctx context.Context, input fileutil.File, test openapi.TestResource) (openapi.TestResource, error) {
+	if test.Spec.PollingProfile == nil {
+		return test, nil
+	}
+
+	pollingProfilePath := test.Spec.PollingProfile
+	if !fileutil.LooksLikeFilePath(*pollingProfilePath) {
+		t.logger.Debug("does not look like a file path",
+			zap.String("path", *pollingProfilePath),
+		)
+
+		return test, nil
+	}
+
+	f, err := fileutil.Read(input.RelativeFile(*pollingProfilePath))
+	if err != nil {
+		return openapi.TestResource{}, fmt.Errorf("cannot read polling profile file: %w", err)
+	}
+
+	testFile, err := t.applyPollingProfileFunc(ctx, f)
+	if err != nil {
+		return openapi.TestResource{}, fmt.Errorf("cannot apply polling profile '%s': %w", *pollingProfilePath, err)
+	}
+
+	var pollingProfile openapi.PollingProfile
+	err = yaml.Unmarshal(testFile.Contents(), &pollingProfile)
+	if err != nil {
+		return openapi.TestResource{}, fmt.Errorf("cannot unmarshal updated pollingProfile '%s': %w", *pollingProfilePath, err)
+	}
+
+	test.Spec.PollingProfile = &pollingProfile.Spec.Id
+
+	return test, nil
 }
 
 func (t test) consolidateGRPCFile(input fileutil.File, test openapi.TestResource) (openapi.TestResource, error) {

--- a/cli/preprocessor/testsuite.go
+++ b/cli/preprocessor/testsuite.go
@@ -11,14 +11,14 @@ import (
 	"go.uber.org/zap"
 )
 
-type applyTestFunc func(context.Context, fileutil.File) (fileutil.File, error)
+type applyResourceFunc func(context.Context, fileutil.File) (fileutil.File, error)
 
 type testSuite struct {
 	logger      *zap.Logger
-	applyTestFn applyTestFunc
+	applyTestFn applyResourceFunc
 }
 
-func TestSuite(logger *zap.Logger, applyTestFn applyTestFunc) testSuite {
+func TestSuite(logger *zap.Logger, applyTestFn applyResourceFunc) testSuite {
 	return testSuite{
 		logger:      cmdutil.GetLogger(),
 		applyTestFn: applyTestFn,

--- a/docs/docs/cli/creating-tests.mdx
+++ b/docs/docs/cli/creating-tests.mdx
@@ -194,3 +194,20 @@ Available functions:
 :::tip
 [Continue reading about Test Outputs, here.](/cli/creating-test-outputs)
 :::
+
+### Defining a polling profile
+
+Some tests have different requirements than others, it means that some will take longer to run than other tests, so it's crucial to be able to
+define the trace polling strategy at the test level:\
+
+```yaml
+type: Test
+spec:
+  name: my test
+  pollingProfile: ./my-polling-profile.yaml
+  trigger: http
+  httpRequest:
+    ...
+```
+
+This will make all runs from this test to use this specific test profile, and in case no value is defined, the test will use your default polling profile.

--- a/server/openapi/model_test_.go
+++ b/server/openapi/model_test_.go
@@ -30,6 +30,9 @@ type Test struct {
 	// If true, the test will not collect a trace
 	SkipTraceCollection bool `json:"skipTraceCollection,omitempty"`
 
+	// ID of the polling profile to be used for this test
+	PollingProfile string `json:"pollingProfile,omitempty"`
+
 	// specification of assertions that are going to be made
 	Specs []TestSpec `json:"specs,omitempty"`
 


### PR DESCRIPTION
This PR makes it possible to reference a polling profile in the definition file of a test.

```yaml
type: Test
spec:
  name: my test
  pollingProfile: ./path-to-polling-profile.yaml
  ...
```

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Loom video

Add your loom video here if your work can be visualized
