### PR TITLE
fix(cli installer): make yum update

### DIFF
--- a/install-cli.sh
+++ b/install-cli.sh
@@ -123,6 +123,7 @@ enabled=1
 gpgcheck=0
 EOF
   $SUDO yum install -y tracetest --refresh
+  $SUDO yum update -y tracetest
 }
 
 install_brew() {


### PR DESCRIPTION
This PR fixes the CLI installer script so that it upgrades tracetst to the latest version when using yum if the package is already installed

## Changes

-

## Fixes

-

## Checklist

- [ ] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Loom video

Add your loom video here if your work can be visualized
