### PR TITLE
chore(tempodb): Adding max size for received messages to 10MB

### DIFF
--- a/agent/tracedb/tempodb.go
+++ b/agent/tracedb/tempodb.go
@@ -90,9 +90,12 @@ func grpcGetTraceByID(ctx context.Context, traceID string, conn *grpc.ClientConn
 		return traces.Trace{}, err
 	}
 
-	resp, err := query.FindTraceByID(ctx, &tempopb.TraceByIDRequest{
+	// This is a temporary solution while we figure out how to paginate the traces from Tempo
+	maxSizeOption := grpc.MaxCallRecvMsgSize(1024 * 1024 * 10) // 10MB
+
+	resp, err := query.FindTraceByID(context.Background(), &tempopb.TraceByIDRequest{
 		TraceID: []byte(trID[:]),
-	})
+	}, maxSizeOption)
 	if err != nil {
 		return traces.Trace{}, handleError(err)
 	}


### PR DESCRIPTION
This PR temporary increases the max size of messages to 10MB, while we work on a way to paginate results from Tempo

## Changes

- Adds max received option to 10MB

## Fixes

- https://github.com/kubeshop/tracetest-cloud/issues/924

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
