### PR TITLE
fix: make agent reconnect on server shutdown

### DIFF
--- a/agent/client/workflow_listen_for_ds_connection_tests.go
+++ b/agent/client/workflow_listen_for_ds_connection_tests.go
@@ -35,7 +35,7 @@ func (c *Client) startDataStoreConnectionTestListener(ctx context.Context) error
 				return
 			}
 
-			reconnected, err := c.handleDisconnectionError(err)
+			reconnected, err := c.handleDisconnectionError(err, &req)
 			if reconnected {
 				logger.Warn("reconnected to data store connection stream")
 				return

--- a/agent/client/workflow_listen_for_otlp_connection_tests.go
+++ b/agent/client/workflow_listen_for_otlp_connection_tests.go
@@ -35,7 +35,7 @@ func (c *Client) startOTLPConnectionTestListener(ctx context.Context) error {
 				return
 			}
 
-			reconnected, err := c.handleDisconnectionError(err)
+			reconnected, err := c.handleDisconnectionError(err, &req)
 			if reconnected {
 				logger.Warn("reconnected to otlp connection stream")
 				return

--- a/agent/client/workflow_listen_for_poll_requests.go
+++ b/agent/client/workflow_listen_for_poll_requests.go
@@ -34,7 +34,7 @@ func (c *Client) startPollerListener(ctx context.Context) error {
 				return
 			}
 
-			reconnected, err := c.handleDisconnectionError(err)
+			reconnected, err := c.handleDisconnectionError(err, &req)
 			if reconnected {
 				logger.Warn("reconnected to poller stream")
 				return

--- a/agent/client/workflow_listen_for_stop_requests.go
+++ b/agent/client/workflow_listen_for_stop_requests.go
@@ -36,7 +36,7 @@ func (c *Client) startStopListener(ctx context.Context) error {
 				return
 			}
 
-			reconnected, err := c.handleDisconnectionError(err)
+			reconnected, err := c.handleDisconnectionError(err, &req)
 			if reconnected {
 				logger.Warn("reconnected to stop stream")
 				return

--- a/agent/client/workflow_listen_for_trigger_requests.go
+++ b/agent/client/workflow_listen_for_trigger_requests.go
@@ -35,7 +35,7 @@ func (c *Client) startTriggerListener(ctx context.Context) error {
 				return
 			}
 
-			reconnected, err := c.handleDisconnectionError(err)
+			reconnected, err := c.handleDisconnectionError(err, &req)
 			if reconnected {
 				logger.Warn("reconnected to stop stream")
 				return

--- a/agent/client/workflow_ping.go
+++ b/agent/client/workflow_ping.go
@@ -27,7 +27,7 @@ func (c *Client) startHeartBeat(ctx context.Context) error {
 				return
 			}
 
-			reconnected, err := c.handleDisconnectionError(err)
+			reconnected, err := c.handleDisconnectionError(err, nil)
 			if reconnected {
 				log.Println("reconnected to ping stream")
 				return

--- a/agent/client/workflow_shutdown.go
+++ b/agent/client/workflow_shutdown.go
@@ -24,8 +24,8 @@ func (c *Client) startShutdownListener(ctx context.Context) error {
 
 	go func() {
 		for {
-			resp := proto.ShutdownRequest{}
-			err := stream.RecvMsg(&resp)
+			req := proto.ShutdownRequest{}
+			err := stream.RecvMsg(&req)
 
 			if err != nil {
 				logger.Error("could not get message from shutdown stream", zap.Error(err))
@@ -36,7 +36,7 @@ func (c *Client) startShutdownListener(ctx context.Context) error {
 				return
 			}
 
-			reconnected, err := c.handleDisconnectionError(err)
+			reconnected, err := c.handleDisconnectionError(err, &req)
 			if reconnected {
 				logger.Warn("reconnected to shutdown stream")
 				return
@@ -50,7 +50,7 @@ func (c *Client) startShutdownListener(ctx context.Context) error {
 			}
 
 			// TODO: get context from request
-			err = c.shutdownListener(context.Background(), &resp)
+			err = c.shutdownListener(context.Background(), &req)
 			if err != nil {
 				logger.Error("could not handle shutdown request", zap.Error(err))
 				fmt.Println(err.Error())


### PR DESCRIPTION
This PR makes the agent reconnect when the server shuts down (probably a rolling release)

## Changes

-

## Fixes

-

## Checklist

- [ ] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Loom video

Add your loom video here if your work can be visualized
