### PR TITLE
chore(cli): Adding version validation to `configure`  and `start`

### DIFF
--- a/cli/cmd/config.go
+++ b/cli/cmd/config.go
@@ -146,12 +146,7 @@ func setupVersion() {
 
 func validateVersionMismatch() {
 	if !isVersionMatch && os.Getenv("TRACETEST_DEV") == "" {
-		fmt.Fprintf(os.Stderr, versionText+`
-✖️ Error: Version Mismatch
-The CLI version and the server version are not compatible. To fix this, you'll need to make sure that both your CLI and server are using compatible versions.
-We recommend upgrading both of them to the latest available version. Check out our documentation https://docs.tracetest.io/configuration/upgrade for simple instructions on how to upgrade.
-Thank you for using Tracetest! We apologize for any inconvenience caused.
-`)
+		fmt.Fprintf(os.Stderr, versionText+config.ErrVersionMismatch.Error())
 		ExitCLI(1)
 	}
 }

--- a/cli/cmd/start_cmd.go
+++ b/cli/cmd/start_cmd.go
@@ -2,6 +2,8 @@ package cmd
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"os"
 
 	agentConfig "github.com/kubeshop/tracetest/agent/config"
@@ -76,7 +78,13 @@ var startCmd = &cobra.Command{
 			cfg.EnvironmentID = flags.EnvironmentID
 		}
 
+		// early exit if the versions are not compatible
 		err = agentRunner.Run(ctx, cliLogger, cliConfig, flags, verbose)
+		if errors.Is(err, config.ErrVersionMismatch) {
+			fmt.Println(err.Error())
+			ExitCLI(1)
+		}
+
 		return "", err
 	})),
 	PostRun: teardownCommand,


### PR DESCRIPTION
This PR adds the version validation to the `configure` and `start` commands.

## Changes

- Adds validation at the configurator level to return the validation error
- CMDs now exit early if version error is found

## Fixes

- https://github.com/kubeshop/tracetest-cloud/issues/930

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Loom video


https://github.com/user-attachments/assets/0acc36d6-56c3-494f-9526-181ae86bdaae


