### PR TITLE
fix(traces): fixing missing span attributes

### DIFF
--- a/server/traces/otel_converter.go
+++ b/server/traces/otel_converter.go
@@ -20,13 +20,16 @@ func FromOtelResourceSpans(resourceSpans []*v1.ResourceSpans) Trace {
 	for _, resource := range resourceSpans {
 		for _, scopeSpans := range resource.ScopeSpans {
 			for _, span := range scopeSpans.Spans {
-				span.Attributes = append(span.Attributes, &v11.KeyValue{
-					Key:   MetadataServiceName,
-					Value: &v11.AnyValue{Value: &v11.AnyValue_StringValue{StringValue: scopeSpans.Scope.Name}},
-				})
+				// if service exists, add it as an attribute
+				if scopeSpans.Scope != nil {
+					span.Attributes = append(span.Attributes, &v11.KeyValue{
+						Key:   MetadataServiceName,
+						Value: &v11.AnyValue{Value: &v11.AnyValue_StringValue{StringValue: scopeSpans.Scope.Name}},
+					})
 
-				// Add attributes from the resource
-				span.Attributes = append(span.Attributes, scopeSpans.Scope.Attributes...)
+					// Add attributes from the resource
+					span.Attributes = append(span.Attributes, scopeSpans.Scope.Attributes...)
+				}
 			}
 
 			flattenSpans = append(flattenSpans, scopeSpans.Spans...)

--- a/server/traces/span_entitiess.go
+++ b/server/traces/span_entitiess.go
@@ -22,6 +22,8 @@ const (
 	TracetestMetadataFieldKind              string = "tracetest.span.kind"
 	TracetestMetadataFieldStatusCode        string = "tracetest.span.status_code"
 	TracetestMetadataFieldStatusDescription string = "tracetest.span.status_description"
+
+	MetadataServiceName string = "service.name"
 )
 
 func NewAttributes(inputs ...map[string]string) Attributes {

--- a/server/traces/span_entitiess.go
+++ b/server/traces/span_entitiess.go
@@ -23,7 +23,8 @@ const (
 	TracetestMetadataFieldStatusCode        string = "tracetest.span.status_code"
 	TracetestMetadataFieldStatusDescription string = "tracetest.span.status_description"
 
-	MetadataServiceName string = "service.name"
+	MetadataServiceName  string = "service.name"
+	TracetestServiceName string = "tracetest"
 )
 
 func NewAttributes(inputs ...map[string]string) Attributes {
@@ -372,5 +373,6 @@ func (span Span) setTriggerResultAttributes(result trigger.TriggerResult) Span {
 		span.Attributes.Set("tracetest.response.headers", string(jsonheaders))
 	}
 
+	span.Attributes.Set(MetadataServiceName, TracetestServiceName)
 	return span
 }


### PR DESCRIPTION
This PR adds the missing span attributes such as
1. Service name
2. Resource spans

## Changes

- Adds resources attribute to base spans
- Adds service name attribute

## Fixes

- https://github.com/kubeshop/tracetest-cloud/issues/890

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

