### PR TITLE
fix(cli): improve display of error responses for token exchange

### DIFF
--- a/cli/cmdutil/logger.go
+++ b/cli/cmdutil/logger.go
@@ -29,7 +29,7 @@ func GetLogger(opts ...loggerOption) *zap.Logger {
 	if loggerConfig.Verbose {
 		atom.SetLevel(zap.DebugLevel)
 	} else {
-		atom.SetLevel(zap.WarnLevel)
+		return zap.NewNop()
 	}
 
 	encoderCfg := zapcore.EncoderConfig{

--- a/cli/cmdutil/logger.go
+++ b/cli/cmdutil/logger.go
@@ -29,7 +29,7 @@ func GetLogger(opts ...loggerOption) *zap.Logger {
 	if loggerConfig.Verbose {
 		atom.SetLevel(zap.DebugLevel)
 	} else {
-		return zap.NewNop()
+		atom.SetLevel(zap.WarnLevel)
 	}
 
 	encoderCfg := zapcore.EncoderConfig{

--- a/cli/config/configurator.go
+++ b/cli/config/configurator.go
@@ -117,7 +117,7 @@ func (c Configurator) Start(ctx context.Context, prev *Config, flags agentConfig
 
 	_, err = c.handleOAuth(ctx, cfg, prev)
 	if err != nil {
-		c.logger.Error("Could not handle OAuth", zap.Error(err))
+		c.logger.Debug("Could not handle OAuth", zap.Error(err))
 		return err
 	}
 
@@ -265,7 +265,7 @@ func (c Configurator) handleOAuth(ctx context.Context, cfg Config, prev *Config)
 		var err error
 		cfg, err = c.exchangeToken(cfg, c.flags.Token)
 		if err != nil {
-			c.logger.Error("Could not exchange token", zap.Error(err))
+			c.logger.Debug("could not exchange token", zap.Error(err))
 			return Config{}, err
 		}
 	}

--- a/cli/config/configurator.go
+++ b/cli/config/configurator.go
@@ -304,7 +304,6 @@ func (c Configurator) exchangeToken(cfg Config, token string) (Config, error) {
 	c.logger.Debug("Exchanging token", zap.String("token", token))
 	jwt, err := oauth.ExchangeToken(cfg.OAuthEndpoint(), token)
 	if err != nil {
-		c.logger.Error("Could not exchange token", zap.Error(err))
 		return Config{}, err
 	}
 


### PR DESCRIPTION
This PR improves the error handling of token exchange by showing user friendly error messages

## Changes

-

## Fixes

-

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Loom video

![Screenshot 2024-09-02 at 15 13 25](https://github.com/user-attachments/assets/40548d8e-e3d7-4017-8c47-4612e0a88eef)

![Screenshot 2024-09-02 at 15 13 56](https://github.com/user-attachments/assets/967079c2-8050-4579-bd12-be2499688dfa)
