### PR TITLE
fix: unescape strings before comparing them

### DIFF
--- a/server/expression/executor.go
+++ b/server/expression/executor.go
@@ -211,7 +211,8 @@ func (e Executor) resolveTerm(term *Term) (value.Value, error) {
 			strValue = fmt.Sprintf(term.Str.Text, stringArgs...)
 		}
 
-		return value.NewFromString(strValue), nil
+		str := value.NewFromString(strValue)
+		return value.NewFromString(str.UnescappedString()), nil
 	}
 
 	return value.Nil, fmt.Errorf("empty term")

--- a/server/expression/executor_test.go
+++ b/server/expression/executor_test.go
@@ -58,6 +58,11 @@ func TestBasicExpressionExecution(t *testing.T) {
 			Query:      `100ms < 200 ms`,
 			ShouldPass: true,
 		},
+		{
+			Name:       "escaped_strings_must_be_equal_to_unescaped_strings",
+			Query:      `'This should be workin\'' = "This should be workin'"`,
+			ShouldPass: true,
+		},
 	}
 
 	executeTestCases(t, testCases)


### PR DESCRIPTION
This PR...

## Changes

-

## Fixes

-

## Checklist

- [ ] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Loom video

Add your loom video here if your work can be visualized
