### PR TITLE
fix: don't use ui endpoint for version checking

### DIFF
--- a/cli/config/version.go
+++ b/cli/config/version.go
@@ -15,12 +15,6 @@ const defaultVersionExtension = "json"
 func GetVersion(ctx context.Context, cfg Config) (string, bool) {
 	result := fmt.Sprintf(`CLI: %s`, Version)
 
-	if cfg.UIEndpoint != "" {
-		scheme, endpoint, path, _ := ParseServerURL(cfg.UIEndpoint)
-		cfg.Scheme = scheme
-		cfg.Endpoint = endpoint
-		cfg.ServerPath = path
-	}
 	client := GetAPIClient(cfg)
 
 	if cfg.IsEmpty() {


### PR DESCRIPTION
This PR removes the dependency on the uiEndpoint when checking the server version.

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
