### PR TITLE
fix(agent): use api-key from env on entrypoint cmd

### DIFF
--- a/agent/entrypoint.sh
+++ b/agent/entrypoint.sh
@@ -7,4 +7,4 @@ if [ -z "$TRACETEST_API_KEY" ]; then
 fi
 
 # Execute tracetest with the API key and any additional arguments
-exec tracetest start --api-key "$TRACETEST_API_KEY" "$@"
+exec tracetest start "$@"


### PR DESCRIPTION
This PR changes the entrypoint script to use the API KEY from env instead of as an argument when calling tracetest. This avoids exposing the API KEY as plain text under some circumstances

## Changes

-

## Fixes

-

## Checklist

- [ ] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Loom video

Add your loom video here if your work can be visualized
