### PR TITLE
fix(agent): update error handling on shutdown

### DIFF
--- a/agent/runner/runstrategy_verbose.go
+++ b/agent/runner/runstrategy_verbose.go
@@ -18,11 +18,11 @@ func (s *Runner) RunVerboseStrategy(ctx context.Context, cfg agentConfig.Config)
 	s.ui.Infof("%s Starting Agent with name %s...", consoleUI.Emoji_Truck, cfg.Name)
 
 	session, err := StartSession(ctx, cfg, &verboseObserver{ui: s.ui}, s.logger)
-
-	if err != nil && errors.Is(err, ErrOtlpServerStart) {
-		s.ui.Errorf("%s Tracetest Agent binds to the OpenTelemetry ports 4317 and 4318 which are used to receive trace information from your system. The agent tried to bind to these ports, but failed.", consoleUI.Emoji_RedCircle)
-
-		s.ui.Finish()
+	if err != nil {
+		if errors.Is(err, ErrOtlpServerStart) {
+			s.ui.Errorf("%s Tracetest Agent binds to the OpenTelemetry ports 4317 and 4318 which are used to receive trace information from your system. The agent tried to bind to these ports, but failed.", consoleUI.Emoji_RedCircle)
+			s.ui.Finish()
+		}
 		return err
 	}
 

--- a/agent/runner/session.go
+++ b/agent/runner/session.go
@@ -28,7 +28,9 @@ type Session struct {
 }
 
 func (s *Session) Close() {
-	s.client.Close()
+	if s != nil && s.client != nil {
+		s.client.Close()
+	}
 }
 
 func (s *Session) WaitUntilDisconnected() {


### PR DESCRIPTION
This PR updates the error handling on the agent when it is stopped after an auth error, causing go to give a nil pointer error.

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test