### PR TITLE
fix: prevent map concurrent writes panic in the agent

### DIFF
--- a/agent/runner/runstrategy_dashboard.go
+++ b/agent/runner/runstrategy_dashboard.go
@@ -3,6 +3,7 @@ package runner
 import (
 	"context"
 	"fmt"
+	"sync"
 	"time"
 
 	"github.com/kubeshop/tracetest/agent/collector"
@@ -60,6 +61,7 @@ func (s *Runner) disableLogger() func() {
 type dashboardObserver struct {
 	runs   map[string]models.TestRun
 	sensor sensors.Sensor
+	mutex  sync.Mutex
 }
 
 func (o *dashboardObserver) EndDataStoreConnection(*proto.DataStoreConnectionTestRequest, error) {
@@ -130,6 +132,8 @@ func (o *dashboardObserver) getRun(testID string, runID int32) models.TestRun {
 }
 
 func (o *dashboardObserver) setRun(model models.TestRun) {
+	o.mutex.Lock()
+	defer o.mutex.Unlock()
 	o.runs[fmt.Sprintf("%s-%s", model.TestID, model.RunID)] = model
 }
 


### PR DESCRIPTION
This PR prevents `map concurrent writes` panic in the agent