### PR TITLE
fix: correctly display general errors

### DIFF
--- a/cli/cloud/runner/multifile_orchestrator.go
+++ b/cli/cloud/runner/multifile_orchestrator.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io"
-	"net/http"
 	"os"
 	"sync"
 
@@ -15,6 +13,7 @@ import (
 	"github.com/kubeshop/tracetest/cli/pkg/fileutil"
 	"github.com/kubeshop/tracetest/cli/pkg/resourcemanager"
 	"github.com/kubeshop/tracetest/cli/runner"
+
 	"github.com/kubeshop/tracetest/cli/varset"
 	"github.com/kubeshop/tracetest/server/pkg/id"
 	"go.uber.org/zap"
@@ -356,30 +355,4 @@ func getRequiredGates(gates []string) []openapi.SupportedGates {
 	}
 
 	return requiredGates
-}
-
-// HandleRunError handles errors returned by the server when running a test.
-// It normalizes the handling of general errors, like 404,
-// but more importantly, it processes the missing environment variables error
-// so the orchestrator can request them from the user.
-func HandleRunError(resp *http.Response, reqErr error) error {
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return fmt.Errorf("could not read response body: %w", err)
-	}
-	resp.Body.Close()
-
-	if resp.StatusCode == http.StatusNotFound {
-		return fmt.Errorf("resource not found in server")
-	}
-
-	if resp.StatusCode == http.StatusUnprocessableEntity {
-		return varset.BuildMissingVarsError(body)
-	}
-
-	if reqErr != nil {
-		return fmt.Errorf("could not run test suite: %w", reqErr)
-	}
-
-	return nil
 }

--- a/cli/cloud/runner/multifile_orchestrator.go
+++ b/cli/cloud/runner/multifile_orchestrator.go
@@ -308,7 +308,7 @@ func (o orchestrator) createRun(ctx context.Context, resource any, vars *varset.
 		}
 		if !errors.Is(err, varset.MissingVarsError{}) {
 			// actual error, return
-			return result, resource, fmt.Errorf("cannot run test: %w", err)
+			return result, resource, fmt.Errorf("cannot create test run: %w", err)
 		}
 
 		// missing vars error

--- a/cli/cmd/resource_run_cmd.go
+++ b/cli/cmd/resource_run_cmd.go
@@ -13,6 +13,7 @@ import (
 	"github.com/spf13/cobra"
 
 	cloudCmd "github.com/kubeshop/tracetest/cli/cloud/cmd"
+	cliRunner "github.com/kubeshop/tracetest/cli/runner"
 )
 
 var (
@@ -109,7 +110,12 @@ func runMultipleFiles(ctx context.Context) (string, error) {
 	}
 
 	exitCode, err := cloudCmd.RunMultipleFiles(ctx, cliLogger, httpClient, runParams, &cliConfig, runnerRegistry, output)
-	ExitCLI(exitCode)
+	// General Error is 1, which is the default for errors. if this is the case,
+	// let the CLI handle the error and exit.
+	// otherwise exit with the exit code.
+	if exitCode > cliRunner.ExitCodeGeneralError {
+		ExitCLI(exitCode)
+	}
 	return "", err
 }
 

--- a/cli/runner/orchestrator.go
+++ b/cli/runner/orchestrator.go
@@ -329,6 +329,7 @@ func HandleRunError(resp *http.Response, reqErr error) error {
 	}
 
 	if ok, msg := attemptToParseStructuredError(body); ok {
+		spew.Dump(body)
 		return fmt.Errorf("could not run resouce: %s", msg)
 	}
 
@@ -346,7 +347,7 @@ func attemptToParseStructuredError(body []byte) (bool, string) {
 	}
 
 	err := jsonFormat.Unmarshal(body, &parsed)
-	if err != nil {
+	if err != nil || parsed.Status == 0 {
 		return false, ""
 	}
 

--- a/cli/runner/orchestrator.go
+++ b/cli/runner/orchestrator.go
@@ -296,8 +296,6 @@ func (a orchestrator) writeJUnitReport(ctx context.Context, r Runner, result Run
 	return err
 }
 
-var source = "cli"
-
 func getRequiredGates(gates []string) []openapi.SupportedGates {
 	if len(gates) == 0 {
 		return nil
@@ -330,9 +328,29 @@ func HandleRunError(resp *http.Response, reqErr error) error {
 		return varset.BuildMissingVarsError(body)
 	}
 
+	if ok, msg := attemptToParseStructuredError(body); ok {
+		return fmt.Errorf("could not run resouce: %s", msg)
+	}
+
 	if reqErr != nil {
-		return fmt.Errorf("could not run test suite: %w", reqErr)
+		return fmt.Errorf("could not run resouce: %w", reqErr)
 	}
 
 	return nil
+}
+
+func attemptToParseStructuredError(body []byte) (bool, string) {
+	var parsed struct {
+		Status int    `json:"status"`
+		Detail string `json:"detail"`
+	}
+
+	err := jsonFormat.Unmarshal(body, &parsed)
+	if err != nil {
+		return false, ""
+	}
+
+	msg := fmt.Sprintf("%s (code %d)", parsed.Detail, parsed.Status)
+
+	return true, msg
 }

--- a/cli/runner/orchestrator.go
+++ b/cli/runner/orchestrator.go
@@ -329,7 +329,6 @@ func HandleRunError(resp *http.Response, reqErr error) error {
 	}
 
 	if ok, msg := attemptToParseStructuredError(body); ok {
-		spew.Dump(body)
 		return fmt.Errorf("could not run resouce: %s", msg)
 	}
 


### PR DESCRIPTION
This PR fixes the error handling of the CLI for the run command. It now allows displaying an error instead of silently failing.

It also attempts to parse the error response from the server as a structured error to display nicer messages when possible

## Changes

-

## Fixes

-

## Checklist

- [ ] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Loom video
![Screenshot 2024-08-28 at 18 57 35](https://github.com/user-attachments/assets/6c976c5c-766c-4d79-90e1-75e55662ec60)

Add your loom video here if your work can be visualized
