### PR TITLE
fix: oauth path building

### DIFF
--- a/cli/config/config.go
+++ b/cli/config/config.go
@@ -43,7 +43,7 @@ type Config struct {
 }
 
 func (c Config) OAuthEndpoint() string {
-	return path.Join(c.URL(), c.Path())
+	return fmt.Sprintf("%s%s", c.URL(), c.Path())
 }
 
 func (c Config) URL() string {

--- a/cli/config/config.go
+++ b/cli/config/config.go
@@ -43,8 +43,7 @@ type Config struct {
 }
 
 func (c Config) OAuthEndpoint() string {
-	return fmt.Sprintf("%s%s", c.URL(), c.Path())
-
+	return path.Join(c.URL(), c.Path())
 }
 
 func (c Config) URL() string {

--- a/cli/config/configurator.go
+++ b/cli/config/configurator.go
@@ -156,6 +156,7 @@ func (c Configurator) getServerURL(prev *Config) (string, error) {
 }
 
 func (c Configurator) createConfig(serverURL string) (Config, error) {
+	serverURL = strings.TrimSuffix(serverURL, "/")
 	scheme, endpoint, path, err := ParseServerURL(serverURL)
 	if err != nil {
 		return Config{}, err

--- a/cli/pkg/oauth/oauth.go
+++ b/cli/pkg/oauth/oauth.go
@@ -6,7 +6,7 @@ import (
 	"io"
 	"net"
 	"net/http"
-	"path"
+	neturl "net/url"
 	"sync"
 
 	"github.com/kubeshop/tracetest/cli/ui"
@@ -59,7 +59,10 @@ func (s *OAuthServer) GetAuthJWT() error {
 		return fmt.Errorf("failed to start oauth server: %w", err)
 	}
 
-	loginUrl := path.Join(s.frontendEndpoint, fmt.Sprintf("oauth?callback=%s", url))
+	loginUrl, err := neturl.JoinPath(s.frontendEndpoint, fmt.Sprintf("oauth?callback=%s", url))
+	if err != nil {
+		return fmt.Errorf("could not build path: %w", err)
+	}
 
 	ui := ui.DefaultUI
 	err = ui.OpenBrowser(loginUrl)

--- a/cli/pkg/oauth/oauth.go
+++ b/cli/pkg/oauth/oauth.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net"
 	"net/http"
+	"path"
 	"sync"
 
 	"github.com/kubeshop/tracetest/cli/ui"
@@ -58,7 +59,7 @@ func (s *OAuthServer) GetAuthJWT() error {
 		return fmt.Errorf("failed to start oauth server: %w", err)
 	}
 
-	loginUrl := fmt.Sprintf("%soauth?callback=%s", s.frontendEndpoint, url)
+	loginUrl := path.Join(s.frontendEndpoint, fmt.Sprintf("oauth?callback=%s", url))
 
 	ui := ui.DefaultUI
 	err = ui.OpenBrowser(loginUrl)


### PR DESCRIPTION
This PR fixes how we build oauth endpoint paths by replacing `fmt.Sprintf` with `path.Join`

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
