### PR TITLE
fix(cli): use correct web dashboard URL

### DIFF
--- a/cli/cmd/dashboard_cmd.go
+++ b/cli/cmd/dashboard_cmd.go
@@ -20,7 +20,7 @@ var dashboardCmd = &cobra.Command{
 		}
 
 		ui := ui.DefaultUI
-		err := ui.OpenBrowser(cliConfig.URL())
+		err := ui.OpenBrowser(cliConfig.UI())
 		if err != nil {
 			return "", fmt.Errorf("failed to open the dashboard url: %s", cliConfig.URL())
 		}

--- a/cli/config/config.go
+++ b/cli/config/config.go
@@ -64,6 +64,10 @@ func (c Config) UI() string {
 		return fmt.Sprintf("%s/organizations/%s/environments/%s", strings.TrimSuffix(c.UIEndpoint, "/"), c.OrganizationID, c.EnvironmentID)
 	}
 
+	if c.UIEndpoint != "" {
+		return fmt.Sprintf("%s%s", c.UIEndpoint, c.Path())
+	}
+
 	return c.URL()
 }
 

--- a/cli/config/config.go
+++ b/cli/config/config.go
@@ -65,7 +65,7 @@ func (c Config) UI() string {
 	}
 
 	if c.UIEndpoint != "" {
-		return fmt.Sprintf("%s%s", c.UIEndpoint, c.Path())
+		return c.UIEndpoint
 	}
 
 	return c.URL()


### PR DESCRIPTION
This PR fixes the `tracetest dashboard` command to use the correct URL. It was directing users to `api.tracetest.io`, resulting in a blank `404` page. 
Now the command will try to use the configured env URL, if no env is set fallback to the `uiEndpoint` ("https://app.tracetest.io"), and ultimately return the api url, which was the original behavior, and requried for OSS

## Changes

-

## Fixes

-

## Checklist

- [ ] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Loom video

Add your loom video here if your work can be visualized
