### PR TITLE
fix: update variable set for pokeshop synthetic test

### DIFF
--- a/testing/synthetic-monitoring/pokeshop/_variableset.yaml
+++ b/testing/synthetic-monitoring/pokeshop/_variableset.yaml
@@ -6,4 +6,4 @@ spec:
     - key: POKESHOP_API_URL
       value: https://demo-pokeshop.tracetest.io
     - key: POKESHOP_KAFKA_BROKER
-      value: demo-pokeshop.tracetest.io:9092
+      value: stream.demo:9092


### PR DESCRIPTION
This PR updates the `POKESHOP_KAFKA_BROKER` value for the pokeshop synthetic monitoring tests.

## Changes

- update `POKESHOP_KAFKA_BROKER`

## Fixes

-

## Checklist

- [ ] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
