### PR TITLE
fix: join url paths properly to build browser URL to open

### DIFF
--- a/agent/runner/runstrategy_desktop.go
+++ b/agent/runner/runstrategy_desktop.go
@@ -3,6 +3,7 @@ package runner
 import (
 	"context"
 	"fmt"
+	"net/url"
 
 	agentConfig "github.com/kubeshop/tracetest/agent/config"
 	"github.com/kubeshop/tracetest/agent/ui/dashboard/sensors"
@@ -27,7 +28,12 @@ You can`
 		{
 			Text: "Open Tracetest in a browser to this environment",
 			Fn: func(_ consoleUI.ConsoleUI) {
-				s.ui.OpenBrowser(fmt.Sprintf("%sorganizations/%s/environments/%s", uiEndpoint, claims["organization_id"], claims["environment_id"]))
+				endpoint, err := url.JoinPath(uiEndpoint, fmt.Sprintf("/organizations/%s/environments/%s", claims["organization_id"], claims["environment_id"]))
+				if err != nil {
+					s.ui.Exit(fmt.Errorf("could not create URL: %w", err).Error())
+				}
+
+				s.ui.OpenBrowser(endpoint)
 			},
 		},
 		{


### PR DESCRIPTION
This PR fixes the way we build the browser URL when opening the environment from the agent UI

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Loom video

Add your loom video here if your work can be visualized
