### PR TITLE
fix(triggers): Fixing Kafka missing variable on URL

### DIFF
--- a/agent/workers/trigger/kafka.go
+++ b/agent/workers/trigger/kafka.go
@@ -77,7 +77,7 @@ func (t *kafkaTriggerer) getConfig(request *KafkaRequest) kafka.Config {
 const TriggerTypeKafka TriggerType = "kafka"
 
 type KafkaRequest struct {
-	BrokerURLs      []string             `json:"brokerUrls"`
+	BrokerURLs      []string             `expr_enabled:"true" json:"brokerUrls"`
 	Topic           string               `expr_enabled:"true" json:"topic"`
 	Headers         []KafkaMessageHeader `json:"headers"`
 	Authentication  *KafkaAuthenticator  `json:"authetication,omitempty"`


### PR DESCRIPTION
This PR fixes a missing entry for the broker URL for kafka trigger to handle expressions

## Changes

- Adds missing expression for kafka url

## Fixes

- https://github.com/kubeshop/tracetest-cloud/issues/664

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
