### PR TITLE
fix(ci): update example tests to use "docker compose" instead of "docker-compose"

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -21,40 +21,6 @@ env:
   CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
 
 jobs:
-  # backend-arch-graph:
-  #   name: Generate backend architecture graph
-  #   runs-on: ubuntu-latest
-  #   continue-on-error: true
-  #   steps:
-  #     - uses: actions/checkout@v3
-  #       with:
-  #         fetch-depth: 0
-  #     - name: Setup go
-  #       uses: actions/setup-go@v3
-  #       with:
-  #         go-version-file: "go.mod"
-  #         cache: true
-  #         cache-dependency-path: go.mod
-  #     - name: install graph tool
-  #       run: |
-  #         mkdir /tmp/go-arch
-  #         cd /tmp/go-arch
-  #         curl -SLO https://github.com/mathnogueira/golang-arch-viewer/archive/refs/heads/master.zip
-  #         unzip master.zip
-  #         cd golang-arch-viewer-master
-  #         make
-  #         mv dist/go-arch /tmp/go-arch/go-arch
-  #     - name: generate graph
-  #       run: |
-  #         cd server
-  #         mkdir -p ../dist/
-  #         /tmp/go-arch/go-arch -o ../dist/architecture.png
-  #     - name: Upload assets
-  #       uses: actions/upload-artifact@v3
-  #       with:
-  #         name: architecture-graph
-  #         path: dist/architecture.png
-
   unit-test-cli:
     name: CLI unit tests
     runs-on: ubuntu-latest
@@ -219,7 +185,7 @@ jobs:
       - name: Build example
         run: |
           cd examples/${{ matrix.example_dir }}
-          docker-compose up -d
+          docker compose up -d
           docker compose logs -f > /tmp/docker-log &
       - name: Run example test
         run: |
@@ -254,7 +220,7 @@ jobs:
       - name: Start server
         run: |
           cd examples/collector
-          docker-compose up -d
+          docker compose up -d
           docker compose logs -f > /tmp/docker-log &
       - name: Run tests
         run: |

--- a/examples/quick-start-java/quick_start_api/.gitignore
+++ b/examples/quick-start-java/quick_start_api/.gitignore
@@ -3,3 +3,5 @@
 
 # Ignore Gradle build output directory
 build
+
+app/bin


### PR DESCRIPTION
This PR updates our CI pipeline script to use `docker compose` commands instead of `docker-compose`.

## Changes

- `.github/workflows/pull-request.yaml` calls `docker compose` for starting examples

## Checklist

- [ ] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test