### PR TITLE
fix(cli): adding validation when trying to run resource that does not exist

### DIFF
--- a/cli/cmd/resource_run_cmd.go
+++ b/cli/cmd/resource_run_cmd.go
@@ -20,7 +20,7 @@ var (
 	runCmd    *cobra.Command
 )
 
-const ExitCodeResourceNotFound = -1
+const ExitCodeResourceNotFound = 3
 
 func init() {
 	runCmd = &cobra.Command{

--- a/cli/cmd/resource_run_cmd.go
+++ b/cli/cmd/resource_run_cmd.go
@@ -8,6 +8,7 @@ import (
 	"github.com/kubeshop/tracetest/cli/cmdutil"
 	"github.com/kubeshop/tracetest/cli/config"
 	"github.com/kubeshop/tracetest/cli/openapi"
+	"github.com/kubeshop/tracetest/cli/pkg/fileutil"
 	"github.com/kubeshop/tracetest/cli/runner"
 	"github.com/spf13/cobra"
 
@@ -19,6 +20,8 @@ var (
 	runCmd    *cobra.Command
 )
 
+const ExitCodeResourceNotFound = -1
+
 func init() {
 	runCmd = &cobra.Command{
 		GroupID: cmdGroupResources.ID,
@@ -29,9 +32,7 @@ func init() {
 		Run: WithResourceMiddleware(func(ctx context.Context, _ *cobra.Command, args []string) (string, error) {
 			runParams.ResourceName = resourceParams.ResourceName
 			if cliConfig.Jwt != "" {
-				exitCode, err := cloudCmd.RunMultipleFiles(ctx, httpClient, runParams, &cliConfig, runnerRegistry, output)
-				ExitCLI(exitCode)
-				return "", err
+				return runMultipleFiles(ctx)
 			}
 
 			return runSingleFile(ctx)
@@ -71,6 +72,12 @@ func runSingleFile(ctx context.Context) (string, error) {
 	var definitionFile string
 	if len(runParams.DefinitionFiles) > 0 {
 		definitionFile = runParams.DefinitionFiles[0]
+
+		if !hasValidResourceFiles() {
+			cliLogger.Warn("Invalid definition file found, stopping execution")
+			ExitCLI(ExitCodeResourceNotFound)
+			return "", nil
+		}
 	}
 
 	ID := ""
@@ -94,6 +101,18 @@ func runSingleFile(ctx context.Context) (string, error) {
 	return "", err
 }
 
+func runMultipleFiles(ctx context.Context) (string, error) {
+	if !hasValidResourceFiles() {
+		cliLogger.Warn("Invalid definition files found, stopping execution")
+		ExitCLI(ExitCodeResourceNotFound)
+		return "", nil
+	}
+
+	exitCode, err := cloudCmd.RunMultipleFiles(ctx, httpClient, runParams, &cliConfig, runnerRegistry, output)
+	ExitCLI(exitCode)
+	return "", err
+}
+
 func validRequiredGatesMsg() string {
 	opts := make([]string, 0, len(openapi.AllowedSupportedGatesEnumValues))
 	for _, v := range openapi.AllowedSupportedGatesEnumValues {
@@ -101,4 +120,21 @@ func validRequiredGatesMsg() string {
 	}
 
 	return "valid options: " + strings.Join(opts, ", ")
+}
+
+func hasValidResourceFiles() bool {
+	if len(runParams.DefinitionFiles) == 0 {
+		return true
+	}
+
+	validResourceFiles := true
+
+	for _, file := range runParams.DefinitionFiles {
+		if !fileutil.IsExistingFile(file) {
+			cliLogger.Warn("Definition file does not exist: " + file)
+			validResourceFiles = false
+		}
+	}
+
+	return validResourceFiles
 }

--- a/cli/pkg/fileutil/path.go
+++ b/cli/pkg/fileutil/path.go
@@ -58,3 +58,8 @@ func IsFilePathToRelativeDir(path, dir string) bool {
 
 	return IsFilePath(fullPath)
 }
+
+func IsExistingFile(path string) bool {
+	_, err := os.Stat(path)
+	return err == nil
+}

--- a/testing/cli-e2etest/testscenarios/test/run_test_test.go
+++ b/testing/cli-e2etest/testscenarios/test/run_test_test.go
@@ -230,6 +230,9 @@ func TestRunTestWithInvalidArgs(t *testing.T) {
 	cliConfig := env.GetCLIConfigPath(t)
 
 	t.Run("should return an error message", func(t *testing.T) {
+		// instantiate require with testing helper
+		require := require.New(t)
+
 		// Given I am a Tracetest CLI user
 		// And I have my server recently created
 		// And the datasource is already set
@@ -240,6 +243,9 @@ func TestRunTestWithInvalidArgs(t *testing.T) {
 
 		command := fmt.Sprintf("run test -f %s", testFile)
 		result := tracetestcli.Exec(t, command, tracetestcli.WithCLIConfig(cliConfig))
-		helpers.RequireExitCodeEqual(t, result, 1)
+		helpers.RequireExitCodeEqual(t, result, 3)
+
+		// checks if the error message is valid
+		require.Contains(result.StdOut, "Invalid definition file found, stopping execution")
 	})
 }

--- a/testing/cli-e2etest/testscenarios/test/run_test_test.go
+++ b/testing/cli-e2etest/testscenarios/test/run_test_test.go
@@ -221,3 +221,25 @@ func TestRunTestWithKafkaTrigger(t *testing.T) {
 		require.Contains(result.StdOut, "✔ A message was received from Kafka stream")
 	})
 }
+
+func TestRunTestWithInvalidArgs(t *testing.T) {
+	// setup isolated e2e environment
+	env := environment.CreateAndStart(t, environment.WithDataStoreEnabled())
+	defer env.Close(t)
+
+	cliConfig := env.GetCLIConfigPath(t)
+
+	t.Run("should return an error message", func(t *testing.T) {
+		// Given I am a Tracetest CLI user
+		// And I have my server recently created
+		// And the datasource is already set
+
+		// When I try to run a test with an invalid file
+		// Then it should give an error message
+		testFile := "./invalid-file.yaml"
+
+		command := fmt.Sprintf("run test -f %s", testFile)
+		result := tracetestcli.Exec(t, command, tracetestcli.WithCLIConfig(cliConfig))
+		helpers.RequireExitCodeEqual(t, result, 1)
+	})
+}

--- a/testing/cli-e2etest/testscenarios/testsuite/run_testsuite_test.go
+++ b/testing/cli-e2etest/testscenarios/testsuite/run_testsuite_test.go
@@ -83,3 +83,31 @@ func TestRunTestSuite(t *testing.T) {
 		require.Contains(result.StdOut, "✔ It should Get Pokemons correctly")
 	})
 }
+
+func TestSuiteRunTestWithInvalidArgs(t *testing.T) {
+	// setup isolated e2e environment
+	env := environment.CreateAndStart(t, environment.WithDataStoreEnabled())
+	defer env.Close(t)
+
+	cliConfig := env.GetCLIConfigPath(t)
+
+	t.Run("should return an error message", func(t *testing.T) {
+		// instantiate require with testing helper
+		require := require.New(t)
+
+		// Given I am a Tracetest CLI user
+		// And I have my server recently created
+		// And the datasource is already set
+
+		// When I try to run a test with an invalid file
+		// Then it should give an error message
+		testFile := "./invalid-file.yaml"
+
+		command := fmt.Sprintf("run testsuite -f %s", testFile)
+		result := tracetestcli.Exec(t, command, tracetestcli.WithCLIConfig(cliConfig))
+		helpers.RequireExitCodeEqual(t, result, 3)
+
+		// checks if the error message is valid
+		require.Contains(result.StdOut, "Invalid definition file found, stopping execution")
+	})
+}


### PR DESCRIPTION
This PR adds a validation on the CLI to inform the user that they tried to run a test / testsuite that doesn't exist. 

Example:
<img width="689" alt="image" src="https://github.com/kubeshop/tracetest/assets/12397879/cc4c3be9-bc4c-40cb-b08c-afb07b496968">

## Changes

- Add validation on `run` command to check if definition files exists

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [x] added a test
