### PR TITLE
fix: add Host to request in trigger

### DIFF
--- a/agent/workers/trigger/http.go
+++ b/agent/workers/trigger/http.go
@@ -75,6 +75,10 @@ func (te *httpTriggerer) Trigger(ctx context.Context, triggerConfig Trigger, opt
 	tReq.Authenticate(req)
 	propagators().Inject(ctx, propagation.HeaderCarrier(req.Header))
 
+	if host := req.Header.Get("Host"); host != "" {
+		req.Host = host
+	}
+
 	resp, err := client.Do(req.WithContext(ctx))
 	if err != nil {
 		return response, err

--- a/agent/workers/trigger/http_test.go
+++ b/agent/workers/trigger/http_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 
 	"github.com/kubeshop/tracetest/agent/workers/trigger"
-	triggerer "github.com/kubeshop/tracetest/agent/workers/trigger"
 	"github.com/kubeshop/tracetest/server/pkg/id"
 	"github.com/stretchr/testify/assert"
 	"go.opentelemetry.io/otel/trace"
@@ -56,7 +55,7 @@ func TestTriggerGet(t *testing.T) {
 		},
 	}
 
-	ex := triggerer.HTTP()
+	ex := trigger.HTTP()
 
 	resp, err := ex.Trigger(createContext(), triggerConfig, nil)
 	assert.NoError(t, err)
@@ -100,7 +99,7 @@ func TestTriggerPost(t *testing.T) {
 		},
 	}
 
-	ex := triggerer.HTTP()
+	ex := trigger.HTTP()
 
 	resp, err := ex.Trigger(createContext(), triggerConfig, nil)
 	assert.NoError(t, err)
@@ -158,7 +157,7 @@ func TestTriggerPostWithApiKeyAuth(t *testing.T) {
 		},
 	}
 
-	ex := triggerer.HTTP()
+	ex := trigger.HTTP()
 
 	resp, err := ex.Trigger(createContext(), triggerConfig, nil)
 	assert.NoError(t, err)
@@ -215,7 +214,7 @@ func TestTriggerPostWithBasicAuth(t *testing.T) {
 		},
 	}
 
-	ex := triggerer.HTTP()
+	ex := trigger.HTTP()
 
 	resp, err := ex.Trigger(createContext(), triggerConfig, nil)
 	assert.NoError(t, err)
@@ -271,7 +270,7 @@ func TestTriggerPostWithBearerAuth(t *testing.T) {
 		},
 	}
 
-	ex := triggerer.HTTP()
+	ex := trigger.HTTP()
 
 	resp, err := ex.Trigger(createContext(), triggerConfig, nil)
 	assert.NoError(t, err)

--- a/server/executor/trigger/http.go
+++ b/server/executor/trigger/http.go
@@ -102,6 +102,10 @@ func (te *httpTriggerer) Trigger(ctx context.Context, test test.Test, opts *Trig
 	tReq.Authenticate(req)
 	propagators().Inject(ctx, propagation.HeaderCarrier(req.Header))
 
+	if host := req.Header.Get("Host"); host != "" {
+		req.Host = host
+	}
+
 	resp, err := client.Do(req.WithContext(ctx))
 	if err != nil {
 		return response, err


### PR DESCRIPTION
This PR makes both agent and opensource triggerer add the `Host` property to the `http.Request` before sending it to the server.

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Loom video

Add your loom video here if your work can be visualized
