### PR TITLE
chore(agent): add debug logs for otlp connection tester

### DIFF
--- a/agent/client/workflow_listen_for_otlp_connection_tests.go
+++ b/agent/client/workflow_listen_for_otlp_connection_tests.go
@@ -51,11 +51,13 @@ func (c *Client) startOTLPConnectionTestListener(ctx context.Context) error {
 			// we want a new context per request, not to reuse the one from the stream
 			ctx := telemetry.InjectMetadataIntoContext(context.Background(), req.Metadata)
 			go func() {
+				logger.Debug("handling otlp connection test request")
 				err = c.otlpConnectionTestListener(ctx, &req)
 				if err != nil {
 					logger.Error("could not handle otlp connection test request", zap.Error(err))
 					fmt.Println(err.Error())
 				}
+				logger.Debug("otlp connection test request handled")
 			}()
 		}
 	}()


### PR DESCRIPTION
This PR adds debug logs to the otlp connection tester to help debugging

## Changes

-

## Fixes

-

## Checklist

- [ ] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Loom video

Add your loom video here if your work can be visualized
