### PR TITLE
fix: reenable debug logging

### DIFF
--- a/cli/cloud/cmd/wait_cmd.go
+++ b/cli/cloud/cmd/wait_cmd.go
@@ -8,10 +8,11 @@ import (
 	"github.com/kubeshop/tracetest/cli/config"
 	"github.com/kubeshop/tracetest/cli/formatters"
 	cliRunner "github.com/kubeshop/tracetest/cli/runner"
+	"go.uber.org/zap"
 )
 
-func Wait(ctx context.Context, cliConfig *config.Config, runGroupID, format string) (int, error) {
-	rungroupWaiter := runner.RunGroup(config.GetAPIClient(*cliConfig))
+func Wait(ctx context.Context, logger *zap.Logger, cliConfig *config.Config, runGroupID, format string) (int, error) {
+	rungroupWaiter := runner.RunGroup(logger, config.GetAPIClient(*cliConfig))
 	runGroup, err := rungroupWaiter.WaitForCompletion(ctx, runGroupID)
 	if err != nil {
 		return runner.ExitCodeGeneralError, err

--- a/cli/cloud/runner/rungroup.go
+++ b/cli/cloud/runner/rungroup.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	"github.com/davecgh/go-spew/spew"
-	"github.com/kubeshop/tracetest/cli/cmdutil"
 	"github.com/kubeshop/tracetest/cli/openapi"
 	"go.uber.org/zap"
 )
@@ -16,9 +15,9 @@ type runGroup struct {
 	logger        *zap.Logger
 }
 
-func RunGroup(openapiClient *openapi.APIClient) *runGroup {
+func RunGroup(logger *zap.Logger, openapiClient *openapi.APIClient) *runGroup {
 	return &runGroup{
-		logger:        cmdutil.GetLogger(),
+		logger:        logger,
 		openapiClient: openapiClient,
 	}
 }

--- a/cli/cmd/config.go
+++ b/cli/cmd/config.go
@@ -130,7 +130,8 @@ func validateConfig(cmd *cobra.Command, args []string) {
 }
 
 func setupLogger(cmd *cobra.Command, args []string) {
-	cliLogger = cmdutil.GetLogger(cmdutil.WithVerbose(verbose))
+	l := cmdutil.GetLogger(cmdutil.WithVerbose(verbose))
+	*cliLogger = *l
 }
 
 func teardownCommand(cmd *cobra.Command, args []string) {

--- a/cli/cmd/resource_run_cmd.go
+++ b/cli/cmd/resource_run_cmd.go
@@ -108,7 +108,7 @@ func runMultipleFiles(ctx context.Context) (string, error) {
 		return "", nil
 	}
 
-	exitCode, err := cloudCmd.RunMultipleFiles(ctx, httpClient, runParams, &cliConfig, runnerRegistry, output)
+	exitCode, err := cloudCmd.RunMultipleFiles(ctx, cliLogger, httpClient, runParams, &cliConfig, runnerRegistry, output)
 	ExitCLI(exitCode)
 	return "", err
 }

--- a/cli/cmd/resources.go
+++ b/cli/cmd/resources.go
@@ -9,13 +9,13 @@ import (
 
 	"github.com/Jeffail/gabs/v2"
 	"github.com/kubeshop/tracetest/cli/analytics"
-	"github.com/kubeshop/tracetest/cli/cmdutil"
 	"github.com/kubeshop/tracetest/cli/formatters"
 	"github.com/kubeshop/tracetest/cli/pkg/fileutil"
 	"github.com/kubeshop/tracetest/cli/pkg/resourcemanager"
 	"github.com/kubeshop/tracetest/cli/processor"
 	"github.com/kubeshop/tracetest/cli/processor/trigger_preprocessor"
 	"github.com/kubeshop/tracetest/cli/runner"
+	"go.uber.org/zap"
 )
 
 var resourceParams = &resourceParameters{}
@@ -41,7 +41,7 @@ var (
 	httpClient = &resourcemanager.HTTPClient{}
 
 	variableSetPreprocessor = processor.VariableSet(cliLogger)
-	variableSetClient       = GetVariableSetClient(httpClient, variableSetPreprocessor)
+	variableSetClient       = GetVariableSetClient(cliLogger, httpClient, variableSetPreprocessor)
 
 	pollingProfileClient = resourcemanager.NewClient(
 		httpClient, cliLogger,
@@ -453,9 +453,9 @@ func formatItemDate(item *gabs.Container, path string) error {
 	return nil
 }
 
-func GetVariableSetClient(httpClient *resourcemanager.HTTPClient, preprocessor processor.Preprocessor) resourcemanager.Client {
+func GetVariableSetClient(logger *zap.Logger, httpClient *resourcemanager.HTTPClient, preprocessor processor.Preprocessor) resourcemanager.Client {
 	variableSetClient := resourcemanager.NewClient(
-		httpClient, cmdutil.GetLogger(),
+		httpClient, logger,
 		"variableset", "variablesets",
 		resourcemanager.WithTableConfig(resourcemanager.TableConfig{
 			Cells: []resourcemanager.TableCellConfig{

--- a/cli/cmd/wait_cmd.go
+++ b/cli/cmd/wait_cmd.go
@@ -17,7 +17,7 @@ var waitCmd = &cobra.Command{
 	Long:    "Waits for a run group to be finished and displays the result",
 	PreRun:  setupCommand(),
 	Run: WithResultHandler(WithParamsHandler(waitParams)(func(_ context.Context, _ *cobra.Command, _ []string) (string, error) {
-		exitCode, err := cmd.Wait(context.Background(), &cliConfig, waitParams.RunGroupID, output)
+		exitCode, err := cmd.Wait(context.Background(), cliLogger, &cliConfig, waitParams.RunGroupID, output)
 
 		ExitCLI(exitCode)
 		return "", err

--- a/cli/cmdutil/logger.go
+++ b/cli/cmdutil/logger.go
@@ -7,8 +7,6 @@ import (
 	"go.uber.org/zap/zapcore"
 )
 
-var logger *zap.Logger
-
 type loggerConfig struct {
 	Verbose bool
 }
@@ -22,10 +20,6 @@ func WithVerbose(verbose bool) loggerOption {
 }
 
 func GetLogger(opts ...loggerOption) *zap.Logger {
-	if logger != nil {
-		return logger
-	}
-
 	loggerConfig := loggerConfig{}
 	for _, opt := range opts {
 		opt(&loggerConfig)

--- a/cli/pkg/resourcemanager/client.go
+++ b/cli/pkg/resourcemanager/client.go
@@ -10,7 +10,6 @@ import (
 	"path"
 	"strings"
 
-	"github.com/kubeshop/tracetest/cli/cmdutil"
 	"go.uber.org/zap"
 	"golang.org/x/text/cases"
 	"golang.org/x/text/language"
@@ -102,7 +101,7 @@ func NewClient(
 		client:             httpClient,
 		resourceName:       resourceName,
 		resourceNamePlural: resourceNamePlural,
-		logger:             cmdutil.GetLogger(),
+		logger:             logger,
 	}
 
 	for _, opt := range opts {

--- a/cli/processor/environment.go
+++ b/cli/processor/environment.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 
 	"github.com/goccy/go-yaml"
-	"github.com/kubeshop/tracetest/cli/cmdutil"
 	"github.com/kubeshop/tracetest/cli/openapi"
 	"github.com/kubeshop/tracetest/cli/pkg/fileutil"
 	"go.uber.org/zap"
@@ -21,7 +20,7 @@ type environment struct {
 }
 
 func Environment(logger *zap.Logger, applyFn applyFn, updateEnvFn updateEnvFn) environment {
-	return environment{logger: cmdutil.GetLogger(), applyFn: applyFn, updateEnvFn: updateEnvFn}
+	return environment{logger: logger, applyFn: applyFn, updateEnvFn: updateEnvFn}
 }
 
 func (e environment) Postprocess(ctx context.Context, input fileutil.File) (fileutil.File, error) {

--- a/cli/processor/monitor.go
+++ b/cli/processor/monitor.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 
 	"github.com/goccy/go-yaml"
-	"github.com/kubeshop/tracetest/cli/cmdutil"
 	"github.com/kubeshop/tracetest/cli/openapi"
 	"github.com/kubeshop/tracetest/cli/pkg/fileutil"
 	"go.uber.org/zap"
@@ -19,7 +18,7 @@ type monitor struct {
 
 func Monitor(logger *zap.Logger, applyTestSuiteFn, applyTestFn applyResourceFunc) monitor {
 	return monitor{
-		logger:           cmdutil.GetLogger(),
+		logger:           logger,
 		applyTestFn:      applyTestFn,
 		applyTestSuiteFn: applyTestSuiteFn,
 	}

--- a/cli/processor/test.go
+++ b/cli/processor/test.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 
 	"github.com/goccy/go-yaml"
-	"github.com/kubeshop/tracetest/cli/cmdutil"
 	"github.com/kubeshop/tracetest/cli/openapi"
 	"github.com/kubeshop/tracetest/cli/pkg/fileutil"
 	"github.com/kubeshop/tracetest/cli/processor/trigger_preprocessor"
@@ -20,7 +19,7 @@ type test struct {
 
 func Test(logger *zap.Logger, triggerProcessorRegistry trigger_preprocessor.Registry, applyPollingProfileFunc applyResourceFunc) test {
 	return test{
-		logger:                   cmdutil.GetLogger(),
+		logger:                   logger,
 		applyPollingProfileFunc:  applyPollingProfileFunc,
 		triggerProcessorRegistry: triggerProcessorRegistry,
 	}

--- a/cli/processor/testsuite.go
+++ b/cli/processor/testsuite.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 
 	"github.com/goccy/go-yaml"
-	"github.com/kubeshop/tracetest/cli/cmdutil"
 	"github.com/kubeshop/tracetest/cli/openapi"
 	"github.com/kubeshop/tracetest/cli/pkg/fileutil"
 	"go.uber.org/zap"
@@ -20,7 +19,7 @@ type testSuite struct {
 
 func TestSuite(logger *zap.Logger, applyTestFn applyResourceFunc) testSuite {
 	return testSuite{
-		logger:      cmdutil.GetLogger(),
+		logger:      logger,
 		applyTestFn: applyTestFn,
 	}
 }

--- a/cli/processor/trigger_preprocessor/graphql.go
+++ b/cli/processor/trigger_preprocessor/graphql.go
@@ -2,7 +2,6 @@ package trigger_preprocessor
 
 import (
 	"github.com/kubeshop/tracetest/agent/workers/trigger"
-	"github.com/kubeshop/tracetest/cli/cmdutil"
 	"github.com/kubeshop/tracetest/cli/openapi"
 	"github.com/kubeshop/tracetest/cli/pkg/fileutil"
 	"go.uber.org/zap"
@@ -13,7 +12,7 @@ type graphql struct {
 }
 
 func GRAPHQL(logger *zap.Logger) graphql {
-	return graphql{logger: cmdutil.GetLogger()}
+	return graphql{logger: logger}
 }
 
 func (g graphql) Type() trigger.TriggerType {

--- a/cli/processor/trigger_preprocessor/grpc.go
+++ b/cli/processor/trigger_preprocessor/grpc.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 
 	"github.com/kubeshop/tracetest/agent/workers/trigger"
-	"github.com/kubeshop/tracetest/cli/cmdutil"
 	"github.com/kubeshop/tracetest/cli/openapi"
 	"github.com/kubeshop/tracetest/cli/pkg/fileutil"
 	"go.uber.org/zap"
@@ -15,7 +14,7 @@ type grpc struct {
 }
 
 func GRPC(logger *zap.Logger) grpc {
-	return grpc{logger: cmdutil.GetLogger()}
+	return grpc{logger: logger}
 }
 
 func (g grpc) Type() trigger.TriggerType {

--- a/cli/processor/trigger_preprocessor/http.go
+++ b/cli/processor/trigger_preprocessor/http.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 
 	"github.com/kubeshop/tracetest/agent/workers/trigger"
-	"github.com/kubeshop/tracetest/cli/cmdutil"
 	"github.com/kubeshop/tracetest/cli/openapi"
 	"github.com/kubeshop/tracetest/cli/pkg/fileutil"
 	"go.uber.org/zap"
@@ -15,7 +14,7 @@ type http struct {
 }
 
 func HTTP(logger *zap.Logger) http {
-	return http{logger: cmdutil.GetLogger()}
+	return http{logger: logger}
 }
 
 func (g http) Type() trigger.TriggerType {

--- a/cli/processor/trigger_preprocessor/playwrightengine.go
+++ b/cli/processor/trigger_preprocessor/playwrightengine.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 
 	"github.com/kubeshop/tracetest/agent/workers/trigger"
-	"github.com/kubeshop/tracetest/cli/cmdutil"
 	"github.com/kubeshop/tracetest/cli/openapi"
 	"github.com/kubeshop/tracetest/cli/pkg/fileutil"
 	"go.uber.org/zap"
@@ -15,7 +14,7 @@ type playwrightengine struct {
 }
 
 func PLAYWRIGHTENGINE(logger *zap.Logger) playwrightengine {
-	return playwrightengine{logger: cmdutil.GetLogger()}
+	return playwrightengine{logger: logger}
 }
 
 func (g playwrightengine) Type() trigger.TriggerType {

--- a/cli/processor/variableset.go
+++ b/cli/processor/variableset.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 
 	"github.com/goccy/go-yaml"
-	"github.com/kubeshop/tracetest/cli/cmdutil"
 	"github.com/kubeshop/tracetest/cli/pkg/fileutil"
 	"go.uber.org/zap"
 )
@@ -21,7 +20,7 @@ type generic struct {
 
 func VariableSet(logger *zap.Logger) variableSet {
 	return variableSet{
-		logger: cmdutil.GetLogger(),
+		logger: logger,
 	}
 }
 

--- a/cli/runner/registry.go
+++ b/cli/runner/registry.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/kubeshop/tracetest/cli/cmdutil"
 	"go.uber.org/zap"
 )
 
@@ -18,7 +17,7 @@ func NewRegistry(logger *zap.Logger) Registry {
 	return Registry{
 		runners: map[string]Runner{},
 		proxies: map[string]string{},
-		logger:  cmdutil.GetLogger(),
+		logger:  logger,
 	}
 }
 


### PR DESCRIPTION
This PR fixes all the references to the logger so they are correctly replaced by a configured instance when ready. this allows to correctly process the verbose flag

## Changes

-

## Fixes

-

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Loom video

Add your loom video here if your work can be visualized
