### PR TITLE
fix(triggers): Fixing playwright engine trigger field

### DIFF
--- a/agent/workers/trigger/trigger_json.go
+++ b/agent/workers/trigger/trigger_json.go
@@ -13,7 +13,7 @@ type triggerJSONV3 struct {
 	GRPC             *GRPCRequest             `json:"grpc,omitempty"`
 	TraceID          *TraceIDRequest          `json:"traceid,omitempty"`
 	Kafka            *KafkaRequest            `json:"kafka,omitempty"`
-	PlaywrightEngine *PlaywrightEngineRequest `json:"playwrightengine,omitempty"`
+	PlaywrightEngine *PlaywrightEngineRequest `json:"playwrightEngine,omitempty"`
 }
 
 func (v3 triggerJSONV3) valid() bool {


### PR DESCRIPTION
This PR fixes the json field for the playwright engine entry, it should be uppercase `E`

## Changes

- Updates field json for playwright engine

## Fixes

- https://github.com/kubeshop/tracetest-cloud/issues/750

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test


