### PR TITLE
feat(agent): allow connections to  controlplane and api with self signed ssl cert on demand

### DIFF
--- a/agent/client/connector.go
+++ b/agent/client/connector.go
@@ -5,6 +5,7 @@ import (
 	"crypto/tls"
 	"fmt"
 	"net"
+	"os"
 	"time"
 
 	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
@@ -96,13 +97,17 @@ func getTransportCredentialsForEndpoint(endpoint string) (credentials.TransportC
 		return nil, fmt.Errorf("cannot parse endpoint: %w", err)
 	}
 
+	tlsCreds := credentials.NewTLS(&tls.Config{
+		InsecureSkipVerify: true,
+	})
+
+	if os.Getenv("TRACETEST_DEV_FORCE_URL") == "true" {
+		return tlsCreds, nil
+	}
+
 	switch port {
 	case "443":
-		tlsConfig := &tls.Config{
-			InsecureSkipVerify: true,
-		}
-		transportCredentials := credentials.NewTLS(tlsConfig)
-		return transportCredentials, nil
+		return tlsCreds, nil
 
 	default:
 		return insecure.NewCredentials(), nil

--- a/cli/config/api.go
+++ b/cli/config/api.go
@@ -1,7 +1,10 @@
 package config
 
 import (
+	"crypto/tls"
 	"fmt"
+	"net/http"
+	"os"
 	"strings"
 
 	"github.com/kubeshop/tracetest/cli/analytics"
@@ -23,6 +26,22 @@ func GetAPIClient(cliConfig Config) *openapi.APIClient {
 	config.AddDefaultHeader("x-organization-id", cliConfig.OrganizationID)
 	config.AddDefaultHeader("x-environment-id", cliConfig.EnvironmentID)
 	config.AddDefaultHeader("Authorization", fmt.Sprintf("Bearer %s", cliConfig.Jwt))
+	if os.Getenv("TRACETEST_DEV_FORCE_URL") == "true" {
+		if config.HTTPClient == nil {
+			config.HTTPClient = http.DefaultClient
+		}
+		if config.HTTPClient.Transport == nil {
+			config.HTTPClient.Transport = http.DefaultTransport
+		}
+
+		if t, ok := config.HTTPClient.Transport.(*http.Transport); ok {
+			if t.TLSClientConfig == nil {
+				t.TLSClientConfig = &tls.Config{}
+			}
+
+			t.TLSClientConfig.InsecureSkipVerify = true
+		}
+	}
 
 	config.Scheme = cliConfig.Scheme
 	config.Host = strings.TrimSuffix(cliConfig.Endpoint, "/")


### PR DESCRIPTION
This PR allows configuring the controlplane client to allow self signed certificates on controlplane servers when the TRACETEST_DEV_FORCE_URL env var is true. This also applies for openapi client