### PR TITLE
fix(cli): add valid environmenttokens and invites resource name plural

### DIFF
--- a/cli/cmd/resources.go
+++ b/cli/cmd/resources.go
@@ -57,12 +57,13 @@ var (
 
 	envTokensClient = resourcemanager.NewClient(
 		httpClient, cliLogger,
-		"token", "tokens",
+		"token", "environmenttokens",
 		resourcemanager.WithTableConfig(resourcemanager.TableConfig{
 			Cells: []resourcemanager.TableCellConfig{
 				{Header: "ID", Path: "spec.id"},
 				{Header: "NAME", Path: "spec.name"},
 				{Header: "ROLE", Path: "spec.role"},
+				{Header: "REVOKED", Path: "spec.isRevoked"},
 				{Header: "ISSUED AT", Path: "spec.issuedAt"},
 				{Header: "EXPIRES AT", Path: "spec.expiresAt"},
 			},
@@ -72,7 +73,7 @@ var (
 
 	orgInvitesClient = resourcemanager.NewClient(
 		httpClient, cliLogger,
-		"organizationinvite", "organizationinvites",
+		"organizationinvite", "invites",
 		resourcemanager.WithTableConfig(resourcemanager.TableConfig{
 			Cells: []resourcemanager.TableCellConfig{
 				{Header: "ID", Path: "spec.id"},


### PR DESCRIPTION
This PR fixes a bug with the plural resource name for `environmenttokens` and `invites`.

## Changes

- fix plural resource names

## Fixes

-

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

