### PR TITLE
fix: panic on CLI error

### DIFF
--- a/cli/formatters/test_run.go
+++ b/cli/formatters/test_run.go
@@ -80,15 +80,20 @@ func (f testRun) json(output TestRunOutput) string {
 
 func (f testRun) pretty(output TestRunOutput) string {
 	if output.IsFailed {
+		lastError := ""
+		if errState := output.Run.LastErrorState; errState != nil {
+			lastError = *errState
+		}
+
+		testInfoMessage := f.formatMessage("%s %s (%s)",
+			FAILED_TEST_ICON,
+			*output.Test.Name,
+			output.RunWebURL,
+		)
+
 		return f.getColoredText(false, fmt.Sprintf("%s\n%s",
-			f.formatMessage("%s %s (%s)",
-				FAILED_TEST_ICON,
-				*output.Test.Name,
-				output.RunWebURL,
-			),
-			f.formatMessage("\tReason: %s\n",
-				*output.Run.LastErrorState,
-			),
+			testInfoMessage,
+			f.formatMessage("\tReason: %s\n", lastError),
 		))
 	}
 


### PR DESCRIPTION
This PR fixes the following panic

```
tracetest run test -f ./test-api.yaml
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x8 pc=0x102c23e1c]

goroutine 1 [running]:
github.com/kubeshop/tracetest/cli/formatters.testRun.pretty({_, _, _}, {0x1, 0x1, {0x140008511b0, 0x140008511d0, 0x140008511f0, 0x1400008b768, 0x14000a101e0, ...}, ...})
	/home/runner/work/tracetest/tracetest/cli/formatters/test_run.go:90 +0x23c
github.com/kubeshop/tracetest/cli/formatters.testRun.Format({_, _, _}, {0x1, 0x1, {0x140008511b0, 0x140008511d0, 0x140008511f0, 0x1400008b768, 0x14000a101e0, ...}, ...}, ...)
	/home/runner/work/tracetest/tracetest/cli/formatters/test_run.go:59 +0xec
github.com/kubeshop/tracetest/cli/runner.testRunner.FormatResult({{0x10575e2a0, {0x103ad1d2e, 0x4}, {0x103ad51a3, 0x5}, 0x1400085e8c0, {0x14000190d20, 0x0, {{...}, 0x10452b040}, ...}}, ...}, ...)
	/home/runner/work/tracetest/tracetest/cli/runner/test_runner.go:147 +0x39c
github.com/kubeshop/tracetest/cli/formatters.multipleRun[...].pretty(0x104559aa0?, {{0x140009b06f0, 0x1, 0x1}, {0x140009cc250, 0x1, 0x1}, 0x1, {{0x140005e7c20, 0x9}, ...}, ...})
	/home/runner/work/tracetest/tracetest/cli/formatters/multiple_runs.go:103 +0x5d4
github.com/kubeshop/tracetest/cli/formatters.multipleRun[...].Format(0x104559aa0?, {{0x140009b06f0, 0x1, 0x1}, {0x140009cc250, 0x1, 0x1}, 0x1, {{0x140005e7c20, 0x9}, ...}, ...}, ...)
	/home/runner/work/tracetest/tracetest/cli/formatters/multiple_runs.go:43 +0xe4
github.com/kubeshop/tracetest/cli/cloud/runner.orchestrator.Run({0x14000928cb0, {0x10453c380, 0x140009087f0}, {0x10575e2a0, {0x103af2673, 0xb}, {0x103af6dec, 0xc}, 0x14000928d90, {0x140006425d0, ...}}, ...}, ...)
	/home/runner/work/tracetest/tracetest/cli/cloud/runner/multifile_orchestrator.go:202 +0xec8
github.com/kubeshop/tracetest/cli/cloud/cmd.RunMultipleFiles({0x10454e040, 0x105796600}, 0x0?, 0x10575eb00, 0x10575f3a0, {0x140008413e0?, 0x14000841410?, 0x1400085ea10?}, {0x0, 0x0})
	/home/runner/work/tracetest/tracetest/cli/cloud/cmd/run_cmd.go:35 +0x37c
github.com/kubeshop/tracetest/cli/cmd.init.11.func1({0x10454e040?, 0x105796600?}, 0x1400086e450?, {0x0?, 0x0?, 0x0?})
	/home/runner/work/tracetest/tracetest/cli/cmd/resource_run_cmd.go:32 +0xac
github.com/kubeshop/tracetest/cli/cmd.WithResourceMiddleware.WithResourceMiddleware.WithParamsHandler.func1.func2({0x10454e040, 0x105796600}, 0x0?, {0x1400086e450, 0x1, 0x3})
	/home/runner/work/tracetest/tracetest/cli/cmd/middleware.go:138 +0x190
github.com/kubeshop/tracetest/cli/cmd.WithResourceMiddleware.WithResultHandler.func3(0x1400065d800?, {0x1400086e450, 0x1, 0x3})
	/home/runner/work/tracetest/tracetest/cli/cmd/middleware.go:50 +0x5c
github.com/spf13/cobra.(*Command).execute(0x1400026f800, {0x1400086e3f0, 0x3, 0x3})
	/home/runner/go/pkg/mod/github.com/spf13/cobra@v1.7.0/command.go:944 +0x654
github.com/spf13/cobra.(*Command).ExecuteC(0x10574c120)
	/home/runner/go/pkg/mod/github.com/spf13/cobra@v1.7.0/command.go:1068 +0x320
github.com/spf13/cobra.(*Command).Execute(...)
	/home/runner/go/pkg/mod/github.com/spf13/cobra@v1.7.0/command.go:992
github.com/kubeshop/tracetest/cli/cmd.Execute()
	/home/runner/work/tracetest/tracetest/cli/cmd/root.go:34 +0x24
main.main()
	/home/runner/work/tracetest/tracetest/cli/main.go:8 +0x1c
```

## Changes

-

## Fixes

-

## Checklist

- [ ] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Loom video

Add your loom video here if your work can be visualized
