### PR TITLE
feat(cli): allow selecting resource type when running multiple files

### DIFF
--- a/cli/pkg/fileutil/file.go
+++ b/cli/pkg/fileutil/file.go
@@ -41,7 +41,6 @@ func ReadDirFileNames(path string) []string {
 
 	var result []string
 	for _, file := range files {
-		// TODO: add validation for file extensions, tracetest runnable definitions (?)
 		if file.IsDir() {
 			result = append(result, ReadDirFileNames(filepath.Join(path, file.Name()))...)
 		} else {


### PR DESCRIPTION
This PR enables the cli to filter files by resource types when running an entire directory. This allows to use a single command to launch multiple testsuites from a directory that also contains tests. For example:

```
$ tree tests
├── 01_step_1.yaml
├── 02_step_2.yaml
└── feature_test_suite.yaml
```

Until now, running `tracetest run -f tests` would cause to run `01_step_1.yaml`, `02_step_2.yaml` and `feature_test_suite.yaml`. This might not be desirable

Now, running `tracetest run testsuite -f tests` would cause to only run `feature_test_suite.yaml`.

## Changes

-

## Fixes

-

## Checklist

- [ ] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Loom video

Add your loom video here if your work can be visualized
