### PR TITLE
fix: add nicer message for missing agent error

### DIFF
--- a/cli/config/configurator.go
+++ b/cli/config/configurator.go
@@ -176,7 +176,6 @@ func (c Configurator) createConfig(serverURL string) (Config, error) {
 }
 
 type invalidServerErr struct {
-	ui        cliUI.UI
 	serverURL string
 	parent    error
 }
@@ -185,9 +184,8 @@ func (e invalidServerErr) Error() string {
 	return fmt.Errorf("cannot reach %s: %w", e.serverURL, e.parent).Error()
 }
 
-func (e invalidServerErr) Render() {
-	msg := fmt.Sprintf(`Cannot reach "%s". Please verify the url and enter it again.`, e.serverURL)
-	e.ui.Error(msg)
+func (e invalidServerErr) Message() string {
+	return fmt.Sprintf(`Cannot reach "%s". Please verify the url and enter it again.`, e.serverURL)
 }
 
 func (c Configurator) populateConfigWithDevConfig(_ context.Context, cfg *Config) {
@@ -227,7 +225,7 @@ func (c Configurator) populateConfigWithVersionInfo(ctx context.Context, cfg Con
 	client := GetAPIClient(cfg)
 	version, err := getVersionMetadata(ctx, client)
 	if err != nil {
-		err = invalidServerErr{c.ui, c.finalServerURL, fmt.Errorf("cannot get version metadata: %w", err)}
+		err = invalidServerErr{c.finalServerURL, fmt.Errorf("cannot get version metadata: %w", err)}
 		return Config{}, err, false
 	}
 

--- a/cli/runner/orchestrator.go
+++ b/cli/runner/orchestrator.go
@@ -329,6 +329,7 @@ func HandleRunError(resp *http.Response, reqErr error) error {
 	}
 
 	if ok, msg := attemptToParseStructuredError(body); ok {
+		spew.Dump(body)
 		return fmt.Errorf("could not run resouce: %s", msg)
 	}
 
@@ -346,7 +347,7 @@ func attemptToParseStructuredError(body []byte) (bool, string) {
 	}
 
 	err := jsonFormat.Unmarshal(body, &parsed)
-	if err != nil {
+	if err != nil || parsed.Status == 0 {
 		return false, ""
 	}
 

--- a/cli/runner/orchestrator.go
+++ b/cli/runner/orchestrator.go
@@ -329,7 +329,6 @@ func HandleRunError(resp *http.Response, reqErr error) error {
 	}
 
 	if ok, msg := attemptToParseStructuredError(body); ok {
-		spew.Dump(body)
 		return fmt.Errorf("could not run resouce: %s", msg)
 	}
 

--- a/cli/runner/orchestrator.go
+++ b/cli/runner/orchestrator.go
@@ -346,7 +346,7 @@ func attemptToParseStructuredError(body []byte) (bool, string) {
 	}
 
 	err := jsonFormat.Unmarshal(body, &parsed)
-	if err != nil || parsed.Status == 0 {
+	if err != nil {
 		return false, ""
 	}
 


### PR DESCRIPTION
This PR shows a nicer message for users for the `agent not started` error

## Changes

-

## Fixes

-

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Loom video

![Screenshot 2024-08-28 at 19 38 54](https://github.com/user-attachments/assets/2cf94e72-9772-4c30-b967-54628da1294d)
