### PR TITLE
feat(cli): save default agent token to local config

### DIFF
--- a/agent/runner/runner.go
+++ b/agent/runner/runner.go
@@ -72,7 +72,7 @@ func (s *Runner) onStartAgent(ctx context.Context, cfg config.Config) {
 		return
 	}
 
-	agentToken, err := s.getAgentToken(ctx, cfg.FullURL(), cfg.OrganizationID, cfg.EnvironmentID, cfg.Jwt)
+	agentToken, err := config.GetAgentToken(ctx, s.logger, cfg.FullURL(), cfg.OrganizationID, cfg.EnvironmentID, cfg.Jwt)
 	if err != nil {
 		s.ui.Error(err.Error())
 	}

--- a/cli/cmd/configure_cmd.go
+++ b/cli/cmd/configure_cmd.go
@@ -51,6 +51,8 @@ var configureCmd = &cobra.Command{
 			flags.OrganizationID = configParams.OrganizationID
 		}
 
+		configurator = configurator.WithLogger(cliLogger)
+
 		// early exit if the versions are not compatible
 		err = configurator.Start(ctx, &cfg, flags)
 		if errors.Is(err, config.ErrVersionMismatch) {

--- a/cli/config/agent_token.go
+++ b/cli/config/agent_token.go
@@ -1,4 +1,4 @@
-package runner
+package config
 
 import (
 	"context"
@@ -14,11 +14,12 @@ type agentResponse struct {
 	Key string `json:"key"`
 }
 
-func (s *Runner) getAgentToken(ctx context.Context, endpoint, orgID, envID, token string) (string, error) {
-	s.logger.Debug("Getting agent token", zap.String("endpoint", endpoint), zap.String("token", token))
-	req, err := http.NewRequestWithContext(ctx, "GET", fmt.Sprintf("%s/organizations/%s/environments/%s/agent", endpoint, orgID, envID), nil)
+func GetAgentToken(ctx context.Context, logger *zap.Logger, endpoint, orgID, envID, token string) (string, error) {
+	reqUrl := fmt.Sprintf("%s/organizations/%s/environments/%s/agent", endpoint, orgID, envID)
+	logger.Debug("Getting agent token", zap.String("endpoint", reqUrl))
+	req, err := http.NewRequestWithContext(ctx, "GET", reqUrl, nil)
 	if err != nil {
-		s.logger.Debug("Failed to create request", zap.Error(err))
+		logger.Debug("Failed to create request", zap.Error(err))
 		return "", fmt.Errorf("failed to create request: %w", err)
 	}
 
@@ -27,30 +28,30 @@ func (s *Runner) getAgentToken(ctx context.Context, endpoint, orgID, envID, toke
 
 	res, err := http.DefaultClient.Do(req)
 	if err != nil {
-		s.logger.Debug("Failed to get agent token", zap.Error(err))
+		logger.Debug("Failed to get agent token", zap.Error(err))
 		return "", fmt.Errorf("failed to get agent token: %w", err)
 	}
 
 	if res.StatusCode != http.StatusOK {
-		s.logger.Debug("Failed to get agent token", zap.String("status", res.Status))
+		logger.Debug("Failed to get agent token", zap.String("status", res.Status))
 		return "", fmt.Errorf("failed to get agent token: %s", res.Status)
 	}
 
 	defer res.Body.Close()
 	body, err := io.ReadAll(res.Body)
 	if err != nil {
-		s.logger.Debug("Failed to read response body", zap.Error(err))
+		logger.Debug("Failed to read response body", zap.Error(err))
 		return "", fmt.Errorf("failed to read response body: %w", err)
 	}
 
 	var agentResponse agentResponse
 	err = json.Unmarshal(body, &agentResponse)
 	if err != nil {
-		s.logger.Debug("Failed to unmarshal response body", zap.Error(err))
+		logger.Debug("Failed to unmarshal response body", zap.Error(err))
 		return "", fmt.Errorf("failed to unmarshal response body: %w", err)
 	}
 
-	s.logger.Debug("Agent token received")
+	logger.Debug("Agent token received")
 
 	return agentResponse.Key, nil
 }

--- a/cli/config/config.go
+++ b/cli/config/config.go
@@ -33,6 +33,7 @@ type Config struct {
 	Token             string `yaml:"token,omitempty"`
 	IsOrgToken        bool   `yaml:"isOrgToken,omitempty"`
 	Jwt               string `yaml:"jwt,omitempty"`
+	DefaultAgenApiKey string `yaml:"defaultAgentApiKey,omitempty"`
 	AgentApiKey       string `yaml:"-"`
 	EndpointOverriden bool   `yaml:"-"`
 

--- a/cli/config/configurator.go
+++ b/cli/config/configurator.go
@@ -398,6 +398,12 @@ func (c Configurator) showOrganizationSelector(ctx context.Context, prev *Config
 		}
 
 		cfg.EnvironmentID = envID
+
+		cfg.DefaultAgenApiKey, err = c.getEnvironmentDefaultAgentApiKey(ctx, cfg)
+		if err != nil {
+			c.errorHandlerFn(ctx, err)
+			return
+		}
 	}
 
 	ctx, err := Save(ctx, cfg)
@@ -408,6 +414,17 @@ func (c Configurator) showOrganizationSelector(ctx context.Context, prev *Config
 	}
 
 	c.onFinish(ctx, cfg)
+}
+
+func (c Configurator) getEnvironmentDefaultAgentApiKey(ctx context.Context, cfg Config) (string, error) {
+	c.logger.Debug("Getting environment default agent API key", zap.String("environmentID", cfg.EnvironmentID))
+	agentApiKey, err := GetAgentToken(ctx, c.logger, cfg.FullURL(), cfg.OrganizationID, cfg.EnvironmentID, cfg.Jwt)
+	if err != nil {
+		c.logger.Debug("Could not get environment", zap.Error(err))
+		return "", err
+	}
+
+	return agentApiKey, nil
 }
 
 func SetupHttpClient(cfg Config) *resourcemanager.HTTPClient {


### PR DESCRIPTION
This PR makes the default agent api key available in the local config file, making it easier to automate agent related setups

## Changes

-

## Fixes

-

## Checklist

- [ ] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Loom video

Add your loom video here if your work can be visualized
