### PR TITLE
chore(testing): update old Transaction types to TestSuites

### DIFF
--- a/demo/transaction.yaml
+++ b/demo/transaction.yaml
@@ -1,4 +1,4 @@
-type: Transaction
+type: TestSuite
 spec:
   name: my transaction
   description: haha

--- a/examples/quick-start-github-actions/tracetest/tests/transaction-api.yaml
+++ b/examples/quick-start-github-actions/tracetest/tests/transaction-api.yaml
@@ -1,4 +1,4 @@
-type: Transaction
+type: TestSuite
 spec:
   id: 3YIB7rPVg
   name: All Tests for the Books List API

--- a/examples/tracetest-aws-step-functions/tests/transaction.yaml
+++ b/examples/tracetest-aws-step-functions/tests/transaction.yaml
@@ -1,4 +1,4 @@
-type: Transaction
+type: TestSuite
 spec:
   id: 3q47ooxVR
   name: Step Functions

--- a/testing/cli-e2etest/testscenarios/testsuite/resources/legacy-transaction.yaml
+++ b/testing/cli-e2etest/testscenarios/testsuite/resources/legacy-transaction.yaml
@@ -1,4 +1,4 @@
-type: Transaction
+type: TestSuite
 spec:
   id: Qti5R3_VR
   name: New Transaction

--- a/testing/synthetic-monitoring/pokeshop-serverless/_testsuite.yaml
+++ b/testing/synthetic-monitoring/pokeshop-serverless/_testsuite.yaml
@@ -1,4 +1,4 @@
-type: Transaction
+type: TestSuite
 spec:
   id: pokeshop-serverless-demo-test-suite
   name: "Serverless - Pokeshop  Synthetic tests"

--- a/testing/synthetic-monitoring/pokeshop/_testsuite.yaml
+++ b/testing/synthetic-monitoring/pokeshop/_testsuite.yaml
@@ -1,4 +1,4 @@
-type: Transaction
+type: TestSuite
 spec:
   id: pokeshop-demo-test-suite
   name: Pokeshop Synthetic tests


### PR DESCRIPTION
This PR fixes our test to stop using the old, deprecated `Transaction` type in favor of `TestSuite`

## Changes

-

## Fixes

-

## Checklist

- [ ] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Loom video

Add your loom video here if your work can be visualized
