### PR TITLE
docs(upsell): add callout for commercial on features

### DIFF
--- a/docs/docs/concepts/environments.mdx
+++ b/docs/docs/concepts/environments.mdx
@@ -12,6 +12,10 @@ keywords:
 image: https://res.cloudinary.com/djwdcmwdz/image/upload/v1698686403/docs/Blog_Thumbnail_14_rsvkmo.jpg
 ---
 
+:::tip Commercial Feature
+[Feature available only in Cloud-based Managed Tracetest & Enterprise Self-hosted Tracetest.](https://tracetest.io/pricing)
+:::
+
 Environments are workspaces where you keep tests, test suites, variable sets, and all other Tracetest resources.
 
 ![](https://res.cloudinary.com/djwdcmwdz/image/upload/v1712585521/docs/app.tracetest.io_organizations_ttorg_2179a9cd8ba8dfa5_environments_ttenv_231b49e808c29e6a_2_wgg8zl.png)

--- a/docs/docs/concepts/organizations.mdx
+++ b/docs/docs/concepts/organizations.mdx
@@ -14,6 +14,10 @@ keywords:
 image: https://res.cloudinary.com/djwdcmwdz/image/upload/v1698686403/docs/Blog_Thumbnail_14_rsvkmo.jpg
 ---
 
+:::tip Commercial Feature
+[Feature available only in Cloud-based Managed Tracetest & Enterprise Self-hosted Tracetest.](https://tracetest.io/pricing)
+:::
+
 Organizations contain a collection of environments, team members, and settings.
 
 When signing up to Tracetest you get a `personal-org` by default. You can create additional organizations by clicking the organization dropdown and selecting `+ Create a New Organization`.

--- a/docs/docs/concepts/polling-profiles.mdx
+++ b/docs/docs/concepts/polling-profiles.mdx
@@ -19,9 +19,15 @@ done running.
 
 This means that Tracetest needs to check periodically if the trace is complete or not. For this, a **Polling Profile** is used. This profile
 tells Tracetest how often and how long to wait for a trace to finish. Every Tracetest environment has one default polling profile, meaning that any
-test will use that profile when trying to fetch the trace from the tracing backend. Since version v1.0.0, users can now specify a different
+test will use that profile when trying to fetch the trace from the tracing backend.
+
+Since version v1.0.0, users can now specify a different
 polling profile per test. This makes more sense than having a single profile, due to some tests being pretty quick to run and others can take minutes
 to hours to finish executing.
+
+:::tip Commercial Feature
+[Using multiple polling profiles is available only in Cloud-based Managed Tracetest & Enterprise Self-hosted Tracetest.](https://tracetest.io/pricing)
+:::
 
 ## Adding a Polling Profile in the CLI
 

--- a/docs/docs/concepts/roles-and-permissions.mdx
+++ b/docs/docs/concepts/roles-and-permissions.mdx
@@ -15,6 +15,10 @@ keywords:
 image: https://res.cloudinary.com/djwdcmwdz/image/upload/v1698686403/docs/Blog_Thumbnail_14_rsvkmo.jpg
 ---
 
+:::tip Commercial Feature
+[Feature available only in Cloud-based Managed Tracetest & Enterprise Self-hosted Tracetest.](https://tracetest.io/pricing)
+:::
+
 In this section, you will learn everything you need to manage your organization members effectively.
 
 Tracetest distinguishes between different roles to help manage organization members' access levels and permissions. These roles are categorized into two groups: organization level and environment level roles.

--- a/docs/docs/concepts/runs.mdx
+++ b/docs/docs/concepts/runs.mdx
@@ -13,6 +13,10 @@ keywords:
 image: https://res.cloudinary.com/djwdcmwdz/image/upload/v1698686403/docs/Blog_Thumbnail_14_rsvkmo.jpg
 ---
 
+:::tip Commercial Feature
+[Feature available only in Cloud-based Managed Tracetest & Enterprise Self-hosted Tracetest.](https://tracetest.io/pricing)
+:::
+
 Tracetest uses the concept of Runs to define every time a Test was triggered.
 
 - [Tests](/concepts/tests)

--- a/docs/docs/concepts/variable-sets.mdx
+++ b/docs/docs/concepts/variable-sets.mdx
@@ -25,6 +25,10 @@ For details on creating and editing varaible sets in the Web UI, please visit [W
 
 ## Secrets Management
 
+:::tip Commercial Feature
+[Secrets management feature is available only in Cloud-based Managed Tracetest & Enterprise Self-hosted Tracetest.](https://tracetest.io/pricing)
+:::
+
 Variable Sets can accept secrets. A variable can be a `secret` or a `raw` variable in the Web UI and CLI. 
 
 ![Create Variable Set Values](../img/create-variable-set-values.png)

--- a/docs/docs/tools-and-integrations/artillery-engine.mdx
+++ b/docs/docs/tools-and-integrations/artillery-engine.mdx
@@ -15,6 +15,10 @@ keywords:
 image: https://res.cloudinary.com/djwdcmwdz/image/upload/v1698686403/docs/Blog_Thumbnail_14_rsvkmo.jpg
 ---
 
+:::tip Commercial Feature
+[Feature available only in Cloud-based Managed Tracetest & Enterprise Self-hosted Tracetest.](https://tracetest.io/pricing)
+:::
+
 :::info Version Compatibility
 This integration is compatible with [Artillery v2.0.10](https://github.com/artilleryio/artillery/releases/tag/artillery-2.0.10) and above.
 :::

--- a/docs/docs/tools-and-integrations/artillery-plugin.mdx
+++ b/docs/docs/tools-and-integrations/artillery-plugin.mdx
@@ -15,6 +15,10 @@ keywords:
 image: https://res.cloudinary.com/djwdcmwdz/image/upload/v1698686403/docs/Blog_Thumbnail_14_rsvkmo.jpg
 ---
 
+:::tip Commercial Feature
+[Feature available only in Cloud-based Managed Tracetest & Enterprise Self-hosted Tracetest.](https://tracetest.io/pricing)
+:::
+
 :::info Version Compatibility
 This integration is compatible with [Artillery v2.0.10](https://github.com/artilleryio/artillery/releases/tag/artillery-2.0.10) and above.
 :::

--- a/docs/docs/tools-and-integrations/cypress.mdx
+++ b/docs/docs/tools-and-integrations/cypress.mdx
@@ -16,6 +16,10 @@ keywords:
 image: https://res.cloudinary.com/djwdcmwdz/image/upload/v1698686403/docs/Blog_Thumbnail_14_rsvkmo.jpg
 ---
 
+:::tip Commercial Feature
+[Feature available only in Cloud-based Managed Tracetest & Enterprise Self-hosted Tracetest.](https://tracetest.io/pricing)
+:::
+
 :::info Tracetest x Cypress Frontend Instrumentation Requirements
 Find out the requirements for your instrumented app to start using [Tracetest x Cypress](https://tracetest.io/blog/tracetest-tip-instrumentation-for-end-to-end-tests).
 :::

--- a/docs/docs/tools-and-integrations/playwright.mdx
+++ b/docs/docs/tools-and-integrations/playwright.mdx
@@ -16,6 +16,10 @@ keywords:
 image: https://res.cloudinary.com/djwdcmwdz/image/upload/v1698686403/docs/Blog_Thumbnail_14_rsvkmo.jpg
 ---
 
+:::tip Commercial Feature
+[Feature available only in Cloud-based Managed Tracetest & Enterprise Self-hosted Tracetest.](https://tracetest.io/pricing)
+:::
+
 :::info Tracetest x Playwright Frontend Instrumentation Requirements
 Find out the requirements for your instrumented app to start using [Tracetest x Playwright](https://tracetest.io/blog/tracetest-tip-instrumentation-for-end-to-end-tests).
 :::

--- a/docs/docs/tools-and-integrations/typescript.mdx
+++ b/docs/docs/tools-and-integrations/typescript.mdx
@@ -14,6 +14,10 @@ keywords:
 image: https://res.cloudinary.com/djwdcmwdz/image/upload/v1698686403/docs/Blog_Thumbnail_14_rsvkmo.jpg
 ---
 
+:::tip Commercial Feature
+[Feature available only in Cloud-based Managed Tracetest & Enterprise Self-hosted Tracetest.](https://tracetest.io/pricing)
+:::
+
 :::note
 [Check out the source code on GitHub here.](https://github.com/kubeshop/tracetest/tree/main/examples/quick-start-typescript)
 :::


### PR DESCRIPTION
This PR adds callouts to feature pages that are only available in commercial Tracetest.

## Changes

-

## Fixes

-

## Checklist

- [ ] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Loom video

Add your loom video here if your work can be visualized
