### PR TITLE
fix: append callback parameter after joining url path

### DIFF
--- a/cli/pkg/oauth/oauth.go
+++ b/cli/pkg/oauth/oauth.go
@@ -59,10 +59,12 @@ func (s *OAuthServer) GetAuthJWT() error {
 		return fmt.Errorf("failed to start oauth server: %w", err)
 	}
 
-	loginUrl, err := neturl.JoinPath(s.frontendEndpoint, fmt.Sprintf("oauth?callback=%s", url))
+	loginUrl, err := neturl.JoinPath(s.frontendEndpoint, "oauth")
 	if err != nil {
 		return fmt.Errorf("could not build path: %w", err)
 	}
+
+	loginUrl += fmt.Sprintf("?callback=%s", url)
 
 	ui := ui.DefaultUI
 	err = ui.OpenBrowser(loginUrl)


### PR DESCRIPTION
This PR fixes the escaping problem when referencing the `?callback` query string in the OAuth URL.

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Loom video

Add your loom video here if your work can be visualized
