### PR TITLE
chore(ci): disable signoz to unblock another PRs

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -204,7 +204,7 @@ jobs:
           - tracetest-opensearch
           - tracetest-tempo
           - tracetest-provisioning-env
-          - tracetest-signoz
+          # - tracetest-signoz # signoz is unstable, we need to review their docker compose structure
     steps:
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
This PR disables Signoz tests temporarily until we find out why its internal clickhouse started to misbehave on the example.

Example of runs with problem:
- https://github.com/kubeshop/tracetest/actions/runs/9489935292/job/26152538458