### PR TITLE
fix(cli): handling of concurrent map read/write

### DIFF
--- a/agent/ui/dashboard/sensors/sensor.go
+++ b/agent/ui/dashboard/sensors/sensor.go
@@ -68,7 +68,7 @@ func (r *sensor) On(eventName string, cb func(Event)) {
 
 func (r *sensor) Emit(eventName string, event interface{}) {
 	r.mutex.Lock()
-	r.mutex.Unlock()
+	defer r.mutex.Unlock()
 
 	listeners := r.listeners[eventName]
 	e := Event{


### PR DESCRIPTION
This PR adds a mising `defer` for the calling of mutex Unlock when emmiting events. This avoids seeing this kinds of errors:

```
fatal error: concurrent map writes

goroutine 585 [running]:
github.com/kubeshop/tracetest/agent/ui/dashboard/sensors.(*sensor).Emit(0x140006c2270, {0x105980599, 0x12}, {0x105fb2380?, 0x107531060})
	/home/runner/work/tracetest/tracetest/agent/ui/dashboard/sensors/sensor.go:79 +0x154
github.com/kubeshop/tracetest/agent/collector.(*forwardIngester).ingestSpans(0x140006c40d0, 0x1400090a540)
	/home/runner/work/tracetest/tracetest/agent/collector/ingester.go:110 +0x1ac
created by github.com/kubeshop/tracetest/agent/collector.(*forwardIngester).Ingest in goroutine 597
	/home/runner/work/tracetest/tracetest/agent/collector/ingester.go:91 +0x70
```

## Fixes

- Defer mutex unlock call

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Loom video

Add your loom video here if your work can be visualized
