### PR TITLE
fix(agent): use correct environment id when starting manually

### DIFF
--- a/agent/runner/runner.go
+++ b/agent/runner/runner.go
@@ -82,7 +82,7 @@ func (s *Runner) onStartAgent(ctx context.Context, cfg config.Config) {
 		return
 	}
 
-	err = s.StartAgent(ctx, cfg, agentToken, "")
+	err = s.StartAgent(ctx, cfg, agentToken, cfg.EnvironmentID)
 	if err != nil {
 		s.ui.Error(err.Error())
 	}


### PR DESCRIPTION
This PR uses the correct Environment ID when manually running `tracetest start` without any flags, and manually selecting the environment from the dropdown.

## Changes

-

## Fixes

-

## Checklist

- [ ] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Loom video

Add your loom video here if your work can be visualized
