### PR TITLE
feat(cli): Adding cloud resources

### DIFF
--- a/cli/cmd/resources.go
+++ b/cli/cmd/resources.go
@@ -57,7 +57,7 @@ var (
 
 	envTokensClient = resourcemanager.NewClient(
 		httpClient, cliLogger,
-		"environmenttoken", "environmenttokens",
+		"token", "tokens",
 		resourcemanager.WithTableConfig(resourcemanager.TableConfig{
 			Cells: []resourcemanager.TableCellConfig{
 				{Header: "ID", Path: "spec.id"},
@@ -72,7 +72,7 @@ var (
 
 	orgInvitesClient = resourcemanager.NewClient(
 		httpClient, cliLogger,
-		"invite", "invites",
+		"organizationinvite", "organizationinvites",
 		resourcemanager.WithTableConfig(resourcemanager.TableConfig{
 			Cells: []resourcemanager.TableCellConfig{
 				{Header: "ID", Path: "spec.id"},

--- a/cli/cmd/resources.go
+++ b/cli/cmd/resources.go
@@ -55,6 +55,48 @@ var (
 		resourcemanager.WithResourceType("PollingProfile"),
 	)
 
+	envTokensClient = resourcemanager.NewClient(
+		httpClient, cliLogger,
+		"environmenttoken", "environmenttokens",
+		resourcemanager.WithTableConfig(resourcemanager.TableConfig{
+			Cells: []resourcemanager.TableCellConfig{
+				{Header: "ID", Path: "spec.id"},
+				{Header: "NAME", Path: "spec.name"},
+				{Header: "ROLE", Path: "spec.role"},
+				{Header: "ISSUED AT", Path: "spec.issuedAt"},
+				{Header: "EXPIRES AT", Path: "spec.expiresAt"},
+			},
+		}),
+		resourcemanager.WithResourceType("EnvironmentToken"),
+	)
+
+	orgInvitesClient = resourcemanager.NewClient(
+		httpClient, cliLogger,
+		"invite", "invites",
+		resourcemanager.WithTableConfig(resourcemanager.TableConfig{
+			Cells: []resourcemanager.TableCellConfig{
+				{Header: "ID", Path: "spec.id"},
+				{Header: "TO", Path: "spec.to"},
+				{Header: "Role", Path: "spec.role"},
+				{Header: "TYPE", Path: "spec.type"},
+				{Header: "STATUS", Path: "spec.status"},
+			},
+		}),
+		resourcemanager.WithResourceType("Invite"),
+	)
+
+	environmentClient = resourcemanager.NewClient(
+		httpClient, cliLogger,
+		"environment", "environments",
+		resourcemanager.WithTableConfig(resourcemanager.TableConfig{
+			Cells: []resourcemanager.TableCellConfig{
+				{Header: "ID", Path: "spec.id"},
+				{Header: "NAME", Path: "spec.name"},
+			},
+		}),
+		resourcemanager.WithResourceType("Environment"),
+	)
+
 	testPreprocessor = preprocessor.Test(cliLogger, func(ctx context.Context, input fileutil.File) (fileutil.File, error) {
 		updated, err := pollingProfileClient.Apply(ctx, input, resourcemanager.Formats.Get(resourcemanager.FormatYAML))
 		if err != nil {
@@ -138,13 +180,6 @@ var (
 		resourcemanager.WithDeprecatedAlias("Transaction"),
 	)
 
-	// deprecated resources
-	deprecatedEnvironmentClient = resourcemanager.NewClient(
-		httpClient, cliLogger,
-		"environment", "environments",
-		resourcemanager.WithProxyResource("variableset"),
-	)
-
 	deprecatedTransactionsClient = resourcemanager.NewClient(
 		httpClient, cliLogger,
 		"transaction", "transactions",
@@ -185,6 +220,8 @@ var (
 				}),
 			),
 		).
+		Register(envTokensClient).
+		Register(orgInvitesClient).
 		Register(pollingProfileClient).
 		Register(
 			resourcemanager.NewClient(
@@ -250,9 +287,9 @@ var (
 		Register(testClient).
 		Register(organizationsClient).
 		Register(environmentClient).
+		Register(environmentMeClient).
 
 		// deprecated resources
-		Register(deprecatedEnvironmentClient).
 		Register(deprecatedTransactionsClient)
 
 	organizationsClient = resourcemanager.NewClient(
@@ -267,7 +304,7 @@ var (
 		resourcemanager.WithListPath("elements"),
 	)
 
-	environmentClient = resourcemanager.NewClient(
+	environmentMeClient = resourcemanager.NewClient(
 		httpClient, cliLogger,
 		"env", "environments",
 		resourcemanager.WithTableConfig(resourcemanager.TableConfig{

--- a/cli/config/configurator.go
+++ b/cli/config/configurator.go
@@ -403,6 +403,13 @@ func SetupHttpClient(cfg Config) *resourcemanager.HTTPClient {
 	extraHeaders.Set("x-environment-id", cfg.EnvironmentID)
 	extraHeaders.Set("Authorization", fmt.Sprintf("Bearer %s", cfg.Jwt))
 
+	if cfg.OrganizationID == "" {
+		extraHeaders.Set("x-organization-id", "default")
+	}
+	if cfg.EnvironmentID == "" {
+		extraHeaders.Set("x-environment-id", "default")
+	}
+
 	return resourcemanager.NewHTTPClient(fmt.Sprintf("%s%s", cfg.URL(), cfg.Path()), extraHeaders)
 }
 

--- a/testing/cli-e2etest/testscenarios/test/run_test_test.go
+++ b/testing/cli-e2etest/testscenarios/test/run_test_test.go
@@ -81,33 +81,6 @@ func TestRunTestWithHttpTriggerAndVariableSetFile(t *testing.T) {
 		require.Equal("https://assets.pokemon.com/assets/cms2/img/pokedex/full/143.png", environmentVars.Spec.Values[1].Value)
 	})
 
-	t.Run("should pass when using the deprecated environment definition file", func(t *testing.T) {
-		result := tracetestcli.Exec(t, "get environment --id deprecated-pokeapi-env", tracetestcli.WithCLIConfig(cliConfig))
-		helpers.RequireExitCodeEqual(t, result, 0)
-		require.Contains(result.StdOut, "The resource `environment` is deprecated and will be removed in a future version. Please use `variableset` instead.")
-		require.Contains(result.StdOut, "Resource variableset with ID deprecated-pokeapi-env not found")
-
-		// When I try to run a test with a http trigger and a variable set file
-		// Then it should pass
-		environmentFile := env.GetTestResourcePath(t, "deprecated-environment")
-		testFile := env.GetTestResourcePath(t, "http-trigger-with-environment-file")
-
-		command := fmt.Sprintf("run test -f %s --environment %s", testFile, environmentFile)
-		result = tracetestcli.Exec(t, command, tracetestcli.WithCLIConfig(cliConfig))
-		helpers.RequireExitCodeEqual(t, result, 0)
-		require.Contains(result.StdOut, "✔ It should add a Pokemon correctly")
-		require.Contains(result.StdOut, "✔ It should save the correct data")
-
-		// When I try to get the variable set created on the previous step
-		// Then it should retrieve it correctly
-		result = tracetestcli.Exec(t, "get environment --id deprecated-pokeapi-env", tracetestcli.WithCLIConfig(cliConfig))
-		helpers.RequireExitCodeEqual(t, result, 0)
-
-		require.Contains(result.StdOut, "The resource `environment` is deprecated and will be removed in a future version. Please use `variableset` instead.")
-		require.Contains(result.StdOut, "VariableSet")
-		require.Contains(result.StdOut, "https://assets.pokemon.com/assets/cms2/img/pokedex/full/143.png")
-	})
-
 	t.Run("should pass when using variable set id", func(t *testing.T) {
 		// Given I am a Tracetest CLI user
 		// And I have my server recently created

--- a/testing/cli-e2etest/testscenarios/variableset/apply_variableset_test.go
+++ b/testing/cli-e2etest/testscenarios/variableset/apply_variableset_test.go
@@ -95,15 +95,4 @@ func TestApplyVariableSet(t *testing.T) {
 		require.Equal("THIRD_VAR", updatedEnvironmentVars.Spec.Values[2].Key)
 		require.Equal("hello", updatedEnvironmentVars.Spec.Values[2].Value) // this value was added
 	})
-
-	t.Run("using the deprecated environment command to apply a variable set", func(t *testing.T) {
-		newEnvironmentPath := env.GetTestResourcePath(t, "deprecated-environment")
-
-		result := tracetestcli.Exec(t, fmt.Sprintf("apply environment --file %s", newEnvironmentPath), tracetestcli.WithCLIConfig(cliConfig))
-		helpers.RequireExitCodeEqual(t, result, 0)
-
-		require.Contains(result.StdOut, "The resource `environment` is deprecated and will be removed in a future version. Please use `variableset` instead.")
-		require.Contains(result.StdOut, "VariableSet")
-		require.Contains(result.StdOut, "deprecated-env")
-	})
 }

--- a/testing/cli-e2etest/testscenarios/variableset/get_variableset_test.go
+++ b/testing/cli-e2etest/testscenarios/variableset/get_variableset_test.go
@@ -111,13 +111,4 @@ func TestGetVariableSet(t *testing.T) {
 		require.Equal(".env", singleLine["NAME"])
 		require.Equal("", singleLine["DESCRIPTION"])
 	})
-
-	t.Run("getting a variable set using the deprecated environment command", func(t *testing.T) {
-		result := tracetestcli.Exec(t, "get environment --id .env", tracetestcli.WithCLIConfig(cliConfig))
-
-		helpers.RequireExitCodeEqual(t, result, 0)
-		require.Contains(result.StdOut, "The resource `environment` is deprecated and will be removed in a future version. Please use `variableset` instead.")
-		require.Contains(result.StdOut, "VariableSet")
-		require.Contains(result.StdOut, ".env")
-	})
 }

--- a/testing/cli-e2etest/testscenarios/variableset/list_variablesets_test.go
+++ b/testing/cli-e2etest/testscenarios/variableset/list_variablesets_test.go
@@ -231,12 +231,4 @@ func TestListVariableSets(t *testing.T) {
 		require.Equal("The", oneMoreEnvironmentVars.Spec.Values[1].Key)
 		require.Equal("Third", oneMoreEnvironmentVars.Spec.Values[1].Value)
 	})
-
-	t.Run("list using deprecated environment command", func(t *testing.T) {
-		result := tracetestcli.Exec(t, "list environment --sortBy name --sortDirection asc --skip 1 --take 2 --output yaml", tracetestcli.WithCLIConfig(cliConfig))
-
-		helpers.RequireExitCodeEqual(t, result, 0)
-		require.Contains(result.StdOut, "The resource `environment` is deprecated and will be removed in a future version. Please use `variableset` instead.")
-		require.Contains(result.StdOut, "VariableSet")
-	})
 }

--- a/testing/cli-e2etest/testscenarios/variableset/resources/deprecated-environment.yaml
+++ b/testing/cli-e2etest/testscenarios/variableset/resources/deprecated-environment.yaml
@@ -1,9 +1,0 @@
-type: Environment
-spec:
-  id: deprecated-env
-  name: deprecated-env
-  values:
-    - key: FIRST_VAR
-      value: some-value
-    - key: SECOND_VAR
-      value: another_value


### PR DESCRIPTION
This PR enables the usage of cloud entities as part of the resources definitions

## Changes

- Adds client for env tokens
- Adds client for org invites
- Adds client for environments

## Fixes

- https://github.com/kubeshop/tracetest-cloud/issues/558

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Loom video

https://www.loom.com/share/1e81fe1cd8dd4c1ba179ff23862ee7a0