### PR TITLE
fix(agent): return correct cors headers for ingestion endpoint

### DIFF
--- a/cli/config/config.go
+++ b/cli/config/config.go
@@ -17,7 +17,7 @@ import (
 var (
 	Version              = "dev"
 	Env                  = "dev"
-	DefaultCloudEndpoint = "http://app.tracetest.io"
+	DefaultCloudEndpoint = "https://app.tracetest.io"
 	DefaultCloudDomain   = "tracetest.io"
 	DefaultCloudPath     = "/"
 )

--- a/go.mod
+++ b/go.mod
@@ -52,6 +52,7 @@ require (
 	github.com/prometheus/prometheus v1.8.2-0.20211217191541-41f1a8125e66
 	github.com/pterm/pterm v0.12.69
 	github.com/rivo/tview v0.0.0-20240122063236-8526c9fe1b54
+	github.com/rs/cors v1.8.0
 	github.com/segmentio/analytics-go/v3 v3.2.1
 	github.com/spf13/cobra v1.7.0
 	github.com/spf13/pflag v1.0.5

--- a/go.sum
+++ b/go.sum
@@ -1669,6 +1669,7 @@ github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFR
 github.com/rogpeppe/go-internal v1.10.0 h1:TMyTOH3F/DB16zRVcYyreMH6GnZZrwQVAoYjRBZyWFQ=
 github.com/rogpeppe/go-internal v1.10.0/go.mod h1:UQnix2H7Ngw/k4C5ijL5+65zddjncjaFoBhdsK/akog=
 github.com/rs/cors v1.6.0/go.mod h1:gFx+x8UowdsKA9AchylcLynDq+nNFfI8FkUZdN/jGCU=
+github.com/rs/cors v1.8.0 h1:P2KMzcFwrPoSjkF1WLRPsp3UMLyql8L4v9hQpVeK5so=
 github.com/rs/cors v1.8.0/go.mod h1:EBwu+T5AvHOcXwvZIkQFjUN6s8Czyqw12GL/Y0tUyRM=
 github.com/rs/xid v1.2.1/go.mod h1:+uKXf+4Djp6Md1KODXJxgGQPKngRmWyn10oCKFzNHOQ=
 github.com/rs/zerolog v1.13.0/go.mod h1:YbFCdg8HfsridGWAh22vktObvhZbQsZXe4/zB0OKkWU=


### PR DESCRIPTION
This PR fixes the agent's OTLP server http ingestion server so that it provides the correct CORS headers. This allows sending traces from a web client directly to the agent.

## Changes

- add cors middleware to the endpoint

## Fixes

- fix incorrect default domain using http instead of https

## Checklist

- [x] tested locally
- [x] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Screenshots

![Screenshot 2024-08-16 at 17 50 49](https://github.com/user-attachments/assets/ca4b347c-3fda-429c-a596-96bfa41aa1fc)

![Screenshot 2024-08-16 at 17 50 35](https://github.com/user-attachments/assets/bd4feea4-dfc4-4ac3-be5b-c3c9070e1481)
