### PR TITLE
fix: agent k8s deployment

### DIFF
--- a/k8s/agent/deploy-agent.sh
+++ b/k8s/agent/deploy-agent.sh
@@ -27,6 +27,7 @@ API_KEY=""
 AGENT_VERSION="latest"
 SKIP_VERIFY=false
 SERVER_URL=""
+ENVIRONMENT=""
 
 POSITIONAL_ARGS=()
 
@@ -38,6 +39,11 @@ while [[ $# -gt 0 ]]; do
             ;;
         --server-url)
             SERVER_URL="$2"
+            shift
+            shift
+            ;;
+        --environment)
+            ENVIRONMENT="$2"
             shift
             shift
             ;;
@@ -81,6 +87,10 @@ fi
 
 if [ -n "$SERVER_URL" ]; then
   extraCmd+=("--server-url" "$SERVER_URL")
+fi
+
+if [ -n "$ENVIRONMENT" ]; then
+  extraCmd+=("--environment" "$ENVIRONMENT")
 fi
 
 

--- a/k8s/agent/deploy-agent.yaml
+++ b/k8s/agent/deploy-agent.yaml
@@ -17,7 +17,7 @@ spec:
       containers:
         - name: tracetest-agent
           image: kubeshop/tracetest-agent:TAG
-          command: [EXTRA_CMD]
+          args: [EXTRA_CMD]
           env:
             - name: TRACETEST_API_KEY
               valueFrom:


### PR DESCRIPTION
This PR adds the `--environment` flag to the script that installs the agent in a Kubernetes cluster. It also replaces the `command` option with the `args` option in the manifest.

Here's a pod running the agent that was installed with this script

![image](https://github.com/user-attachments/assets/9c329dbb-c398-4921-abae-bdc276c058cb)
